### PR TITLE
fix(bridge): add fallback socket dir for missing XDG_RUNTIME_DIR

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -128,6 +128,16 @@ def get_socket_dir() -> Path:
     xdg = os.environ.get("XDG_RUNTIME_DIR")
     if xdg:
         return Path(xdg) / "ghidra-mcp"
+
+    getuid = getattr(os, "getuid", None)
+    if callable(getuid):
+        run_user_dir = Path(f"/run/user/{getuid()}")
+        try:
+            if run_user_dir.exists():
+                return run_user_dir / "ghidra-mcp"
+        except OSError:
+            logger.debug("Ignoring unusable runtime dir candidate: %s", run_user_dir)
+
     user = os.getenv("USER", "unknown")
     tmpdir = os.environ.get("TMPDIR")
     if tmpdir:


### PR DESCRIPTION
Codex-launched bridge processes could not detect existing Ghidra MCP instances because XDG_RUNTIME_DIR was missing, causing socket discovery to use the wrong location.

When XDG_RUNTIME_DIR is unavailable, fall back to /run/user/<uid>/ghidra-mcp so the bridge can still find the active socket files.