### PR TITLE
Add MCP SSE bridge support with dual-port architecture

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
-# GhidraMCP Headless Server Docker Image
-# Multi-stage build for minimal runtime image
+# GhidraMCP Docker Image - Full MCP Server
+# Includes Ghidra headless server + Python MCP bridge
+# Exposes MCP protocol via SSE transport for LLM clients
 
 # =============================================================================
 # Stage 1: Builder - Download Ghidra and build the plugin
@@ -70,9 +71,12 @@ RUN mvn clean package -P headless -DskipTests -q
 # =============================================================================
 FROM eclipse-temurin:21-jre
 
-# Install runtime dependencies
+# Install runtime dependencies (Java runtime + Python for MCP bridge)
 RUN apt-get update && apt-get install -y \
     curl \
+    python3 \
+    python3-pip \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Ghidra from builder
@@ -83,25 +87,36 @@ ENV GHIDRA_HOME=/opt/ghidra
 ENV GHIDRA_MCP_PORT=8089
 ENV JAVA_OPTS="-Xmx4g -XX:+UseG1GC"
 
+# MCP bridge configuration
+ENV MCP_TRANSPORT=sse
+ENV MCP_HOST=0.0.0.0
+ENV MCP_PORT=8081
+ENV ENABLE_MCP_BRIDGE=true
+
 # Create directories
 RUN mkdir -p /app /data /projects
 
-# Copy the built headless JAR (lib directory may not exist with system-scoped deps)
-# Copy the built JAR (naming may vary based on version)
+# Copy the built headless JAR
 COPY --from=builder /build/target/GhidraMCP-*.jar /app/GhidraMCP.jar
+
+# Copy MCP bridge and install Python dependencies
+COPY bridge_mcp_ghidra.py /app/
+COPY requirements.txt /app/
+RUN python3 -m venv /app/venv && \
+    /app/venv/bin/pip install --no-cache-dir -r /app/requirements.txt
 
 # Copy entrypoint script and fix line endings (Windows -> Unix)
 COPY docker/entrypoint.sh /app/
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
-# Expose port
-EXPOSE 8089
+# Expose ports: 8081 = MCP SSE (primary), 8089 = Ghidra HTTP API (internal/debug)
+EXPOSE 8081 8089
 
 # Volume for persistent data and projects
 VOLUME ["/data", "/projects"]
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+# Health check (checks Java server; bridge depends on it)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
     CMD curl -f http://localhost:${GHIDRA_MCP_PORT}/check_connection || exit 1
 
 # Set working directory

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,27 @@
-# GhidraMCP Headless Server - Docker Deployment
+# GhidraMCP Docker - Full MCP Server
 
-Run GhidraMCP as a headless REST API server in Docker containers.
+Run GhidraMCP as a fully functional MCP server in Docker. The container includes both the Ghidra headless analysis engine and the MCP protocol bridge, allowing LLM clients to connect directly and perform binary analysis.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Docker Container                             │
+│                                                                     │
+│  ┌───────────────────────────┐    ┌──────────────────────────────┐  │
+│  │   bridge_mcp_ghidra.py    │    │  GhidraMCPHeadlessServer     │  │
+│  │   (MCP Protocol Bridge)   │───▶│  (Ghidra Analysis Engine)    │  │
+│  │                           │    │                              │  │
+│  │  - 193 MCP tools          │    │  - Program/project mgmt     │  │
+│  │  - SSE transport          │    │  - Auto-analysis             │  │
+│  │  - Tool validation        │    │  - Decompilation             │  │
+│  └───────────┬───────────────┘    └──────────────────────────────┘  │
+│              │                              │                       │
+│        Port 8081 (MCP SSE)           Port 8089 (HTTP API)          │
+└──────────────┼──────────────────────────────┼───────────────────────┘
+               │                              │
+          LLM Clients                   Debug/Direct Access
+```
 
 ## Quick Start
 
@@ -11,8 +32,36 @@ Run GhidraMCP as a headless REST API server in Docker containers.
 cd docker
 docker-compose up -d
 
-# Check status
+# Verify the server is running
 curl http://localhost:8089/check_connection
+```
+
+The MCP server is available at `http://localhost:8081/sse`.
+
+### Connect an MCP Client
+
+**Claude Desktop** (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "ghidra": {
+      "url": "http://localhost:8081/sse"
+    }
+  }
+}
+```
+
+**Claude Code** (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ghidra": {
+      "url": "http://localhost:8081/sse"
+    }
+  }
+}
 ```
 
 ### Multiple Instances with Load Balancer
@@ -22,19 +71,45 @@ curl http://localhost:8089/check_connection
 docker-compose -f docker-compose.multi.yml up -d --scale ghidra-mcp=3
 ```
 
+## Usage Workflow
+
+Once connected, the LLM can perform the full reverse engineering workflow through MCP tools:
+
+1. **Create a project**: `create_project` - Create a Ghidra project for organizing binaries
+2. **Import a binary**: `load_program` - Import a binary file for analysis (mount binaries via volumes)
+3. **Auto-analyze**: Analysis runs automatically on import
+4. **Explore**: `list_functions`, `list_strings`, `list_imports`, `list_exports`
+5. **Analyze**: `decompile_function`, `disassemble_function`, `get_xrefs_to`
+6. **Annotate**: `rename_function`, `rename_variable`, `set_decompiler_comment`
+7. **Deep analysis**: `analyze_control_flow`, `find_anti_analysis`, `extract_iocs`
+
+All 193 MCP tools are available. See the main project README for the complete tool reference.
+
+### Mounting Binaries
+
+To analyze local binaries, mount them into the container:
+
+```yaml
+# In docker-compose.yml
+volumes:
+  - ./my-binaries:/binaries:ro
+```
+
+Then use the `load_program` tool to import `/binaries/target.exe`.
+
 ## Building
 
 ### Build Docker Image
 
 ```bash
 # From project root
-docker build -t ghidra-mcp-headless:latest -f docker/Dockerfile .
+docker build -t ghidra-mcp:latest -f docker/Dockerfile .
 ```
 
 ### Build with Maven
 
 ```bash
-# Build headless JAR
+# Build headless JAR only
 mvn clean package -P headless -DskipTests
 
 # Build Docker image via Maven
@@ -47,10 +122,22 @@ mvn clean package -P docker -DskipTests
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GHIDRA_MCP_PORT` | `8089` | HTTP server port |
+| `GHIDRA_MCP_PORT` | `8089` | Ghidra HTTP server port (internal) |
 | `JAVA_OPTS` | `-Xmx4g -XX:+UseG1GC` | JVM options |
+| `MCP_TRANSPORT` | `sse` | MCP transport: `sse` or `stdio` |
+| `MCP_HOST` | `0.0.0.0` | MCP SSE listen address |
+| `MCP_PORT` | `8081` | MCP SSE listen port |
+| `ENABLE_MCP_BRIDGE` | `true` | Set `false` for HTTP-only mode (no MCP) |
 | `PROGRAM_FILE` | - | Path to binary file to load on startup |
 | `PROJECT_PATH` | - | Path to Ghidra project directory |
+| `GHIDRA_USER` | - | Override user for project ownership |
+
+### Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| `8081` | MCP SSE | Primary interface for LLM clients |
+| `8089` | HTTP | Ghidra REST API (debugging/direct access) |
 
 ### Volumes
 
@@ -59,118 +146,39 @@ mvn clean package -P docker -DskipTests
 | `ghidra-data` | `/data` | Persistent data storage |
 | `ghidra-projects` | `/projects` | Ghidra project files |
 
-## API Endpoints
+## HTTP-Only Mode
 
-The headless server exposes the same REST API as the GUI plugin. Currently implemented:
-
-### Health & Metadata
-- `GET /check_connection` - Health check
-- `GET /get_version` - Server version
-- `GET /get_metadata` - Program metadata
-
-### Listing
-- `GET /list_methods` - List function names
-- `GET /list_functions` - List functions with addresses
-- `GET /list_classes` - List namespaces
-- `GET /list_segments` - List memory segments
-- `GET /list_imports` - List imports
-- `GET /list_exports` - List exports
-- `GET /list_data_items` - List defined data
-- `GET /list_strings` - List defined strings
-- `GET /list_data_types` - List data types
-
-### Analysis
-- `GET /decompile_function` - Decompile function
-- `GET /disassemble_function` - Disassemble function
-- `GET /get_function_by_address` - Get function info
-- `GET /get_xrefs_to` - Get cross-references to address
-- `GET /get_xrefs_from` - Get cross-references from address
-- `GET /search_functions` - Search functions by name
-
-### Modification (POST)
-- `POST /rename_function` - Rename function by name
-- `POST /rename_function_by_address` - Rename function by address
-- `POST /rename_data` - Rename data label
-- `POST /rename_variable` - Rename variable
-- `POST /set_decompiler_comment` - Set PRE_COMMENT
-- `POST /set_disassembly_comment` - Set EOL_COMMENT
-
-### Program Management
-- `GET /list_open_programs` - List loaded programs
-- `GET /get_current_program_info` - Current program info
-- `POST /switch_program` - Switch active program
-- `POST /load_program` - Load program from file (headless only)
-- `POST /close_program` - Close a program (headless only)
-
-## Testing
-
-### Run Integration Tests
+To run without the MCP bridge (original behavior, REST API only):
 
 ```bash
-# Install test requirements
-pip install -r tests/requirements.txt
-
-# Run tests against local server
-python tests/run_tests.py --integration --server http://localhost:8089
-
-# Run all tests with verbose output
-python tests/run_tests.py --all -v
-```
-
-### Test Endpoint Coverage
-
-```bash
-# Run endpoint registration tests
-pytest tests/integration/test_all_endpoints.py -v
-```
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     Docker Container                         │
-│  ┌────────────────────────────────────────────────────────┐ │
-│  │              GhidraMCPHeadlessServer                    │ │
-│  │  ┌──────────────────┐  ┌─────────────────────────────┐ │ │
-│  │  │ HeadlessProgram  │  │ HeadlessEndpointHandler     │ │ │
-│  │  │    Provider      │  │   (127 REST endpoints)      │ │ │
-│  │  └──────────────────┘  └─────────────────────────────┘ │ │
-│  │  ┌──────────────────┐  ┌─────────────────────────────┐ │ │
-│  │  │ DirectThreading  │  │     Ghidra Headless         │ │ │
-│  │  │    Strategy      │  │    (Analysis Engine)        │ │ │
-│  │  └──────────────────┘  └─────────────────────────────┘ │ │
-│  └────────────────────────────────────────────────────────┘ │
-│              Port 8089 ─────────────────────────────────────┼──▶ HTTP API
-└─────────────────────────────────────────────────────────────┘
-
-Multi-Instance Setup:
-┌─────────────┐     ┌─────────────────────────────────────────┐
-│   Client    │────▶│  Nginx Load Balancer (Port 8089)        │
-└─────────────┘     └──────┬──────────┬──────────┬────────────┘
-                           │          │          │
-                    ┌──────▼───┐┌─────▼────┐┌────▼─────┐
-                    │Instance 1││Instance 2││Instance 3│
-                    │ (8089)   ││ (8089)   ││ (8089)   │
-                    └──────────┘└──────────┘└──────────┘
+docker run -p 8089:8089 -e ENABLE_MCP_BRIDGE=false ghidra-mcp:latest
 ```
 
 ## Troubleshooting
 
 ### Server won't start
 
-1. Check if port 8089 is in use: `netstat -an | grep 8089`
-2. Check Docker logs: `docker logs ghidra-mcp`
-3. Verify Ghidra home: `docker exec ghidra-mcp ls /opt/ghidra`
+1. Check Docker logs: `docker logs ghidra-mcp`
+2. Check if ports are in use: `netstat -an | grep -E '8081|8089'`
+3. Verify Ghidra installation inside container: `docker exec ghidra-mcp ls /opt/ghidra`
+
+### MCP bridge won't connect
+
+1. The bridge waits up to 120 seconds for the Ghidra server to start
+2. Check that port 8089 isn't blocked inside the container
+3. Verify bridge logs: `docker logs ghidra-mcp 2>&1 | grep -i bridge`
 
 ### No program loaded
 
-1. Load a program via API: `curl -X POST -d "file=/data/binary.exe" http://localhost:8089/load_program`
-2. Or set `PROGRAM_FILE` environment variable
+1. Mount binaries and use `load_program` tool: mount a directory to `/binaries`
+2. Or set `PROGRAM_FILE` environment variable for auto-loading
+3. Use `create_project` to organize binaries into Ghidra projects
 
 ### Memory issues
 
 1. Increase Java heap: `JAVA_OPTS=-Xmx8g`
 2. Monitor usage: `docker stats ghidra-mcp`
+3. Container default limit is 6GB; increase in docker-compose if needed
 
 ## License
 

--- a/docker/docker-compose.multi.yml
+++ b/docker/docker-compose.multi.yml
@@ -1,4 +1,4 @@
-# GhidraMCP Headless Server - Multi-Instance Deployment with Load Balancer
+# GhidraMCP Server - Multi-Instance Deployment with Load Balancer
 # Usage: docker-compose -f docker-compose.multi.yml up -d --scale ghidra-mcp=3
 
 version: '3.8'
@@ -9,7 +9,8 @@ services:
     image: nginx:alpine
     container_name: ghidra-mcp-lb
     ports:
-      - "8089:80"
+      - "8081:8081"   # MCP SSE (load balanced with sticky sessions)
+      - "8089:80"     # REST API (load balanced)
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
@@ -26,22 +27,27 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: ghidra-mcp-headless:latest
+    image: ghidra-mcp:latest
     # Note: container_name not set to allow scaling
     expose:
       - "8089"
+      - "8081"
     volumes:
       - ghidra-data:/data
       - ghidra-projects:/projects
     environment:
       - GHIDRA_MCP_PORT=8089
       - JAVA_OPTS=-Xmx4g -XX:+UseG1GC
+      - MCP_TRANSPORT=sse
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8081
+      - ENABLE_MCP_BRIDGE=true
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8089/check_connection"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8089/check_connection"]
       interval: 30s
       timeout: 10s
-      start_period: 60s
+      start_period: 90s
       retries: 3
     deploy:
       mode: replicated

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,5 @@
-# GhidraMCP Headless Server - Single Instance Deployment
+# GhidraMCP Server - Single Instance Deployment
+# Runs a full MCP server with Ghidra analysis capabilities
 # Usage: docker-compose up -d
 
 version: '3.8'
@@ -8,10 +9,11 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: ghidra-mcp-headless:latest
+    image: ghidra-mcp:latest
     container_name: ghidra-mcp
     ports:
-      - "8089:8089"
+      - "8081:8081"   # MCP SSE endpoint (primary - for LLM clients)
+      - "8089:8089"   # Ghidra HTTP API (optional - for debugging/direct access)
     volumes:
       # Persistent data storage
       - ghidra-data:/data
@@ -20,16 +22,24 @@ services:
       # Optional: Mount local binaries for analysis
       # - ./binaries:/binaries:ro
     environment:
+      # Ghidra headless server
       - GHIDRA_MCP_PORT=8089
       - JAVA_OPTS=-Xmx4g -XX:+UseG1GC
+      # MCP bridge
+      - MCP_TRANSPORT=sse
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8081
+      - ENABLE_MCP_BRIDGE=true
       # Optional: Auto-load a program on startup
       # - PROGRAM_FILE=/binaries/target.exe
+      # Optional: Set to 'false' for HTTP-only mode (no MCP bridge)
+      # - ENABLE_MCP_BRIDGE=false
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8089/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8089/check_connection"]
       interval: 30s
       timeout: 10s
-      start_period: 60s
+      start_period: 90s
       retries: 3
     deploy:
       resources:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# GhidraMCP Headless Server Entrypoint Script
+# GhidraMCP Server Entrypoint Script
+# Starts the Ghidra headless server and MCP bridge together
 
 set -e
 
@@ -8,6 +9,12 @@ PORT=${GHIDRA_MCP_PORT:-8089}
 BIND_ADDRESS=${GHIDRA_MCP_BIND_ADDRESS:-"0.0.0.0"}  # Default to all interfaces for Docker
 JAVA_OPTS=${JAVA_OPTS:-"-Xmx4g -XX:+UseG1GC"}
 GHIDRA_USER=${GHIDRA_USER:-""}  # Set to project owner name to bypass ownership checks
+
+# MCP bridge configuration
+MCP_TRANSPORT=${MCP_TRANSPORT:-"sse"}
+MCP_HOST=${MCP_HOST:-"0.0.0.0"}
+MCP_PORT=${MCP_PORT:-8081}
+ENABLE_MCP_BRIDGE=${ENABLE_MCP_BRIDGE:-"true"}
 
 # Shared Ghidra server configuration
 GHIDRA_SERVER_HOST=${GHIDRA_SERVER_HOST:-""}
@@ -21,16 +28,24 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 echo -e "${GREEN}========================================${NC}"
-echo -e "${GREEN}  GhidraMCP Headless Server${NC}"
+echo -e "${GREEN}  GhidraMCP Server${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo ""
 
 # Print configuration
 echo -e "${YELLOW}Configuration:${NC}"
 echo "  Bind Address: ${BIND_ADDRESS}"
-echo "  Port: ${PORT}"
+echo "  Ghidra HTTP Port: ${PORT}"
 echo "  Java Options: ${JAVA_OPTS}"
 echo "  Ghidra Home: ${GHIDRA_HOME}"
+if [ "${ENABLE_MCP_BRIDGE}" = "true" ]; then
+    echo "  MCP Bridge: enabled"
+    echo "  MCP Transport: ${MCP_TRANSPORT}"
+    echo "  MCP Host: ${MCP_HOST}"
+    echo "  MCP Port: ${MCP_PORT}"
+else
+    echo "  MCP Bridge: disabled (HTTP-only mode)"
+fi
 if [ -n "${GHIDRA_USER}" ]; then
     echo "  Ghidra User: ${GHIDRA_USER}"
 fi
@@ -74,15 +89,38 @@ if [ -d "/app/lib" ]; then
     done
 fi
 
-# Handle graceful shutdown
+# PID tracking for process management
+JAVA_PID=""
+BRIDGE_PID=""
+
+# Handle graceful shutdown - kill both processes
 cleanup() {
     echo ""
     echo -e "${YELLOW}Shutting down GhidraMCP server...${NC}"
-    # The Java application handles SIGTERM
+    [ -n "$BRIDGE_PID" ] && kill $BRIDGE_PID 2>/dev/null
+    [ -n "$JAVA_PID" ] && kill $JAVA_PID 2>/dev/null
+    wait 2>/dev/null
     exit 0
 }
 
 trap cleanup SIGTERM SIGINT
+
+# Wait for Java server to be ready
+wait_for_server() {
+    local max_attempts=60
+    local attempt=0
+    echo -e "${YELLOW}Waiting for Ghidra headless server to start...${NC}"
+    while [ $attempt -lt $max_attempts ]; do
+        if curl -sf http://127.0.0.1:${PORT}/check_connection > /dev/null 2>&1; then
+            echo -e "${GREEN}Ghidra headless server is ready.${NC}"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 2
+    done
+    echo -e "${RED}Ghidra server failed to start within $((max_attempts * 2)) seconds${NC}"
+    return 1
+}
 
 # Build command arguments
 ARGS="--port ${PORT} --bind ${BIND_ADDRESS}"
@@ -104,21 +142,66 @@ if [ -n "${PROJECT_PATH}" ] && [ -d "${PROJECT_PATH}" ]; then
     ARGS="${ARGS} --project ${PROJECT_PATH}"
 fi
 
-echo -e "${GREEN}Starting server...${NC}"
-echo ""
-
 # Build user.name option if GHIDRA_USER is set
 USER_OPT=""
 if [ -n "${GHIDRA_USER}" ]; then
     USER_OPT="-Duser.name=${GHIDRA_USER}"
 fi
 
-# Start the server
-exec java \
+echo -e "${GREEN}Starting Ghidra headless server...${NC}"
+echo ""
+
+# Start the Java server in background
+java \
     ${JAVA_OPTS} \
     ${USER_OPT} \
     -Dghidra.home=${GHIDRA_HOME} \
     -Dapplication.name=GhidraMCP \
     -classpath "${CLASSPATH}" \
     com.xebyte.headless.GhidraMCPHeadlessServer \
-    ${ARGS}
+    ${ARGS} &
+JAVA_PID=$!
+
+if [ "${ENABLE_MCP_BRIDGE}" = "true" ]; then
+    # Wait for Java server to be healthy before starting the bridge
+    wait_for_server || { kill $JAVA_PID 2>/dev/null; exit 1; }
+
+    echo -e "${GREEN}Starting MCP bridge (${MCP_TRANSPORT} on ${MCP_HOST}:${MCP_PORT})...${NC}"
+    echo ""
+
+    # Set the Ghidra server URL for the bridge
+    export GHIDRA_SERVER_URL="http://127.0.0.1:${PORT}"
+
+    /app/venv/bin/python3 /app/bridge_mcp_ghidra.py \
+        --ghidra-server "http://127.0.0.1:${PORT}" \
+        --transport "${MCP_TRANSPORT}" \
+        --mcp-host "${MCP_HOST}" \
+        --mcp-port "${MCP_PORT}" &
+    BRIDGE_PID=$!
+
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  GhidraMCP server is ready!${NC}"
+    echo -e "${GREEN}  MCP endpoint: http://${MCP_HOST}:${MCP_PORT}/sse${NC}"
+    echo -e "${GREEN}  HTTP API: http://${BIND_ADDRESS}:${PORT}${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+
+    # Monitor both processes - exit if either dies
+    while true; do
+        if ! kill -0 $JAVA_PID 2>/dev/null; then
+            echo -e "${RED}Ghidra headless server exited unexpectedly${NC}"
+            kill $BRIDGE_PID 2>/dev/null
+            exit 1
+        fi
+        if ! kill -0 $BRIDGE_PID 2>/dev/null; then
+            echo -e "${RED}MCP bridge exited unexpectedly${NC}"
+            kill $JAVA_PID 2>/dev/null
+            exit 1
+        fi
+        sleep 5
+    done
+else
+    # No bridge - just wait on Java server (HTTP-only mode)
+    echo -e "${YELLOW}MCP bridge disabled. Running in HTTP-only mode.${NC}"
+    wait $JAVA_PID
+fi

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,6 @@
 # Nginx Load Balancer Configuration for GhidraMCP
 # Routes requests across multiple GhidraMCP server instances
+# Handles both REST API (port 80) and MCP SSE (port 8081)
 
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
@@ -37,23 +38,26 @@ http {
     gzip_comp_level 6;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
 
-    # Upstream configuration for GhidraMCP servers
+    # Upstream: Ghidra REST API (least connections)
     upstream ghidra_mcp {
-        # Least connections load balancing
-        # Routes to the server with fewest active connections
         least_conn;
-
-        # Docker Compose DNS resolution
-        # Docker automatically load-balances across replicas
         server ghidra-mcp:8089;
+        keepalive 32;
+    }
 
-        # Health check settings
+    # Upstream: MCP SSE bridge (sticky sessions required for SSE)
+    upstream ghidra_mcp_sse {
+        ip_hash;
+        server ghidra-mcp:8081;
         keepalive 32;
     }
 
     # Rate limiting zone
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=100r/s;
 
+    # ==========================================================================
+    # REST API server (port 80 -> external port 8089)
+    # ==========================================================================
     server {
         listen 80;
         server_name _;
@@ -149,6 +153,80 @@ http {
         location = /50x.html {
             root /usr/share/nginx/html;
             internal;
+        }
+    }
+
+    # ==========================================================================
+    # MCP SSE server (port 8081)
+    # ==========================================================================
+    server {
+        listen 8081;
+        server_name _;
+
+        # SSE endpoint - persistent connection for server-sent events
+        location /sse {
+            proxy_pass http://ghidra_mcp_sse;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+
+            # Critical for SSE: disable all buffering
+            proxy_buffering off;
+            proxy_cache off;
+            add_header X-Accel-Buffering no always;
+
+            # Long timeouts for persistent SSE connections
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 86400s;  # 24 hours
+            proxy_send_timeout 300s;
+
+            # CORS
+            add_header Access-Control-Allow-Origin * always;
+        }
+
+        # MCP message endpoint (POST requests from MCP clients)
+        location /messages/ {
+            proxy_pass http://ghidra_mcp_sse;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+
+            # Disable buffering for streaming responses
+            proxy_buffering off;
+
+            # Generous timeouts for tool execution (analysis can be slow)
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+
+            client_max_body_size 100M;
+
+            # CORS
+            add_header Access-Control-Allow-Origin * always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Origin, Content-Type, Accept" always;
+
+            if ($request_method = OPTIONS) {
+                add_header Access-Control-Allow-Origin *;
+                add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+                add_header Access-Control-Allow-Headers "Origin, Content-Type, Accept";
+                add_header Content-Length 0;
+                add_header Content-Type text/plain;
+                return 204;
+            }
+        }
+
+        # Health check for MCP
+        location /health {
+            access_log off;
+            return 200 "mcp-healthy\n";
+            add_header Content-Type text/plain;
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds full MCP (Model Context Protocol) server support to GhidraMCP, enabling LLM clients to connect directly via the MCP protocol. The container now runs both the Ghidra headless analysis engine (HTTP API on port 8089) and a Python MCP bridge (SSE transport on port 8081) simultaneously.

## Key Changes

- **Dual-port architecture**: 
  - Port 8089: Ghidra HTTP REST API (internal/debugging)
  - Port 8081: MCP SSE endpoint (primary interface for LLM clients)

- **Nginx load balancer enhancements**:
  - Added separate upstream for MCP SSE with `ip_hash` for sticky sessions (required for SSE)
  - New server block on port 8081 with `/sse` and `/messages/` endpoints
  - Disabled buffering for SSE streams with `proxy_buffering off`
  - Extended timeouts for persistent connections (24-hour read timeout for SSE)

- **Entrypoint script refactoring**:
  - Now starts both Java server and Python MCP bridge as background processes
  - Added `wait_for_server()` function to ensure Ghidra is ready before starting bridge
  - Proper signal handling for graceful shutdown of both processes
  - New environment variables: `MCP_TRANSPORT`, `MCP_HOST`, `MCP_PORT`, `ENABLE_MCP_BRIDGE`

- **Docker configuration updates**:
  - Added Python 3 and pip to runtime dependencies
  - Dockerfile now copies MCP bridge script and sets up Python virtual environment
  - Updated docker-compose files to expose port 8081 and configure MCP environment variables
  - Added `ENABLE_MCP_BRIDGE` flag for HTTP-only mode (backward compatibility)

- **Documentation updates**:
  - Updated README with MCP client connection examples (Claude Desktop, Claude Code)
  - Added usage workflow showing full reverse engineering pipeline through MCP tools
  - Clarified port purposes and added MCP-specific troubleshooting section
  - Updated architecture diagrams to show MCP bridge integration

## Implementation Details

- The MCP bridge waits up to 120 seconds for the Ghidra server to become healthy before starting
- Sticky sessions (`ip_hash`) ensure SSE clients maintain connection to the same backend instance in multi-instance deployments
- SSE buffering is explicitly disabled to ensure real-time event delivery
- Both processes are monitored; if either dies, the container exits with appropriate error handling
- Backward compatible: setting `ENABLE_MCP_BRIDGE=false` runs HTTP-only mode

https://claude.ai/code/session_01CdrpnYJ3fyzqmPBWc5ZnmQ