### PR TITLE
build: add Gradle-based Ghidra extension build

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
    mvn clean package assembly:single -DskipTests
    ```
 
+   ```bash
+   # Manual Gradle build (requires GHIDRA_INSTALL_DIR)
+   GHIDRA_INSTALL_DIR=/path/to/ghidra gradle buildExtension
+   ```
+
 ### Installation (Linux — Ubuntu/Debian)
 
 > Use `ghidra-mcp-setup.sh` as the primary entry point on Linux.
@@ -757,7 +762,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
 ### Quick Start
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Build and test your changes (`mvn clean package assembly:single -DskipTests`)
+3. Build and test your changes (`mvn clean package assembly:single -DskipTests` or `GHIDRA_INSTALL_DIR=/path/to/ghidra gradle buildExtension`)
 4. Update documentation as needed
 5. Commit your changes (`git commit -m 'Add amazing feature'`)
 6. Push to the branch (`git push origin feature/amazing-feature`)

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,117 @@
+import groovy.xml.XmlSlurper
+
+plugins {
+    id 'java'
+}
+
+def pom = new XmlSlurper().parse(file('pom.xml'))
+group = pom.groupId.text()
+version = pom.version.text()
+description = pom.description.text()
+
+def ghidraInstallDir = providers.gradleProperty('GHIDRA_INSTALL_DIR')
+    .orElse(providers.environmentVariable('GHIDRA_INSTALL_DIR'))
+    .orNull
+
+if (!ghidraInstallDir) {
+    throw new GradleException('GHIDRA_INSTALL_DIR is not defined')
+}
+
+def ghidraRoot = file(ghidraInstallDir)
+def ghidraDir = new File(ghidraRoot, 'Ghidra').exists() ? new File(ghidraRoot, 'Ghidra') : ghidraRoot
+def ghidraProperties = new Properties()
+def applicationProperties = new File(ghidraDir, 'application.properties')
+
+if (!applicationProperties.exists()) {
+    throw new GradleException("Unable to find application.properties under ${ghidraRoot}")
+}
+
+applicationProperties.withReader { reader ->
+    ghidraProperties.load(reader)
+}
+
+def ghidraVersion = ghidraProperties.getProperty('application.version')
+def buildTimestamp = new Date().format('yyyyMMdd-HHmmss')
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation fileTree(dir: new File(ghidraDir, 'Framework'), include: '**/*.jar')
+    implementation fileTree(dir: new File(ghidraDir, 'Features'), include: '**/*.jar')
+    implementation fileTree(dir: new File(ghidraDir, 'Debug'), include: '**/*.jar')
+    implementation fileTree(dir: new File(ghidraDir, 'Processors'), include: '**/*.jar')
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.8.0'
+}
+
+processResources {
+    filteringCharset = 'UTF-8'
+
+    filesMatching(['version.properties', 'extension.properties']) {
+        filter { line ->
+            line
+                .replace('${project.version}', project.version.toString())
+                .replace('${ghidra.version}', ghidraVersion)
+                .replace('${build.timestamp}', buildTimestamp)
+                .replace('${build.number}', buildTimestamp)
+        }
+    }
+}
+
+jar {
+    archiveBaseName = 'GhidraMCP'
+
+    manifest {
+        attributes(
+            'Manifest-Version': '1.0',
+            'Plugin-Class': 'com.xebyte.GhidraMCPPlugin',
+            'Plugin-Name': 'GhidraMCP',
+            'Plugin-Version': project.version.toString(),
+            'Plugin-Author': 'Ben Ethington',
+            'Plugin-Description': 'GhidraMCP - HTTP server plugin with 195+ MCP tools for reverse engineering automation',
+        )
+    }
+}
+
+tasks.register('buildExtension', Zip) {
+    group = 'build'
+    description = 'Builds the Ghidra extension ZIP.'
+
+    dependsOn(tasks.jar, tasks.processResources)
+
+    archiveBaseName = 'GhidraMCP'
+    archiveVersion = project.version.toString()
+    destinationDirectory = layout.buildDirectory.dir('dist')
+
+    from(layout.buildDirectory.dir('resources/main')) {
+        include 'extension.properties'
+        into 'GhidraMCP'
+    }
+
+    from('src/main/resources') {
+        include 'Module.manifest'
+        into 'GhidraMCP'
+    }
+
+    from(tasks.jar) {
+        into 'GhidraMCP/lib'
+    }
+
+    from(configurations.runtimeClasspath) {
+        exclude { element ->
+            element.file.canonicalPath.startsWith(ghidraDir.canonicalPath)
+        }
+        into 'GhidraMCP/lib'
+    }
+}
+
+assemble.dependsOn(tasks.named('buildExtension'))

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'GhidraMCP'


### PR DESCRIPTION
## Summary

Add a Gradle-based build for the Ghidra extension artifact.

This keeps the existing project layout and artifact shape, but makes it possible to build `dist/GhidraMCP-<version>.zip` directly from Gradle using `GHIDRA_INSTALL_DIR`, without relying on the current Maven assembly flow for the extension ZIP.

## Why

The project already targets the standard Ghidra extension layout, but today the extension ZIP is only produced through the Maven build.

Ghidra's extension build flow has been Gradle-oriented for a long time now, so it would be nice for `ghidra-mcp` to support that path directly as well instead of only exposing the Maven assembly flow.

Adding a Gradle build path makes it easier to integrate with environments that expect Ghidra extensions to expose a `buildExtension` task and a `dist/*.zip` output (like nixpkgs).

## What Changed

- added `build.gradle`
- added `settings.gradle`
- added a short README note for the Gradle build path
- kept the existing Maven build in place for now
