### PR TITLE
chore: add GitHub Sponsors + fix stale docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: bethington

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -121,7 +121,7 @@ All Ghidra libraries are automatically downloaded and configured:
 - Utility.jar, Gui.jar
 
 ### Quality Assurance
-- **Full test suite execution** (offline + integration test suite)
+- **Automated CI validation** (offline Java tests, Python unit tests, build verification)
 - **Build verification** before release creation
 - **Artifact validation** and proper naming
 - **Professional documentation** generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,17 +160,14 @@ Priority: Medium - helpful for malware analysis
    ```
 
 3. Document in `tests/endpoints.json`:
-   ```markdown
-   ### my_new_tool()
-   
-   Brief description.
-   
-   ```python
-   result = my_new_tool(param1="value", param2=5)
-   # Returns: {...}
-   ```
-   
-   **Use when**: Specific use case
+   ```json
+   {
+     "path": "/my_new_tool",
+     "method": "GET",
+     "category": "analysis",
+     "params": ["param1", "param2", "program"],
+     "description": "Brief description."
+   }
    ```
 
 4. Add example in `examples/`:

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -202,4 +202,4 @@ Each release directory should contain:
 
 - For the latest release: See [CHANGELOG.md](../../CHANGELOG.md) (v5.4.1)
 - For specific versions: Browse the version directories above
-- For overall project changes: See [CHANGELOG.md](../CHANGELOG.md) in the project root
+- For overall project changes: See [CHANGELOG.md](../../CHANGELOG.md) in the project root


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` so the **Sponsor** button appears on the repo, pointing to [@bethington](https://github.com/sponsors/bethington).
- Bundles three small doc corrections that surfaced during v5.4.1 release review.

## Doc fixes included
- **CONTRIBUTING.md** — "How to add a new endpoint" step 3 told contributors to add a Markdown description block to `tests/endpoints.json`, but that file is JSON. Replaced with the correct JSON entry shape.
- **docs/releases/README.md** — broken relative link to `../CHANGELOG.md` (file is at repo root, needed `../../`).
- **.github/workflows/README.md** — replaced aspirational "Full test suite execution" language with an accurate description of what CI actually runs (offline Java + Python unit + build verify).

## Supersedes #124
PR #124 carried a contaminating 15K-line `@McpTool`/`@Param` annotation refactor alongside the single-line FUNDING.yml add — not what its title advertised. This PR ships the FUNDING.yml clean, on its own, bundled only with other one-line doc hygiene fixes.

## Test plan
- [x] FUNDING.yml validates against [GitHub's syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository)
- [x] Relative link in `docs/releases/README.md` resolves to existing `CHANGELOG.md` at repo root
- [x] CONTRIBUTING.md JSON example matches actual `tests/endpoints.json` entry shape
- [ ] After merge: close #124, verify Sponsor button appears on repo homepage