### PR TITLE
Fix: Reordering tool handler params so that params with default values are at the end

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -957,6 +957,9 @@ def _make_tool_handler(tool_def: dict):
             )
         )
 
+    # Reorder the param names list so that params with default values are at the end of the list
+    sig_params.sort(key=lambda x: x.default == inspect.Parameter.empty, reverse=True)
+
     sig = inspect.Signature(sig_params, return_annotation=str)
 
     # Separate query vs body params


### PR DESCRIPTION
When the script is parsing tool definitions from Ghidra, it is possible for params with default values to be parsed before params with no default values. The inspect library (and Python) requires all function params with default value to come after params with no default value.

2026-03-09 10:05:35,939 - __main__ - INFO - [<Parameter "struct_name: str">, <Parameter "field_name: str">, <Parameter "field_type: str">, <Parameter "offset: int = -1">, <Parameter "program: str">]
2026-03-09 10:05:35,939 - __main__ - INFO - struct_name: str
2026-03-09 10:05:35,939 - __main__ - INFO - field_name: str
2026-03-09 10:05:35,939 - __main__ - INFO - field_type: str
2026-03-09 10:05:35,940 - __main__ - INFO - offset: int = -1
2026-03-09 10:05:35,940 - __main__ - INFO - program: str
2026-03-09 10:05:35,940 - __main__ - WARNING - Error during schema tool registration: non-default argument follows default argument

This patch simply calls the sort() function on sig_params to put the params-with-default-values at the end.