### PR TITLE
feat(fun-doc): per-function escalation + audit tracking with dashboard visibility

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -1251,7 +1251,7 @@ def populate_call_graph(state, prog_path):
     # BFS layers are computed on non-thunk functions only so they match the
     # dashboard's Call Graph Layers visualization. Thunks participate in
     # callee lists (so readiness can track them) but don't get layer numbers.
-    prog_addrs = set()       # all addresses (including thunks)
+    prog_addrs = set()  # all addresses (including thunks)
     scoreable_addrs = set()  # non-thunk only (for BFS)
     addr_to_key = {}
     stamped = 0
@@ -1519,7 +1519,9 @@ def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=N
                 pinned_list_copy.remove(key)
                 queue["pinned"] = pinned_list_copy
                 save_priority_queue(queue)
-                print(f"  Auto-unpinned {func.get('name', key)} after {consecutive_fails} consecutive failures")
+                print(
+                    f"  Auto-unpinned {func.get('name', key)} after {consecutive_fails} consecutive failures"
+                )
             continue
 
         # Recovery-pass one-shot: massive functions get exactly one
@@ -4428,6 +4430,12 @@ def process_function(
                         handoff_reason,
                         new_count,
                     )
+                    # Stamp per-function escalation tracking
+                    func["escalation_count"] = func.get("escalation_count", 0) + 1
+                    func["last_escalated"] = datetime.now().isoformat()
+                    func["last_escalation_from"] = effective_provider
+                    func["last_escalation_to"] = handoff_provider
+                    update_function_state(func_key, func)
                     # Swap provider for the rest of this function's processing
                     provider = handoff_provider
                     effective_provider = handoff_provider
@@ -4928,6 +4936,13 @@ def process_function(
             # Save program after audit writes
             if audit_tool_calls != 0:
                 ghidra_post("/save_program", params={"program": program})
+
+            # Stamp per-function audit tracking
+            func["audit_count"] = func.get("audit_count", 0) + 1
+            func["last_audited"] = datetime.now().isoformat()
+            func["last_audit_provider"] = audit_provider
+            func["last_audit_delta"] = audit_diff if audit_new_score is not None else 0
+            update_function_state(func_key, func)
 
     # Track partial_runs for requeue deprioritization
     if result == "partial":

--- a/fun-doc/templates/dashboard.html
+++ b/fun-doc/templates/dashboard.html
@@ -300,6 +300,8 @@
             <div class="stat-card"><div class="stat-value" id="stat-pct">{{ stats.pct }}%</div><div class="stat-label">Progress</div></div>
             <div class="stat-card"><div class="stat-value text-magic" id="stat-today">{{ stats.run_stats.today_runs }}</div><div class="stat-label">Runs Today</div></div>
             <div class="stat-card"><div class="stat-value" id="stat-delta">{{ stats.run_stats.avg_delta }}%</div><div class="stat-label">Avg Delta</div></div>
+            <div class="stat-card"><div class="stat-value" id="stat-audited" style="color: var(--color-magic);">{{ stats.audited }}</div><div class="stat-label">Audited</div></div>
+            <div class="stat-card"><div class="stat-value" id="stat-escalated" style="color: var(--color-rare);">{{ stats.escalated }}</div><div class="stat-label">Escalated</div></div>
         </div>
 
         <!-- Progress bar -->
@@ -832,6 +834,8 @@
                 document.getElementById("stat-pct").textContent = stats.pct + "%";
                 document.getElementById("stat-today").textContent = stats.run_stats.today_runs;
                 document.getElementById("stat-delta").textContent = stats.run_stats.avg_delta + "%";
+                document.getElementById("stat-audited").textContent = stats.audited;
+                document.getElementById("stat-escalated").textContent = stats.escalated;
                 document.getElementById("progressInner").style.width = stats.pct + "%";
                 document.getElementById("progressText").textContent = `${stats.done} / ${stats.total} (${stats.pct}%)`;
 

--- a/fun-doc/web.py
+++ b/fun-doc/web.py
@@ -148,6 +148,7 @@ class WorkerManager:
                 load_priority_queue,
                 reset_handoff_counter,
                 _bump_handoff_counter,
+                update_function_state,
             )
 
             worker["status"] = "running"
@@ -328,13 +329,27 @@ class WorkerManager:
                             and current_score > 0
                             and escalate_to
                         ):
-                            reason = "failed" if result in ("failed", "needs_redo") else f"score {current_score}%"
+                            reason = (
+                                "failed"
+                                if result in ("failed", "needs_redo")
+                                else f"score {current_score}%"
+                            )
                             escalation_count = _bump_handoff_counter()
                             print(
                                 f"\n  AUTO-ESCALATE #{escalation_count}: {worker['provider']} → {escalate_to} "
                                 f"({reason}, below {good_enough}%)",
                                 flush=True,
                             )
+                            # Stamp per-function escalation tracking
+                            from datetime import datetime as _dt
+
+                            fresh_func["escalation_count"] = (
+                                fresh_func.get("escalation_count", 0) + 1
+                            )
+                            fresh_func["last_escalated"] = _dt.now().isoformat()
+                            fresh_func["last_escalation_from"] = worker["provider"]
+                            fresh_func["last_escalation_to"] = escalate_to
+                            update_function_state(key, fresh_func)
                             escalate_result = process_function(
                                 key,
                                 fresh_func,
@@ -697,7 +712,18 @@ def create_app(state_file, event_bus=None):
             "failure_modes": {},
             "regressions": 0,
             "zero_delta": 0,
-            "audit": {"ran": 0, "improved": 0, "regressed": 0, "no_change": 0, "skipped_good": 0, "skipped_delta": 0, "today_ran": 0, "today_improved": 0, "today_skipped_good": 0, "today_skipped_delta": 0},
+            "audit": {
+                "ran": 0,
+                "improved": 0,
+                "regressed": 0,
+                "no_change": 0,
+                "skipped_good": 0,
+                "skipped_delta": 0,
+                "today_ran": 0,
+                "today_improved": 0,
+                "today_skipped_good": 0,
+                "today_skipped_delta": 0,
+            },
             "today": {"runs": 0, "success_rate": 0, "avg_delta": 0, "by_provider": {}},
         }
         if not logs:
@@ -926,6 +952,8 @@ def create_app(state_file, event_bus=None):
                 "fixable": 0,
                 "needs_work": 0,
                 "pct": 0,
+                "audited": 0,
+                "escalated": 0,
                 "buckets": {},
                 "by_program": {},
                 "sessions": [],
@@ -948,6 +976,10 @@ def create_app(state_file, event_bus=None):
         )
         needs_work = sum(1 for f in scoreable.values() if f["score"] < fixable_lo)
         pct = (done / total * 100) if total > 0 else 0
+        audited = sum(1 for f in scoreable.values() if f.get("audit_count", 0) > 0)
+        escalated = sum(
+            1 for f in scoreable.values() if f.get("escalation_count", 0) > 0
+        )
         buckets = {
             "100": 0,
             "90-99": 0,
@@ -1023,6 +1055,8 @@ def create_app(state_file, event_bus=None):
             "fixable": fixable_count,
             "needs_work": needs_work,
             "pct": round(pct, 1),
+            "audited": audited,
+            "escalated": escalated,
             "buckets": buckets,
             "by_program": dict(by_program),
             "sessions": state.get("sessions", [])[-10:],


### PR DESCRIPTION
## Summary

Ships the per-function escalation + audit tracking that was sitting in a local stash. Adds dashboard visibility for both.

## What it does

When a worker **escalates mid-function** (hands off from its current provider to a stronger one because the score dropped below `good_enough`), the function record is now stamped with:

```python
func["escalation_count"] += 1
func["last_escalated"] = "2026-04-18T17:45:00"
func["last_escalation_from"] = "codex"
func["last_escalation_to"] = "claude"
```

Both escalation paths are covered:
- `fun_doc.py process_function()` — direct escalation when in-process (single worker)
- `web.py WorkerManager` — background-worker escalation via the `escalate_to` config

When the **audit pass** runs at end-of-function, the function record is stamped with:

```python
func["audit_count"] += 1
func["last_audited"] = "2026-04-18T17:50:00"
func["last_audit_provider"] = "claude"
func["last_audit_delta"] = 12   # score improvement, if any
```

Dashboard `/api/stats` now surfaces two new counters:
- `audited` — functions with `audit_count > 0`
- `escalated` — functions with `escalation_count > 0`

And `dashboard.html` has matching stat cards.

## Why

Enables retrospection on where the escalation/audit machinery is actually earning its keep:
- Which specific functions needed a stronger provider to reach `good_enough`?
- Which audit passes actually moved the score, and by how much?
- Are any providers consistently needing escalation?

Previously this data was only in the aggregate run-level counters. Per-function stamping unlocks drill-down.

## Test plan
- [x] Schema additive: new fields default to missing/`.get(k, 0)` — no existing state files break
- [x] `/api/stats` shape additive: two new numeric fields
- [ ] Live smoke in a worker cycle (next run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
