### PR TITLE
Fix LoadResults.save() API for Ghidra 12.0.4 compatibility

### DIFF
--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -593,7 +593,7 @@ public class ProgramScriptService {
                     return Response.err("Import failed: no primary program. Log: " + log);
                 }
                 // Save to project folder before releasing (prevents "Database is closed")
-                loadResults.save(project, ghidra.util.task.TaskMonitor.DUMMY);
+                loadResults.save(ghidra.util.task.TaskMonitor.DUMMY);
                 loadResults.release(this);
             }
 


### PR DESCRIPTION
## Summary

- Ghidra 12.0.4 changed `LoadResults.save()` signature from `save(Project, TaskMonitor)` to `save(TaskMonitor)`, removing the `Project` parameter
- This caused a compilation failure when building against 12.0.4 JARs
- One-line fix: remove the `project` argument from the call in `ProgramScriptService.java:596`

## Test plan

- [x] Build with `mvn clean package assembly:single -DskipTests` against Ghidra 12.0.4 — compiles cleanly with this fix
- [x] Unit tests: `python3 -m pytest tests/unit/` — 89 passed
- [ ] Verify import-binary functionality at runtime (requires live Ghidra instance with loaded binary)