### PR TITLE
fix(catalog): correct headless endpoint params and extend parity scan

### DIFF
--- a/src/test/java/com/xebyte/offline/ServiceFactory.java
+++ b/src/test/java/com/xebyte/offline/ServiceFactory.java
@@ -13,6 +13,9 @@ import com.xebyte.core.ProgramScriptService;
 import com.xebyte.core.SymbolLabelService;
 import com.xebyte.core.ThreadingStrategy;
 import com.xebyte.core.XrefCallGraphService;
+import com.xebyte.headless.GhidraServerManager;
+import com.xebyte.headless.HeadlessManagementService;
+import com.xebyte.headless.HeadlessProgramProvider;
 
 /**
  * Builds the full set of service instances that {@link com.xebyte.core.ServerManager}
@@ -45,6 +48,9 @@ public final class ServiceFactory {
         MalwareSecurityService malwareSecurityService = new MalwareSecurityService(provider, ts);
         ProgramScriptService programScriptService = new ProgramScriptService(provider, ts);
 
+        HeadlessManagementService headlessManagementService =
+            new HeadlessManagementService(new HeadlessProgramProvider(), new GhidraServerManager());
+
         return new Object[] {
             listingService,
             functionService,
@@ -56,6 +62,7 @@ public final class ServiceFactory {
             documentationHashService,
             malwareSecurityService,
             programScriptService,
+            headlessManagementService,
         };
     }
 

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -347,16 +347,16 @@
     {
       "path": "/close_program",
       "method": "POST",
-      "category": "program",
+      "category": "headless",
       "params": [
-        "program"
+        "name"
       ],
-      "description": "Close a loaded program (headless)"
+      "description": "Close a loaded program and free its resources"
     },
     {
       "path": "/close_project",
       "method": "POST",
-      "category": "project",
+      "category": "headless",
       "params": [],
       "description": "Close the currently open project"
     },
@@ -500,7 +500,7 @@
     {
       "path": "/create_project",
       "method": "POST",
-      "category": "project",
+      "category": "headless",
       "params": [
         "parentDir",
         "name"
@@ -1070,9 +1070,9 @@
     {
       "path": "/get_project_info",
       "method": "GET",
-      "category": "program",
+      "category": "headless",
       "params": [],
-      "description": "Get project information (headless)"
+      "description": "Get info about the currently open project"
     },
     {
       "path": "/get_struct_layout",
@@ -1410,19 +1410,18 @@
     {
       "path": "/load_program",
       "method": "POST",
-      "category": "program",
+      "category": "headless",
       "params": [
-        "path"
+        "file"
       ],
-      "description": "Load program into headless server"
+      "description": "Load a binary file into the headless server for analysis"
     },
     {
       "path": "/load_program_from_project",
       "method": "POST",
-      "category": "program",
+      "category": "headless",
       "params": [
-        "project_path",
-        "program_path"
+        "path"
       ],
       "description": "Load program from Ghidra project (headless)"
     },
@@ -1497,11 +1496,11 @@
     {
       "path": "/open_project",
       "method": "POST",
-      "category": "project",
+      "category": "headless",
       "params": [
         "path"
       ],
-      "description": "Open an existing Ghidra project"
+      "description": "Open an existing Ghidra project (.gpr file or directory)"
     },
     {
       "path": "/project/info",
@@ -1873,9 +1872,9 @@
     {
       "path": "/server/status",
       "method": "GET",
-      "category": "server",
+      "category": "headless",
       "params": [],
-      "description": "Get server connection status"
+      "description": "Check headless server connection status"
     },
     {
       "path": "/server/version_control/add",


### PR DESCRIPTION
## Summary
- Fixes three param-name mismatches in `tests/endpoints.json` that have been wrong since the headless management endpoints were originally added via manual `createContext` (they silently disagreed with the Java implementation)
- Extends `ServiceFactory.buildAllServices()` to scan `HeadlessManagementService` (added in #122) so the parity test catches future drift in headless-only annotations
- Unifies `category: "headless"` across the eight management endpoints so the catalog matches what the live `/mcp/schema` now reports

## Changes
| Endpoint | Was in catalog | Now matches code |
|---|---|---|
| `/load_program` | `path` | `file` |
| `/close_program` | `program` | `name` |
| `/load_program_from_project` | `project_path`, `program_path` | `path` |

## Test plan
- [x] `mvn test -Dtest='com.xebyte.offline.*Test'` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)