### PR TITLE
fix(ci): install Ghidra Debugger JARs in all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
         Framework/DB/lib/DB.jar
         Framework/Emulation/lib/Emulation.jar
         Framework/Help/lib/Help.jar
+        Debug/Debugger-api/lib/Debugger-api.jar
+        Debug/Framework-TraceModeling/lib/Framework-TraceModeling.jar
+        Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace.jar
 
     steps:
     - uses: actions/checkout@v4
@@ -70,6 +73,14 @@ jobs:
             -DgroupId=ghidra -DartifactId=Emulation -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
         mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Help/lib/Help.jar" \
             -DgroupId=ghidra -DartifactId=Help -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+
+        # Install Debugger JARs (for DebuggerService, v5.4.0+)
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Debug/Debugger-api/lib/Debugger-api.jar" \
+            -DgroupId=ghidra -DartifactId=Debugger-api -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Debug/Framework-TraceModeling/lib/Framework-TraceModeling.jar" \
+            -DgroupId=ghidra -DartifactId=Framework-TraceModeling -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace.jar" \
+            -DgroupId=ghidra -DartifactId=Debugger-rmi-trace -Dversion=${{ env.GHIDRA_VERSION }} -Dpackaging=jar
 
         # Install Feature JARs
         mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/Base/lib/Base.jar" \

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -70,6 +70,11 @@ jobs:
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Framework/Emulation/lib/Emulation.jar"       -DgroupId=ghidra -DartifactId=Emulation          -Dversion=${GV} -Dpackaging=jar
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Framework/Help/lib/Help.jar"                 -DgroupId=ghidra -DartifactId=Help               -Dversion=${GV} -Dpackaging=jar
 
+        # Debugger JARs (for DebuggerService, v5.4.0+)
+        mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Debug/Debugger-api/lib/Debugger-api.jar"                     -DgroupId=ghidra -DartifactId=Debugger-api              -Dversion=${GV} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Debug/Framework-TraceModeling/lib/Framework-TraceModeling.jar" -DgroupId=ghidra -DartifactId=Framework-TraceModeling -Dversion=${GV} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace.jar"         -DgroupId=ghidra -DartifactId=Debugger-rmi-trace        -Dversion=${GV} -Dpackaging=jar
+
         # Feature JARs
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Features/Base/lib/Base.jar"                  -DgroupId=ghidra -DartifactId=Base               -Dversion=${GV} -Dpackaging=jar
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Features/Decompiler/lib/Decompiler.jar"      -DgroupId=ghidra -DartifactId=Decompiler         -Dversion=${GV} -Dpackaging=jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,10 @@ jobs:
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Features/PDB/lib/PDB.jar"                    -DgroupId=ghidra -DartifactId=PDB               -Dversion=${GV} -Dpackaging=jar
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Features/FunctionID/lib/FunctionID.jar"      -DgroupId=ghidra -DartifactId=FunctionID       -Dversion=${GV} -Dpackaging=jar
         mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Framework/Help/lib/Help.jar"              -DgroupId=ghidra -DartifactId=Help             -Dversion=${GV} -Dpackaging=jar
-        echo "✅ Installed 15 Ghidra JARs to Maven local repository"
+        mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Debug/Debugger-api/lib/Debugger-api.jar"                     -DgroupId=ghidra -DartifactId=Debugger-api              -Dversion=${GV} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Debug/Framework-TraceModeling/lib/Framework-TraceModeling.jar" -DgroupId=ghidra -DartifactId=Framework-TraceModeling -Dversion=${GV} -Dpackaging=jar
+        mvn -q install:install-file -Dfile="${GHIDRA_DIR}/Ghidra/Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace.jar"         -DgroupId=ghidra -DartifactId=Debugger-rmi-trace        -Dversion=${GV} -Dpackaging=jar
+        echo "✅ Installed 18 Ghidra JARs to Maven local repository"
 
     - name: Build with Maven
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,14 @@ jobs:
         mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Framework/Help/lib/Help.jar" \
             -DgroupId=ghidra -DartifactId=Help -Dversion=$GHIDRA_VERSION -Dpackaging=jar
 
+        # Install Debugger JARs (for DebuggerService, v5.4.0+)
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Debug/Debugger-api/lib/Debugger-api.jar" \
+            -DgroupId=ghidra -DartifactId=Debugger-api -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Debug/Framework-TraceModeling/lib/Framework-TraceModeling.jar" \
+            -DgroupId=ghidra -DartifactId=Framework-TraceModeling -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+        mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Debug/Debugger-rmi-trace/lib/Debugger-rmi-trace.jar" \
+            -DgroupId=ghidra -DartifactId=Debugger-rmi-trace -Dversion=$GHIDRA_VERSION -Dpackaging=jar
+
         # Install Feature JARs
         mvn -q install:install-file -Dfile="$GHIDRA_DIR/Ghidra/Features/Base/lib/Base.jar" \
             -DgroupId=ghidra -DartifactId=Base -Dversion=$GHIDRA_VERSION -Dpackaging=jar


### PR DESCRIPTION
## Summary

Every CI run on `main` since the v5.4.0 debugger merge (#128) has been **failing** because the three Ghidra Debugger JARs aren't installed into Maven's local repo by the workflows. The build aborts at:

```
Could not find artifact ghidra:Debugger-api:jar:12.0.3 in ...
```

This PR adds `install:install-file` blocks for `Debugger-api`, `Framework-TraceModeling`, and `Debugger-rmi-trace` to all four workflows.

## Impact

- **Unblocks CI on main** — every post-#128 commit currently red
- **Unblocks `release.yml`** — v5.4.0 release page is empty because the release job never reached the upload step
- No source or dependency changes; only CI plumbing

## Files changed

- `.github/workflows/build.yml` — adds to 7z extraction list + install blocks
- `.github/workflows/tests.yml` — install blocks only (uses full unzip)
- `.github/workflows/release.yml` — install blocks, bumps log message "15 → 18 JARs"
- `.github/workflows/pre-release.yml` — install blocks

## Test plan
- [x] All four install paths match the real layout on a Ghidra 12.0.3 install (`ghidra-mcp-setup.ps1` uses the same paths successfully)
- [x] pom.xml already references these three artifacts (`groupId=ghidra`, `version=${ghidra.version}`)
- [ ] CI green on this PR (next push will exercise `build.yml` + `tests.yml`)
- [ ] `release.yml` re-run against tag `v5.4.0` uploads artifacts to the release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
