### PR TITLE
fix: drop Python 3.8/3.9 from CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `mcp` package requires Python >= 3.10 (`requires-python = ">=3.10"`), so the 3.8 and 3.9 CI jobs always fail with `ModuleNotFoundError: No module named 'mcp'`
- Replace 3.8/3.9 with 3.12/3.13 to cover current Python releases

## Test plan
- [ ] Verify all four Python CI jobs pass (3.10, 3.11, 3.12, 3.13)