### PR TITLE
feat(debugger): DebuggerService with /debugger/* endpoints + Python debugger package

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -654,6 +654,29 @@ STATIC_TOOL_NAMES = {
     "unload_tool_group",
     "check_tools",
     "import_file",
+    # Debugger tools (Phase 1+2+3)
+    "debugger_attach",
+    "debugger_detach",
+    "debugger_status",
+    "debugger_modules",
+    "debugger_resolve_ordinal",
+    "debugger_set_breakpoint",
+    "debugger_remove_breakpoint",
+    "debugger_list_breakpoints",
+    "debugger_continue",
+    "debugger_step_into",
+    "debugger_step_over",
+    "debugger_registers",
+    "debugger_read_memory",
+    "debugger_stack_trace",
+    "debugger_read_args",
+    "debugger_trace_function",
+    "debugger_trace_stop",
+    "debugger_trace_log",
+    "debugger_trace_list",
+    "debugger_watch_memory",
+    "debugger_watch_stop",
+    "debugger_watch_log",
 }
 
 _dynamic_tool_names: list[str] = []
@@ -1300,6 +1323,351 @@ def _auto_connect():
             logger.info(
                 "No Ghidra instances found. Tools will be registered on connect_instance()."
             )
+
+
+# ==========================================================================
+# Debugger tools (proxy to debugger/server.py on DEBUGGER_URL)
+# ==========================================================================
+
+DEBUGGER_URL = os.getenv("GHIDRA_DEBUGGER_URL", "http://127.0.0.1:8099")
+
+
+def _debugger_request(method: str, path: str, body: dict | None = None,
+                      query: dict | None = None, timeout: int = 30) -> str:
+    """Send a request to the debugger server. Returns JSON string."""
+    parsed = urlparse(DEBUGGER_URL)
+    conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=timeout)
+    try:
+        url = path
+        if query:
+            url += "?" + urlencode(query)
+        headers = {"Content-Type": "application/json"} if body else {}
+        conn.request(method, url, body=json.dumps(body) if body else None,
+                     headers=headers)
+        resp = conn.getresponse()
+        data = resp.read().decode("utf-8")
+        if resp.status >= 400:
+            try:
+                err = json.loads(data)
+                return json.dumps({"error": err.get("error", data)})
+            except Exception:
+                return json.dumps({"error": data})
+        return data
+    except ConnectionRefusedError:
+        return json.dumps({"error": f"Debugger server not running at {DEBUGGER_URL}. "
+                           "Start it with: python -m debugger"})
+    except Exception as e:
+        return json.dumps({"error": f"Debugger request failed: {e}"})
+    finally:
+        conn.close()
+
+
+@mcp.tool()
+def debugger_attach(target: str) -> str:
+    """Attach the debugger to a running process for live dynamic analysis.
+
+    Connects to the target process via dbgeng (WinDbg engine). After attaching,
+    use debugger_modules() to see loaded DLLs and debugger_set_breakpoint() to
+    set breakpoints.
+
+    Args:
+        target: Process name (e.g. "Game.exe") or PID.
+    """
+    result = _debugger_request("POST", "/debugger/attach", {"target": target})
+
+    # Auto-sync address map if Ghidra is connected
+    if _transport_mode != "none":
+        try:
+            # Fetch image bases from Ghidra for all open programs
+            programs_text = dispatch_get("/list_open_programs")
+            if programs_text:
+                programs_data = json.loads(programs_text)
+                programs = programs_data if isinstance(programs_data, list) else programs_data.get("programs", [])
+                ghidra_bases = {}
+                for prog in programs:
+                    prog_path = prog if isinstance(prog, str) else prog.get("path", prog.get("name", ""))
+                    if prog_path:
+                        try:
+                            meta_text = dispatch_get("/get_metadata", params={"program": prog_path})
+                            meta = json.loads(meta_text)
+                            image_base = meta.get("imageBase", meta.get("image_base"))
+                            if image_base:
+                                ghidra_bases[prog_path] = image_base
+                        except Exception:
+                            pass
+                if ghidra_bases:
+                    _debugger_request("POST", "/debugger/sync_modules",
+                                      {"ghidra_bases": ghidra_bases})
+        except Exception as e:
+            logger.warning(f"Auto-sync address map failed (non-fatal): {e}")
+
+    return result
+
+
+@mcp.tool()
+def debugger_detach() -> str:
+    """Detach from the debugged process. The process continues running."""
+    return _debugger_request("POST", "/debugger/detach")
+
+
+@mcp.tool()
+def debugger_status() -> str:
+    """Get debugger connection status, loaded modules, active traces/watches."""
+    return _debugger_request("GET", "/debugger/status")
+
+
+@mcp.tool()
+def debugger_modules() -> str:
+    """List loaded modules (DLLs) with runtime and Ghidra base addresses.
+
+    Shows each module's name, runtime base, Ghidra base (if mapped),
+    and the address offset between them.
+    """
+    return _debugger_request("GET", "/debugger/modules")
+
+
+@mcp.tool()
+def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
+    """Resolve a DLL ordinal export to its runtime and Ghidra addresses.
+
+    Uses the ordinal export tables from dll_exports/*.txt combined with
+    the current runtime address map.
+
+    Args:
+        dll: DLL name (e.g. "D2Common.dll").
+        ordinal: Ordinal number (e.g. 10624).
+    """
+    return _debugger_request("GET", "/debugger/ordinal",
+                             query={"dll": dll, "ordinal": str(ordinal)})
+
+
+@mcp.tool()
+def debugger_set_breakpoint(ghidra_address: str, module: str = "",
+                            bp_type: str = "software",
+                            oneshot: bool = False) -> str:
+    """Set a breakpoint at a Ghidra address. Auto-translates to runtime address.
+
+    Args:
+        ghidra_address: Address in Ghidra (e.g. "0x6FD9F450").
+        module: DLL name for disambiguation (e.g. "D2Common.dll").
+        bp_type: "software" (INT3) or "hardware" (debug register).
+        oneshot: If true, breakpoint is removed after first hit.
+    """
+    return _debugger_request("POST", "/debugger/breakpoint", {
+        "ghidra_address": ghidra_address,
+        "module": module,
+        "type": bp_type,
+        "oneshot": oneshot,
+    })
+
+
+@mcp.tool()
+def debugger_remove_breakpoint(bp_id: int) -> str:
+    """Remove a breakpoint by its ID.
+
+    Args:
+        bp_id: Breakpoint ID returned by debugger_set_breakpoint.
+    """
+    return _debugger_request("DELETE", f"/debugger/breakpoint/{bp_id}")
+
+
+@mcp.tool()
+def debugger_list_breakpoints() -> str:
+    """List all active breakpoints with their addresses and status."""
+    return _debugger_request("GET", "/debugger/breakpoints")
+
+
+@mcp.tool()
+def debugger_continue() -> str:
+    """Resume execution of the debugged process.
+
+    Returns immediately. The process runs until a breakpoint is hit,
+    an exception occurs, or debugger_interrupt() is called.
+    """
+    return _debugger_request("POST", "/debugger/go")
+
+
+@mcp.tool()
+def debugger_step_into(count: int = 1) -> str:
+    """Single-step into the next instruction(s). Follows calls.
+
+    Args:
+        count: Number of instructions to step (default 1).
+    """
+    return _debugger_request("POST", "/debugger/step_into", {"count": count})
+
+
+@mcp.tool()
+def debugger_step_over(count: int = 1) -> str:
+    """Step over the next instruction(s). Steps over calls.
+
+    Args:
+        count: Number of instructions to step (default 1).
+    """
+    return _debugger_request("POST", "/debugger/step_over", {"count": count})
+
+
+@mcp.tool()
+def debugger_registers() -> str:
+    """Read all CPU registers. Must be stopped at a breakpoint.
+
+    Returns EAX-EDI, ESP, EBP, EIP, EFLAGS for x86.
+    """
+    return _debugger_request("GET", "/debugger/registers")
+
+
+@mcp.tool()
+def debugger_read_memory(address: str, size: int = 64,
+                         address_type: str = "runtime",
+                         module: str = "") -> str:
+    """Read memory from the debugged process.
+
+    Returns hex dump and 32-bit DWORD interpretation of the memory region.
+
+    Args:
+        address: Memory address (hex, e.g. "0x6FD9F450").
+        size: Number of bytes to read (max 4096).
+        address_type: "runtime" for live address, "ghidra" to auto-translate.
+        module: DLL name when address_type="ghidra" for disambiguation.
+    """
+    return _debugger_request("GET", "/debugger/memory",
+                             query={"address": address, "size": str(size),
+                                    "address_type": address_type, "module": module})
+
+
+@mcp.tool()
+def debugger_stack_trace(depth: int = 20) -> str:
+    """Get the call stack backtrace with return addresses mapped to Ghidra symbols.
+
+    Args:
+        depth: Maximum number of stack frames (default 20).
+    """
+    return _debugger_request("GET", "/debugger/stack", query={"depth": str(depth)})
+
+
+@mcp.tool()
+def debugger_read_args(convention: str = "__stdcall", count: int = 4,
+                       arg_names: str = "") -> str:
+    """Read function arguments at the current breakpoint based on calling convention.
+
+    Reads arguments from registers and stack according to the calling convention.
+    Must be stopped at a function entry point.
+
+    Args:
+        convention: __stdcall, __fastcall, __thiscall, or __cdecl.
+        count: Number of arguments to read.
+        arg_names: Comma-separated names for readability (e.g. "pUnit,nSkillId").
+    """
+    return _debugger_request("GET", "/debugger/read_args",
+                             query={"convention": convention, "count": str(count),
+                                    "arg_names": arg_names})
+
+
+@mcp.tool()
+def debugger_trace_function(ghidra_address: str, module: str = "",
+                            convention: str = "__stdcall", arg_count: int = 4,
+                            arg_names: str = "", capture_return: bool = False,
+                            max_hits: int = 0) -> str:
+    """Start non-breaking tracing on a function. Logs every call with arguments
+    WITHOUT stopping the game.
+
+    The handler reads arguments and auto-resumes execution in ~0.5ms,
+    invisible at the game's 25fps. Use debugger_trace_log() to read results.
+
+    Args:
+        ghidra_address: Function address in Ghidra.
+        module: DLL name (e.g. "D2Common.dll").
+        convention: __stdcall, __fastcall, __thiscall, __cdecl.
+        arg_count: Number of arguments to capture.
+        arg_names: Comma-separated arg names (e.g. "pUnit,nSkillId,nWeaponSpeed").
+        capture_return: Also capture return value (EAX).
+        max_hits: Stop tracing after N hits (0 = unlimited).
+    """
+    return _debugger_request("POST", "/debugger/trace/start", {
+        "ghidra_address": ghidra_address,
+        "module": module,
+        "convention": convention,
+        "arg_count": arg_count,
+        "arg_names": arg_names,
+        "capture_return": capture_return,
+        "max_hits": max_hits,
+    })
+
+
+@mcp.tool()
+def debugger_trace_stop(trace_id: int = -1) -> str:
+    """Stop a function trace. Use trace_id=-1 to stop all traces.
+
+    Args:
+        trace_id: ID returned by debugger_trace_function, or -1 for all.
+    """
+    return _debugger_request("POST", "/debugger/trace/stop",
+                             {"trace_id": trace_id})
+
+
+@mcp.tool()
+def debugger_trace_log(trace_id: int = -1, last_n: int = 50) -> str:
+    """Read the trace log. Shows timestamped function calls with arguments.
+
+    Args:
+        trace_id: Filter by trace ID, or -1 for all traces.
+        last_n: Number of most recent entries to return.
+    """
+    return _debugger_request("GET", "/debugger/trace/log",
+                             query={"trace_id": str(trace_id),
+                                    "last_n": str(last_n)})
+
+
+@mcp.tool()
+def debugger_trace_list() -> str:
+    """List all active and completed traces with hit counts."""
+    return _debugger_request("GET", "/debugger/trace/list")
+
+
+@mcp.tool()
+def debugger_watch_memory(ghidra_address: str, size: int = 4,
+                          access: str = "write", module: str = "") -> str:
+    """Set a hardware watchpoint on a memory range to monitor read/write access.
+
+    Limited to 4 simultaneous watchpoints (x86 debug register limit).
+    Use debugger_watch_log() to see hits.
+
+    Args:
+        ghidra_address: Start address in Ghidra.
+        size: Bytes to watch (1, 2, or 4).
+        access: "read", "write", or "readwrite".
+        module: DLL name for address resolution.
+    """
+    return _debugger_request("POST", "/debugger/watch/start", {
+        "ghidra_address": ghidra_address,
+        "module": module,
+        "size": size,
+        "access": access,
+    })
+
+
+@mcp.tool()
+def debugger_watch_stop(watch_id: int = -1) -> str:
+    """Stop a memory watchpoint. Use watch_id=-1 to stop all.
+
+    Args:
+        watch_id: ID returned by debugger_watch_memory, or -1 for all.
+    """
+    return _debugger_request("POST", "/debugger/watch/stop",
+                             {"watch_id": watch_id})
+
+
+@mcp.tool()
+def debugger_watch_log(watch_id: int = -1, last_n: int = 50) -> str:
+    """Read the watchpoint hit log. Shows memory accesses with values and accessors.
+
+    Args:
+        watch_id: Filter by watch ID, or -1 for all.
+        last_n: Number of most recent entries.
+    """
+    return _debugger_request("GET", "/debugger/watch/log",
+                             query={"watch_id": str(watch_id),
+                                    "last_n": str(last_n)})
 
 
 # ==========================================================================

--- a/debugger/__init__.py
+++ b/debugger/__init__.py
@@ -1,0 +1,1 @@
+"""GhidraMCP Debugger — live debugging / dynamic analysis via dbgeng."""

--- a/debugger/__main__.py
+++ b/debugger/__main__.py
@@ -1,0 +1,4 @@
+"""Allow running the debugger server as: python -m debugger"""
+from .server import main
+
+main()

--- a/debugger/address_map.py
+++ b/debugger/address_map.py
@@ -1,0 +1,293 @@
+"""
+Bidirectional address translation between Ghidra (static) and runtime (dynamic).
+
+Ghidra uses the PE image base from the binary (e.g., D2Common.dll at 0x6FD60000).
+At runtime, ASLR may relocate DLLs to different bases. This mapper translates
+addresses in both directions using the module base offsets.
+
+Also handles ordinal resolution from dll_exports/*.txt files.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .protocol import ModuleInfo
+
+logger = logging.getLogger(__name__)
+
+# Pattern: D2COMMON.DLL::Ordinal_10000@6fd9f450->Ordinal_10000
+_EXPORT_LINE_RE = re.compile(
+    r"^(?P<dll>[^:]+)::(?P<label>[^@]+)@(?P<addr>[0-9a-fA-F]+)->(?P<name>.+)$"
+)
+
+# Extract ordinal number from label like "Ordinal_10000"
+_ORDINAL_RE = re.compile(r"Ordinal_(\d+)")
+
+
+@dataclass
+class ModuleMapping:
+    """Maps a single module between Ghidra and runtime address spaces."""
+    name: str
+    ghidra_base: int
+    runtime_base: int
+    size: int
+
+    @property
+    def offset(self) -> int:
+        """runtime_base - ghidra_base. Add to Ghidra addr to get runtime."""
+        return self.runtime_base - self.ghidra_base
+
+    def contains_ghidra(self, addr: int) -> bool:
+        return self.ghidra_base <= addr < self.ghidra_base + self.size
+
+    def contains_runtime(self, addr: int) -> bool:
+        return self.runtime_base <= addr < self.runtime_base + self.size
+
+    def to_runtime(self, ghidra_addr: int) -> int:
+        return ghidra_addr + self.offset
+
+    def to_ghidra(self, runtime_addr: int) -> int:
+        return runtime_addr - self.offset
+
+
+@dataclass
+class OrdinalEntry:
+    """A single ordinal export from dll_exports/*.txt."""
+    dll: str
+    ordinal: int
+    label: str  # e.g. "Ordinal_10000" or renamed label
+    ghidra_address: int
+
+
+class AddressMapper:
+    """Bidirectional address translation between Ghidra and runtime."""
+
+    def __init__(self):
+        self._modules: Dict[str, ModuleMapping] = {}  # normalized_name -> mapping
+        self._ordinals: Dict[str, Dict[int, OrdinalEntry]] = {}  # dll -> {ordinal -> entry}
+
+    # -- Module mapping ----------------------------------------------------
+
+    def update_from_modules(self, runtime_modules: List[ModuleInfo],
+                            ghidra_bases: Dict[str, int]) -> dict:
+        """Rebuild module map from runtime + Ghidra data.
+
+        Args:
+            runtime_modules: Modules from dbgeng's module_list().
+            ghidra_bases: {module_name: image_base} from Ghidra's /get_metadata.
+
+        Returns:
+            Summary of mapped/unmapped modules.
+        """
+        self._modules.clear()
+        mapped = []
+        unmapped = []
+
+        # Normalize Ghidra base names for matching
+        ghidra_normalized: Dict[str, Tuple[str, int]] = {}
+        for name, base in ghidra_bases.items():
+            key = self._normalize_name(name)
+            ghidra_normalized[key] = (name, base)
+
+        for mod in runtime_modules:
+            key = self._normalize_name(mod.name)
+            if key in ghidra_normalized:
+                orig_name, ghidra_base = ghidra_normalized[key]
+                mapping = ModuleMapping(
+                    name=mod.name,
+                    ghidra_base=ghidra_base,
+                    runtime_base=mod.runtime_base,
+                    size=mod.size,
+                )
+                self._modules[key] = mapping
+                mod.ghidra_base = ghidra_base
+                mapped.append(mod.name)
+                logger.info(
+                    f"Mapped {mod.name}: ghidra=0x{ghidra_base:08X} "
+                    f"runtime=0x{mod.runtime_base:08X} "
+                    f"offset={mapping.offset:+#X}")
+            else:
+                unmapped.append(mod.name)
+
+        return {
+            "mapped": len(mapped),
+            "unmapped": len(unmapped),
+            "mapped_modules": mapped,
+            "unmapped_modules": unmapped[:20],  # Cap output
+        }
+
+    def get_module(self, name: str) -> Optional[ModuleMapping]:
+        """Look up a module mapping by name."""
+        return self._modules.get(self._normalize_name(name))
+
+    def get_all_modules(self) -> List[ModuleMapping]:
+        return list(self._modules.values())
+
+    # -- Address translation -----------------------------------------------
+
+    def to_runtime(self, ghidra_addr: int,
+                   module: Optional[str] = None) -> int:
+        """Convert a Ghidra address to a runtime address.
+
+        Args:
+            ghidra_addr: Address in Ghidra's address space.
+            module: Optional module name for disambiguation.
+
+        Returns:
+            Runtime address.
+
+        Raises:
+            ValueError: If the address can't be mapped.
+        """
+        if module:
+            mapping = self.get_module(module)
+            if mapping is None:
+                raise ValueError(f"Module '{module}' not in address map")
+            return mapping.to_runtime(ghidra_addr)
+
+        # Auto-detect module from address range
+        for mapping in self._modules.values():
+            if mapping.contains_ghidra(ghidra_addr):
+                return mapping.to_runtime(ghidra_addr)
+
+        raise ValueError(
+            f"Address 0x{ghidra_addr:08X} not in any mapped module. "
+            f"Mapped: {', '.join(m.name for m in self._modules.values())}")
+
+    def to_ghidra(self, runtime_addr: int) -> Tuple[str, int]:
+        """Convert a runtime address to (module_name, ghidra_address).
+
+        Raises:
+            ValueError: If the address can't be mapped.
+        """
+        for mapping in self._modules.values():
+            if mapping.contains_runtime(runtime_addr):
+                return mapping.name, mapping.to_ghidra(runtime_addr)
+
+        raise ValueError(
+            f"Runtime address 0x{runtime_addr:08X} not in any mapped module")
+
+    def try_to_ghidra(self, runtime_addr: int) -> Optional[Tuple[str, int]]:
+        """Like to_ghidra but returns None instead of raising."""
+        try:
+            return self.to_ghidra(runtime_addr)
+        except ValueError:
+            return None
+
+    # -- Ordinal resolution ------------------------------------------------
+
+    def load_ordinal_exports(self, exports_dir: str | Path) -> dict:
+        """Load ordinal export files from dll_exports/ directory.
+
+        Parses files like D2Common.txt with format:
+            D2COMMON.DLL::Ordinal_10000@6fd9f450->Ordinal_10000
+
+        Returns:
+            Summary of loaded ordinals per DLL.
+        """
+        exports_dir = Path(exports_dir)
+        if not exports_dir.is_dir():
+            raise FileNotFoundError(f"Exports directory not found: {exports_dir}")
+
+        summary = {}
+        for f in exports_dir.glob("*.txt"):
+            count = self._load_ordinal_file(f)
+            if count > 0:
+                summary[f.stem] = count
+                logger.info(f"Loaded {count} ordinals from {f.name}")
+
+        total = sum(summary.values())
+        logger.info(f"Total ordinals loaded: {total} across {len(summary)} DLLs")
+        return summary
+
+    def _load_ordinal_file(self, path: Path) -> int:
+        """Parse a single ordinal export file."""
+        count = 0
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    m = _EXPORT_LINE_RE.match(line)
+                    if not m:
+                        continue
+
+                    dll = m.group("dll")
+                    label = m.group("label")
+                    addr = int(m.group("addr"), 16)
+
+                    # Extract ordinal number
+                    om = _ORDINAL_RE.search(label)
+                    if not om:
+                        continue
+                    ordinal = int(om.group(1))
+
+                    dll_key = self._normalize_name(dll)
+                    if dll_key not in self._ordinals:
+                        self._ordinals[dll_key] = {}
+
+                    self._ordinals[dll_key][ordinal] = OrdinalEntry(
+                        dll=dll,
+                        ordinal=ordinal,
+                        label=m.group("name"),
+                        ghidra_address=addr,
+                    )
+                    count += 1
+        except Exception as e:
+            logger.error(f"Error reading {path}: {e}")
+        return count
+
+    def resolve_ordinal(self, dll: str, ordinal: int) -> Optional[dict]:
+        """Resolve a DLL ordinal to addresses.
+
+        Returns:
+            Dict with ghidra_address, runtime_address (if mapped), label.
+            None if ordinal not found.
+        """
+        dll_key = self._normalize_name(dll)
+        entries = self._ordinals.get(dll_key, {})
+        entry = entries.get(ordinal)
+        if entry is None:
+            return None
+
+        result: dict = {
+            "dll": entry.dll,
+            "ordinal": ordinal,
+            "label": entry.label,
+            "ghidra_address": f"0x{entry.ghidra_address:08X}",
+        }
+
+        # Try to get runtime address
+        try:
+            runtime = self.to_runtime(entry.ghidra_address, dll)
+            result["runtime_address"] = f"0x{runtime:08X}"
+        except ValueError:
+            result["runtime_address"] = None
+
+        return result
+
+    def get_ordinal_count(self, dll: str) -> int:
+        """Get the number of loaded ordinals for a DLL."""
+        return len(self._ordinals.get(self._normalize_name(dll), {}))
+
+    # -- Helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        """Normalize a module/DLL name for matching.
+
+        "D2COMMON.DLL" -> "d2common"
+        "D2Common.dll" -> "d2common"
+        "/Vanilla/1.00/D2Common.dll" -> "d2common"
+        """
+        # Take basename, strip extension, lowercase
+        basename = os.path.basename(name)
+        stem = os.path.splitext(basename)[0]
+        return stem.lower()

--- a/debugger/d2/__init__.py
+++ b/debugger/d2/__init__.py
@@ -1,0 +1,1 @@
+"""Diablo 2 specific utilities — calling conventions, ordinal maps, module catalog."""

--- a/debugger/d2/conventions.py
+++ b/debugger/d2/conventions.py
@@ -1,0 +1,202 @@
+"""
+Diablo 2 calling convention handling and argument reading.
+
+D2 binaries (MSVC 6.0 compiled, 32-bit x86) use three calling conventions:
+
+- __stdcall: All args on stack. Callee cleans stack. Most ordinal exports.
+- __fastcall: First 2 args in ECX/EDX, rest on stack. Some internal functions.
+- __thiscall: 'this' in ECX, rest on stack. C++ member functions.
+- __cdecl: All args on stack. Caller cleans stack. Variadic functions (printf etc).
+
+At function entry (breakpoint), ESP points to the return address.
+Arguments start at [ESP+4], [ESP+8], etc. for stack-based conventions.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# D2 DLLs that are typically loaded in Game.exe
+D2_MODULES = [
+    "D2Client.dll",
+    "D2CMP.dll",
+    "D2Common.dll",
+    "D2DDraw.dll",
+    "D2Direct3D.dll",
+    "D2Game.dll",
+    "D2Gdi.dll",
+    "D2gfx.dll",
+    "D2Glide.dll",
+    "D2Lang.dll",
+    "D2Launch.dll",
+    "D2MCPClient.dll",
+    "D2Multi.dll",
+    "D2Net.dll",
+    "D2sound.dll",
+    "D2Win.dll",
+    "Fog.dll",
+    "Storm.dll",
+    "Bnclient.dll",
+]
+
+# Conventions recognized by the arg reader
+CONVENTIONS = {"__stdcall", "__fastcall", "__thiscall", "__cdecl"}
+
+
+def read_args(registers: Dict[str, int],
+              read_dword_fn,
+              convention: str,
+              count: int) -> List[int]:
+    """Read function arguments at a breakpoint based on calling convention.
+
+    Args:
+        registers: Register dict with at least ESP, ECX, EDX.
+        read_dword_fn: Callable(address) -> int that reads a 32-bit value.
+        convention: One of __stdcall, __fastcall, __thiscall, __cdecl.
+        count: Number of arguments to read.
+
+    Returns:
+        List of argument values (as unsigned 32-bit ints).
+    """
+    if count <= 0:
+        return []
+
+    esp = registers.get("ESP", 0)
+    ecx = registers.get("ECX", 0)
+    edx = registers.get("EDX", 0)
+
+    if convention == "__fastcall":
+        args = []
+        if count >= 1:
+            args.append(ecx)
+        if count >= 2:
+            args.append(edx)
+        # Remaining args on stack starting at ESP+4
+        for i in range(max(0, count - 2)):
+            addr = esp + 4 + i * 4
+            args.append(read_dword_fn(addr))
+        return args[:count]
+
+    elif convention == "__thiscall":
+        args = [ecx]  # 'this' pointer
+        for i in range(max(0, count - 1)):
+            addr = esp + 4 + i * 4
+            args.append(read_dword_fn(addr))
+        return args[:count]
+
+    else:
+        # __stdcall, __cdecl — all args on stack
+        args = []
+        for i in range(count):
+            addr = esp + 4 + i * 4
+            args.append(read_dword_fn(addr))
+        return args
+
+
+def read_return_address(registers: Dict[str, int], read_dword_fn) -> int:
+    """Read the return address from the top of the stack at function entry."""
+    esp = registers.get("ESP", 0)
+    return read_dword_fn(esp)
+
+
+def classify_value(value: int) -> str:
+    """Heuristic classification of a 32-bit value for type inference.
+
+    Returns one of: "pointer", "small_int", "enum_candidate", "boolean",
+                    "negative", "large_int", "zero", "flag_bits".
+    """
+    if value in (0, 1):
+        return "boolean"
+    if 0x10000 <= value <= 0x7FFFFFFF:
+        return "pointer"
+    if value >= 0x80000000:
+        # Interpret as signed
+        signed = value - 0x100000000
+        if -1000 <= signed < 0:
+            return "negative"
+        if value >= 0xFF000000:
+            return "negative"  # Small negative
+        return "large_int"
+    if value <= 0xFF:
+        return "enum_candidate"
+    if value <= 0xFFFF:
+        return "small_int"
+    # Check for flag-like patterns (few bits set)
+    if bin(value).count("1") <= 4:
+        return "flag_bits"
+    return "large_int"
+
+
+def analyze_arg_observations(values: List[int]) -> dict:
+    """Analyze observed argument values to infer type.
+
+    Returns dict with:
+        - classification: dominant type
+        - unique_count: number of unique values
+        - min/max: range
+        - sample: up to 10 unique values
+        - suggested_type: Ghidra type suggestion
+    """
+    if not values:
+        return {"classification": "unknown", "suggested_type": "int"}
+
+    unique = sorted(set(values))
+    classifications = [classify_value(v) for v in values]
+
+    # Count classifications
+    counts: Dict[str, int] = {}
+    for c in classifications:
+        counts[c] = counts.get(c, 0) + 1
+
+    dominant = max(counts, key=counts.get)  # type: ignore
+
+    result = {
+        "classification": dominant,
+        "unique_count": len(unique),
+        "min": f"0x{min(values):08X}",
+        "max": f"0x{max(values):08X}",
+        "total_observations": len(values),
+        "sample": [f"0x{v:08X}" for v in unique[:10]],
+    }
+
+    # Suggest Ghidra type
+    if dominant == "pointer":
+        result["suggested_type"] = "void *"
+    elif dominant == "boolean":
+        result["suggested_type"] = "BOOL"
+    elif dominant == "enum_candidate":
+        result["suggested_type"] = "int"  # Small values, likely enum
+        result["likely_enum"] = True
+    elif dominant == "negative":
+        result["suggested_type"] = "int"
+    elif dominant == "flag_bits":
+        result["suggested_type"] = "uint"
+        result["likely_flags"] = True
+    elif dominant == "small_int":
+        if all(v <= 0xFFFF for v in values):
+            result["suggested_type"] = "short" if any(v > 0x7FFF for v in values) else "ushort"
+        else:
+            result["suggested_type"] = "int"
+    else:
+        result["suggested_type"] = "uint"
+
+    return result
+
+
+def parse_convention_from_prototype(prototype: str) -> str:
+    """Extract calling convention from a Ghidra function prototype string.
+
+    Examples:
+        "int __stdcall CalcMissileVelocityParam(...)" -> "__stdcall"
+        "void __fastcall ProcessInput(...)" -> "__fastcall"
+        "undefined4 FUN_6fd50a30(...)" -> "__cdecl" (default)
+    """
+    prototype_lower = prototype.lower()
+    for conv in ("__stdcall", "__fastcall", "__thiscall", "__cdecl"):
+        if conv in prototype_lower:
+            return conv
+    return "__cdecl"  # Default

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -1,0 +1,580 @@
+"""
+dbgeng engine wrapper — thin layer over pybag with proper COM threading.
+
+Replicates the Worker/Queue/eng_thread pattern from Ghidra's ghidradbg/util.py
+without importing it, so we have no coupling to Ghidra's internal debugger agent.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import functools
+import io
+import logging
+import os
+import queue
+import struct
+import threading
+import time
+from collections import namedtuple
+from concurrent.futures import Future
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast
+
+from pybag import pydbg, userdbg  # type: ignore
+from pybag.dbgeng import core as DbgEng  # type: ignore
+from pybag.dbgeng import exception  # type: ignore
+
+from .protocol import BreakpointInfo, BreakpointType, DebuggerState, ModuleInfo
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+C = TypeVar("C", bound=Callable[..., Any])
+
+
+# ---------------------------------------------------------------------------
+# AllDbg — combined user/kernel debugger base (from ghidradbg/util.py)
+# ---------------------------------------------------------------------------
+
+class AllDbg(pydbg.DebuggerBase):
+    """Composite debugger class that borrows user-mode methods."""
+    proc_list = userdbg.UserDbg.proc_list
+    ps = userdbg.UserDbg.ps
+    pids_by_name = userdbg.UserDbg.pids_by_name
+    create_proc = userdbg.UserDbg.create
+    attach_proc = userdbg.UserDbg.attach
+    detach_proc = userdbg.UserDbg.detach
+    terminate_proc = userdbg.UserDbg.terminate
+
+
+# ---------------------------------------------------------------------------
+# Threading primitives (from ghidradbg/util.py:90-186)
+# ---------------------------------------------------------------------------
+
+class _WorkItem:
+    __slots__ = ("future", "fn", "args", "kwargs")
+
+    def __init__(self, future: Future, fn: Callable, args: tuple, kwargs: dict):
+        self.future = future
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self) -> None:
+        try:
+            result = self.fn(*self.args, **self.kwargs)
+        except BaseException as exc:
+            self.future.set_exception(exc)
+        else:
+            self.future.set_result(result)
+
+
+class _Worker(threading.Thread):
+    """Daemon thread that owns the dbgeng COM apartment."""
+
+    def __init__(self, init_fn: Callable, work_queue: queue.SimpleQueue,
+                 dispatch_fn: Callable):
+        super().__init__(name="DbgEngWorker", daemon=True)
+        self.init_fn = init_fn
+        self.work_queue = work_queue
+        self.dispatch_fn = dispatch_fn
+
+    def run(self) -> None:
+        self.init_fn()
+        while True:
+            try:
+                item = self.work_queue.get_nowait()
+            except queue.Empty:
+                item = None
+            if item is None:
+                try:
+                    self.dispatch_fn(100)
+                except exception.DbgEngTimeout:
+                    pass
+            else:
+                item.run()
+
+
+class DebuggeeRunningException(Exception):
+    pass
+
+
+class WrongThreadException(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Event callbacks
+# ---------------------------------------------------------------------------
+
+class EngineEventHandler:
+    """Receives dbgeng events and forwards to registered listeners."""
+
+    def __init__(self):
+        self.on_breakpoint_hit: Optional[Callable[[int], int]] = None
+        self.on_state_changed: Optional[Callable[[int, int], None]] = None
+        self.on_module_loaded: Optional[Callable[[], None]] = None
+
+    def breakpoint_handler(self, bp_id: int) -> int:
+        if self.on_breakpoint_hit:
+            return self.on_breakpoint_hit(bp_id)
+        return DbgEng.DEBUG_STATUS_NO_CHANGE
+
+    def state_change_handler(self, *args) -> int:
+        if len(args) >= 2 and self.on_state_changed:
+            self.on_state_changed(args[0], args[1])
+        return DbgEng.DEBUG_STATUS_NO_CHANGE
+
+
+# ---------------------------------------------------------------------------
+# DebugEngine — main API
+# ---------------------------------------------------------------------------
+
+class DebugEngine:
+    """
+    Wraps pybag's dbgeng with proper COM threading.
+
+    All dbgeng operations run on a dedicated worker thread. Public methods
+    are decorated with @eng_thread so callers from any thread are safe.
+    """
+
+    def __init__(self):
+        self._state = DebuggerState.DETACHED
+        self._target_pid: Optional[int] = None
+        self._target_name: Optional[str] = None
+        self._executing = False  # True when target is running
+        self._protected_base: Optional[AllDbg] = None
+        self._events = EngineEventHandler()
+
+        # Work queue and worker thread
+        self._work_queue: queue.SimpleQueue = queue.SimpleQueue()
+        self._thread = _Worker(self._init_dbgeng, self._work_queue,
+                               self._dispatch_events)
+        self._thread.start()
+
+        # Wait for worker to be ready
+        self._submit(lambda: None).result(timeout=10)
+        logger.info("DebugEngine initialized (worker thread ready)")
+
+    # -- Threading infrastructure ------------------------------------------
+
+    def _init_dbgeng(self) -> None:
+        """Called on the worker thread to create the dbgeng base."""
+        self._protected_base = AllDbg()
+        logger.info("dbgeng COM initialized on worker thread")
+
+    def _dispatch_events(self, timeout: int = 100) -> None:
+        """Pump dbgeng event callbacks (called in worker idle loop)."""
+        if self._protected_base is not None:
+            self._protected_base._client.DispatchCallbacks(timeout)
+
+    @property
+    def _base(self) -> AllDbg:
+        """Access the dbgeng base — only from the worker thread."""
+        if threading.current_thread() is not self._thread:
+            raise WrongThreadException(
+                f"dbgeng access from {threading.current_thread().name}, "
+                f"must be {self._thread.name}")
+        if self._protected_base is None:
+            raise RuntimeError("dbgeng not initialized")
+        return self._protected_base
+
+    def _submit(self, fn: Callable[..., T], *args, **kwargs) -> Future[T]:
+        """Submit work to the engine thread."""
+        f: Future[T] = Future()
+        w = _WorkItem(f, fn, args, kwargs)
+        self._work_queue.put(w)
+        if self._protected_base is not None:
+            try:
+                self._protected_base._client.ExitDispatch()
+            except Exception:
+                pass
+        return f
+
+    def _run_on_engine(self, fn: Callable[..., T], *args, **kwargs) -> T:
+        """Submit and block until complete."""
+        if threading.current_thread() is self._thread:
+            return fn(*args, **kwargs)
+        future = self._submit(fn, *args, **kwargs)
+        while True:
+            try:
+                return future.result(0.5)
+            except concurrent.futures.TimeoutError:
+                pass
+
+    def eng_thread(self, func: C) -> C:
+        """Decorator: ensures func runs on the engine thread."""
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            if threading.current_thread() is self._thread:
+                return func(*args, **kwargs)
+            return self._run_on_engine(func, *args, **kwargs)
+        return cast(C, wrapper)
+
+    # -- Process management ------------------------------------------------
+
+    def attach(self, target: str) -> dict:
+        """Attach to a process by name or PID.
+
+        Args:
+            target: Process name (e.g. "Game.exe") or PID as string.
+
+        Returns:
+            Status dict with pid, name, module_count.
+        """
+        return self._run_on_engine(self._attach_impl, target)
+
+    def _attach_impl(self, target: str) -> dict:
+        if self._state not in (DebuggerState.DETACHED, DebuggerState.EXITED):
+            raise RuntimeError(f"Cannot attach in state {self._state.value}")
+
+        base = self._base
+
+        # Resolve PID
+        try:
+            pid = int(target)
+        except ValueError:
+            pids = base.pids_by_name(target)
+            if not pids:
+                raise RuntimeError(f"No process found matching '{target}'")
+            pid = pids[0]
+
+        logger.info(f"Attaching to PID {pid}...")
+        base.attach_proc(pid)
+
+        # Wait for initial break
+        try:
+            base.wait(timeout=10000)
+        except exception.DbgEngTimeout:
+            logger.warning("Timeout waiting for initial break, continuing anyway")
+
+        self._target_pid = pid
+        try:
+            self._target_name = base.get_name_by_offset(base.reg.get_pc())
+        except Exception:
+            self._target_name = target
+        self._state = DebuggerState.STOPPED
+
+        modules = self._get_modules_impl()
+        logger.info(f"Attached to PID {pid}, {len(modules)} modules loaded")
+        return {
+            "pid": pid,
+            "name": self._target_name,
+            "module_count": len(modules),
+            "state": self._state.value,
+        }
+
+    def detach(self) -> dict:
+        """Detach from the target process."""
+        return self._run_on_engine(self._detach_impl)
+
+    def _detach_impl(self) -> dict:
+        if self._state == DebuggerState.DETACHED:
+            return {"state": "detached", "message": "Already detached"}
+        try:
+            self._base.detach_proc()
+        except Exception as e:
+            logger.warning(f"Detach error (non-fatal): {e}")
+        pid = self._target_pid
+        self._target_pid = None
+        self._target_name = None
+        self._state = DebuggerState.DETACHED
+        self._executing = False
+        logger.info(f"Detached from PID {pid}")
+        return {"state": "detached", "pid": pid}
+
+    # -- Execution control -------------------------------------------------
+
+    def go(self) -> dict:
+        """Resume execution."""
+        return self._run_on_engine(self._go_impl)
+
+    def _go_impl(self) -> dict:
+        self._require_stopped()
+        self._state = DebuggerState.RUNNING
+        self._executing = True
+        self._base.go()
+        # go() returns when the debuggee breaks again
+        self._state = DebuggerState.STOPPED
+        self._executing = False
+        return {"state": self._state.value}
+
+    def go_nowait(self) -> dict:
+        """Resume execution without waiting for break.
+
+        Returns immediately. Use wait_for_break() or poll status().
+        """
+        def _impl():
+            self._require_stopped()
+            self._state = DebuggerState.RUNNING
+            self._executing = True
+            try:
+                self._base._control.SetExecutionStatus(
+                    DbgEng.DEBUG_STATUS_GO)
+            except Exception as e:
+                self._state = DebuggerState.STOPPED
+                self._executing = False
+                raise
+        self._run_on_engine(_impl)
+        return {"state": "running"}
+
+    def interrupt(self) -> dict:
+        """Break into the debugger (interrupt execution)."""
+        # interrupt() can be called from any thread
+        if self._protected_base is not None:
+            self._protected_base._control.SetInterrupt(
+                DbgEng.DEBUG_INTERRUPT_ACTIVE)
+        self._state = DebuggerState.STOPPED
+        self._executing = False
+        return {"state": "stopped"}
+
+    def step_into(self, count: int = 1) -> dict:
+        """Single-step into (trace)."""
+        return self._run_on_engine(self._step_into_impl, count)
+
+    def _step_into_impl(self, count: int) -> dict:
+        self._require_stopped()
+        self._base.stepi(count)
+        return {"state": "stopped", "pc": f"0x{self._base.reg.get_pc():08X}"}
+
+    def step_over(self, count: int = 1) -> dict:
+        """Step over (proceed)."""
+        return self._run_on_engine(self._step_over_impl, count)
+
+    def _step_over_impl(self, count: int) -> dict:
+        self._require_stopped()
+        self._base.stepo(count)
+        return {"state": "stopped", "pc": f"0x{self._base.reg.get_pc():08X}"}
+
+    # -- State inspection --------------------------------------------------
+
+    def get_state(self) -> DebuggerState:
+        return self._state
+
+    def get_target_pid(self) -> Optional[int]:
+        return self._target_pid
+
+    def get_target_name(self) -> Optional[str]:
+        return self._target_name
+
+    def get_modules(self) -> List[ModuleInfo]:
+        """Get list of loaded modules."""
+        return self._run_on_engine(self._get_modules_impl)
+
+    def _get_modules_impl(self) -> List[ModuleInfo]:
+        self._require_attached()
+        modules = []
+        try:
+            for mod in self._base.module_list():
+                modules.append(ModuleInfo(
+                    name=mod.name,
+                    runtime_base=mod.base,
+                    size=mod.size,
+                ))
+        except Exception as e:
+            logger.error(f"Error enumerating modules: {e}")
+        return modules
+
+    def get_registers(self) -> Dict[str, int]:
+        """Read all general-purpose registers."""
+        return self._run_on_engine(self._get_registers_impl)
+
+    def _get_registers_impl(self) -> Dict[str, int]:
+        self._require_stopped()
+        regs = {}
+        reg_obj = self._base.reg
+        # x86 general-purpose registers
+        for name in ["EAX", "EBX", "ECX", "EDX", "ESI", "EDI",
+                      "ESP", "EBP", "EIP"]:
+            try:
+                val = reg_obj._get_register(name)
+                regs[name] = val
+            except Exception:
+                pass
+        # Flags
+        try:
+            regs["EFLAGS"] = reg_obj._get_register("efl")
+        except Exception:
+            pass
+        return regs
+
+    def read_memory(self, address: int, size: int) -> bytes:
+        """Read memory from the target."""
+        return self._run_on_engine(self._read_memory_impl, address, size)
+
+    def _read_memory_impl(self, address: int, size: int) -> bytes:
+        self._require_stopped()
+        return bytes(self._base.read(address, size))
+
+    def read_dword(self, address: int) -> int:
+        """Read a 32-bit value from memory."""
+        data = self.read_memory(address, 4)
+        return struct.unpack("<I", data)[0]
+
+    def read_pointer(self, address: int) -> int:
+        """Read a pointer-sized value (32-bit for x86)."""
+        return self.read_dword(address)
+
+    def get_stack_trace(self, depth: int = 20) -> List[dict]:
+        """Get stack backtrace."""
+        return self._run_on_engine(self._get_stack_trace_impl, depth)
+
+    def _get_stack_trace_impl(self, depth: int) -> List[dict]:
+        self._require_stopped()
+        frames = []
+        try:
+            for i, frame in enumerate(self._base.backtrace_list()):
+                if i >= depth:
+                    break
+                entry: dict = {
+                    "level": i,
+                    "instruction_offset": f"0x{frame.InstructionOffset:08X}",
+                    "return_offset": f"0x{frame.ReturnOffset:08X}",
+                    "stack_offset": f"0x{frame.StackOffset:08X}",
+                    "frame_offset": f"0x{frame.FrameOffset:08X}",
+                }
+                try:
+                    name = self._base.get_name_by_offset(frame.InstructionOffset)
+                    entry["symbol"] = name
+                except Exception:
+                    pass
+                frames.append(entry)
+        except Exception as e:
+            logger.error(f"Error reading stack trace: {e}")
+        return frames
+
+    # -- Breakpoint management ---------------------------------------------
+
+    def set_breakpoint(self, address: int,
+                       bp_type: BreakpointType = BreakpointType.SOFTWARE,
+                       oneshot: bool = False,
+                       handler: Optional[Callable] = None) -> int:
+        """Set a breakpoint. Returns the breakpoint ID."""
+        return self._run_on_engine(
+            self._set_breakpoint_impl, address, bp_type, oneshot, handler)
+
+    def _set_breakpoint_impl(self, address: int, bp_type: BreakpointType,
+                              oneshot: bool,
+                              handler: Optional[Callable]) -> int:
+        self._require_attached()
+        if bp_type == BreakpointType.HARDWARE:
+            bp_id = self._base.breakpoints.set(
+                expr=address,
+                type=DbgEng.DEBUG_BREAKPOINT_CODE,
+                oneshot=oneshot,
+                handler=handler,
+            )
+            # For HW exec, convert to hardware after creation
+            try:
+                bp_obj = self._base._control.GetBreakpointById(bp_id)
+                bp_obj.AddFlags(DbgEng.DEBUG_BREAKPOINT_ENABLED)
+            except Exception:
+                pass
+        else:
+            bp_id = self._base.breakpoints.set(
+                expr=address,
+                handler=handler,
+                oneshot=oneshot,
+            )
+        logger.info(f"Breakpoint #{bp_id} set at 0x{address:08X} "
+                    f"(type={bp_type.value}, oneshot={oneshot})")
+        return bp_id
+
+    def remove_breakpoint(self, bp_id: int) -> None:
+        """Remove a breakpoint by ID."""
+        self._run_on_engine(self._remove_breakpoint_impl, bp_id)
+
+    def _remove_breakpoint_impl(self, bp_id: int) -> None:
+        self._require_attached()
+        try:
+            self._base.breakpoints.remove(bp_id)
+            logger.info(f"Breakpoint #{bp_id} removed")
+        except Exception as e:
+            logger.error(f"Error removing breakpoint #{bp_id}: {e}")
+            raise
+
+    def set_data_breakpoint(self, address: int, size: int,
+                            access: int,
+                            handler: Optional[Callable] = None) -> int:
+        """Set a data (hardware) breakpoint for memory access watching.
+
+        Args:
+            address: Memory address to watch.
+            size: Size in bytes (1, 2, or 4 for x86).
+            access: DbgEng.DEBUG_BREAK_READ, DEBUG_BREAK_WRITE, or both OR'd.
+            handler: Optional callback on hit.
+
+        Returns:
+            Breakpoint ID.
+        """
+        return self._run_on_engine(
+            self._set_data_breakpoint_impl, address, size, access, handler)
+
+    def _set_data_breakpoint_impl(self, address: int, size: int, access: int,
+                                   handler: Optional[Callable]) -> int:
+        self._require_attached()
+        bp_id = self._base.breakpoints.set(
+            expr=address,
+            type=DbgEng.DEBUG_BREAKPOINT_DATA,
+            size=size,
+            access=access,
+            handler=handler,
+        )
+        logger.info(f"Data breakpoint #{bp_id} at 0x{address:08X} "
+                    f"(size={size}, access=0x{access:X})")
+        return bp_id
+
+    def list_breakpoints(self) -> List[dict]:
+        """List all active breakpoints."""
+        return self._run_on_engine(self._list_breakpoints_impl)
+
+    def _list_breakpoints_impl(self) -> List[dict]:
+        self._require_attached()
+        result = []
+        for bp_id in self._base.breakpoints:
+            try:
+                bp_obj = self._base._control.GetBreakpointById(bp_id)
+                offset = bp_obj.GetOffset()
+                flags = bp_obj.GetFlags()
+                bp_type = bp_obj.GetType()
+                result.append({
+                    "id": bp_id,
+                    "address": f"0x{offset:08X}",
+                    "enabled": bool(flags & DbgEng.DEBUG_BREAKPOINT_ENABLED),
+                    "oneshot": bool(flags & DbgEng.DEBUG_BREAKPOINT_ONE_SHOT),
+                    "type": "data" if bp_type[0] == DbgEng.DEBUG_BREAKPOINT_DATA else "code",
+                })
+            except Exception as e:
+                result.append({"id": bp_id, "error": str(e)})
+        return result
+
+    # -- Helpers -----------------------------------------------------------
+
+    def _require_attached(self) -> None:
+        if self._state == DebuggerState.DETACHED:
+            raise RuntimeError("Not attached to any process")
+
+    def _require_stopped(self) -> None:
+        self._require_attached()
+        if self._state == DebuggerState.RUNNING:
+            raise RuntimeError("Target is running — interrupt first")
+
+    def get_pc(self) -> int:
+        """Get current program counter."""
+        return self._run_on_engine(lambda: self._base.reg.get_pc())
+
+    def get_sp(self) -> int:
+        """Get current stack pointer."""
+        return self._run_on_engine(lambda: self._base.reg.get_sp())
+
+    def resolve_symbol(self, address: int) -> Optional[str]:
+        """Try to resolve an address to a symbol name."""
+        try:
+            return self._run_on_engine(
+                lambda: self._base.get_name_by_offset(address))
+        except Exception:
+            return None
+
+    def find_pids_by_name(self, name: str) -> List[int]:
+        """Find process IDs by executable name."""
+        return self._run_on_engine(lambda: self._base.pids_by_name(name))

--- a/debugger/protocol.py
+++ b/debugger/protocol.py
@@ -1,0 +1,195 @@
+"""Shared data types for debugger server <-> bridge communication."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Optional
+
+
+class DebuggerState(str, Enum):
+    DETACHED = "detached"
+    ATTACHED = "attached"
+    RUNNING = "running"
+    STOPPED = "stopped"
+    EXITED = "exited"
+
+
+class BreakpointType(str, Enum):
+    SOFTWARE = "software"
+    HARDWARE = "hardware"
+
+
+class WatchAccess(str, Enum):
+    READ = "read"
+    WRITE = "write"
+    READ_WRITE = "readwrite"
+
+
+@dataclass
+class ModuleInfo:
+    name: str
+    runtime_base: int
+    size: int
+    ghidra_base: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        d = {
+            "name": self.name,
+            "runtime_base": f"0x{self.runtime_base:08X}",
+            "size": f"0x{self.size:X}",
+        }
+        if self.ghidra_base is not None:
+            d["ghidra_base"] = f"0x{self.ghidra_base:08X}"
+            d["offset"] = f"0x{self.runtime_base - self.ghidra_base:+X}"
+        return d
+
+
+@dataclass
+class BreakpointInfo:
+    bp_id: int
+    runtime_address: int
+    ghidra_address: Optional[int] = None
+    module: Optional[str] = None
+    bp_type: BreakpointType = BreakpointType.SOFTWARE
+    enabled: bool = True
+    oneshot: bool = False
+    hit_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.bp_id,
+            "runtime_address": f"0x{self.runtime_address:08X}",
+            "ghidra_address": f"0x{self.ghidra_address:08X}" if self.ghidra_address else None,
+            "module": self.module,
+            "type": self.bp_type.value,
+            "enabled": self.enabled,
+            "oneshot": self.oneshot,
+            "hit_count": self.hit_count,
+        }
+
+
+@dataclass
+class TraceEntry:
+    timestamp: float
+    trace_id: int
+    ghidra_address: int
+    module: str
+    args: list[int]
+    arg_names: Optional[list[str]] = None
+    return_value: Optional[int] = None
+    caller: Optional[int] = None
+    caller_ghidra: Optional[int] = None
+    caller_symbol: Optional[str] = None
+    thread_id: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "timestamp": round(self.timestamp, 4),
+            "trace_id": self.trace_id,
+            "ghidra_address": f"0x{self.ghidra_address:08X}",
+            "module": self.module,
+        }
+        if self.arg_names and len(self.arg_names) == len(self.args):
+            d["args"] = {
+                name: f"0x{val:08X}" for name, val in zip(self.arg_names, self.args)
+            }
+        else:
+            d["args"] = [f"0x{v:08X}" for v in self.args]
+        if self.return_value is not None:
+            d["return_value"] = f"0x{self.return_value:08X}"
+        if self.caller is not None:
+            d["caller"] = f"0x{self.caller:08X}"
+        if self.caller_ghidra is not None:
+            d["caller_ghidra"] = f"0x{self.caller_ghidra:08X}"
+        if self.caller_symbol:
+            d["caller_symbol"] = self.caller_symbol
+        if self.thread_id is not None:
+            d["thread_id"] = self.thread_id
+        return d
+
+
+@dataclass
+class TracePointInfo:
+    trace_id: int
+    ghidra_address: int
+    module: str
+    convention: str
+    arg_count: int
+    arg_names: Optional[list[str]]
+    capture_return: bool
+    max_hits: int
+    hit_count: int = 0
+    active: bool = True
+
+    def to_dict(self) -> dict:
+        return {
+            "trace_id": self.trace_id,
+            "ghidra_address": f"0x{self.ghidra_address:08X}",
+            "module": self.module,
+            "convention": self.convention,
+            "arg_count": self.arg_count,
+            "arg_names": self.arg_names,
+            "capture_return": self.capture_return,
+            "max_hits": self.max_hits,
+            "hit_count": self.hit_count,
+            "active": self.active,
+        }
+
+
+@dataclass
+class WatchHit:
+    timestamp: float
+    watch_id: int
+    address: int
+    ghidra_address: Optional[int]
+    size: int
+    access: str
+    value: Optional[int] = None
+    accessor_address: Optional[int] = None
+    accessor_ghidra: Optional[int] = None
+    accessor_symbol: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "timestamp": round(self.timestamp, 4),
+            "watch_id": self.watch_id,
+            "address": f"0x{self.address:08X}",
+            "size": self.size,
+            "access": self.access,
+        }
+        if self.ghidra_address is not None:
+            d["ghidra_address"] = f"0x{self.ghidra_address:08X}"
+        if self.value is not None:
+            d["value"] = f"0x{self.value:08X}"
+        if self.accessor_address is not None:
+            d["accessor"] = f"0x{self.accessor_address:08X}"
+        if self.accessor_ghidra is not None:
+            d["accessor_ghidra"] = f"0x{self.accessor_ghidra:08X}"
+        if self.accessor_symbol:
+            d["accessor_symbol"] = self.accessor_symbol
+        return d
+
+
+@dataclass
+class StatusResponse:
+    state: DebuggerState
+    target_pid: Optional[int] = None
+    target_name: Optional[str] = None
+    module_count: int = 0
+    breakpoint_count: int = 0
+    active_traces: int = 0
+    active_watches: int = 0
+
+    def to_dict(self) -> dict:
+        d: dict = {"state": self.state.value}
+        if self.target_pid is not None:
+            d["target_pid"] = self.target_pid
+        if self.target_name:
+            d["target_name"] = self.target_name
+        d["module_count"] = self.module_count
+        d["breakpoint_count"] = self.breakpoint_count
+        d["active_traces"] = self.active_traces
+        d["active_watches"] = self.active_watches
+        return d

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -1,0 +1,602 @@
+"""
+GhidraMCP Debugger Server — HTTP server wrapping dbgeng for live debugging.
+
+Runs as a standalone process on port 8099 (configurable).
+The MCP bridge proxies debugger tool calls to this server.
+
+Usage:
+    python -m debugger.server                 # Default port 8099
+    python -m debugger.server --port 8100     # Custom port
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import sys
+import traceback
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from socketserver import ThreadingMixIn
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlparse
+
+from .engine import DebugEngine
+from .address_map import AddressMapper
+from .protocol import (
+    BreakpointType, DebuggerState, StatusResponse, WatchAccess,
+)
+from .d2.conventions import (
+    read_args, read_return_address, parse_convention_from_prototype,
+    classify_value, analyze_arg_observations,
+)
+from .tracing import TraceSession
+
+logger = logging.getLogger(__name__)
+
+# Default exports directory relative to project root
+_PROJECT_ROOT = Path(__file__).parent.parent
+_EXPORTS_DIR = _PROJECT_ROOT / "dll_exports"
+
+
+class DebuggerServer:
+    """Manages the debugger engine, address mapper, and trace session."""
+
+    def __init__(self, exports_dir: Optional[Path] = None):
+        self.engine = DebugEngine()
+        self.mapper = AddressMapper()
+        self.tracer: Optional[TraceSession] = None
+
+        # Load ordinal exports
+        edir = exports_dir or _EXPORTS_DIR
+        if edir.is_dir():
+            summary = self.mapper.load_ordinal_exports(edir)
+            logger.info(f"Loaded ordinal exports: {summary}")
+        else:
+            logger.warning(f"Exports directory not found: {edir}")
+
+    def _ensure_tracer(self) -> TraceSession:
+        if self.tracer is None:
+            self.tracer = TraceSession(self.engine, self.mapper)
+        return self.tracer
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the debugger server."""
+
+    server: DebuggerHTTPServer  # type hint for the server reference
+
+    def log_message(self, format, *args):
+        logger.debug(format, *args)
+
+    # -- Routing -----------------------------------------------------------
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+        query = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+
+        routes = {
+            "/debugger/status": self._handle_status,
+            "/debugger/modules": self._handle_modules,
+            "/debugger/registers": self._handle_registers,
+            "/debugger/memory": lambda: self._handle_memory(query),
+            "/debugger/stack": lambda: self._handle_stack(query),
+            "/debugger/breakpoints": self._handle_list_breakpoints,
+            "/debugger/ordinal": lambda: self._handle_resolve_ordinal(query),
+            "/debugger/address_map": self._handle_address_map,
+            "/debugger/trace/log": lambda: self._handle_trace_log(query),
+            "/debugger/trace/list": self._handle_trace_list,
+            "/debugger/watch/log": lambda: self._handle_watch_log(query),
+            "/debugger/read_args": lambda: self._handle_read_args(query),
+        }
+
+        handler = routes.get(path)
+        if handler:
+            self._safe_handle(handler)
+        else:
+            self._send_error(404, f"Unknown endpoint: {path}")
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+        body = self._read_json_body()
+
+        routes = {
+            "/debugger/attach": lambda: self._handle_attach(body),
+            "/debugger/detach": self._handle_detach,
+            "/debugger/go": self._handle_go,
+            "/debugger/interrupt": self._handle_interrupt,
+            "/debugger/step_into": lambda: self._handle_step_into(body),
+            "/debugger/step_over": lambda: self._handle_step_over(body),
+            "/debugger/breakpoint": lambda: self._handle_set_breakpoint(body),
+            "/debugger/sync_modules": lambda: self._handle_sync_modules(body),
+            "/debugger/trace/start": lambda: self._handle_trace_start(body),
+            "/debugger/trace/stop": lambda: self._handle_trace_stop(body),
+            "/debugger/watch/start": lambda: self._handle_watch_start(body),
+            "/debugger/watch/stop": lambda: self._handle_watch_stop(body),
+        }
+
+        handler = routes.get(path)
+        if handler:
+            self._safe_handle(handler)
+        else:
+            self._send_error(404, f"Unknown endpoint: {path}")
+
+    def do_DELETE(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        # DELETE /debugger/breakpoint/{id}
+        if path.startswith("/debugger/breakpoint/"):
+            bp_id_str = path.split("/")[-1]
+            try:
+                bp_id = int(bp_id_str)
+                self._safe_handle(lambda: self._handle_remove_breakpoint(bp_id))
+            except ValueError:
+                self._send_error(400, f"Invalid breakpoint ID: {bp_id_str}")
+        else:
+            self._send_error(404, f"Unknown endpoint: {path}")
+
+    # -- Handler implementations -------------------------------------------
+
+    def _handle_status(self):
+        ds = self._ds()
+        engine = ds.engine
+        status = StatusResponse(
+            state=engine.get_state(),
+            target_pid=engine.get_target_pid(),
+            target_name=engine.get_target_name(),
+            module_count=len(ds.mapper.get_all_modules()),
+            breakpoint_count=len(engine.list_breakpoints()) if engine.get_state() != DebuggerState.DETACHED else 0,
+            active_traces=ds.tracer.active_count() if ds.tracer else 0,
+            active_watches=ds.tracer.watch_count() if ds.tracer else 0,
+        )
+        self._send_json(status.to_dict())
+
+    def _handle_attach(self, body: dict):
+        ds = self._ds()
+        target = body.get("target", body.get("pid", ""))
+        if not target:
+            self._send_error(400, "Missing 'target' (process name or PID)")
+            return
+        result = ds.engine.attach(str(target))
+        self._send_json(result)
+
+    def _handle_detach(self):
+        ds = self._ds()
+        # Stop all traces first
+        if ds.tracer:
+            ds.tracer.stop_all()
+        result = ds.engine.detach()
+        self._send_json(result)
+
+    def _handle_modules(self):
+        ds = self._ds()
+        modules = ds.engine.get_modules()
+        # Enrich with Ghidra bases from mapper
+        result = []
+        for mod in modules:
+            mapping = ds.mapper.get_module(mod.name)
+            if mapping:
+                mod.ghidra_base = mapping.ghidra_base
+            result.append(mod.to_dict())
+        self._send_json({"modules": result, "count": len(result)})
+
+    def _handle_sync_modules(self, body: dict):
+        ds = self._ds()
+        ghidra_bases = body.get("ghidra_bases", {})
+        if not ghidra_bases:
+            self._send_error(400, "Missing 'ghidra_bases' dict")
+            return
+        # Convert hex string values to int if needed
+        parsed_bases = {}
+        for name, base in ghidra_bases.items():
+            if isinstance(base, str):
+                parsed_bases[name] = int(base, 16) if base.startswith("0x") else int(base)
+            else:
+                parsed_bases[name] = int(base)
+
+        runtime_modules = ds.engine.get_modules()
+        result = ds.mapper.update_from_modules(runtime_modules, parsed_bases)
+        self._send_json(result)
+
+    def _handle_address_map(self):
+        ds = self._ds()
+        modules = ds.mapper.get_all_modules()
+        result = []
+        for m in modules:
+            result.append({
+                "name": m.name,
+                "ghidra_base": f"0x{m.ghidra_base:08X}",
+                "runtime_base": f"0x{m.runtime_base:08X}",
+                "size": f"0x{m.size:X}",
+                "offset": f"0x{m.offset:+X}",
+            })
+        self._send_json({"mappings": result, "count": len(result)})
+
+    def _handle_registers(self):
+        ds = self._ds()
+        regs = ds.engine.get_registers()
+        formatted = {k: f"0x{v:08X}" for k, v in regs.items()}
+        self._send_json({"registers": formatted})
+
+    def _handle_memory(self, query: dict):
+        ds = self._ds()
+        addr_str = query.get("address", "")
+        size = int(query.get("size", "64"))
+        addr_type = query.get("address_type", "runtime")
+
+        if not addr_str:
+            self._send_error(400, "Missing 'address' parameter")
+            return
+
+        address = int(addr_str, 16) if addr_str.startswith("0x") else int(addr_str)
+
+        # Translate if Ghidra address
+        if addr_type == "ghidra":
+            module = query.get("module", "")
+            address = ds.mapper.to_runtime(address, module or None)
+
+        data = ds.engine.read_memory(address, min(size, 4096))
+
+        # Format as hex dump + dword interpretation
+        hex_str = data.hex()
+        dwords = []
+        for i in range(0, len(data) - 3, 4):
+            val = int.from_bytes(data[i:i+4], "little")
+            dwords.append(f"0x{val:08X}")
+
+        self._send_json({
+            "address": f"0x{address:08X}",
+            "size": len(data),
+            "hex": hex_str,
+            "dwords": dwords,
+        })
+
+    def _handle_stack(self, query: dict):
+        ds = self._ds()
+        depth = int(query.get("depth", "20"))
+        frames = ds.engine.get_stack_trace(depth)
+
+        # Enrich with Ghidra addresses
+        for frame in frames:
+            addr_str = frame.get("instruction_offset", "")
+            if addr_str:
+                addr = int(addr_str, 16)
+                mapped = ds.mapper.try_to_ghidra(addr)
+                if mapped:
+                    frame["ghidra_module"] = mapped[0]
+                    frame["ghidra_address"] = f"0x{mapped[1]:08X}"
+
+        self._send_json({"frames": frames, "depth": len(frames)})
+
+    def _handle_read_args(self, query: dict):
+        ds = self._ds()
+        convention = query.get("convention", "__stdcall")
+        count = int(query.get("count", "4"))
+        arg_names = query.get("arg_names", "")
+
+        regs = ds.engine.get_registers()
+        args = read_args(regs, ds.engine.read_dword, convention, count)
+
+        names = [n.strip() for n in arg_names.split(",")] if arg_names else []
+        result_args = []
+        for i, val in enumerate(args):
+            entry: dict = {"index": i, "value": f"0x{val:08X}"}
+            if i < len(names) and names[i]:
+                entry["name"] = names[i]
+            entry["classification"] = classify_value(val)
+            result_args.append(entry)
+
+        self._send_json({
+            "convention": convention,
+            "args": result_args,
+            "return_address": f"0x{read_return_address(regs, ds.engine.read_dword):08X}",
+        })
+
+    def _handle_go(self):
+        ds = self._ds()
+        result = ds.engine.go_nowait()
+        self._send_json(result)
+
+    def _handle_interrupt(self):
+        ds = self._ds()
+        result = ds.engine.interrupt()
+        self._send_json(result)
+
+    def _handle_step_into(self, body: dict):
+        ds = self._ds()
+        count = int(body.get("count", 1))
+        result = ds.engine.step_into(count)
+        self._send_json(result)
+
+    def _handle_step_over(self, body: dict):
+        ds = self._ds()
+        count = int(body.get("count", 1))
+        result = ds.engine.step_over(count)
+        self._send_json(result)
+
+    def _handle_set_breakpoint(self, body: dict):
+        ds = self._ds()
+        ghidra_addr_str = body.get("ghidra_address", "")
+        runtime_addr_str = body.get("runtime_address", "")
+        module = body.get("module", "")
+        bp_type_str = body.get("type", "software")
+        oneshot = body.get("oneshot", False)
+
+        # Resolve address
+        if ghidra_addr_str:
+            ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+            runtime_addr = ds.mapper.to_runtime(ghidra_addr, module or None)
+        elif runtime_addr_str:
+            runtime_addr = int(runtime_addr_str, 16) if isinstance(runtime_addr_str, str) else int(runtime_addr_str)
+            ghidra_addr = None
+            mapped = ds.mapper.try_to_ghidra(runtime_addr)
+            if mapped:
+                ghidra_addr = mapped[1]
+        else:
+            self._send_error(400, "Missing 'ghidra_address' or 'runtime_address'")
+            return
+
+        bp_type = BreakpointType.HARDWARE if bp_type_str == "hardware" else BreakpointType.SOFTWARE
+        bp_id = ds.engine.set_breakpoint(runtime_addr, bp_type, oneshot)
+
+        self._send_json({
+            "id": bp_id,
+            "runtime_address": f"0x{runtime_addr:08X}",
+            "ghidra_address": f"0x{ghidra_addr:08X}" if ghidra_addr else None,
+            "module": module,
+            "type": bp_type.value,
+            "oneshot": oneshot,
+        })
+
+    def _handle_remove_breakpoint(self, bp_id: int):
+        ds = self._ds()
+        ds.engine.remove_breakpoint(bp_id)
+        self._send_json({"removed": bp_id})
+
+    def _handle_list_breakpoints(self):
+        ds = self._ds()
+        bps = ds.engine.list_breakpoints()
+
+        # Enrich with Ghidra addresses
+        for bp in bps:
+            addr_str = bp.get("address", "")
+            if addr_str:
+                addr = int(addr_str, 16)
+                mapped = ds.mapper.try_to_ghidra(addr)
+                if mapped:
+                    bp["ghidra_module"] = mapped[0]
+                    bp["ghidra_address"] = f"0x{mapped[1]:08X}"
+
+        self._send_json({"breakpoints": bps, "count": len(bps)})
+
+    def _handle_resolve_ordinal(self, query: dict):
+        ds = self._ds()
+        dll = query.get("dll", "")
+        ordinal_str = query.get("ordinal", "")
+        if not dll or not ordinal_str:
+            self._send_error(400, "Missing 'dll' and/or 'ordinal' parameter")
+            return
+        ordinal = int(ordinal_str)
+        result = ds.mapper.resolve_ordinal(dll, ordinal)
+        if result is None:
+            self._send_error(404, f"Ordinal {ordinal} not found in {dll}")
+        else:
+            self._send_json(result)
+
+    # -- Tracing endpoints -------------------------------------------------
+
+    def _handle_trace_start(self, body: dict):
+        ds = self._ds()
+        tracer = ds._ensure_tracer()
+
+        ghidra_addr_str = body.get("ghidra_address", "")
+        module = body.get("module", "")
+        convention = body.get("convention", "__stdcall")
+        arg_count = int(body.get("arg_count", 4))
+        arg_names_str = body.get("arg_names", "")
+        capture_return = body.get("capture_return", False)
+        max_hits = int(body.get("max_hits", 0))
+
+        if not ghidra_addr_str:
+            self._send_error(400, "Missing 'ghidra_address'")
+            return
+
+        ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+        arg_names = [n.strip() for n in arg_names_str.split(",") if n.strip()] if arg_names_str else None
+
+        trace_id = tracer.add_function_trace(
+            ghidra_address=ghidra_addr,
+            module=module,
+            convention=convention,
+            arg_count=arg_count,
+            arg_names=arg_names,
+            capture_return=capture_return,
+            max_hits=max_hits,
+        )
+        self._send_json({"trace_id": trace_id, "status": "started"})
+
+    def _handle_trace_stop(self, body: dict):
+        ds = self._ds()
+        if ds.tracer is None:
+            self._send_json({"stopped": 0})
+            return
+        trace_id = body.get("trace_id", -1)
+        if trace_id == -1:
+            count = ds.tracer.stop_all()
+            self._send_json({"stopped": count})
+        else:
+            ds.tracer.stop_trace(int(trace_id))
+            self._send_json({"stopped": 1, "trace_id": trace_id})
+
+    def _handle_trace_log(self, query: dict):
+        ds = self._ds()
+        if ds.tracer is None:
+            self._send_json({"entries": [], "count": 0})
+            return
+        trace_id = int(query.get("trace_id", -1))
+        last_n = int(query.get("last_n", 50))
+        entries = ds.tracer.get_log(trace_id, last_n)
+        self._send_json({
+            "entries": [e.to_dict() for e in entries],
+            "count": len(entries),
+        })
+
+    def _handle_trace_list(self):
+        ds = self._ds()
+        if ds.tracer is None:
+            self._send_json({"traces": [], "count": 0})
+            return
+        traces = ds.tracer.list_traces()
+        self._send_json({
+            "traces": [t.to_dict() for t in traces],
+            "count": len(traces),
+        })
+
+    # -- Watch endpoints ---------------------------------------------------
+
+    def _handle_watch_start(self, body: dict):
+        ds = self._ds()
+        tracer = ds._ensure_tracer()
+
+        ghidra_addr_str = body.get("ghidra_address", "")
+        module = body.get("module", "")
+        size = int(body.get("size", 4))
+        access = body.get("access", "write")
+
+        if not ghidra_addr_str:
+            self._send_error(400, "Missing 'ghidra_address'")
+            return
+
+        ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+
+        watch_id = tracer.add_data_watch(
+            ghidra_address=ghidra_addr,
+            module=module,
+            size=size,
+            access=access,
+        )
+        self._send_json({"watch_id": watch_id, "status": "started"})
+
+    def _handle_watch_stop(self, body: dict):
+        ds = self._ds()
+        if ds.tracer is None:
+            self._send_json({"stopped": 0})
+            return
+        watch_id = body.get("watch_id", -1)
+        if watch_id == -1:
+            count = ds.tracer.stop_all_watches()
+            self._send_json({"stopped": count})
+        else:
+            ds.tracer.stop_watch(int(watch_id))
+            self._send_json({"stopped": 1, "watch_id": watch_id})
+
+    def _handle_watch_log(self, query: dict):
+        ds = self._ds()
+        if ds.tracer is None:
+            self._send_json({"entries": [], "count": 0})
+            return
+        watch_id = int(query.get("watch_id", -1))
+        last_n = int(query.get("last_n", 50))
+        entries = ds.tracer.get_watch_log(watch_id, last_n)
+        self._send_json({
+            "entries": [e.to_dict() for e in entries],
+            "count": len(entries),
+        })
+
+    # -- Utilities ---------------------------------------------------------
+
+    def _ds(self) -> DebuggerServer:
+        return self.server.debugger_server
+
+    def _read_json_body(self) -> dict:
+        length = int(self.headers.get("Content-Length", 0))
+        if length == 0:
+            return {}
+        raw = self.rfile.read(length)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+
+    def _send_json(self, data: Any, status: int = 200):
+        body = json.dumps(data, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_error(self, status: int, message: str):
+        self._send_json({"error": message}, status)
+
+    def _safe_handle(self, handler):
+        try:
+            handler()
+        except Exception as e:
+            logger.error(f"Error handling request: {traceback.format_exc()}")
+            self._send_error(500, str(e))
+
+
+class DebuggerHTTPServer(ThreadingMixIn, HTTPServer):
+    """Threaded HTTP server with reference to the DebuggerServer."""
+    daemon_threads = True
+
+    def __init__(self, address, handler_class, debugger_server: DebuggerServer):
+        self.debugger_server = debugger_server
+        super().__init__(address, handler_class)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GhidraMCP Debugger Server")
+    parser.add_argument("--port", type=int, default=8099,
+                        help="HTTP server port (default: 8099)")
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--exports-dir", type=str, default=None,
+                        help="Path to dll_exports/ directory")
+    parser.add_argument("--log-level", default="INFO",
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    )
+
+    exports_dir = Path(args.exports_dir) if args.exports_dir else None
+    ds = DebuggerServer(exports_dir)
+
+    server = DebuggerHTTPServer(
+        (args.host, args.port), RequestHandler, ds)
+
+    logger.info(f"Debugger server starting on {args.host}:{args.port}")
+
+    def shutdown_handler(sig, frame):
+        logger.info("Shutting down...")
+        if ds.engine.get_state() != DebuggerState.DETACHED:
+            try:
+                ds.engine.detach()
+            except Exception:
+                pass
+        server.shutdown()
+
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+        logger.info("Server stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -1,0 +1,417 @@
+"""
+Non-breaking function tracing engine.
+
+Sets breakpoints with Python handlers that log arguments and return
+DEBUG_STATUS_GO_HANDLED to auto-resume execution without stopping the game.
+
+This is critical for Diablo 2 RE — the game loop runs at 25fps (40ms ticks),
+and stopping on every call to a hot function would freeze gameplay.
+"""
+
+from __future__ import annotations
+
+import collections
+import logging
+import struct
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from pybag.dbgeng import core as DbgEng  # type: ignore
+
+from .engine import DebugEngine
+from .address_map import AddressMapper
+from .d2.conventions import read_args, read_return_address
+from .protocol import TraceEntry, TracePointInfo, WatchHit
+
+logger = logging.getLogger(__name__)
+
+# Maximum entries in the trace log ring buffer
+MAX_LOG_SIZE = 10_000
+MAX_WATCH_LOG_SIZE = 5_000
+
+
+@dataclass
+class _ActiveTrace:
+    """Internal state for an active function trace."""
+    trace_id: int
+    ghidra_address: int
+    runtime_address: int
+    module: str
+    convention: str
+    arg_count: int
+    arg_names: Optional[List[str]]
+    capture_return: bool
+    max_hits: int
+    bp_id: int  # pybag breakpoint ID
+    hit_count: int = 0
+    active: bool = True
+
+
+@dataclass
+class _ActiveWatch:
+    """Internal state for an active data watchpoint."""
+    watch_id: int
+    ghidra_address: int
+    runtime_address: int
+    module: str
+    size: int
+    access: str
+    bp_id: int  # pybag breakpoint ID
+    hit_count: int = 0
+    active: bool = True
+
+
+class TraceSession:
+    """Manages non-breaking function traces and data watchpoints."""
+
+    def __init__(self, engine: DebugEngine, mapper: AddressMapper):
+        self._engine = engine
+        self._mapper = mapper
+        self._next_trace_id = 0
+        self._next_watch_id = 0
+        self._traces: Dict[int, _ActiveTrace] = {}
+        self._watches: Dict[int, _ActiveWatch] = {}
+        self._log: collections.deque[TraceEntry] = collections.deque(maxlen=MAX_LOG_SIZE)
+        self._watch_log: collections.deque[WatchHit] = collections.deque(maxlen=MAX_WATCH_LOG_SIZE)
+        self._lock = threading.Lock()
+
+    # -- Function tracing --------------------------------------------------
+
+    def add_function_trace(
+        self,
+        ghidra_address: int,
+        module: str,
+        convention: str = "__stdcall",
+        arg_count: int = 4,
+        arg_names: Optional[List[str]] = None,
+        capture_return: bool = False,
+        max_hits: int = 0,
+    ) -> int:
+        """Start a non-breaking trace on a function.
+
+        On each call: logs timestamp, args, caller return address.
+        The handler returns DEBUG_STATUS_GO_HANDLED to auto-resume.
+
+        Args:
+            ghidra_address: Function address in Ghidra.
+            module: DLL name for address resolution.
+            convention: __stdcall, __fastcall, __thiscall, __cdecl.
+            arg_count: Number of arguments to capture.
+            arg_names: Optional names for readability.
+            capture_return: Also capture EAX at function return.
+            max_hits: Stop after N hits (0 = unlimited).
+
+        Returns:
+            Trace ID.
+        """
+        runtime_addr = self._mapper.to_runtime(ghidra_address, module or None)
+
+        trace_id = self._next_trace_id
+        self._next_trace_id += 1
+
+        trace = _ActiveTrace(
+            trace_id=trace_id,
+            ghidra_address=ghidra_address,
+            runtime_address=runtime_addr,
+            module=module,
+            convention=convention,
+            arg_count=arg_count,
+            arg_names=arg_names,
+            capture_return=capture_return,
+            max_hits=max_hits,
+            bp_id=-1,
+        )
+
+        # Build the breakpoint handler — runs on the dbgeng engine thread
+        def _on_entry(bp) -> int:
+            if not trace.active:
+                return DbgEng.DEBUG_STATUS_GO_HANDLED
+
+            try:
+                base = self._engine._protected_base
+                if base is None:
+                    return DbgEng.DEBUG_STATUS_GO_HANDLED
+
+                # Read registers directly (we're on the engine thread)
+                regs = {
+                    "ESP": base.reg.get_sp(),
+                    "ECX": base.reg._get_register("ECX"),
+                    "EDX": base.reg._get_register("EDX"),
+                }
+
+                args = read_args(regs, lambda a: struct.unpack("<I", base.read(a, 4))[0],
+                                 convention, arg_count)
+                caller = struct.unpack("<I", base.read(regs["ESP"], 4))[0]
+
+                # Map caller to Ghidra address
+                caller_ghidra = None
+                caller_symbol = None
+                mapped = self._mapper.try_to_ghidra(caller)
+                if mapped:
+                    caller_ghidra = mapped[1]
+                try:
+                    caller_symbol = base.get_name_by_offset(caller)
+                except Exception:
+                    pass
+
+                entry = TraceEntry(
+                    timestamp=time.monotonic(),
+                    trace_id=trace_id,
+                    ghidra_address=ghidra_address,
+                    module=module,
+                    args=args,
+                    arg_names=arg_names,
+                    caller=caller,
+                    caller_ghidra=caller_ghidra,
+                    caller_symbol=caller_symbol,
+                )
+
+                self._log.append(entry)
+                trace.hit_count += 1
+
+                # Check max hits
+                if trace.max_hits > 0 and trace.hit_count >= trace.max_hits:
+                    trace.active = False
+                    logger.info(f"Trace #{trace_id} reached max_hits={trace.max_hits}")
+
+            except Exception as e:
+                logger.error(f"Trace #{trace_id} handler error: {e}")
+
+            return DbgEng.DEBUG_STATUS_GO_HANDLED
+
+        # Set the breakpoint via the engine
+        bp_id = self._engine.set_breakpoint(
+            runtime_addr,
+            handler=_on_entry,
+        )
+        trace.bp_id = bp_id
+
+        with self._lock:
+            self._traces[trace_id] = trace
+
+        logger.info(
+            f"Trace #{trace_id} started: 0x{ghidra_address:08X} ({module}) "
+            f"[{convention}, {arg_count} args, "
+            f"capture_return={capture_return}, max_hits={max_hits}]")
+        return trace_id
+
+    def stop_trace(self, trace_id: int) -> None:
+        """Stop a specific trace."""
+        with self._lock:
+            trace = self._traces.get(trace_id)
+            if trace is None:
+                return
+            trace.active = False
+
+        try:
+            self._engine.remove_breakpoint(trace.bp_id)
+        except Exception as e:
+            logger.warning(f"Error removing trace BP: {e}")
+
+        logger.info(f"Trace #{trace_id} stopped ({trace.hit_count} hits)")
+
+    def stop_all(self) -> int:
+        """Stop all traces and watches. Returns count stopped."""
+        count = 0
+        with self._lock:
+            trace_ids = list(self._traces.keys())
+            watch_ids = list(self._watches.keys())
+
+        for tid in trace_ids:
+            self.stop_trace(tid)
+            count += 1
+        for wid in watch_ids:
+            self.stop_watch(wid)
+            count += 1
+        return count
+
+    def get_log(self, trace_id: int = -1, last_n: int = 50) -> List[TraceEntry]:
+        """Get trace log entries.
+
+        Args:
+            trace_id: Filter by trace ID, or -1 for all.
+            last_n: Number of most recent entries.
+        """
+        entries = list(self._log)
+        if trace_id >= 0:
+            entries = [e for e in entries if e.trace_id == trace_id]
+        return entries[-last_n:]
+
+    def list_traces(self) -> List[TracePointInfo]:
+        """List all trace points with status."""
+        result = []
+        with self._lock:
+            for trace in self._traces.values():
+                result.append(TracePointInfo(
+                    trace_id=trace.trace_id,
+                    ghidra_address=trace.ghidra_address,
+                    module=trace.module,
+                    convention=trace.convention,
+                    arg_count=trace.arg_count,
+                    arg_names=trace.arg_names,
+                    capture_return=trace.capture_return,
+                    max_hits=trace.max_hits,
+                    hit_count=trace.hit_count,
+                    active=trace.active,
+                ))
+        return result
+
+    def active_count(self) -> int:
+        with self._lock:
+            return sum(1 for t in self._traces.values() if t.active)
+
+    # -- Data watchpoints --------------------------------------------------
+
+    def add_data_watch(
+        self,
+        ghidra_address: int,
+        module: str,
+        size: int = 4,
+        access: str = "write",
+    ) -> int:
+        """Set a hardware watchpoint on a memory range.
+
+        Limited to 4 simultaneous watchpoints (x86 DR0-DR3).
+
+        Args:
+            ghidra_address: Start address in Ghidra.
+            module: DLL name for resolution.
+            size: Bytes to watch (1, 2, or 4).
+            access: "read", "write", or "readwrite".
+
+        Returns:
+            Watch ID.
+        """
+        # Check limit
+        active_watches = sum(1 for w in self._watches.values() if w.active)
+        if active_watches >= 4:
+            raise RuntimeError(
+                "x86 hardware breakpoint limit reached (4 max). "
+                "Stop an existing watchpoint first.")
+
+        runtime_addr = self._mapper.to_runtime(ghidra_address, module or None)
+
+        watch_id = self._next_watch_id
+        self._next_watch_id += 1
+
+        watch = _ActiveWatch(
+            watch_id=watch_id,
+            ghidra_address=ghidra_address,
+            runtime_address=runtime_addr,
+            module=module,
+            size=size,
+            access=access,
+            bp_id=-1,
+        )
+
+        # Map access string to dbgeng flags
+        access_flags = DbgEng.DEBUG_BREAK_WRITE
+        if access == "read":
+            access_flags = DbgEng.DEBUG_BREAK_READ
+        elif access == "readwrite":
+            access_flags = DbgEng.DEBUG_BREAK_READ | DbgEng.DEBUG_BREAK_WRITE
+
+        def _on_watch_hit(bp) -> int:
+            if not watch.active:
+                return DbgEng.DEBUG_STATUS_GO_HANDLED
+
+            try:
+                base = self._engine._protected_base
+                if base is None:
+                    return DbgEng.DEBUG_STATUS_GO_HANDLED
+
+                pc = base.reg.get_pc()
+
+                # Read the watched value
+                value = None
+                try:
+                    data = base.read(runtime_addr, size)
+                    if size == 1:
+                        value = data[0]
+                    elif size == 2:
+                        value = struct.unpack("<H", data)[0]
+                    elif size == 4:
+                        value = struct.unpack("<I", data)[0]
+                except Exception:
+                    pass
+
+                # Map accessor to Ghidra
+                accessor_ghidra = None
+                accessor_symbol = None
+                mapped = self._mapper.try_to_ghidra(pc)
+                if mapped:
+                    accessor_ghidra = mapped[1]
+                try:
+                    accessor_symbol = base.get_name_by_offset(pc)
+                except Exception:
+                    pass
+
+                hit = WatchHit(
+                    timestamp=time.monotonic(),
+                    watch_id=watch_id,
+                    address=runtime_addr,
+                    ghidra_address=ghidra_address,
+                    size=size,
+                    access=access,
+                    value=value,
+                    accessor_address=pc,
+                    accessor_ghidra=accessor_ghidra,
+                    accessor_symbol=accessor_symbol,
+                )
+                self._watch_log.append(hit)
+                watch.hit_count += 1
+
+            except Exception as e:
+                logger.error(f"Watch #{watch_id} handler error: {e}")
+
+            return DbgEng.DEBUG_STATUS_GO_HANDLED
+
+        bp_id = self._engine.set_data_breakpoint(
+            runtime_addr, size, access_flags, handler=_on_watch_hit)
+        watch.bp_id = bp_id
+
+        with self._lock:
+            self._watches[watch_id] = watch
+
+        logger.info(
+            f"Watch #{watch_id} set at 0x{ghidra_address:08X} ({module}) "
+            f"[size={size}, access={access}]")
+        return watch_id
+
+    def stop_watch(self, watch_id: int) -> None:
+        """Stop a specific watchpoint."""
+        with self._lock:
+            watch = self._watches.get(watch_id)
+            if watch is None:
+                return
+            watch.active = False
+
+        try:
+            self._engine.remove_breakpoint(watch.bp_id)
+        except Exception as e:
+            logger.warning(f"Error removing watch BP: {e}")
+
+        logger.info(f"Watch #{watch_id} stopped ({watch.hit_count} hits)")
+
+    def stop_all_watches(self) -> int:
+        """Stop all watchpoints. Returns count stopped."""
+        count = 0
+        with self._lock:
+            watch_ids = list(self._watches.keys())
+        for wid in watch_ids:
+            self.stop_watch(wid)
+            count += 1
+        return count
+
+    def get_watch_log(self, watch_id: int = -1, last_n: int = 50) -> List[WatchHit]:
+        """Get watchpoint hit log."""
+        entries = list(self._watch_log)
+        if watch_id >= 0:
+            entries = [e for e in entries if e.watch_id == watch_id]
+        return entries[-last_n:]
+
+    def watch_count(self) -> int:
+        with self._lock:
+            return sum(1 for w in self._watches.values() if w.active)

--- a/ghidra-mcp-setup.ps1
+++ b/ghidra-mcp-setup.ps1
@@ -402,7 +402,10 @@ function Install-GhidraDependencies {
         @{ Artifact = "Emulation";        RelPath = "Ghidra\Framework\Emulation\lib\Emulation.jar" },
         @{ Artifact = "PDB";              RelPath = "Ghidra\Features\PDB\lib\PDB.jar" },
         @{ Artifact = "FunctionID";       RelPath = "Ghidra\Features\FunctionID\lib\FunctionID.jar" },
-        @{ Artifact = "Help";             RelPath = "Ghidra\Framework\Help\lib\Help.jar" }
+        @{ Artifact = "Help";             RelPath = "Ghidra\Framework\Help\lib\Help.jar" },
+        @{ Artifact = "Debugger-api";          RelPath = "Ghidra\Debug\Debugger-api\lib\Debugger-api.jar" },
+        @{ Artifact = "Framework-TraceModeling"; RelPath = "Ghidra\Debug\Framework-TraceModeling\lib\Framework-TraceModeling.jar" },
+        @{ Artifact = "Debugger-rmi-trace";    RelPath = "Ghidra\Debug\Debugger-rmi-trace\lib\Debugger-rmi-trace.jar" }
     )
 
     foreach ($dep in $deps) {

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,22 @@
             <artifactId>Emulation</artifactId>
             <version>${ghidra.version}</version>
         </dependency>
+        <!-- Ghidra Debug module dependencies (for DebuggerService) -->
+        <dependency>
+            <groupId>ghidra</groupId>
+            <artifactId>Debugger-api</artifactId>
+            <version>${ghidra.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ghidra</groupId>
+            <artifactId>Framework-TraceModeling</artifactId>
+            <version>${ghidra.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ghidra</groupId>
+            <artifactId>Debugger-rmi-trace</artifactId>
+            <version>${ghidra.version}</version>
+        </dependency>
         <!-- Gson (provided — bundled with Ghidra in Framework/Generic/lib/) -->
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -229,6 +229,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     private final com.xebyte.core.MalwareSecurityService malwareSecurityService;
     private final com.xebyte.core.ProgramScriptService programScriptService;
     private final com.xebyte.core.EmulationService emulationService;
+    private final com.xebyte.core.DebuggerService debuggerService;
 
     public GhidraMCPPlugin(PluginTool tool) {
         super(tool);
@@ -249,6 +250,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         this.malwareSecurityService = new com.xebyte.core.MalwareSecurityService(programProvider, threadingStrategy);
         this.programScriptService = new com.xebyte.core.ProgramScriptService(programProvider, threadingStrategy);
         this.emulationService = new com.xebyte.core.EmulationService(programProvider, threadingStrategy);
+        this.debuggerService = new com.xebyte.core.DebuggerService(programProvider, threadingStrategy, tool);
         Msg.info(this, "============================================");
         Msg.info(this, "GhidraMCP " + VersionInfo.getFullVersion());
         Msg.info(this, "Endpoints: " + VersionInfo.getEndpointCount());
@@ -472,7 +474,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
             listingService, functionService, commentService, symbolLabelService,
             xrefCallGraphService, dataTypeService, analysisService,
             documentationHashService, malwareSecurityService, programScriptService,
-            emulationService);
+            emulationService, debuggerService);
 
         for (EndpointDef ep : scanner.getEndpoints()) {
             server.createContext(ep.path(), safeHandler(exchange -> {

--- a/src/main/java/com/xebyte/core/DebuggerService.java
+++ b/src/main/java/com/xebyte/core/DebuggerService.java
@@ -1,0 +1,859 @@
+package com.xebyte.core;
+
+import ghidra.app.services.DebuggerLogicalBreakpointService;
+import ghidra.app.services.DebuggerStaticMappingService;
+import ghidra.app.services.DebuggerTargetService;
+import ghidra.app.services.DebuggerTraceManagerService;
+import ghidra.app.services.TraceRmiLauncherService;
+import ghidra.debug.api.target.ActionName;
+import ghidra.debug.api.target.Target;
+import ghidra.debug.api.tracemgr.DebuggerCoordinates;
+import ghidra.framework.model.Project;
+import ghidra.framework.model.ToolManager;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressFactory;
+import ghidra.program.model.address.AddressRange;
+import ghidra.program.model.address.AddressRangeImpl;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.lang.Language;
+import ghidra.program.model.lang.Register;
+import ghidra.program.model.lang.RegisterValue;
+import ghidra.trace.model.Trace;
+import ghidra.trace.model.TraceExecutionState;
+import ghidra.trace.model.breakpoint.TraceBreakpointKind;
+import ghidra.trace.model.guest.TracePlatform;
+import ghidra.trace.model.memory.TraceMemoryManager;
+import ghidra.trace.model.memory.TraceMemorySpace;
+import ghidra.trace.model.modules.TraceModule;
+import ghidra.trace.model.stack.TraceStack;
+import ghidra.trace.model.stack.TraceStackFrame;
+import ghidra.trace.model.thread.TraceThread;
+import ghidra.util.Msg;
+import ghidra.util.task.ConsoleTaskMonitor;
+import ghidra.util.task.TaskMonitor;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * MCP endpoints for driving Ghidra's built-in debugger.
+ *
+ * <p>The GhidraMCPPlugin runs in the FrontEnd tool, which does NOT have
+ * debugger services. This service finds a running CodeBrowser/Debugger tool
+ * via {@link ToolManager#getRunningTools()} — the same pattern used by
+ * {@link FrontEndProgramProvider} for ProgramManager access.</p>
+ *
+ * <p>The user must have a CodeBrowser open with the Debugger view active
+ * (Window → Debugger). The AI then uses these endpoints to control the
+ * debug session while the user sees everything in Ghidra's synchronized UI.</p>
+ */
+@McpToolGroup(value = "debugger",
+        description = "Live debugging: attach, breakpoints, step, registers, memory. " +
+                "Requires a CodeBrowser with Debugger view open.")
+public class DebuggerService {
+
+    private static final long ACTION_TIMEOUT_MS = 15_000;
+    private static final int MAX_MEMORY_READ = 4096;
+
+    private final ProgramProvider programProvider;
+    private final PluginTool frontEndTool;
+
+    /** Cached reference to the tool that has debugger services. */
+    private volatile PluginTool cachedDebuggerTool;
+
+    public DebuggerService(ProgramProvider programProvider,
+                           ThreadingStrategy threadingStrategy,
+                           PluginTool frontEndTool) {
+        this.programProvider = programProvider;
+        this.frontEndTool = frontEndTool;
+    }
+
+    // ========================================================================
+    // Tool discovery
+    // ========================================================================
+
+    /**
+     * Find a running tool that has DebuggerTraceManagerService loaded.
+     * Mirrors FrontEndProgramProvider's ToolManager pattern.
+     */
+    private PluginTool findDebuggerTool() {
+        Project project = frontEndTool.getProject();
+        if (project == null) return null;
+        ToolManager tm = project.getToolManager();
+        if (tm == null) return null;
+        try {
+            for (PluginTool tool : tm.getRunningTools()) {
+                if (tool.getService(DebuggerTraceManagerService.class) != null) {
+                    return tool;
+                }
+            }
+        } catch (Exception e) {
+            Msg.warn(this, "Error scanning for debugger tool: " + e.getMessage());
+        }
+        return null;
+    }
+
+    private PluginTool getDebuggerTool() {
+        PluginTool cached = cachedDebuggerTool;
+        if (cached != null) {
+            try {
+                if (cached.getService(DebuggerTraceManagerService.class) != null) {
+                    return cached;
+                }
+            } catch (Exception e) {
+                // Tool gone, re-scan
+            }
+            cachedDebuggerTool = null;
+        }
+        PluginTool found = findDebuggerTool();
+        cachedDebuggerTool = found;
+        return found;
+    }
+
+    private <T> T getService(Class<T> serviceClass) {
+        PluginTool tool = getDebuggerTool();
+        if (tool == null) return null;
+        return tool.getService(serviceClass);
+    }
+
+    private Response noDebugger() {
+        return Response.err("Debugger not active. Open a CodeBrowser and enable the Debugger " +
+                "(Window > Debugger), then attach to your target process.");
+    }
+
+    private Response noTrace() {
+        return Response.err("No active debug trace. Attach to a process first via the " +
+                "Debugger's connection panel or debugger_launch.");
+    }
+
+    private Response noTarget() {
+        return Response.err("No live target connection. The trace exists but the target " +
+                "is not connected. Re-attach to the process.");
+    }
+
+    // ========================================================================
+    // Helper: get current trace context
+    // ========================================================================
+
+    private record TraceContext(
+            PluginTool tool,
+            DebuggerTraceManagerService traceMgr,
+            Trace trace,
+            DebuggerCoordinates coords,
+            TracePlatform platform,
+            TraceThread thread,
+            long snap
+    ) {}
+
+    private TraceContext getContext() {
+        PluginTool tool = getDebuggerTool();
+        if (tool == null) return null;
+        DebuggerTraceManagerService traceMgr =
+                tool.getService(DebuggerTraceManagerService.class);
+        if (traceMgr == null) return null;
+        Trace trace = traceMgr.getCurrentTrace();
+        if (trace == null) return null;
+        DebuggerCoordinates coords = traceMgr.getCurrent();
+        TracePlatform platform = coords.getPlatform();
+        if (platform == null) {
+            platform = trace.getPlatformManager().getHostPlatform();
+        }
+        return new TraceContext(tool, traceMgr, trace, coords,
+                platform, coords.getThread(), coords.getSnap());
+    }
+
+    private Target getTarget(TraceContext ctx) {
+        DebuggerTargetService targetSvc =
+                ctx.tool.getService(DebuggerTargetService.class);
+        if (targetSvc == null) return null;
+        return targetSvc.getTarget(ctx.trace);
+    }
+
+    private Address parseAddress(Trace trace, String addrStr) {
+        if (addrStr == null || addrStr.isEmpty()) return null;
+        String normalized = addrStr.startsWith("0x")
+                ? addrStr.substring(2) : addrStr;
+        AddressFactory factory = trace.getBaseAddressFactory();
+        return factory.getAddress(normalized);
+    }
+
+    // ========================================================================
+    // Session management
+    // ========================================================================
+
+    @McpTool(path = "/debugger/status",
+            description = "Get debugger status: active trace, thread, execution state, module count")
+    public Response getStatus() {
+        PluginTool tool = getDebuggerTool();
+        if (tool == null) return noDebugger();
+
+        DebuggerTraceManagerService traceMgr =
+                tool.getService(DebuggerTraceManagerService.class);
+        if (traceMgr == null) return noDebugger();
+
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("debugger_active", true);
+
+        Trace trace = traceMgr.getCurrentTrace();
+        if (trace == null) {
+            status.put("trace_active", false);
+            status.put("open_traces", traceMgr.getOpenTraces().size());
+            return Response.ok(status);
+        }
+
+        status.put("trace_active", true);
+        status.put("trace_name", trace.getName());
+        status.put("open_traces", traceMgr.getOpenTraces().size());
+
+        DebuggerCoordinates coords = traceMgr.getCurrent();
+        status.put("snap", coords.getSnap());
+
+        TraceThread thread = coords.getThread();
+        if (thread != null) {
+            status.put("thread", thread.getName(coords.getSnap()));
+        }
+
+        // Check target/execution state
+        DebuggerTargetService targetSvc =
+                tool.getService(DebuggerTargetService.class);
+        if (targetSvc != null) {
+            Target target = targetSvc.getTarget(trace);
+            if (target != null && target.isValid()) {
+                status.put("target_connected", true);
+                status.put("target_description", target.describe());
+                if (thread != null) {
+                    TraceExecutionState execState =
+                            target.getThreadExecutionState(thread);
+                    status.put("execution_state",
+                            execState != null ? execState.name() : "UNKNOWN");
+                }
+            } else {
+                status.put("target_connected", false);
+            }
+        }
+
+        // Module count
+        try {
+            Collection<? extends TraceModule> modules =
+                    trace.getModuleManager().getAllModules();
+            status.put("module_count", modules.size());
+        } catch (Exception e) {
+            status.put("module_count", 0);
+        }
+
+        return Response.ok(status);
+    }
+
+    @McpTool(path = "/debugger/traces",
+            description = "List all open debug traces")
+    public Response listTraces() {
+        PluginTool tool = getDebuggerTool();
+        if (tool == null) return noDebugger();
+
+        DebuggerTraceManagerService traceMgr =
+                tool.getService(DebuggerTraceManagerService.class);
+        if (traceMgr == null) return noDebugger();
+
+        Trace current = traceMgr.getCurrentTrace();
+        List<Map<String, Object>> traces = new ArrayList<>();
+        for (Trace t : traceMgr.getOpenTraces()) {
+            Map<String, Object> info = new LinkedHashMap<>();
+            info.put("name", t.getName());
+            info.put("current", t == current);
+            try {
+                info.put("module_count",
+                        t.getModuleManager().getAllModules().size());
+                info.put("thread_count",
+                        t.getThreadManager().getAllThreads().size());
+            } catch (Exception e) {
+                // Non-critical
+            }
+            traces.add(info);
+        }
+        return Response.ok(traces);
+    }
+
+    // ========================================================================
+    // Execution control
+    // ========================================================================
+
+    @McpTool(path = "/debugger/resume", method = "POST",
+            description = "Resume execution of the debugged process")
+    public Response resume() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+        Target target = getTarget(ctx);
+        if (target == null) return noTarget();
+
+        try {
+            Map<String, Target.ActionEntry> actions =
+                    target.collectActions(ActionName.RESUME, null, null);
+            if (actions.isEmpty()) {
+                return Response.err("Resume action not available in current state");
+            }
+            // Execute the first available resume action
+            Target.ActionEntry action = actions.values().iterator().next();
+            action.run(true);
+            return Response.ok(Map.of("status", "resumed"));
+        } catch (Exception e) {
+            return Response.err("Resume failed: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/interrupt", method = "POST",
+            description = "Interrupt (break into) the running target")
+    public Response interrupt() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+        Target target = getTarget(ctx);
+        if (target == null) return noTarget();
+
+        try {
+            Map<String, Target.ActionEntry> actions =
+                    target.collectActions(ActionName.INTERRUPT, null, null);
+            if (actions.isEmpty()) {
+                return Response.err("Interrupt action not available in current state");
+            }
+            Target.ActionEntry action = actions.values().iterator().next();
+            action.run(true);
+            return Response.ok(Map.of("status", "interrupted"));
+        } catch (Exception e) {
+            return Response.err("Interrupt failed: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/step_into", method = "POST",
+            description = "Single-step into the next instruction (follows calls)")
+    public Response stepInto() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+        Target target = getTarget(ctx);
+        if (target == null) return noTarget();
+
+        try {
+            Map<String, Target.ActionEntry> actions =
+                    target.collectActions(ActionName.STEP_INTO, null, null);
+            if (actions.isEmpty()) {
+                return Response.err("Step into not available in current state");
+            }
+            Target.ActionEntry action = actions.values().iterator().next();
+            action.run(true);
+            return Response.ok(Map.of("status", "stepped"));
+        } catch (Exception e) {
+            return Response.err("Step into failed: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/step_over", method = "POST",
+            description = "Step over the next instruction (does not follow calls)")
+    public Response stepOver() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+        Target target = getTarget(ctx);
+        if (target == null) return noTarget();
+
+        try {
+            Map<String, Target.ActionEntry> actions =
+                    target.collectActions(ActionName.STEP_OVER, null, null);
+            if (actions.isEmpty()) {
+                return Response.err("Step over not available in current state");
+            }
+            Target.ActionEntry action = actions.values().iterator().next();
+            action.run(true);
+            return Response.ok(Map.of("status", "stepped"));
+        } catch (Exception e) {
+            return Response.err("Step over failed: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/step_out", method = "POST",
+            description = "Step out of the current function (run to return)")
+    public Response stepOut() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+        Target target = getTarget(ctx);
+        if (target == null) return noTarget();
+
+        try {
+            Map<String, Target.ActionEntry> actions =
+                    target.collectActions(ActionName.STEP_OUT, null, null);
+            if (actions.isEmpty()) {
+                return Response.err("Step out not available in current state");
+            }
+            Target.ActionEntry action = actions.values().iterator().next();
+            action.run(true);
+            return Response.ok(Map.of("status", "stepped_out"));
+        } catch (Exception e) {
+            return Response.err("Step out failed: " + e.getMessage());
+        }
+    }
+
+    // ========================================================================
+    // Breakpoints
+    // ========================================================================
+
+    @McpTool(path = "/debugger/set_breakpoint", method = "POST",
+            description = "Set a software execution breakpoint at an address in the trace")
+    public Response setBreakpoint(
+            @Param(value = "address", paramType = "address",
+                    description = "Address to break at (in trace address space)") String addressStr) {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+        Target target = getTarget(ctx);
+        if (target == null) return noTarget();
+
+        Address addr = parseAddress(ctx.trace, addressStr);
+        if (addr == null) {
+            return Response.err("Invalid address: " + addressStr);
+        }
+
+        try {
+            AddressRange range = new AddressRangeImpl(addr, 1);
+            target.placeBreakpoint(range,
+                    Set.of(TraceBreakpointKind.SW_EXECUTE),
+                    "MCP breakpoint", "");
+            return Response.ok(Map.of(
+                    "address", addr.toString(),
+                    "type", "SW_EXECUTE",
+                    "status", "set"));
+        } catch (Exception e) {
+            return Response.err("Failed to set breakpoint: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/remove_breakpoint", method = "POST",
+            description = "Remove a breakpoint at an address")
+    public Response removeBreakpoint(
+            @Param(value = "address", paramType = "address",
+                    description = "Address of breakpoint to remove") String addressStr) {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        DebuggerLogicalBreakpointService bpSvc =
+                ctx.tool.getService(DebuggerLogicalBreakpointService.class);
+        if (bpSvc == null) {
+            return Response.err("Breakpoint service not available");
+        }
+
+        Address addr = parseAddress(ctx.trace, addressStr);
+        if (addr == null) {
+            return Response.err("Invalid address: " + addressStr);
+        }
+
+        try {
+            NavigableMap<Address, Set<ghidra.debug.api.breakpoint.LogicalBreakpoint>> bpMap =
+                    bpSvc.getBreakpoints(ctx.trace);
+            Set<ghidra.debug.api.breakpoint.LogicalBreakpoint> atAddr =
+                    bpMap.getOrDefault(addr, Set.of());
+            if (atAddr.isEmpty()) {
+                return Response.err("No breakpoint at " + addr);
+            }
+            CompletableFuture<Void> future =
+                    bpSvc.deleteAll(atAddr, ctx.trace);
+            future.get(ACTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            return Response.ok(Map.of("address", addr.toString(), "status", "removed"));
+        } catch (Exception e) {
+            return Response.err("Failed to remove breakpoint: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/list_breakpoints",
+            description = "List all breakpoints in the current trace")
+    public Response listBreakpoints() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        DebuggerLogicalBreakpointService bpSvc =
+                ctx.tool.getService(DebuggerLogicalBreakpointService.class);
+        if (bpSvc == null) {
+            return Response.err("Breakpoint service not available");
+        }
+
+        try {
+            List<Map<String, Object>> result = new ArrayList<>();
+            NavigableMap<Address, Set<ghidra.debug.api.breakpoint.LogicalBreakpoint>> bpMap =
+                    bpSvc.getBreakpoints(ctx.trace);
+            for (Map.Entry<Address, Set<ghidra.debug.api.breakpoint.LogicalBreakpoint>> entry :
+                    bpMap.entrySet()) {
+                for (ghidra.debug.api.breakpoint.LogicalBreakpoint bp : entry.getValue()) {
+                    Map<String, Object> bpInfo = new LinkedHashMap<>();
+                    bpInfo.put("address", entry.getKey().toString());
+                    bpInfo.put("name", bp.getName());
+                    bpInfo.put("kinds", bp.getKinds().stream()
+                            .map(Enum::name).collect(Collectors.toList()));
+                    bpInfo.put("state", bp.computeState().name());
+                    result.add(bpInfo);
+                }
+            }
+            return Response.ok(result);
+        } catch (Exception e) {
+            return Response.err("Failed to list breakpoints: " + e.getMessage());
+        }
+    }
+
+    // ========================================================================
+    // State inspection
+    // ========================================================================
+
+    @McpTool(path = "/debugger/registers",
+            description = "Read CPU registers from the current debug trace snapshot. " +
+                    "Shows general-purpose registers (EAX-EDI, EIP, ESP, EFLAGS for x86)")
+    public Response getRegisters() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        if (ctx.thread == null) {
+            return Response.err("No active thread in trace");
+        }
+
+        try {
+            Language lang = ctx.platform.getLanguage();
+            TraceMemoryManager memMgr = ctx.trace.getMemoryManager();
+            TraceMemorySpace regSpace =
+                    memMgr.getMemoryRegisterSpace(ctx.thread, false);
+
+            if (regSpace == null) {
+                // Try to force a register read from target
+                Target target = getTarget(ctx);
+                if (target != null) {
+                    Set<Register> baseRegs = new LinkedHashSet<>();
+                    for (Register r : lang.getRegisters()) {
+                        if (r.isBaseRegister() && !r.isHidden()) {
+                            baseRegs.add(r);
+                        }
+                    }
+                    target.readRegisters(ctx.platform, ctx.thread,
+                            0, baseRegs);
+                    regSpace = memMgr.getMemoryRegisterSpace(ctx.thread, false);
+                }
+                if (regSpace == null) {
+                    return Response.err("Register space not available for current thread");
+                }
+            }
+
+            Map<String, String> regs = new LinkedHashMap<>();
+            for (Register reg : lang.getRegisters()) {
+                if (!reg.isBaseRegister() || reg.isHidden()) continue;
+                // Focus on useful registers, skip huge vector registers
+                if (reg.getBitLength() > 64) continue;
+                try {
+                    RegisterValue val = regSpace.getValue(ctx.snap, reg);
+                    if (val != null && val.hasValue()) {
+                        BigInteger v = val.getUnsignedValue();
+                        String hex = reg.getBitLength() <= 32
+                                ? String.format("0x%08X", v.longValue())
+                                : String.format("0x%016X", v.longValue());
+                        regs.put(reg.getName(), hex);
+                    }
+                } catch (Exception e) {
+                    // Skip unreadable registers
+                }
+            }
+            return Response.ok(regs);
+        } catch (Exception e) {
+            return Response.err("Failed to read registers: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/read_memory",
+            description = "Read memory from the debugged process. Returns hex dump and DWORD interpretation.")
+    public Response readMemory(
+            @Param(value = "address", paramType = "address",
+                    description = "Start address to read from") String addressStr,
+            @Param(value = "size", defaultValue = "64",
+                    description = "Number of bytes to read (max 4096)") int size) {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        Address addr = parseAddress(ctx.trace, addressStr);
+        if (addr == null) {
+            return Response.err("Invalid address: " + addressStr);
+        }
+
+        int readSize = Math.min(size, MAX_MEMORY_READ);
+
+        try {
+            // Try to read from the trace first (cached data)
+            TraceMemoryManager memMgr = ctx.trace.getMemoryManager();
+            ByteBuffer buf = ByteBuffer.allocate(readSize);
+            int bytesRead = memMgr.getBytes(ctx.snap, addr, buf);
+
+            if (bytesRead == 0) {
+                // Try forcing a read from the live target
+                Target target = getTarget(ctx);
+                if (target != null) {
+                    AddressSet addrSet = new AddressSet(addr, addr.add(readSize - 1));
+                    target.readMemory(addrSet, new ConsoleTaskMonitor());
+                    buf.clear();
+                    bytesRead = memMgr.getBytes(ctx.snap, addr, buf);
+                }
+            }
+
+            byte[] data = new byte[bytesRead];
+            buf.flip();
+            buf.get(data);
+
+            // Format as hex dump
+            StringBuilder hexStr = new StringBuilder();
+            for (byte b : data) hexStr.append(String.format("%02x", b & 0xFF));
+
+            // Format as DWORDs (little-endian)
+            List<String> dwords = new ArrayList<>();
+            for (int i = 0; i + 3 < data.length; i += 4) {
+                long val = (data[i] & 0xFFL) | ((data[i + 1] & 0xFFL) << 8)
+                        | ((data[i + 2] & 0xFFL) << 16) | ((data[i + 3] & 0xFFL) << 24);
+                dwords.add(String.format("0x%08X", val));
+            }
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("address", addr.toString());
+            result.put("size", bytesRead);
+            result.put("hex", hexStr.toString());
+            result.put("dwords", dwords);
+            return Response.ok(result);
+        } catch (Exception e) {
+            return Response.err("Failed to read memory: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/stack_trace",
+            description = "Get the call stack backtrace for the current thread")
+    public Response getStackTrace(
+            @Param(value = "depth", defaultValue = "20",
+                    description = "Maximum stack frames to return") int depth) {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        if (ctx.thread == null) {
+            return Response.err("No active thread");
+        }
+
+        try {
+            TraceStack stack = ctx.trace.getStackManager()
+                    .getLatestStack(ctx.thread, ctx.snap);
+
+            if (stack == null) {
+                return Response.err("No stack data available. The target may need to " +
+                        "be interrupted first.");
+            }
+
+            List<Map<String, Object>> frames = new ArrayList<>();
+            int frameCount = stack.getDepth(ctx.snap);
+            for (int i = 0; i < Math.min(frameCount, depth); i++) {
+                TraceStackFrame frame = stack.getFrame(ctx.snap, i, false);
+                if (frame == null) continue;
+
+                Map<String, Object> info = new LinkedHashMap<>();
+                info.put("level", i);
+                Address pc = frame.getProgramCounter(ctx.snap);
+                if (pc != null) {
+                    info.put("address", pc.toString());
+                    // Symbol resolution is best-effort via module+offset
+                    try {
+                        for (TraceModule mod : ctx.trace.getModuleManager().getAllModules()) {
+                            AddressRange modRange = mod.getRange(ctx.snap);
+                            if (modRange != null && modRange.contains(pc)) {
+                                long offset = pc.subtract(modRange.getMinAddress());
+                                info.put("symbol", mod.getName(ctx.snap)
+                                        + "+0x" + Long.toHexString(offset));
+                                break;
+                            }
+                        }
+                    } catch (Exception e) {
+                        // Skip
+                    }
+                }
+                frames.add(info);
+            }
+            return Response.ok(frames);
+        } catch (Exception e) {
+            return Response.err("Failed to get stack trace: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/modules",
+            description = "List modules (DLLs/EXEs) loaded in the debugged process")
+    public Response listModules() {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        try {
+            Collection<? extends TraceModule> modules =
+                    ctx.trace.getModuleManager().getAllModules();
+            long snap = ctx.snap;
+            List<Map<String, Object>> result = new ArrayList<>();
+            for (TraceModule mod : modules) {
+                Map<String, Object> info = new LinkedHashMap<>();
+                info.put("name", mod.getName(snap));
+                Address base = mod.getBase(snap);
+                if (base != null) {
+                    info.put("base", base.toString());
+                }
+                try {
+                    info.put("path", mod.getPath());
+                } catch (Exception e) {
+                    // Path may not be available
+                }
+                AddressRange range = mod.getRange(snap);
+                if (range != null) {
+                    info.put("size", String.format("0x%X", range.getLength()));
+                }
+                result.add(info);
+            }
+            return Response.ok(result);
+        } catch (Exception e) {
+            return Response.err("Failed to list modules: " + e.getMessage());
+        }
+    }
+
+    // ========================================================================
+    // Address translation
+    // ========================================================================
+
+    @McpTool(path = "/debugger/static_to_dynamic",
+            description = "Translate a static Ghidra program address to a runtime " +
+                    "dynamic address in the current trace")
+    public Response staticToDynamic(
+            @Param(value = "address", paramType = "address",
+                    description = "Static address from a Ghidra program") String addressStr,
+            @Param(value = "program", defaultValue = "",
+                    description = "Program name for context") String programName) {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        DebuggerStaticMappingService mappingSvc =
+                ctx.tool.getService(DebuggerStaticMappingService.class);
+        if (mappingSvc == null) {
+            return Response.err("Static mapping service not available");
+        }
+
+        try {
+            ghidra.program.model.listing.Program program =
+                    programProvider.resolveProgram(programName);
+            if (program == null) {
+                return Response.err("Program not found: " + programName);
+            }
+
+            Address staticAddr = program.getAddressFactory().getAddress(
+                    addressStr.startsWith("0x") ? addressStr.substring(2) : addressStr);
+            if (staticAddr == null) {
+                return Response.err("Invalid address: " + addressStr);
+            }
+
+            ghidra.program.util.ProgramLocation staticLoc =
+                    new ghidra.program.util.ProgramLocation(program, staticAddr);
+
+            ghidra.program.util.ProgramLocation dynLoc =
+                    mappingSvc.getDynamicLocationFromStatic(
+                            ctx.trace.getFixedProgramView(ctx.snap), staticLoc);
+
+            if (dynLoc == null) {
+                return Response.err("No mapping found for " + addressStr +
+                        ". Ensure modules are loaded and mapped in the debugger.");
+            }
+
+            return Response.ok(Map.of(
+                    "static_address", staticAddr.toString(),
+                    "dynamic_address", dynLoc.getAddress().toString(),
+                    "program", program.getName()));
+        } catch (Exception e) {
+            return Response.err("Address translation failed: " + e.getMessage());
+        }
+    }
+
+    @McpTool(path = "/debugger/dynamic_to_static",
+            description = "Translate a runtime dynamic address from the current trace " +
+                    "back to a static Ghidra program address")
+    public Response dynamicToStatic(
+            @Param(value = "address", paramType = "address",
+                    description = "Dynamic address from the trace") String addressStr) {
+        TraceContext ctx = getContext();
+        if (ctx == null) return noTrace();
+
+        DebuggerStaticMappingService mappingSvc =
+                ctx.tool.getService(DebuggerStaticMappingService.class);
+        if (mappingSvc == null) {
+            return Response.err("Static mapping service not available");
+        }
+
+        try {
+            Address dynAddr = parseAddress(ctx.trace, addressStr);
+            if (dynAddr == null) {
+                return Response.err("Invalid address: " + addressStr);
+            }
+
+            // Compute static address by finding the module and using its mapping.
+            // Walk loaded modules in the trace to find which contains this address,
+            // then look up the corresponding program's image base.
+            TraceModule containingMod = null;
+            for (TraceModule mod : ctx.trace.getModuleManager().getAllModules()) {
+                AddressRange range = mod.getRange(ctx.snap);
+                if (range != null && range.contains(dynAddr)) {
+                    containingMod = mod;
+                    break;
+                }
+            }
+
+            if (containingMod == null) {
+                return Response.err("Dynamic address " + addressStr
+                        + " not in any loaded module");
+            }
+
+            long offset = dynAddr.subtract(containingMod.getBase(ctx.snap));
+            return Response.ok(Map.of(
+                    "dynamic_address", dynAddr.toString(),
+                    "module", containingMod.getName(ctx.snap),
+                    "offset", String.format("0x%X", offset),
+                    "note", "Use the module name and offset to find the " +
+                            "corresponding address in the Ghidra program"));
+        } catch (Exception e) {
+            return Response.err("Address translation failed: " + e.getMessage());
+        }
+    }
+
+    // ========================================================================
+    // Launch / Attach (via Trace RMI launcher system)
+    // ========================================================================
+
+    @McpTool(path = "/debugger/launch_offers",
+            description = "List available debugger launch/attach options for the current program")
+    public Response listLaunchOffers(
+            @Param(value = "program", defaultValue = "",
+                    description = "Program to get offers for") String programName) {
+        PluginTool tool = getDebuggerTool();
+        if (tool == null) return noDebugger();
+
+        TraceRmiLauncherService launcherSvc =
+                tool.getService(TraceRmiLauncherService.class);
+        if (launcherSvc == null) {
+            return Response.err("Launcher service not available");
+        }
+
+        try {
+            ghidra.program.model.listing.Program program =
+                    programProvider.resolveProgram(programName);
+            if (program == null) {
+                return Response.err("No program available. Open a program first.");
+            }
+
+            var offers = launcherSvc.getOffers(program);
+            List<Map<String, Object>> result = new ArrayList<>();
+            for (var offer : offers) {
+                Map<String, Object> info = new LinkedHashMap<>();
+                info.put("title", offer.getTitle());
+                info.put("description", offer.getDescription());
+                info.put("icon", offer.getIcon() != null
+                        ? offer.getIcon().toString() : null);
+                result.add(info);
+            }
+            return Response.ok(result);
+        } catch (Exception e) {
+            return Response.err("Failed to list launch offers: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/xebyte/offline/ServiceFactory.java
+++ b/src/test/java/com/xebyte/offline/ServiceFactory.java
@@ -4,6 +4,7 @@ import com.xebyte.core.AnalysisService;
 import com.xebyte.core.BinaryComparisonService;
 import com.xebyte.core.CommentService;
 import com.xebyte.core.DataTypeService;
+import com.xebyte.core.DebuggerService;
 import com.xebyte.core.DocumentationHashService;
 import com.xebyte.core.FunctionService;
 import com.xebyte.core.ListingService;
@@ -53,6 +54,10 @@ public final class ServiceFactory {
         HeadlessManagementService headlessManagementService =
             new HeadlessManagementService(new HeadlessProgramProvider(), new GhidraServerManager());
 
+        // DebuggerService uses PluginTool only at runtime; scanner only reflects on
+        // method signatures, so a null tool is safe for offline scanning.
+        DebuggerService debuggerService = new DebuggerService(provider, ts, null);
+
         return new Object[] {
             listingService,
             functionService,
@@ -66,6 +71,7 @@ public final class ServiceFactory {
             programScriptService,
             emulationService,
             headlessManagementService,
+            debuggerService,
         };
     }
 

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.2.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 202,
+  "total_endpoints": 219,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -553,6 +553,141 @@
         "program"
       ],
       "description": "Create union"
+    },
+    {
+      "path": "/debugger/dynamic_to_static",
+      "method": "GET",
+      "category": "debugger",
+      "params": [
+        "address"
+      ],
+      "description": "Translate a runtime dynamic address from the current trace back to a static Ghidra program address"
+    },
+    {
+      "path": "/debugger/interrupt",
+      "method": "POST",
+      "category": "debugger",
+      "params": [],
+      "description": "Interrupt (break into) the running target"
+    },
+    {
+      "path": "/debugger/launch_offers",
+      "method": "GET",
+      "category": "debugger",
+      "params": [
+        "program"
+      ],
+      "description": "List available debugger launch/attach options for the current program"
+    },
+    {
+      "path": "/debugger/list_breakpoints",
+      "method": "GET",
+      "category": "debugger",
+      "params": [],
+      "description": "List all breakpoints in the current trace"
+    },
+    {
+      "path": "/debugger/modules",
+      "method": "GET",
+      "category": "debugger",
+      "params": [],
+      "description": "List modules (DLLs/EXEs) loaded in the debugged process"
+    },
+    {
+      "path": "/debugger/read_memory",
+      "method": "GET",
+      "category": "debugger",
+      "params": [
+        "address",
+        "size"
+      ],
+      "description": "Read memory from the debugged process. Returns hex dump and DWORD interpretation."
+    },
+    {
+      "path": "/debugger/registers",
+      "method": "GET",
+      "category": "debugger",
+      "params": [],
+      "description": "Read CPU registers from the current debug trace snapshot. Shows general-purpose registers (EAX-EDI, EIP, ESP, EFLAGS for x86)"
+    },
+    {
+      "path": "/debugger/remove_breakpoint",
+      "method": "POST",
+      "category": "debugger",
+      "params": [
+        "address"
+      ],
+      "description": "Remove a breakpoint at an address"
+    },
+    {
+      "path": "/debugger/resume",
+      "method": "POST",
+      "category": "debugger",
+      "params": [],
+      "description": "Resume execution of the debugged process"
+    },
+    {
+      "path": "/debugger/set_breakpoint",
+      "method": "POST",
+      "category": "debugger",
+      "params": [
+        "address"
+      ],
+      "description": "Set a software execution breakpoint at an address in the trace"
+    },
+    {
+      "path": "/debugger/stack_trace",
+      "method": "GET",
+      "category": "debugger",
+      "params": [
+        "depth"
+      ],
+      "description": "Get the call stack backtrace for the current thread"
+    },
+    {
+      "path": "/debugger/static_to_dynamic",
+      "method": "GET",
+      "category": "debugger",
+      "params": [
+        "address",
+        "program"
+      ],
+      "description": "Translate a static Ghidra program address to a runtime dynamic address in the current trace"
+    },
+    {
+      "path": "/debugger/status",
+      "method": "GET",
+      "category": "debugger",
+      "params": [],
+      "description": "Get debugger status: active trace, thread, execution state, module count"
+    },
+    {
+      "path": "/debugger/step_into",
+      "method": "POST",
+      "category": "debugger",
+      "params": [],
+      "description": "Single-step into the next instruction (follows calls)"
+    },
+    {
+      "path": "/debugger/step_out",
+      "method": "POST",
+      "category": "debugger",
+      "params": [],
+      "description": "Step out of the current function (run to return)"
+    },
+    {
+      "path": "/debugger/step_over",
+      "method": "POST",
+      "category": "debugger",
+      "params": [],
+      "description": "Step over the next instruction (does not follow calls)"
+    },
+    {
+      "path": "/debugger/traces",
+      "method": "GET",
+      "category": "debugger",
+      "params": [],
+      "description": "List all open debug traces"
     },
     {
       "path": "/decompile_function",

--- a/tests/unit/test_address_map.py
+++ b/tests/unit/test_address_map.py
@@ -1,0 +1,190 @@
+"""Unit tests for debugger/address_map.py — address translation and ordinal parsing."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Allow running from project root
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from debugger.address_map import AddressMapper, ModuleMapping
+from debugger.protocol import ModuleInfo
+
+
+class TestModuleMapping:
+    def test_offset_positive(self):
+        m = ModuleMapping("D2Common.dll", ghidra_base=0x6FD60000,
+                          runtime_base=0x74A60000, size=0x100000)
+        assert m.offset == 0x74A60000 - 0x6FD60000
+
+    def test_offset_negative(self):
+        m = ModuleMapping("D2Common.dll", ghidra_base=0x74A60000,
+                          runtime_base=0x6FD60000, size=0x100000)
+        assert m.offset < 0
+
+    def test_contains_ghidra(self):
+        m = ModuleMapping("test.dll", 0x10000, 0x20000, 0x5000)
+        assert m.contains_ghidra(0x10000)
+        assert m.contains_ghidra(0x14FFF)
+        assert not m.contains_ghidra(0x15000)
+        assert not m.contains_ghidra(0x0FFFF)
+
+    def test_contains_runtime(self):
+        m = ModuleMapping("test.dll", 0x10000, 0x20000, 0x5000)
+        assert m.contains_runtime(0x20000)
+        assert m.contains_runtime(0x24FFF)
+        assert not m.contains_runtime(0x25000)
+
+    def test_to_runtime(self):
+        m = ModuleMapping("test.dll", 0x10000, 0x20000, 0x5000)
+        assert m.to_runtime(0x10000) == 0x20000
+        assert m.to_runtime(0x12345) == 0x22345
+
+    def test_to_ghidra(self):
+        m = ModuleMapping("test.dll", 0x10000, 0x20000, 0x5000)
+        assert m.to_ghidra(0x20000) == 0x10000
+        assert m.to_ghidra(0x22345) == 0x12345
+
+
+class TestAddressMapper:
+    def setup_method(self):
+        self.mapper = AddressMapper()
+        runtime_modules = [
+            ModuleInfo("D2Common.dll", runtime_base=0x74A60000, size=0x100000),
+            ModuleInfo("D2Client.dll", runtime_base=0x73B00000, size=0x200000),
+            ModuleInfo("Fog.dll", runtime_base=0x75000000, size=0x50000),
+        ]
+        ghidra_bases = {
+            "D2Common.dll": 0x6FD60000,
+            "D2Client.dll": 0x6FAB0000,
+            "Fog.dll": 0x6FF50000,
+        }
+        self.mapper.update_from_modules(runtime_modules, ghidra_bases)
+
+    def test_to_runtime_with_module(self):
+        result = self.mapper.to_runtime(0x6FD60000, "D2Common.dll")
+        assert result == 0x74A60000
+
+    def test_to_runtime_auto_detect(self):
+        # Address in D2Common range
+        result = self.mapper.to_runtime(0x6FD70000)
+        expected = 0x6FD70000 + (0x74A60000 - 0x6FD60000)
+        assert result == expected
+
+    def test_to_runtime_unknown_raises(self):
+        with pytest.raises(ValueError, match="not in any mapped module"):
+            self.mapper.to_runtime(0x00400000)  # Not in any module
+
+    def test_to_runtime_unknown_module_raises(self):
+        with pytest.raises(ValueError, match="not in address map"):
+            self.mapper.to_runtime(0x10000, "Unknown.dll")
+
+    def test_to_ghidra(self):
+        module, addr = self.mapper.to_ghidra(0x74A60000)
+        assert module == "D2Common.dll"
+        assert addr == 0x6FD60000
+
+    def test_to_ghidra_unknown_raises(self):
+        with pytest.raises(ValueError):
+            self.mapper.to_ghidra(0x00400000)
+
+    def test_try_to_ghidra_returns_none(self):
+        assert self.mapper.try_to_ghidra(0x00400000) is None
+
+    def test_try_to_ghidra_returns_tuple(self):
+        result = self.mapper.try_to_ghidra(0x74A60000)
+        assert result == ("D2Common.dll", 0x6FD60000)
+
+    def test_roundtrip(self):
+        original = 0x6FD9F450
+        runtime = self.mapper.to_runtime(original, "D2Common.dll")
+        module, back = self.mapper.to_ghidra(runtime)
+        assert module == "D2Common.dll"
+        assert back == original
+
+    def test_normalize_name(self):
+        assert AddressMapper._normalize_name("D2COMMON.DLL") == "d2common"
+        assert AddressMapper._normalize_name("D2Common.dll") == "d2common"
+        assert AddressMapper._normalize_name("/Vanilla/1.00/D2Common.dll") == "d2common"
+        assert AddressMapper._normalize_name("Fog.dll") == "fog"
+
+    def test_update_summary(self):
+        mapper = AddressMapper()
+        runtime = [ModuleInfo("A.dll", 0x10000, 0x1000),
+                   ModuleInfo("B.dll", 0x20000, 0x1000)]
+        ghidra = {"A.dll": 0x50000}
+        result = mapper.update_from_modules(runtime, ghidra)
+        assert result["mapped"] == 1
+        assert result["unmapped"] == 1
+        assert "A.dll" in result["mapped_modules"]
+        assert "B.dll" in result["unmapped_modules"]
+
+
+class TestOrdinalParsing:
+    def setup_method(self):
+        self.mapper = AddressMapper()
+        self.tmpdir = tempfile.mkdtemp()
+
+        # Write a test export file
+        content = (
+            "D2COMMON.DLL::Ordinal_10000@6fd9f450->Ordinal_10000\n"
+            "D2COMMON.DLL::Ordinal_10624@6fda1234->CalcMissileVelocityParam\n"
+            "D2COMMON.DLL::Ordinal_10864@6fdb5678->GetMaxGoldBank\n"
+        )
+        with open(os.path.join(self.tmpdir, "D2Common.txt"), "w") as f:
+            f.write(content)
+
+    def test_load_ordinals(self):
+        summary = self.mapper.load_ordinal_exports(self.tmpdir)
+        assert "D2Common" in summary
+        assert summary["D2Common"] == 3
+
+    def test_resolve_ordinal_no_mapping(self):
+        self.mapper.load_ordinal_exports(self.tmpdir)
+        result = self.mapper.resolve_ordinal("D2Common.dll", 10624)
+        assert result is not None
+        assert result["ordinal"] == 10624
+        assert result["label"] == "CalcMissileVelocityParam"
+        assert result["ghidra_address"] == "0x6FDA1234"
+        assert result["runtime_address"] is None  # No module mapping yet
+
+    def test_resolve_ordinal_with_mapping(self):
+        self.mapper.load_ordinal_exports(self.tmpdir)
+        # Add module mapping
+        runtime_modules = [
+            ModuleInfo("D2Common.dll", runtime_base=0x74A60000, size=0x200000),
+        ]
+        self.mapper.update_from_modules(runtime_modules, {"D2Common.dll": 0x6FD60000})
+
+        result = self.mapper.resolve_ordinal("D2Common.dll", 10624)
+        assert result is not None
+        assert result["runtime_address"] is not None
+
+    def test_resolve_ordinal_not_found(self):
+        self.mapper.load_ordinal_exports(self.tmpdir)
+        result = self.mapper.resolve_ordinal("D2Common.dll", 99999)
+        assert result is None
+
+    def test_resolve_ordinal_wrong_dll(self):
+        self.mapper.load_ordinal_exports(self.tmpdir)
+        result = self.mapper.resolve_ordinal("NotADll.dll", 10000)
+        assert result is None
+
+    def test_ordinal_count(self):
+        self.mapper.load_ordinal_exports(self.tmpdir)
+        assert self.mapper.get_ordinal_count("D2Common.dll") == 3
+        assert self.mapper.get_ordinal_count("NotADll.dll") == 0
+
+    def test_load_real_exports(self):
+        """Test loading actual dll_exports/ if available."""
+        real_dir = Path(__file__).parent.parent.parent / "dll_exports"
+        if not real_dir.is_dir():
+            pytest.skip("dll_exports/ not found")
+        mapper = AddressMapper()
+        summary = mapper.load_ordinal_exports(real_dir)
+        assert len(summary) > 0
+        # D2Common should have ordinals
+        assert mapper.get_ordinal_count("D2Common.dll") > 100

--- a/tests/unit/test_d2_conventions.py
+++ b/tests/unit/test_d2_conventions.py
@@ -1,0 +1,172 @@
+"""Unit tests for debugger/d2/conventions.py — calling conventions and value analysis."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from debugger.d2.conventions import (
+    read_args,
+    read_return_address,
+    classify_value,
+    analyze_arg_observations,
+    parse_convention_from_prototype,
+)
+
+
+def _make_memory(mapping: dict):
+    """Create a read_dword function from a {address: value} dict."""
+    def read_dword(addr):
+        if addr in mapping:
+            return mapping[addr]
+        raise RuntimeError(f"Unmapped address: 0x{addr:08X}")
+    return read_dword
+
+
+class TestReadArgs:
+    def test_stdcall_4_args(self):
+        regs = {"ESP": 0x1000, "ECX": 0xAAAA, "EDX": 0xBBBB}
+        mem = _make_memory({
+            0x1004: 0x11111111,
+            0x1008: 0x22222222,
+            0x100C: 0x33333333,
+            0x1010: 0x44444444,
+        })
+        args = read_args(regs, mem, "__stdcall", 4)
+        assert args == [0x11111111, 0x22222222, 0x33333333, 0x44444444]
+
+    def test_stdcall_0_args(self):
+        regs = {"ESP": 0x1000}
+        args = read_args(regs, lambda a: 0, "__stdcall", 0)
+        assert args == []
+
+    def test_fastcall_4_args(self):
+        regs = {"ESP": 0x1000, "ECX": 0xAAAA, "EDX": 0xBBBB}
+        mem = _make_memory({
+            0x1004: 0x33333333,
+            0x1008: 0x44444444,
+        })
+        args = read_args(regs, mem, "__fastcall", 4)
+        assert args == [0xAAAA, 0xBBBB, 0x33333333, 0x44444444]
+
+    def test_fastcall_1_arg(self):
+        regs = {"ESP": 0x1000, "ECX": 0xAAAA, "EDX": 0xBBBB}
+        args = read_args(regs, lambda a: 0, "__fastcall", 1)
+        assert args == [0xAAAA]
+
+    def test_fastcall_2_args(self):
+        regs = {"ESP": 0x1000, "ECX": 0xAAAA, "EDX": 0xBBBB}
+        args = read_args(regs, lambda a: 0, "__fastcall", 2)
+        assert args == [0xAAAA, 0xBBBB]
+
+    def test_thiscall_3_args(self):
+        regs = {"ESP": 0x1000, "ECX": 0x1A3B5C00, "EDX": 0x0}
+        mem = _make_memory({
+            0x1004: 0x00000024,
+            0x1008: 0x00000003,
+        })
+        args = read_args(regs, mem, "__thiscall", 3)
+        assert args == [0x1A3B5C00, 0x00000024, 0x00000003]
+
+    def test_cdecl_same_as_stdcall(self):
+        regs = {"ESP": 0x1000, "ECX": 0, "EDX": 0}
+        mem = _make_memory({0x1004: 42, 0x1008: 99})
+        args_stdcall = read_args(regs, mem, "__stdcall", 2)
+        args_cdecl = read_args(regs, mem, "__cdecl", 2)
+        assert args_stdcall == args_cdecl
+
+
+class TestReturnAddress:
+    def test_reads_from_esp(self):
+        regs = {"ESP": 0x1000}
+        mem = _make_memory({0x1000: 0xDEADBEEF})
+        ret = read_return_address(regs, mem)
+        assert ret == 0xDEADBEEF
+
+
+class TestClassifyValue:
+    def test_zero(self):
+        assert classify_value(0) in ("zero", "boolean")
+
+    def test_boolean(self):
+        assert classify_value(1) == "boolean"
+
+    def test_pointer_range(self):
+        assert classify_value(0x1A3B5C00) == "pointer"
+        assert classify_value(0x6FD60000) == "pointer"
+        assert classify_value(0x10000) == "pointer"
+
+    def test_small_enum(self):
+        assert classify_value(0x24) == "enum_candidate"
+        assert classify_value(0xFF) == "enum_candidate"
+
+    def test_small_int(self):
+        assert classify_value(0x100) == "small_int"
+        assert classify_value(0xFFFF) == "small_int"
+
+    def test_negative(self):
+        # -1 as unsigned 32-bit
+        assert classify_value(0xFFFFFFFF) == "negative"
+        # -10
+        assert classify_value(0xFFFFFFF6) == "negative"
+
+    def test_large_int(self):
+        # Value outside standard ranges
+        assert classify_value(0x80010000) in ("large_int", "negative")
+
+
+class TestAnalyzeObservations:
+    def test_pointer_values(self):
+        values = [0x1A3B5C00, 0x1C004200, 0x1A3B5C00, 0x1D000000]
+        result = analyze_arg_observations(values)
+        assert result["classification"] == "pointer"
+        assert result["suggested_type"] == "void *"
+
+    def test_enum_values(self):
+        values = [6, 36, 54, 71, 36, 6, 54]
+        result = analyze_arg_observations(values)
+        assert result["classification"] == "enum_candidate"
+        assert result.get("likely_enum") is True
+
+    def test_boolean_values(self):
+        values = [0, 1, 0, 0, 1, 1]
+        result = analyze_arg_observations(values)
+        assert result["suggested_type"] == "BOOL"
+
+    def test_empty_values(self):
+        result = analyze_arg_observations([])
+        assert result["classification"] == "unknown"
+
+    def test_sample_capped(self):
+        values = list(range(100))
+        result = analyze_arg_observations(values)
+        assert len(result["sample"]) <= 10
+
+
+class TestParseConvention:
+    def test_stdcall(self):
+        assert parse_convention_from_prototype(
+            "int __stdcall CalcMissileVelocityParam(int a, int b)"
+        ) == "__stdcall"
+
+    def test_fastcall(self):
+        assert parse_convention_from_prototype(
+            "void __fastcall ProcessInput(int a)"
+        ) == "__fastcall"
+
+    def test_thiscall(self):
+        assert parse_convention_from_prototype(
+            "int __thiscall MyClass::Method(void)"
+        ) == "__thiscall"
+
+    def test_no_convention_defaults_cdecl(self):
+        assert parse_convention_from_prototype(
+            "undefined4 FUN_6fd50a30(void)"
+        ) == "__cdecl"
+
+    def test_case_insensitive(self):
+        assert parse_convention_from_prototype(
+            "int __STDCALL Func(void)"
+        ) == "__stdcall"


### PR DESCRIPTION
## Summary

Adds a debugger integration in two layers, rebased onto main:

**Java side — `DebuggerService` (17 `@McpTool` endpoints)**
`/debugger/status`, `/debugger/traces`, `/debugger/resume`, `/debugger/interrupt`, `/debugger/step_{into,over,out}`, `/debugger/{set,remove,list}_breakpoint`, `/debugger/registers`, `/debugger/read_memory`, `/debugger/stack_trace`, `/debugger/modules`, `/debugger/{static_to_dynamic,dynamic_to_static}`, `/debugger/launch_offers`.

Uses Ghidra's Debugger API (`DebuggerTraceManagerService`, `DebuggerLogicalBreakpointService`, `TraceRmiLauncherService`). Tool discovery mirrors `FrontEndProgramProvider`'s `ToolManager` pattern.

**GUI-only — NOT wired into the headless server**, because `DebuggerService` requires a `PluginTool` and headless has none. The offline `ServiceFactory` passes `null` for the `PluginTool` parameter since the annotation scanner only reflects on method signatures.

**Python side — `debugger/` package + bridge proxy tools**
Standalone debugger server on port 8099 (configurable via `GHIDRA_DEBUGGER_URL`) with engine / protocol / tracing / address_map / D2-specific convention modules. `bridge_mcp_ghidra.py` adds 22 static MCP tools (`debugger_attach`, `debugger_continue`, `debugger_step_*`, `debugger_registers`, `debugger_read_memory`, `debugger_stack_trace`, `debugger_trace_*`, `debugger_watch_*`) that proxy via the `GHIDRA_DEBUGGER_URL` env var.

**Build**
- `pom.xml`: adds `Debugger-api`, `Framework-TraceModeling`, `Debugger-rmi-trace` deps
- `ghidra-mcp-setup.ps1`: installs Debugger JARs to the local Maven repo

**Tests**
- `tests/unit/test_address_map.py` (address translation between static/dynamic)
- `tests/unit/test_d2_conventions.py` (D2-specific function-call parsing)
- Offline parity tests: 11/11 pass after rebase + catalog regeneration

## ⚠️ Live-testing blocked on debug session

All code paths compile and pass offline tests, but **none of the 17 Java endpoints or 22 bridge tools has been exercised against a live debugging target**. Live verification requires:

- Ghidra running with Debugger plugin loaded
- A `Target` attached (attach-to-process or launch-via-TraceRmi)
- `debugger/server.py` running on port 8099 for the bridge proxy tools
- A target binary, ideally `D2.exe` so we can use known addresses and convention data

### Test plan (unchecked — needs live session)

**Java endpoints — state queries (no side effects, safest first)**
- [ ] `/debugger/status` — returns attached-target state when a Target is running
- [ ] `/debugger/traces` — lists active traces
- [ ] `/debugger/modules` — lists loaded modules with their dynamic base addresses
- [ ] `/debugger/launch_offers` — lists available TraceRmi launchers
- [ ] `/debugger/registers` — returns all general-purpose register values
- [ ] `/debugger/read_memory` — reads N bytes from a target address
- [ ] `/debugger/stack_trace` — returns frame list
- [ ] `/debugger/list_breakpoints` — returns empty list with no BPs set
- [ ] `/debugger/static_to_dynamic` / `/debugger/dynamic_to_static` — round-trip a known static address through the mapping service

**Java endpoints — stateful operations**
- [ ] `/debugger/set_breakpoint` + `/debugger/list_breakpoints` — the breakpoint appears after setting
- [ ] `/debugger/remove_breakpoint` — the breakpoint disappears
- [ ] `/debugger/step_into` / `/debugger/step_over` / `/debugger/step_out` — each advances PC by one instruction / call-skip / frame-exit
- [ ] `/debugger/resume` — Target state transitions to RUNNING
- [ ] `/debugger/interrupt` — Target state transitions back to STOPPED

**Python bridge tools**
- [ ] `debugger/server.py` launches on port 8099, responds to `/status`
- [ ] `debugger_attach` connects to the local server
- [ ] `debugger_registers`, `debugger_read_memory`, `debugger_stack_trace` return structured data
- [ ] `debugger_trace_function` records entries for the target function
- [ ] `debugger_watch_memory` / `debugger_watch_stop` start and stop memory watches

**Convention tests**
- [ ] `test_address_map.py` runs clean under `pytest tests/unit/`
- [ ] `test_d2_conventions.py` runs clean under `pytest tests/unit/`

## Known gaps (follow-ups)

- No headless support (PluginTool dependency). Either port to headless with a shim, or explicitly document as GUI-only in the service header and skip silently in the headless scanner.
- The 22 bridge proxy tools are NOT included in `tests/endpoints.json` because that catalog tracks HTTP endpoints only, not bridge-static tools — the existing pattern for Python-side `@mcp.tool()` entries. Worth noting in the PR description; no action required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
