### PR TITLE
chore(fun-doc): expand tool inventory + add extract utility

### DIFF
--- a/fun-doc/_extract_tools.py
+++ b/fun-doc/_extract_tools.py
@@ -1,0 +1,147 @@
+"""Temporary script to extract MCP tool names from prompts and fun_doc.py"""
+
+import re, glob, os
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+# Known MCP tools from the ghidra-mcp project (from endpoints.json + bridge)
+# We'll use these to validate what we find
+KNOWN_TOOL_PREFIXES = [
+    "analyze_",
+    "apply_",
+    "batch_",
+    "can_rename",
+    "clear_",
+    "clone_",
+    "compare_",
+    "convert_",
+    "create_",
+    "decompile_",
+    "delete_",
+    "detect_",
+    "diff_",
+    "disassemble_",
+    "extract_",
+    "find_",
+    "force_",
+    "get_",
+    "import_",
+    "inspect_",
+    "list_",
+    "modify_",
+    "move_",
+    "open_",
+    "read_",
+    "rename_",
+    "remove_",
+    "run_",
+    "save_",
+    "search_",
+    "set_",
+    "suggest_",
+    "switch_",
+    "validate_",
+]
+
+
+def is_likely_tool(name):
+    """Check if a name looks like an MCP tool name"""
+    return any(name.startswith(p) for p in KNOWN_TOOL_PREFIXES)
+
+
+# 1) Extract from prompt files
+prompt_tools = set()
+for f in glob.glob("prompts/*.md"):
+    text = open(f, encoding="utf-8").read()
+    # Backtick-wrapped identifiers
+    for m in re.findall(r"`([a-z_][a-z0-9_]*)`", text):
+        if is_likely_tool(m):
+            prompt_tools.add(m)
+    # Plain text tool references (word boundaries)
+    for m in re.findall(r"\b([a-z_][a-z0-9_]*)\b", text):
+        if is_likely_tool(m) and len(m) > 8:
+            prompt_tools.add(m)
+
+print("=" * 60)
+print("1) TOOL NAMES FROM PROMPT FILES (sorted)")
+print("=" * 60)
+for t in sorted(prompt_tools):
+    print(f"  {t}")
+print(f"\nTotal unique: {len(prompt_tools)}")
+
+# 2) Extract from fun_doc.py
+fundoc_text = open("fun_doc.py", encoding="utf-8").read()
+
+# RELEVANT_TOOLS set
+rt_match = re.search(r"RELEVANT_TOOLS\s*=\s*\{([^}]+)\}", fundoc_text)
+relevant_tools = set()
+if rt_match:
+    relevant_tools = set(re.findall(r'"([a-z_][a-z0-9_]*)"', rt_match.group(1)))
+
+# ghidra_get/ghidra_post paths -> tool names
+api_paths = set()
+for m in re.findall(
+    r'ghidra_(?:get|post)\s*\(\s*["\']/?([a-z_][a-z0-9_/]*)["\']', fundoc_text
+):
+    # Convert path to tool name (strip leading /)
+    path = m.strip("/")
+    if "/" not in path:
+        api_paths.add(path)
+
+# String literals that look like tool names
+string_tools = set()
+for m in re.findall(r'["\']([a-z_][a-z0-9_]*)["\']', fundoc_text):
+    if is_likely_tool(m) and len(m) > 8:
+        string_tools.add(m)
+
+all_fundoc = relevant_tools | api_paths | string_tools
+
+print("\n" + "=" * 60)
+print("2) TOOL NAMES FROM fun_doc.py (sorted)")
+print("=" * 60)
+print("\n  --- RELEVANT_TOOLS set ---")
+for t in sorted(relevant_tools):
+    print(f"  {t}")
+print(f"  ({len(relevant_tools)} tools)")
+
+print("\n  --- ghidra_get/ghidra_post API paths ---")
+for t in sorted(api_paths):
+    print(f"  {t}")
+print(f"  ({len(api_paths)} paths)")
+
+print("\n  --- Other string literal tool refs ---")
+other = string_tools - relevant_tools - api_paths
+for t in sorted(other):
+    print(f"  {t}")
+print(f"  ({len(other)} additional)")
+
+print(f"\n  Total unique in fun_doc.py: {len(all_fundoc)}")
+
+# 3) In prompts but NOT in RELEVANT_TOOLS
+print("\n" + "=" * 60)
+print("3) IN PROMPTS but NOT in RELEVANT_TOOLS")
+print("=" * 60)
+diff = prompt_tools - relevant_tools
+for t in sorted(diff):
+    in_api = " (but IS in ghidra_get/post calls)" if t in api_paths else ""
+    in_str = " (but IS in other string refs)" if t in string_tools else ""
+    print(f"  {t}{in_api}{in_str}")
+print(f"\nTotal: {len(diff)}")
+
+# 4) In RELEVANT_TOOLS but NOT in prompts
+print("\n" + "=" * 60)
+print("4) IN RELEVANT_TOOLS but NOT in prompts")
+print("=" * 60)
+diff2 = relevant_tools - prompt_tools
+for t in sorted(diff2):
+    print(f"  {t}")
+print(f"\nTotal: {len(diff2)}")
+
+# 5) In ghidra_get/post but NOT in RELEVANT_TOOLS
+print("\n" + "=" * 60)
+print("5) API paths used but NOT in RELEVANT_TOOLS")
+print("=" * 60)
+diff3 = api_paths - relevant_tools
+for t in sorted(diff3):
+    print(f"  {t}")
+print(f"\nTotal: {len(diff3)}")

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -4116,11 +4116,13 @@ def _inject_tool_block(prompt):
     RELEVANT_TOOLS = {
         "analyze_for_documentation",
         "get_function_variables",
+        "get_plate_comment",
         "set_variables",
         "rename_function_by_address",
         "set_function_prototype",
         "set_local_variable_type",
         "set_parameter_type",
+        "batch_set_variable_types",
         "rename_variable",
         "rename_variables",
         "batch_set_comments",

--- a/fun-doc/prompts/step-type-audit.md
+++ b/fun-doc/prompts/step-type-audit.md
@@ -4,6 +4,7 @@
 - `get_function_variables` (refresh after prototype changes in Step 2)
 - `set_local_variable_type`
 - `set_parameter_type`
+- `batch_set_variable_types` (set multiple variable types in one call -- saves call budget)
 - `set_variables` (atomic type + rename in one call, preferred)
 - `rename_variables` (batch rename only, if types already resolved)
 - `set_function_prototype` (only if this-pointer type needs fixing)


### PR DESCRIPTION
## Summary
Three related fun-doc tool-inventory updates, all scoped to the \`fun-doc/\` subdirectory (no impact on the MCP server itself):

- **[fun-doc/fun_doc.py](../blob/chore/fun-doc-tool-inventory/fun-doc/fun_doc.py)** — add \`get_plate_comment\` and \`batch_set_variable_types\` to the \`RELEVANT_TOOLS\` set used by \`_inject_tool_block\`, so those tools surface in the per-function tool list the model sees.
- **[fun-doc/prompts/step-type-audit.md](../blob/chore/fun-doc-tool-inventory/fun-doc/prompts/step-type-audit.md)** — list \`batch_set_variable_types\` as an allowed tool in Step 3 (type audit + variable renaming) so the model uses one batched call instead of per-variable \`set_local_variable_type\` calls. Saves call budget. Also normalizes line endings to LF to match the rest of the repo.
- **[fun-doc/_extract_tools.py](../blob/chore/fun-doc-tool-inventory/fun-doc/_extract_tools.py)** — new utility that scrapes tool names from \`prompts/*.md\` and \`fun_doc.py\`, used to audit coverage of the \`RELEVANT_TOOLS\` set against the actual endpoint catalog.

## Test plan
- [x] fun-doc still runs against the current endpoint schema (both \`get_plate_comment\` and \`batch_set_variable_types\` are already registered server-side)
- [x] \`_extract_tools.py\` runs locally without error and produces a tool-name inventory
- [x] LF normalization in \`step-type-audit.md\` is the only whitespace change; content diff is one added tool line