### PR TITLE
fix(bridge): set_decompiler_comment address param not reaching server

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -624,6 +624,8 @@ def _parse_schema(raw: dict) -> list[dict]:
                 pdef["description"] = p["description"]
             if "default" in p and p["default"] is not None:
                 pdef["default"] = p["default"]
+            if p.get("param_type"):
+                pdef["param_type"] = p["param_type"]
             properties[p["name"]] = pdef
             if p.get("required", False):
                 required.append(p["name"])
@@ -706,7 +708,7 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
         # Sanitize address parameters before dispatch
         for pname, pdef in properties.items():
             if (
-                pdef.get("paramType") == "address"
+                pdef.get("param_type") == "address"
                 and pname in kwargs
                 and kwargs[pname] is not None
             ):

--- a/tests/integration/test_safe_write_endpoints.py
+++ b/tests/integration/test_safe_write_endpoints.py
@@ -214,7 +214,7 @@ class TestSafeCommentOperations:
         # Decompiler comments are typically per-line, use function entry
         response = http_client.post(
             "/set_decompiler_comment",
-            data={"address": address, "comment": ""},  # Empty comment is safe
+            json_data={"address": address, "comment": ""},
         )
 
         # May not have existing comment, empty should be safe


### PR DESCRIPTION
Fixes #147

Two bugs in the bridge:
  - _parse_schema never forwarded param_type from the server schema, so address sanitization was never triggered
  - _build_tool_function checked paramType instead of param_type

  The integration test was also sending the POST body as form-encoded (data=) rather than JSON, which GSON silently discards.