### PR TITLE
chore: suppress deprecated-API warning + bump requests floor (CVE-2024-35195)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@
 mcp>=1.5.0,<2.0.0
 
 # HTTP client library
-requests>=2.28.0,<3.0.0
+# 2.32.0 is the floor for CVE-2024-35195 (certificate verification bypass).
+requests>=2.32.0,<3.0.0
 
 # URL parsing utilities (included in stdlib but explicit for clarity)
 # urllib.parse - included in Python standard library

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -826,7 +826,13 @@ public class HeadlessEndpointHandler {
 
     /**
      * Set multiple comments in a single batch operation.
+     *
+     * Suppresses the deprecated-API warning for Ghidra 12's Listing.setComment(Address, int, String)
+     * and CodeUnit.PLATE_COMMENT / PRE_COMMENT / EOL_COMMENT int constants. The replacement
+     * ghidra.program.model.listing.CommentType enum API will be adopted when this handler is
+     * refactored to delegate to CommentService (the GUI-side path already uses the enum).
      */
+    @SuppressWarnings("deprecation")
     public String batchSetComments(String functionAddress, String decompilerCommentsJson,
                                    String disassemblyCommentsJson, String plateComment, String programName) {
         Program program = getProgram(programName);


### PR DESCRIPTION
## Summary

Two small hygiene fixes identified in the v5.4.0 production-readiness audit:

### 1. Suppress the Ghidra 12 deprecated-API warning in `HeadlessEndpointHandler.batchSetComments`

Every clean build emits:
```
[WARNING] Some input files use or override a deprecated API.
[WARNING] Recompile with -Xlint:deprecation for details.
```

Source: `HeadlessEndpointHandler.java:864–905` uses the Ghidra 12 deprecated `Listing.setComment(Address, int, String)` and `CodeUnit.PLATE_COMMENT / PRE_COMMENT / EOL_COMMENT` int constants. The non-deprecated replacement is `CommentType` enum with a 2-arg `setComment`.

This PR adds `@SuppressWarnings("deprecation")` with a docstring explaining the plan: when this handler migrates to delegate to `CommentService` (which already uses the enum API on the GUI-side path), the suppression goes away. Silences the noise without papering over the debt.

### 2. Bump `requests` floor to 2.32.0 per CVE-2024-35195

`requirements.txt:8` had `requests>=2.28.0` which is below the fix for [CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195) (certificate verification bypass via `verify=False` persisting to later requests). Upper bound unchanged.

## Test plan
- [x] Clean build: `mvn clean compile` — no more deprecation warning
- [x] Offline tests: 11/11 pass
- [x] No other code changes — pure hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)
