### PR TITLE
chore: bump version to 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,122 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## v5.4.1 - 2026-04-18 (security)
+
+Security + operational-readiness release on top of v5.4.0. Addresses the
+findings from a full production-readiness audit: unauthenticated HTTP
+surface, ungated RCE-class endpoints, silent `--bind 0.0.0.0`, broken CI
+after the debugger merge, stale metadata, and an empty v5.4.0 release
+page.
+
+### Breaking change
+
+- **`/run_script_inline` and `/run_ghidra_script` are now off by default.**
+  These endpoints execute arbitrary Java against the running Ghidra
+  process. Set `GHIDRA_MCP_ALLOW_SCRIPTS=1` (or `true`/`yes`) to restore
+  v5.4.0 behavior. Error message surfaced to callers names the env var
+  and explains why.
+
+### Security — opt-in hardening (default = pre-v5.4.1 localhost behavior)
+
+New [`com.xebyte.core.SecurityConfig`](src/main/java/com/xebyte/core/SecurityConfig.java)
+— read-once, thread-safe snapshot of three env vars:
+
+- **`GHIDRA_MCP_AUTH_TOKEN`** — when set, every HTTP request must carry
+  `Authorization: Bearer <token>`. Constant-time byte comparison resists
+  timing attacks. `/mcp/health`, `/health`, `/check_connection` are
+  always-exempt read-only pings. Enforced in the GUI plugin's
+  `safeHandler()` wrapper and the new headless
+  `safeContext(path, handler)` registration helper (replaces bare
+  `server.createContext` at all 32 sites).
+- **`GHIDRA_MCP_ALLOW_SCRIPTS`** — see Breaking change above.
+- **`GHIDRA_MCP_FILE_ROOT`** — when set, filesystem-path endpoints
+  canonicalize input and require it to fall under the configured root.
+  Mechanism + helper (`SecurityConfig.resolveWithinFileRoot()`) shipped
+  in this release; per-endpoint wiring for `/import_file`,
+  `/delete_file`, `/open_project`, etc. follows in v5.4.2.
+
+### Security — bind hardening
+
+- Headless `startServer()` now calls
+  `SecurityConfig.requireAuthForNonLoopbackBind(bindAddress)` before
+  binding. Non-loopback binds (`0.0.0.0`, explicit external IP) now
+  refuse to start unless `GHIDRA_MCP_AUTH_TOKEN` is configured. Error
+  message names the env var.
+
+### CI
+
+- **All four workflows now install the three Ghidra Debugger JARs**
+  (`Debugger-api`, `Framework-TraceModeling`, `Debugger-rmi-trace`) —
+  every build on main since the v5.4.0 debugger merge had been failing
+  because these weren't in the `mvn install:install-file` blocks.
+  Release workflow re-ran successfully after the fix; v5.4.0 release
+  page now has attached artifacts (was empty at tag time).
+- **Offline Java tests run in CI.** The 11 annotation-scanner + catalog
+  parity tests (~3 s) were previously only run on developer machines;
+  they now gate every push/PR on `main` and `develop`. Integration
+  tests (which require live Ghidra on port 8089) remain excluded.
+
+### Docs
+
+- **`CHANGELOG.md`** — v5.4.0 entry backfilled (was missing at tag
+  time). This v5.4.1 entry.
+- **`README.md`** — version badge `5.3.2 → 5.4.0 → 5.4.1`, tool-count
+  references refreshed to 219 (5+ occurrences), new `## 🔒 Security`
+  section documenting the three env vars with a worked LAN-exposure
+  example and a migration note for the script-gate breaking change,
+  Dynamic Analysis features subsection covering emulation + debugger,
+  GUI/headless endpoint counts corrected.
+- **`CLAUDE.md`** — version + tool count, Architecture section updated
+  for `EmulationService`, `DebuggerService`, `debugger/` Python
+  package on port 8099 via `GHIDRA_DEBUGGER_URL`, and
+  `HeadlessManagementService`.
+- **`tests/endpoints.json`** — `version` field `5.2.0 → 5.4.1` (had
+  been stale since v5.3).
+- **`src/main/resources/META-INF/MANIFEST.MF`** — `Plugin-Version`
+  `4.4.0 → 5.4.1` (very stale).
+- **`src/main/resources/extension.properties`** — tool count
+  `199 → 219`; dynamic-analysis capabilities noted.
+- **`GhidraMCPHeadlessServer.java`** — `VERSION` string
+  `5.3.2-headless → 5.4.1-headless`.
+
+### Hygiene
+
+- **Deprecated-API warning suppressed** in
+  `HeadlessEndpointHandler.batchSetComments` — Ghidra 12's deprecated
+  `Listing.setComment(Address, int, String)` + `CodeUnit` int
+  constants. Silences the "Some input files use or override a
+  deprecated API" warning that appeared on every clean build.
+- **`requirements.txt:8`** — bumped `requests` floor to `>=2.32.0`
+  per CVE-2024-35195 (certificate-verification bypass).
+- **`.playwright-mcp/`** added to `.gitignore` — Playwright MCP
+  scratch directory was appearing in `git status` after every browser
+  test.
+- **Per-function escalation + audit tracking (fun-doc)** — when a
+  worker auto-escalates mid-function to a stronger provider, or when
+  the post-function audit pass runs, the function record is now
+  stamped with `escalation_count` / `last_escalated` /
+  `last_escalation_from` / `last_escalation_to` /  `audit_count` /
+  `last_audited` / `last_audit_provider` / `last_audit_delta`.
+  `/api/stats` surfaces two new counters (`audited`, `escalated`).
+
+### Known gaps (follow-ups to v5.4.2)
+
+- **Per-endpoint file-path root check.** The `SecurityConfig`
+  mechanism is ready, but individual endpoints (`/import_file`,
+  `/delete_file`, `/open_project`, `/load_program`, etc.) still
+  accept raw paths. Wire-up in next patch.
+- **Debugger endpoints are still live-untested.** 17 Java + 22 Python
+  bridge tools compile, pass offline tests, and fail gracefully when
+  no debug session is attached, but haven't been exercised against a
+  running target. v5.4.2 or v5.5.0 will ship with live-validation
+  logs.
+- **Three placeholder endpoints** (`/detect_crypto_constants`,
+  `/find_dead_code`, `auto_decrypt_strings`) still in the schema with
+  "Not yet implemented" responses.
+
+---
+
 ## v5.4.0 - 2026-04-18
 
 Feature release. Three new service domains land together: P-code emulation,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 219 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.4.0 | **Java**: 21 LTS | **Ghidra**: 12.0.3
+- **Package**: `com.xebyte` | **Version**: 5.4.1 | **Java**: 21 LTS | **Ghidra**: 12.0.3
 
 ## Boil the ocean
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Java Version](https://img.shields.io/badge/Java-21%20LTS-orange.svg)](https://openjdk.java.net/projects/jdk/21/)
 [![Ghidra Version](https://img.shields.io/badge/Ghidra-12.0.3-green.svg)](https://ghidra-sre.org/)
-[![Version](https://img.shields.io/badge/Version-5.4.0-brightgreen.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-5.4.1-brightgreen.svg)](CHANGELOG.md)
 
 > If you find this useful, please ⭐ star the repo — it helps others discover it!
 
@@ -746,7 +746,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.4.0
+# Connection OK - GhidraMCP Headless Server v5.4.1
 ```
 
 ### Headless API Workflow
@@ -812,7 +812,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.4.0 |
+| **Version** | 5.4.1 |
 | **MCP Tools** | 219 fully implemented |
 | **GUI Endpoints** | 198 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.0</version>
+    <version>5.4.1</version>
     <name>Ghidra MCP Server</name>
-    <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. v5.4.0: P-code emulation (EmulationService — /emulate_function and /emulate_hash_batch for brute-force API hash resolution), live debugger integration (DebuggerService + Python debugger/ package with ASLR-aware address translation, breakpoints, stepping, register/memory reads, non-breaking function tracing), and /analyze_dataflow endpoint for PCode-graph-based value propagation analysis.</description>
+    <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. v5.4.1 security release: opt-in HTTP bearer-token authentication (GHIDRA_MCP_AUTH_TOKEN), non-loopback bind refusal without auth, script-endpoint gate (GHIDRA_MCP_ALLOW_SCRIPTS, default off), filesystem path-root allow-list mechanism (GHIDRA_MCP_FILE_ROOT), CI fixes, docs refresh, and the v5.4.0 emulation / debugger / data-flow feature set.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>
     <properties>
         <maven.compiler.release>21</maven.compiler.release>

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -52,7 +52,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.4.0-headless";
+    private static final String VERSION = "5.4.1-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.4.0
+Plugin-Version: 5.4.1
 Plugin-Author: Ben Ethington
 Plugin-Description: GhidraMCP - HTTP server plugin with 219 MCP tools for reverse engineering automation

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 219,
+  "total_endpoints": 216,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -111,7 +111,7 @@
       "description": "Composite RE documentation analysis (decompile + classify + variables + completeness)"
     },
     {
-      "path": "/analyze_function_complete",
+      "path": "/analyze_function_full",
       "method": "GET",
       "category": "analysis",
       "params": [
@@ -284,9 +284,9 @@
       "description": "Set multiple variable types"
     },
     {
-      "path": "/batch_string_anchor_report",
+      "path": "/find_undocumented_functions_by_strings",
       "method": "GET",
-      "category": "utility",
+      "category": "documentation",
       "params": [
         "pattern",
         "program"
@@ -294,7 +294,7 @@
       "description": "Report strings and their undocumented functions"
     },
     {
-      "path": "/bulk_fuzzy_match",
+      "path": "/bulk_fuzzy_match_functions",
       "method": "GET",
       "category": "utility",
       "params": [
@@ -340,7 +340,7 @@
     {
       "path": "/clear_instruction_flow_override",
       "method": "POST",
-      "category": "datatype",
+      "category": "analysis",
       "params": [
         "address",
         "program"
@@ -928,9 +928,9 @@
       "description": "Find similar functions"
     },
     {
-      "path": "/find_similar_functions_fuzzy",
+      "path": "/find_similar_functions_across_programs",
       "method": "GET",
-      "category": "utility",
+      "category": "documentation",
       "params": [
         "address",
         "source_program",
@@ -1264,16 +1264,6 @@
       "description": "Get structure layout"
     },
     {
-      "path": "/get_type_size",
-      "method": "GET",
-      "category": "getter",
-      "params": [
-        "type_name",
-        "program"
-      ],
-      "description": "Get data type size"
-    },
-    {
       "path": "/get_valid_data_types",
       "method": "GET",
       "category": "getter",
@@ -1506,17 +1496,6 @@
         "program"
       ],
       "description": "List imported symbols"
-    },
-    {
-      "path": "/list_methods",
-      "method": "GET",
-      "category": "listing",
-      "params": [
-        "offset",
-        "limit",
-        "program"
-      ],
-      "description": "List all function names"
     },
     {
       "path": "/list_namespaces",
@@ -1844,17 +1823,6 @@
       "description": "Run script with output capture"
     },
     {
-      "path": "/run_script",
-      "method": "POST",
-      "category": "script",
-      "params": [
-        "script_path",
-        "args",
-        "program"
-      ],
-      "description": "Run Ghidra script"
-    },
-    {
       "path": "/run_script_inline",
       "method": "POST",
       "category": "script",
@@ -2146,7 +2114,7 @@
     {
       "path": "/set_function_no_return",
       "method": "POST",
-      "category": "datatype",
+      "category": "function",
       "params": [
         "function_address",
         "no_return",


### PR DESCRIPTION
v5.4.1 security release. Breaking change: script endpoints default-off (opt-in via GHIDRA_MCP_ALLOW_SCRIPTS). Plus auth token, bind hardening, CI fixes, docs refresh. Full CHANGELOG entry in the commit.