### PR TITLE
fix(docker): correct Ghidra 12.0.2 release date

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ FROM eclipse-temurin:21-jdk AS builder
 
 # Build arguments
 ARG GHIDRA_VERSION=12.0.2
-ARG GHIDRA_DATE=20250206
+ARG GHIDRA_DATE=20260129
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Fixes Docker build failure - the release date for Ghidra 12.0.2 is 20260129, not 20250206.