### PR TITLE
fix(ci): install Ghidra JARs to Maven repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,13 +42,43 @@ jobs:
         wget --no-verbose -O ghidra.zip https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${{ env.GHIDRA_VERSION }}_build/ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC_${{ env.GHIDRA_DATE }}.zip
         7z x -bd ghidra.zip
 
-    - name: Copy Ghidra libs
+    - name: Install Ghidra JARs to Maven local repository
       run: |
-        mkdir -p ./lib
-        for libfile in ${{ env.GHIDRA_LIBS }}
-          do echo "Copying ${libfile} to lib/"
-          cp ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC/Ghidra/${libfile} ./lib/
-        done
+        GHIDRA_DIR="ghidra_${{ env.GHIDRA_VERSION }}_PUBLIC"
+        
+        # Install Framework JARs
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Generic/lib/Generic.jar" \
+            -DgroupId=ghidra -DartifactId=Generic -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/SoftwareModeling/lib/SoftwareModeling.jar" \
+            -DgroupId=ghidra -DartifactId=SoftwareModeling -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Project/lib/Project.jar" \
+            -DgroupId=ghidra -DartifactId=Project -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Docking/lib/Docking.jar" \
+            -DgroupId=ghidra -DartifactId=Docking -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Utility/lib/Utility.jar" \
+            -DgroupId=ghidra -DartifactId=Utility -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Gui/lib/Gui.jar" \
+            -DgroupId=ghidra -DartifactId=Gui -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/FileSystem/lib/FileSystem.jar" \
+            -DgroupId=ghidra -DartifactId=FileSystem -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Graph/lib/Graph.jar" \
+            -DgroupId=ghidra -DartifactId=Graph -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/DB/lib/DB.jar" \
+            -DgroupId=ghidra -DartifactId=DB -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Emulation/lib/Emulation.jar" \
+            -DgroupId=ghidra -DartifactId=Emulation -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        
+        # Install Feature JARs
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/Base/lib/Base.jar" \
+            -DgroupId=ghidra -DartifactId=Base -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/Decompiler/lib/Decompiler.jar" \
+            -DgroupId=ghidra -DartifactId=Decompiler -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/PDB/lib/PDB.jar" \
+            -DgroupId=ghidra -DartifactId=PDB -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/FunctionID/lib/FunctionID.jar" \
+            -DgroupId=ghidra -DartifactId=FunctionID -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        
+        echo "✅ Installed Ghidra JARs to Maven local repository"
 
     - name: Build with Maven
       run: mvn clean package assembly:single -DskipTests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,32 +41,45 @@ jobs:
         unzip -q /tmp/ghidra.zip -d /tmp/ghidra
         rm /tmp/ghidra.zip
     
-    - name: Copy Ghidra JARs to lib/
+    - name: Install Ghidra JARs to Maven local repository
       run: |
         GHIDRA_DIR=$(find /tmp/ghidra -maxdepth 1 -type d -name 'ghidra_*' | head -1)
+        GHIDRA_VERSION="12.0.2"
         echo "Using Ghidra directory: $GHIDRA_DIR"
-        mkdir -p lib
         
-        # Framework JARs
-        cp "$GHIDRA_DIR/Ghidra/Framework/Generic/lib/Generic.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/SoftwareModeling/lib/SoftwareModeling.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/Project/lib/Project.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/Docking/lib/Docking.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/Utility/lib/Utility.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/Gui/lib/Gui.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/FileSystem/lib/FileSystem.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/Graph/lib/Graph.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/DB/lib/DB.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Framework/Emulation/lib/Emulation.jar" lib/
+        # Install Framework JARs
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Generic/lib/Generic.jar" \
+            -DgroupId=ghidra -DartifactId=Generic -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/SoftwareModeling/lib/SoftwareModeling.jar" \
+            -DgroupId=ghidra -DartifactId=SoftwareModeling -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Project/lib/Project.jar" \
+            -DgroupId=ghidra -DartifactId=Project -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Docking/lib/Docking.jar" \
+            -DgroupId=ghidra -DartifactId=Docking -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Utility/lib/Utility.jar" \
+            -DgroupId=ghidra -DartifactId=Utility -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Gui/lib/Gui.jar" \
+            -DgroupId=ghidra -DartifactId=Gui -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/FileSystem/lib/FileSystem.jar" \
+            -DgroupId=ghidra -DartifactId=FileSystem -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Graph/lib/Graph.jar" \
+            -DgroupId=ghidra -DartifactId=Graph -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/DB/lib/DB.jar" \
+            -DgroupId=ghidra -DartifactId=DB -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Emulation/lib/Emulation.jar" \
+            -DgroupId=ghidra -DartifactId=Emulation -Dversion=$GHIDRA_VERSION -Dpackaging=jar
         
-        # Feature JARs
-        cp "$GHIDRA_DIR/Ghidra/Features/Base/lib/Base.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Features/Decompiler/lib/Decompiler.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Features/PDB/lib/PDB.jar" lib/
-        cp "$GHIDRA_DIR/Ghidra/Features/FunctionID/lib/FunctionID.jar" lib/
+        # Install Feature JARs
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/Base/lib/Base.jar" \
+            -DgroupId=ghidra -DartifactId=Base -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/Decompiler/lib/Decompiler.jar" \
+            -DgroupId=ghidra -DartifactId=Decompiler -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/PDB/lib/PDB.jar" \
+            -DgroupId=ghidra -DartifactId=PDB -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/FunctionID/lib/FunctionID.jar" \
+            -DgroupId=ghidra -DartifactId=FunctionID -Dversion=$GHIDRA_VERSION -Dpackaging=jar
         
-        echo "✅ Copied $(ls lib/*.jar | wc -l) Ghidra JARs to lib/"
-        ls -la lib/*.jar
+        echo "✅ Installed Ghidra JARs to Maven local repository"
     
     - name: Build with Maven
       run: mvn clean package assembly:single -q -DskipTests


### PR DESCRIPTION
## Summary
Fixes CI build failures that started after PR #18 was merged.

## Problem
PR #18 changed `pom.xml` from system-scoped dependencies:
```xml
<scope>system</scope>
<systemPath>${project.basedir}/lib/Generic.jar</systemPath>
```

To standard Maven dependencies:
```xml
<version>${ghidra.version}</version>
```

However, the CI workflows were not updated. They still just copied JARs to `lib/`, which no longer works with the new pom.xml.

## Solution
Replace the "Copy Ghidra libs" step with `mvn install:install-file` commands that properly install each Ghidra JAR into the Maven local repository.

## Files Changed
- `.github/workflows/tests.yml`
- `.github/workflows/build.yml`

## Impact
- Unblocks all PRs (#20, #21, #22) which are failing due to this CI issue
- Allows proper Maven dependency management as intended by PR #18