### PR TITLE
fix: mock safe_get in set_function_prototype test

### DIFF
--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -495,8 +495,10 @@ class TestRenameVariables:
 class TestSetFunctionPrototype:
     """Test set_function_prototype static tool."""
 
+    @patch.object(bridge_mcp_ghidra, "safe_get")
     @patch.object(bridge_mcp_ghidra, "safe_post_json")
-    def test_set_prototype(self, mock_post):
+    def test_set_prototype(self, mock_post, mock_get):
+        mock_get.return_value = "Function: main @ 0x401000"
         mock_post.return_value = "success: prototype set"
         result = bridge_mcp_ghidra.set_function_prototype(
             function_address="0x401000",


### PR DESCRIPTION
## Summary
- `TestSetFunctionPrototype::test_set_prototype` fails in CI because `set_function_prototype` calls `safe_get("get_function_by_address", ...)` to verify the function exists before calling `safe_post_json`, but only `safe_post_json` was mocked
- Added `@patch.object(bridge_mcp_ghidra, "safe_get")` to prevent the real HTTP call to localhost:8089

## Test plan
- [x] `pytest tests/unit/test_mcp_tool_functions.py::TestSetFunctionPrototype` passes
- [x] All 192 unit tests pass