### PR TITLE
chore: gitignore .playwright-mcp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -584,3 +584,6 @@ fun-doc/state.json.corrupt-*
 fun-doc/logs/
 fun-doc/priority_queue.json
 fun-doc/debug/
+
+# Playwright MCP scratch directory (snapshots, screenshots, console logs)
+.playwright-mcp/


### PR DESCRIPTION
## Summary

Adds `.playwright-mcp/` to `.gitignore`. The Playwright MCP server writes per-session snapshots, screenshots, and console logs to this directory under the project root. These are scratch artifacts — not something we want tracked.

Motivated by: during the Playwright-driven smoke test for PR #126, the directory appeared in `git status` after each `browser_snapshot` / `browser_take_screenshot` call, causing noise on unrelated branches.

## Test plan
- [x] Directory is intentionally the Playwright MCP default output path (`.playwright-mcp/page-*.yml`, `page-*.png`, `console-*.log`)
- [x] Nothing in that directory is source-of-truth or worth tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
