### PR TITLE
v5.2.0 — Request serialization, dry-run mode, composable completeness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.1.0
+- **Version**: 5.2.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
 - **Key feature**: 193 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## v5.2.0 - 2026-04-11
+
+### Ghidra Plugin
+
+#### Added
+
+- **Request serialization in MCP bridge** — Added `threading.Lock` around all Ghidra HTTP calls in `bridge_mcp_ghidra.py` to prevent JSON-RPC stdout corruption when multiple MCP tool calls arrive concurrently (#91).
+- **Dry-run mode for mutating endpoints** — Pass `dry_run=true` query parameter to any POST endpoint to preview changes without committing to the Ghidra database. Implemented via nested transaction rollback in `AnnotationScanner` — no service code changes needed. All dynamic MCP tools for POST endpoints now include an optional `dry_run` parameter (#110).
+- **Composable completeness scoring** — Added `include_completeness` flag to `analyze_function_complete` endpoint. When enabled, includes full completeness scoring in the same response, eliminating the need for a separate `analyze_function_completeness` call (#109).
+
+---
+
 ## v5.1.0 - 2026-04-10
 
 ### fun-doc: Multi-Provider Dashboard & Worker System

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 193 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.1.0 | **Java**: 21 LTS | **Ghidra**: 12.0.3
+- **Package**: `com.xebyte` | **Version**: 5.2.0 | **Java**: 21 LTS | **Ghidra**: 12.0.3
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Java Version](https://img.shields.io/badge/Java-21%20LTS-orange.svg)](https://openjdk.java.net/projects/jdk/21/)
 [![Ghidra Version](https://img.shields.io/badge/Ghidra-12.0.3-green.svg)](https://ghidra-sre.org/)
-[![Version](https://img.shields.io/badge/Version-5.1.0-brightgreen.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-5.2.0-brightgreen.svg)](CHANGELOG.md)
 
 > If you find this useful, please ⭐ star the repo — it helps others discover it!
 
@@ -715,7 +715,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.1.0
+# Connection OK - GhidraMCP Headless Server v5.2.0
 ```
 
 ### Headless API Workflow
@@ -781,7 +781,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.1.0 |
+| **Version** | 5.2.0 |
 | **MCP Tools** | 193 fully implemented |
 | **GUI Endpoints** | 175 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 183 (GhidraMCPHeadlessServer) |

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -24,6 +24,7 @@ import os
 import re
 import socket
 import time
+import threading
 import http.client
 import inspect
 from pathlib import Path
@@ -93,7 +94,15 @@ mcp._mcp_server.create_initialization_options = _patched_init_options
 _active_socket: str | None = None  # UDS socket path
 _active_tcp: str | None = None  # TCP base URL (e.g. "http://127.0.0.1:8089")
 _transport_mode: str = "none"  # "uds", "tcp", or "none"
+
+# Serialization lock for Ghidra HTTP calls — prevents stdout corruption when
+# multiple MCP tool calls arrive concurrently (see GitHub issue #91).
+_ghidra_lock = asyncio.Lock()
 _connected_project: str | None = None  # Project name for auto-reconnect
+
+# Serialization lock for Ghidra HTTP calls — prevents stdout corruption when
+# multiple MCP tool calls arrive concurrently (see GitHub issue #91).
+_ghidra_lock = threading.Lock()
 
 
 # ==========================================================================
@@ -275,15 +284,20 @@ def do_request(
     json_data: dict | None = None,
     timeout: int = 30,
 ) -> tuple[str, int]:
-    """Route request to the active transport (UDS or TCP)."""
-    if _transport_mode == "uds" and _active_socket:
-        return uds_request(_active_socket, method, endpoint, params, json_data, timeout)
-    elif _transport_mode == "tcp" and _active_tcp:
-        return tcp_request(_active_tcp, method, endpoint, params, json_data, timeout)
-    else:
-        raise ConnectionError(
-            "No Ghidra instance connected. Use connect_instance() first."
-        )
+    """Route request to the active transport (UDS or TCP).
+
+    All requests are serialized via _ghidra_lock to prevent concurrent
+    responses from corrupting JSON-RPC framing on stdio (GitHub #91).
+    """
+    with _ghidra_lock:
+        if _transport_mode == "uds" and _active_socket:
+            return uds_request(_active_socket, method, endpoint, params, json_data, timeout)
+        elif _transport_mode == "tcp" and _active_tcp:
+            return tcp_request(_active_tcp, method, endpoint, params, json_data, timeout)
+        else:
+            raise ConnectionError(
+                "No Ghidra instance connected. Use connect_instance() first."
+            )
 
 
 # ==========================================================================
@@ -523,7 +537,7 @@ def dispatch_get(endpoint: str, params: dict | None = None, retries: int = 3) ->
     return json.dumps({"error": "Max retries exceeded"})
 
 
-def dispatch_post(endpoint: str, data: dict, retries: int = 3) -> str:
+def dispatch_post(endpoint: str, data: dict, retries: int = 3, query_params: dict | None = None) -> str:
     """POST JSON request via active transport. Returns raw response text."""
     err = _ensure_connected()
     if err:
@@ -532,7 +546,7 @@ def dispatch_post(endpoint: str, data: dict, retries: int = 3) -> str:
     timeout = get_timeout(endpoint, data)
     for attempt in range(retries):
         try:
-            text, status = do_request("POST", endpoint, json_data=data, timeout=timeout)
+            text, status = do_request("POST", endpoint, params=query_params, json_data=data, timeout=timeout)
             if status == 200:
                 return text.strip()
             if status >= 500 and attempt < retries - 1:
@@ -658,12 +672,19 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
                 and kwargs[pname] is not None
             ):
                 kwargs[pname] = sanitize_address(str(kwargs[pname]))
+        # Extract dry_run before filtering — it goes as a query param, not in the body
+        dry_run = kwargs.pop("dry_run", None)
         filtered = {k: v for k, v in kwargs.items() if v is not None}
         if http_method == "GET":
             str_params = {k: str(v) for k, v in filtered.items()}
+            if dry_run:
+                str_params["dry_run"] = "true"
             return dispatch_get(endpoint, params=str_params if str_params else None)
         else:
-            return dispatch_post(endpoint, data=filtered)
+            query_params = None
+            if dry_run:
+                query_params = {"dry_run": "true"}
+            return dispatch_post(endpoint, data=filtered, query_params=query_params)
 
     # Build function signature with proper types and defaults
     # Params with defaults must come after params without defaults
@@ -686,6 +707,14 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
             optional_params.append(param)
 
     sig_params = required_params + optional_params
+    # Add dry_run parameter for POST (write) endpoints
+    if http_method == "POST":
+        sig_params.append(
+            inspect.Parameter(
+                "dry_run", inspect.Parameter.KEYWORD_ONLY,
+                default=False, annotation=bool
+            )
+        )
     handler.__signature__ = inspect.Signature(sig_params, return_annotation=str)
     handler.__annotations__ = {p.name: p.annotation for p in sig_params}
     handler.__annotations__["return"] = str

--- a/docs/project-management/BACKLOG.md
+++ b/docs/project-management/BACKLOG.md
@@ -48,7 +48,7 @@ Server-side, dispatches to existing service methods — no new business logic.
 - fun_doc's `fetch_function_data()` can switch to a single call
 
 ### Write Safety / Dry-Run Mode
-**Status:** Planning
+**Status:** Implemented (v5.1.0)
 **Effort:** Low (1 day)
 **Inspiration:** GhidraMCPd's `ENABLE_WRITES` and `dry_run` flags
 **GitHub Issue:** #110
@@ -56,12 +56,9 @@ Server-side, dispatches to existing service methods — no new business logic.
 Add a `dry_run` query parameter to all write endpoints that returns "would have
 done X" without committing to the Ghidra database.
 
-**Implementation notes:**
-- Add `DRY_RUN` flag to `ServiceUtils` or a new `WriteGuard` utility
-- Write endpoints check the flag before opening a transaction
-- Returns the same JSON shape but with `"dry_run": true` and no actual changes
-- Configurable via env var `GHIDRA_MCP_DRY_RUN=true` for global default
-- Individual calls can override with `?dry_run=true` or `?dry_run=false`
+**Implementation:** AnnotationScanner intercepts `dry_run=true` on POST endpoints,
+wraps the call in a nested transaction that always rolls back. Bridge auto-adds
+`dry_run` parameter to all POST tool signatures.
 
 ## Priority: Plan For
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,7 +4,7 @@ This directory contains version-specific release documentation for the Ghidra MC
 
 ## Available Releases
 
-### v5.1.0 (Latest)
+### v5.2.0 (Latest)
 
 - **Major Feature Release** - Completeness scoring redesign, naming convention enforcement, fun-doc automation engine
 - Log-scaled budget scoring system with tiered plate comment quality

--- a/ghidra-mcp-setup.ps1
+++ b/ghidra-mcp-setup.ps1
@@ -59,7 +59,7 @@ function Write-LogError { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor
 
 # Configuration
 $DefaultGhidraVersion = "12.0.3"
-$PluginVersion = "5.1.0"
+$PluginVersion = "5.2.0"
 
 function Show-Usage {
     Write-Host ""

--- a/ghidra-mcp-setup.sh
+++ b/ghidra-mcp-setup.sh
@@ -34,7 +34,7 @@ log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
 # ============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_GHIDRA_VERSION="12.0.3"
-PLUGIN_VERSION="5.1.0"
+PLUGIN_VERSION="5.2.0"
 
 # Parameters (defaults)
 ACTION=""

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.1.0</version>
+    <version>5.2.0</version>
     <name>Ghidra MCP Server</name>
-    <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. v5.1.0: 195+ MCP tools, completeness scoring with budgeted deductions, naming convention enforcement, atomic set_variables tool, CodeBrowser integration, fun-doc automation engine, and multi-provider AI support (Claude/Codex).</description>
+    <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. v5.2.0: 195+ MCP tools, completeness scoring with budgeted deductions, naming convention enforcement, atomic set_variables tool, CodeBrowser integration, fun-doc automation engine, and multi-provider AI support (Claude/Codex).</description>
     <url>https://github.com/bethington/ghidra-mcp</url>
     <properties>
         <maven.compiler.release>21</maven.compiler.release>

--- a/scripts/create-backlog-issues.ps1
+++ b/scripts/create-backlog-issues.ps1
@@ -1,0 +1,144 @@
+# Creates GitHub issues for the engineering backlog items.
+# Requires: gh auth login (GitHub CLI authenticated)
+# Usage: .\create-backlog-issues.ps1
+
+$repo = "bethington/ghidra-mcp"
+
+# Issue 1: Streamable HTTP transport docs
+gh issue create --repo $repo `
+    --title "Document streamable-http transport as recommended option" `
+    --label "enhancement","documentation" `
+    --body @"
+## Summary
+Streamable HTTP transport is already supported (MCP SDK 1.21.1, argparse accepts it), but docs still reference SSE as the HTTP transport option.
+
+## Tasks
+- [ ] Update README client setup examples to show ``--transport streamable-http``
+- [ ] Update mcp-config.json with streamable-http example
+- [ ] Update help text for ``--mcp-host`` and ``--mcp-port`` to say "HTTP transport" not "SSE transport"
+- [ ] Note SSE deprecation in MCP spec
+- [ ] End-to-end test with Claude Desktop / VS Code Copilot
+
+## Context
+MCP spec has deprecated SSE in favor of streamable HTTP. Our SDK already supports it — this is docs-only.
+"@
+
+# Issue 2: Composable batch query endpoint
+gh issue create --repo $repo `
+    --title "Composable batch query endpoint (analyze_function_bundle)" `
+    --label "enhancement" `
+    --body @"
+## Summary
+Add a single endpoint that accepts a list of data fields and returns all requested data in one call, replacing the need for 4+ sequential tool calls.
+
+## Problem
+- ``fun_doc``'s ``fetch_function_data()`` makes 4 sequential HTTP calls per function
+- AI agent loops waste tokens on repeated round-trips and JSON envelopes
+- Every consumer independently re-discovers the same multi-call pattern
+
+## Proposed API
+``````
+POST /analyze_function_bundle
+{
+  ""address"": ""0x10042a30"",
+  ""program"": ""/path/to/program"",
+  ""fields"": [""decompile"", ""variables"", ""completeness"", ""callers"", ""callees"", ""xrefs_to""]
+}
+``````
+
+Returns a single JSON object with all requested data keyed by field name.
+
+## Implementation Plan
+- New ``@McpTool`` method in ``AnalysisService.java``
+- Fields map to existing service methods (no new business logic)
+- ``analyze_for_documentation`` is a partial version — this generalizes it
+- Bridge auto-discovers via annotation scanner
+- ``fun_doc`` switches ``fetch_function_data()`` to single call
+
+## Inspiration
+GhidraMCPd's ``/api/collect.json`` endpoint
+"@
+
+# Issue 3: Write safety / dry-run mode
+gh issue create --repo $repo `
+    --title "Write safety: dry_run mode for all write endpoints" `
+    --label "enhancement","security" `
+    --body @"
+## Summary
+Add a ``dry_run`` parameter to write endpoints that previews changes without committing to the Ghidra database.
+
+## Motivation
+- Cheaper models (MiniMax) sometimes make incorrect changes
+- New users want to explore safely without corrupting their Ghidra project
+- Enables preview-then-apply workflow: cheap model in dry-run, better model reviews and applies
+
+## Design
+- ``?dry_run=true`` query param on all write endpoints
+- Returns same JSON shape with ``""dry_run"": true`` flag — no actual transaction
+- Global default via ``GHIDRA_MCP_DRY_RUN=true`` env var
+- Individual calls can override
+
+## Implementation
+- Add dry-run check in ``ServiceUtils`` before transaction open
+- ~50 lines across service utilities
+- No annotation scanner changes needed
+
+## Inspiration
+GhidraMCPd's ``ENABLE_WRITES`` and ``dry_run`` flags
+"@
+
+# Issue 4: Data flow analysis
+gh issue create --repo $repo `
+    --title "Data flow analysis tool (forward/backward value tracking)" `
+    --label "enhancement" `
+    --body @"
+## Summary
+Track how data flows through a function — forward (where does this value go?) and backward (where did this value come from?).
+
+## Value
+High-signal context for AI models: knowing ""this parameter flows into a memcpy size argument"" produces better function names and documentation than decompiled code alone.
+
+## Proposed API
+``````
+GET /analyze_data_flow?address=0x10042a30&direction=forward&max_steps=10&program=...
+``````
+
+Returns a chain of operations showing value provenance or propagation through Varnode/PcodeOp graph.
+
+## Implementation
+- New ``@McpTool`` method in ``AnalysisService.java`` (~200-300 lines)
+- Uses Ghidra's ``DecompInterface`` Varnode/PcodeOp graph
+- Self-contained — no existing code changes needed
+
+## Inspiration
+starsong-consulting/GhydraMCP ``analysis_get_dataflow``
+"@
+
+# Issue 5: Offline test fixtures
+gh issue create --repo $repo `
+    --title "Offline test fixtures for CI without running Ghidra" `
+    --label "enhancement","testing" `
+    --body @"
+## Summary
+CI integration tests that don't require a running Ghidra instance, using fixture data and a mock ProgramProvider.
+
+## Problem
+- CI can only run unit tests (mocked)
+- Integration tests require manual Ghidra setup
+- Contributors can't validate service layer changes without Ghidra installed
+
+## Design
+- ``FixtureProgramProvider`` implementing ``ProgramProvider`` interface
+- Returns canned data for a reference binary
+- Tests AnnotationScanner, response format, endpoint routing
+- Ships a small reference binary in ``tests/fixtures/``
+
+## Implementation
+- Services already take ``ProgramProvider`` via constructor injection
+- Clean seam for dependency injection — architecture supports this by design
+
+## Inspiration
+GhidraMCPd's reference firmware fixture + stub MCP server
+"@
+
+Write-Host "`nAll backlog issues created successfully."

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -96,7 +96,7 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.1.0"; // Default fallback
+    private static String VERSION = "5.2.0"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven
@@ -109,7 +109,7 @@ class VersionInfo {
             if (input != null) {
                 Properties props = new Properties();
                 props.load(input);
-                VERSION = props.getProperty("app.version", "5.1.0");
+                VERSION = props.getProperty("app.version", "5.2.0");
                 APP_NAME = props.getProperty("app.name", "GhidraMCP");
                 GHIDRA_VERSION = props.getProperty("ghidra.version", "unknown");
                 BUILD_TIMESTAMP = props.getProperty("build.timestamp", "dev");
@@ -460,7 +460,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         // Discovers @McpTool-annotated methods on service instances via reflection
         // ==========================================================================
 
-        AnnotationScanner scanner = new AnnotationScanner(
+        AnnotationScanner scanner = new AnnotationScanner(programProvider,
             listingService, functionService, commentService, symbolLabelService,
             xrefCallGraphService, dataTypeService, analysisService,
             documentationHashService, malwareSecurityService, programScriptService);

--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -1859,6 +1859,7 @@ public class AnalysisService {
             @Param(value = "include_callers", defaultValue = "true") boolean includeCallers,
             @Param(value = "include_disasm", defaultValue = "true") boolean includeDisasm,
             @Param(value = "include_variables", defaultValue = "true") boolean includeVariables,
+            @Param(value = "include_completeness", defaultValue = "false", description = "Include completeness scoring (undefined vars, naming violations, recommendations)") boolean includeCompleteness,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2052,6 +2053,15 @@ public class AnalysisService {
                         data.put("locals", localList);
                     }
 
+                    // Include completeness scoring (GitHub #109)
+                    if (includeCompleteness) {
+                        String addrStr = func.getEntryPoint().toString(false);
+                        Response completenessResp = analyzeFunctionCompleteness(addrStr, true, programName);
+                        if (completenessResp instanceof Response.Ok ok) {
+                            data.put("completeness", ok.data());
+                        }
+                    }
+
                     resultData.set(data);
                 } catch (Exception e) {
                     errorMsg.set(e.getMessage());
@@ -2068,10 +2078,16 @@ public class AnalysisService {
         return Response.ok(resultData.get());
     }
 
-    // Backward compatibility overload
+    // Backward compatibility overloads
     public Response analyzeFunctionComplete(String name, boolean includeXrefs, boolean includeCallees,
                                           boolean includeCallers, boolean includeDisasm, boolean includeVariables) {
-        return analyzeFunctionComplete(name, includeXrefs, includeCallees, includeCallers, includeDisasm, includeVariables, null);
+        return analyzeFunctionComplete(name, includeXrefs, includeCallees, includeCallers, includeDisasm, includeVariables, false, null);
+    }
+
+    public Response analyzeFunctionComplete(String name, boolean includeXrefs, boolean includeCallees,
+                                          boolean includeCallers, boolean includeDisasm, boolean includeVariables,
+                                          String programName) {
+        return analyzeFunctionComplete(name, includeXrefs, includeCallees, includeCallers, includeDisasm, includeVariables, false, programName);
     }
 
     /**

--- a/src/main/java/com/xebyte/core/AnnotationScanner.java
+++ b/src/main/java/com/xebyte/core/AnnotationScanner.java
@@ -8,6 +8,8 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import ghidra.program.model.listing.Program;
+
 /**
  * Discovers {@link McpTool}-annotated methods on service instances via reflection
  * and generates {@link EndpointDef} records for HTTP registration plus JSON schemas
@@ -36,6 +38,7 @@ public class AnnotationScanner {
 
     private final List<EndpointDef> endpoints = new ArrayList<>();
     private final List<ToolDescriptor> descriptors = new ArrayList<>();
+    private final ProgramProvider programProvider;
 
     /**
      * Scan the given service instances for {@link McpTool}-annotated methods.
@@ -43,6 +46,17 @@ public class AnnotationScanner {
      * @param services service objects to scan (e.g., ListingService, FunctionService, ...)
      */
     public AnnotationScanner(Object... services) {
+        this(null, services);
+    }
+
+    /**
+     * Scan the given service instances for {@link McpTool}-annotated methods.
+     *
+     * @param programProvider provider for resolving programs (enables dry-run support)
+     * @param services        service objects to scan
+     */
+    public AnnotationScanner(ProgramProvider programProvider, Object... services) {
+        this.programProvider = programProvider;
         for (Object service : services) {
             scanService(service);
         }
@@ -131,6 +145,7 @@ public class AnnotationScanner {
 
     private EndpointDef.EndpointHandler createHandler(Object service, Method method,
             McpTool tool, ParamBinding[] bindings) {
+        boolean isWrite = "POST".equalsIgnoreCase(tool.method());
         return (query, body) -> {
             try {
                 Object[] args = new Object[bindings.length];
@@ -139,6 +154,21 @@ public class AnnotationScanner {
                         args[i] = resolveParam(bindings[i], query, body);
                     }
                 }
+
+                // Dry-run support: wrap POST endpoints in a transaction that always rolls back
+                if (isWrite && "true".equalsIgnoreCase(query.get("dry_run")) && programProvider != null) {
+                    Program program = resolveProgramForDryRun(bindings, query);
+                    if (program != null) {
+                        int tx = program.startTransaction("[DRY RUN] " + tool.path());
+                        try {
+                            Response result = (Response) method.invoke(service, args);
+                            return wrapDryRunResponse(result);
+                        } finally {
+                            program.endTransaction(tx, false); // Always rollback
+                        }
+                    }
+                }
+
                 return (Response) method.invoke(service, args);
             } catch (InvocationTargetException e) {
                 Throwable cause = e.getCause();
@@ -150,6 +180,36 @@ public class AnnotationScanner {
                 return Response.err("Error invoking " + tool.path() + ": " + e.getMessage());
             }
         };
+    }
+
+    /**
+     * Resolve the Program for dry-run wrapping by finding the "program" param binding.
+     */
+    private Program resolveProgramForDryRun(ParamBinding[] bindings, Map<String, String> query) {
+        // Look for a @Param(value = "program") binding
+        for (ParamBinding binding : bindings) {
+            if (binding != null && "program".equals(binding.param.value())) {
+                String programName = query.get("program");
+                if (programName != null && !programName.isEmpty()) {
+                    return programProvider.getProgram(programName);
+                }
+                break;
+            }
+        }
+        // Fall back to current program
+        return programProvider.getCurrentProgram();
+    }
+
+    /**
+     * Wrap a response to indicate it was a dry-run (no changes were committed).
+     */
+    private static Response wrapDryRunResponse(Response response) {
+        String json = response.toJson();
+        if (json.startsWith("{")) {
+            // Inject dry_run flag into the JSON object
+            return Response.text("{\"dry_run\":true," + json.substring(1));
+        }
+        return Response.text("{\"dry_run\":true,\"result\":" + json + "}");
     }
 
     // ==================================================================

--- a/src/main/java/com/xebyte/core/ServerManager.java
+++ b/src/main/java/com/xebyte/core/ServerManager.java
@@ -59,7 +59,7 @@ public class ServerManager {
             MalwareSecurityService malwareSecurityService = new MalwareSecurityService(programProvider, ts);
             ProgramScriptService programScriptService = new ProgramScriptService(programProvider, ts);
 
-            AnnotationScanner scanner = new AnnotationScanner(
+            AnnotationScanner scanner = new AnnotationScanner(programProvider,
                 listingService, functionService, commentService, symbolLabelService,
                 xrefCallGraphService, dataTypeService, analysisService,
                 documentationHashService, malwareSecurityService, programScriptService);

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -52,7 +52,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.1.0-headless";
+    private static final String VERSION = "5.2.0-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 
@@ -294,7 +294,7 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
         // SHARED ENDPOINTS — Annotation-driven registration via AnnotationScanner
         // ==========================================================================
 
-        AnnotationScanner scanner = new AnnotationScanner(
+        AnnotationScanner scanner = new AnnotationScanner(endpointHandler.getProgramProvider(),
             endpointHandler.getListingService(), endpointHandler.getFunctionService(),
             endpointHandler.getCommentService(), endpointHandler.getSymbolLabelService(),
             endpointHandler.getXrefCallGraphService(), endpointHandler.getDataTypeService(),

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -42,7 +42,7 @@ import ghidra.app.cmd.disassemble.DisassembleCommand;
  */
 public class HeadlessEndpointHandler {
 
-    private static final String VERSION = "5.1.0-headless";
+    private static final String VERSION = "5.2.0-headless";
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
     private final TaskMonitor monitor;
@@ -92,6 +92,7 @@ public class HeadlessEndpointHandler {
     public com.xebyte.core.DocumentationHashService getDocumentationHashService() { return documentationHashService; }
     public com.xebyte.core.MalwareSecurityService getMalwareSecurityService() { return malwareSecurityService; }
     public com.xebyte.core.ProgramScriptService getProgramScriptService() { return programScriptService; }
+    public ProgramProvider getProgramProvider() { return programProvider; }
 
     // ==========================================================================
     // UTILITY METHODS

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "GhidraMCP REST API Endpoint Specification",
   "total_endpoints": 193,
   "categories": {
@@ -1265,6 +1265,7 @@
         "include_callers",
         "include_disasm",
         "include_variables",
+        "include_completeness",
         "program"
       ],
       "description": "Complete function analysis"


### PR DESCRIPTION
## v5.2.0 Release

### Features

- **Request serialization in MCP bridge** (#91) — Added `threading.Lock` around all Ghidra HTTP calls in `bridge_mcp_ghidra.py` to prevent JSON-RPC stdout corruption when multiple MCP tool calls arrive concurrently.

- **Dry-run mode for mutating endpoints** (#110) — Pass `dry_run=true` query parameter to any POST endpoint to preview changes without committing to the Ghidra database. Implemented via nested transaction rollback in `AnnotationScanner` — no service code changes needed. All dynamic MCP tools for POST endpoints now include an optional `dry_run` parameter.

- **Composable completeness scoring** (#109) — Added `include_completeness` flag to `analyze_function_complete` endpoint. When enabled, includes full completeness scoring in the same response, eliminating the need for a separate `analyze_function_completeness` call.

### Changes

- Version bumped 5.1.0 → 5.2.0 across all 14 files
- BACKLOG.md updated: dry-run mode marked as Implemented
- CHANGELOG.md: new v5.2.0 section with the three features above
- `endpoints.json`: `include_completeness` param added to `analyze_function_complete`

### Verification

- `mvn clean compile -q` — clean
- `mvn clean package assembly:single -DskipTests` — BUILD SUCCESS, `GhidraMCP-5.2.0.zip` produced
- `pytest tests/unit/ -v --no-cov` — 3/3 passed
- `ghidra-mcp-setup.ps1 -BuildOnly` — SUCCESS

Closes #91, closes #110, closes #109