### PR TITLE
test(python): sync unit test expectations with v5.4.x reality

### DIFF
--- a/tests/unit/test_address_map.py
+++ b/tests/unit/test_address_map.py
@@ -1,7 +1,6 @@
 """Unit tests for debugger/address_map.py — address translation and ordinal parsing."""
 
 import os
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -126,16 +125,7 @@ class TestAddressMapper:
 class TestOrdinalParsing:
     def setup_method(self):
         self.mapper = AddressMapper()
-        self.tmpdir = tempfile.mkdtemp()
-
-        # Write a test export file
-        content = (
-            "D2COMMON.DLL::Ordinal_10000@6fd9f450->Ordinal_10000\n"
-            "D2COMMON.DLL::Ordinal_10624@6fda1234->CalcMissileVelocityParam\n"
-            "D2COMMON.DLL::Ordinal_10864@6fdb5678->GetMaxGoldBank\n"
-        )
-        with open(os.path.join(self.tmpdir, "D2Common.txt"), "w") as f:
-            f.write(content)
+        self.tmpdir = Path(__file__).parent.parent / "fixtures" / "dll_exports"
 
     def test_load_ordinals(self):
         summary = self.mapper.load_ordinal_exports(self.tmpdir)

--- a/tests/unit/test_endpoint_catalog.py
+++ b/tests/unit/test_endpoint_catalog.py
@@ -130,15 +130,17 @@ class TestBridgeIsDynamic(unittest.TestCase):
     """Verify the bridge uses dynamic registration, not hardcoded tools."""
 
     def test_bridge_has_few_static_tools(self):
-        """Bridge should only have static tools (list_instances, connect_instance, tool group mgmt)."""
+        """Bridge static tool decorators should match the explicit static tool allowlist."""
+        import bridge_mcp_ghidra as bridge
+
         bridge_path = PROJECT_ROOT / "bridge_mcp_ghidra.py"
         content = bridge_path.read_text()
         tool_count = len(re.findall(r"@mcp\.tool\(\)", content))
-        self.assertLessEqual(
+        self.assertEqual(
             tool_count,
-            10,
-            f"Bridge has {tool_count} @mcp.tool() decorators. "
-            "Expected <=10 (only static tools)",
+            len(bridge.STATIC_TOOL_NAMES),
+            f"Bridge has {tool_count} @mcp.tool() decorators but "
+            f"{len(bridge.STATIC_TOOL_NAMES)} static tool names",
         )
 
     def test_bridge_has_schema_registration(self):
@@ -149,11 +151,11 @@ class TestBridgeIsDynamic(unittest.TestCase):
         self.assertIn("/mcp/schema", content)
 
     def test_bridge_size_reasonable(self):
-        """Thin bridge should stay manageable while allowing modest feature growth."""
+        """Thin bridge should stay manageable while allowing debugger/tool-group growth."""
         bridge_path = PROJECT_ROOT / "bridge_mcp_ghidra.py"
         lines = len(bridge_path.read_text().splitlines())
         self.assertLess(
-            lines, 1400, f"Bridge is {lines} lines, expected <1400 for thin multiplexer"
+            lines, 2000, f"Bridge is {lines} lines, expected <2000 for thin multiplexer"
         )
 
 

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -164,7 +164,8 @@ class TestSchemaEdgeCases(unittest.TestCase):
         schema = {"properties": props, "required": ["param_0"]}
         fn = _build_tool_function("/test", "POST", schema)
         sig = inspect.signature(fn)
-        self.assertEqual(len(sig.parameters), 20)
+        self.assertEqual(len(sig.parameters), 21)
+        self.assertIn("dry_run", sig.parameters)
 
 
 class TestToolRegistrationRoundTrip(unittest.TestCase):

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -181,7 +181,8 @@ class TestSchemaFormat(unittest.TestCase):
         }
         fn = _build_tool_function("/test", "POST", schema)
         sig = inspect.signature(fn)
-        self.assertEqual(len(sig.parameters), 4)
+        self.assertEqual(len(sig.parameters), 5)
+        self.assertIn("dry_run", sig.parameters)
 
     def test_schema_with_descriptions(self):
         """Schema properties with descriptions should not affect function building."""


### PR DESCRIPTION
Four test files had pre-v5.4.x assumptions that made CI red.

- test_bridge_has_few_static_tools: switched from 'assertLessEqual 10' to 'assertEqual len(STATIC_TOOL_NAMES)'. The v5.4.0 debugger integration intentionally added 22 static proxy tools; the invariant worth guarding is 'every @mcp.tool() is on the STATIC_TOOL_NAMES allowlist', not 'bridge has <=10 static tools'.
- test_bridge_size_reasonable: threshold 1400 -> 2000 to accommodate debugger proxy + tool-group loaders (~1744 current lines).
- test_mcp_tool_functions / test_mcp_tools parameter-count fixtures bumped by 1 (dry_run is auto-added universally post-v5.3).
- test_address_map TestOrdinalParsing: replaced inline tempfile with the committed tests/fixtures/dll_exports/ path.

Local run: 64 passed in 3.89s. CI on this branch should go green and clear the last red on main.