### PR TITLE
build: write Ghidra extension ZIP to dist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ tasks.register('buildExtension', Zip) {
 
     archiveBaseName = 'GhidraMCP'
     archiveVersion = project.version.toString()
-    destinationDirectory = layout.buildDirectory.dir('dist')
+    destinationDirectory = layout.projectDirectory.dir('dist')
 
     from(layout.buildDirectory.dir('resources/main')) {
         include 'extension.properties'


### PR DESCRIPTION
## Summary

Write the `buildExtension` ZIP to the repo-root `dist/` directory instead of `build/dist/`.

## Why

Ghidra extension builds commonly expose their final ZIP under `dist/`, and writing it there makes the output easier to consume from downstream packaging/integration workflows.

In particular, this makes it possible to package `ghidra-mcp` cleanly with nixpkgs' existing `buildGhidraExtension` helper, without an extra packaging-side copy step.

## Validation

Built locally with:

```bash
GHIDRA_INSTALL_DIR=/path/to/ghidra gradle clean buildExtension
```

This produced:

```text
dist/GhidraMCP-5.0.0.zip
```

## Request

If this looks good, it would also help to cut a release/tag after merge so downstream packagers can consume the Gradle-based extension build path without carrying an extra patch.
