### PR TITLE
[codex] repair Windows debugger attach and WOW64 register views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,21 @@ New [`com.xebyte.core.SecurityConfig`](src/main/java/com/xebyte/core/SecurityCon
   they now gate every push/PR on `main` and `develop`. Integration
   tests (which require live Ghidra on port 8089) remain excluded.
 
+### Fixed
+
+- **Python debugger startup + target query flow on Windows** — the
+  debugger backend now validates `WINDBG_DIR` before importing `pybag`,
+  falls back to a Microsoft Store WinDbg cache when the Windows Kits
+  debugger directory is incomplete, stops double-waiting after
+  `AttachProcess`, parses `pybag` module tuples correctly, and reads
+  x64 register sets (`RAX`-`R15`/`RIP`) instead of returning empty
+  register output on 64-bit targets.
+- **WOW64 register context** — when attached to 32-bit processes under
+  WOW64, debugger register reads now switch dbgeng's effective
+  processor to x86 so the API returns `EAX`/`ECX`/`ESP`/`EIP` instead of
+  the host-side 64-bit `R*` context. The same x86 view is used for
+  stack-context reads that depend on those registers.
+
 ### Docs
 
 - **`CHANGELOG.md`** — v5.4.0 entry backfilled (was missing at tag

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -20,12 +20,14 @@ from collections import namedtuple
 from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast
 
-_pybag_cache = os.path.join(os.environ.get("LOCALAPPDATA", ""), "pybag_cache")
-if (
-    "WINDBG_DIR" not in os.environ
-    and os.path.exists(os.path.join(_pybag_cache, "dbgeng.dll"))
-):
-    os.environ["WINDBG_DIR"] = _pybag_cache
+_localappdata = os.environ.get("LOCALAPPDATA")
+if os.name == "nt" and _localappdata:
+    _pybag_cache = os.path.join(_localappdata, "pybag_cache")
+    if (
+        "WINDBG_DIR" not in os.environ
+        and os.path.exists(os.path.join(_pybag_cache, "dbgeng.dll"))
+    ):
+        os.environ["WINDBG_DIR"] = _pybag_cache
 
 from pybag import pydbg, userdbg  # type: ignore
 from pybag.dbgeng import core as DbgEng  # type: ignore
@@ -38,7 +40,11 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 C = TypeVar("C", bound=Callable[..., Any])
 
-PE_MACHINE_I386 = 0x014C
+IMAGE_FILE_MACHINE_I386 = 0x014C
+DBGENG_PROCESSOR_X86 = getattr(DbgEng, "DEBUG_PROCESSOR_X86", 0)
+IMAGE_TO_DBGENG_PROCESSOR_TYPES = {
+    IMAGE_FILE_MACHINE_I386: DBGENG_PROCESSOR_X86,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +158,9 @@ class DebugEngine:
         self._target_pid: Optional[int] = None
         self._target_name: Optional[str] = None
         self._executing = False  # True when target is running
+        self._target_image_path: Optional[str] = None
+        self._target_pe_machine: Optional[int] = None
+        self._target_processor_type: Optional[int] = None
         self._protected_base: Optional[AllDbg] = None
         self._events = EngineEventHandler()
 
@@ -225,9 +234,7 @@ class DebugEngine:
             modules = self._base.module_list()
         except Exception:
             return None
-        if not modules:
-            return None
-        return modules[0]
+        return next(iter(modules), None)
 
     def _read_pe_machine_from_file(self, image_path: str) -> Optional[int]:
         try:
@@ -248,32 +255,54 @@ class DebugEngine:
         except OSError:
             return None
 
-    def _configure_target_context(self) -> None:
-        base = self._base
-
+    def _detect_target_processor_type(self) -> None:
         main_module = self._get_main_module_entry()
-        if main_module is not None:
-            module_names, _ = main_module
-            image_path = next(
-                (candidate for candidate in module_names if candidate and os.path.exists(candidate)),
-                None,
-            )
-            if image_path:
-                machine = self._read_pe_machine_from_file(image_path)
-                if machine == PE_MACHINE_I386:
-                    try:
-                        effective = base._control.GetEffectiveProcessorType()
-                    except Exception:
-                        effective = None
-                    if effective != PE_MACHINE_I386:
-                        base._control.SetEffectiveProcessorType(PE_MACHINE_I386)
-                        logger.info("Switched effective processor to x86 for %s", image_path)
+        if main_module is None:
+            return
 
+        module_names, _ = main_module
+        image_path = next((
+            candidate
+            for candidate in module_names
+            if candidate and os.path.exists(candidate)
+        ), None)
+        if not image_path or image_path == self._target_image_path:
+            return
+
+        self._target_image_path = image_path
+        self._target_pe_machine = self._read_pe_machine_from_file(image_path)
+        self._target_processor_type = IMAGE_TO_DBGENG_PROCESSOR_TYPES.get(
+            self._target_pe_machine
+        )
+
+    def _apply_target_processor_type(self) -> None:
+        if self._target_processor_type is None:
+            return
+        base = self._base
+        try:
+            effective = base._control.GetEffectiveProcessorType()
+        except Exception:
+            effective = None
+        if effective != self._target_processor_type:
+            base._control.SetEffectiveProcessorType(self._target_processor_type)
+            logger.info(
+                "Switched effective processor to x86 for %s",
+                self._target_image_path or "<unknown>",
+            )
+
+    def _select_event_thread(self) -> None:
+        base = self._base
         try:
             event_thread = base._systems.GetEventThread()
             base._systems.SetCurrentThreadId(event_thread)
         except Exception:
             pass
+
+    def _configure_target_context(self, detect_processor: bool = False) -> None:
+        if detect_processor:
+            self._detect_target_processor_type()
+        self._apply_target_processor_type()
+        self._select_event_thread()
 
     # -- Process management ------------------------------------------------
 
@@ -305,7 +334,7 @@ class DebugEngine:
 
         logger.info(f"Attaching to PID {pid}...")
         base.attach_proc(pid)
-        self._configure_target_context()
+        self._configure_target_context(detect_processor=True)
 
         self._target_pid = pid
         try:
@@ -337,6 +366,9 @@ class DebugEngine:
         pid = self._target_pid
         self._target_pid = None
         self._target_name = None
+        self._target_image_path = None
+        self._target_pe_machine = None
+        self._target_processor_type = None
         self._state = DebuggerState.DETACHED
         self._executing = False
         logger.info(f"Detached from PID {pid}")
@@ -390,7 +422,7 @@ class DebugEngine:
             self._state = DebuggerState.RUNNING
             self._executing = True
             raise RuntimeError("Timed out waiting for debuggee to break") from exc
-        self._configure_target_context()
+        self._configure_target_context(detect_processor=True)
         self._state = DebuggerState.STOPPED
         self._executing = False
         return {"state": "stopped"}
@@ -457,7 +489,7 @@ class DebugEngine:
         except Exception:
             effective = None
 
-        if effective == PE_MACHINE_I386:
+        if effective == DBGENG_PROCESSOR_X86:
             reg_names = [
                 ("eax", "EAX"),
                 ("ebx", "EBX"),

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -20,6 +20,13 @@ from collections import namedtuple
 from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast
 
+_pybag_cache = os.path.join(os.environ.get("LOCALAPPDATA", ""), "pybag_cache")
+if (
+    "WINDBG_DIR" not in os.environ
+    and os.path.exists(os.path.join(_pybag_cache, "dbgeng.dll"))
+):
+    os.environ["WINDBG_DIR"] = _pybag_cache
+
 from pybag import pydbg, userdbg  # type: ignore
 from pybag.dbgeng import core as DbgEng  # type: ignore
 from pybag.dbgeng import exception  # type: ignore
@@ -30,6 +37,8 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 C = TypeVar("C", bound=Callable[..., Any])
+
+PE_MACHINE_I386 = 0x014C
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +220,61 @@ class DebugEngine:
             return self._run_on_engine(func, *args, **kwargs)
         return cast(C, wrapper)
 
+    def _get_main_module_entry(self) -> Optional[Tuple[Tuple[str, str, str], Any]]:
+        try:
+            modules = self._base.module_list()
+        except Exception:
+            return None
+        if not modules:
+            return None
+        return modules[0]
+
+    def _read_pe_machine_from_file(self, image_path: str) -> Optional[int]:
+        try:
+            with open(image_path, "rb") as fh:
+                header = fh.read(0x1000)
+            if len(header) < 0x40 or header[:2] != b"MZ":
+                return None
+            pe_offset = struct.unpack_from("<I", header, 0x3C)[0]
+            if pe_offset + 6 <= len(header):
+                pe_header = header[pe_offset:pe_offset + 6]
+            else:
+                with open(image_path, "rb") as fh:
+                    fh.seek(pe_offset)
+                    pe_header = fh.read(6)
+            if len(pe_header) < 6 or pe_header[:4] != b"PE\x00\x00":
+                return None
+            return struct.unpack_from("<H", pe_header, 4)[0]
+        except OSError:
+            return None
+
+    def _configure_target_context(self) -> None:
+        base = self._base
+
+        main_module = self._get_main_module_entry()
+        if main_module is not None:
+            module_names, _ = main_module
+            image_path = next(
+                (candidate for candidate in module_names if candidate and os.path.exists(candidate)),
+                None,
+            )
+            if image_path:
+                machine = self._read_pe_machine_from_file(image_path)
+                if machine == PE_MACHINE_I386:
+                    try:
+                        effective = base._control.GetEffectiveProcessorType()
+                    except Exception:
+                        effective = None
+                    if effective != PE_MACHINE_I386:
+                        base._control.SetEffectiveProcessorType(PE_MACHINE_I386)
+                        logger.info("Switched effective processor to x86 for %s", image_path)
+
+        try:
+            event_thread = base._systems.GetEventThread()
+            base._systems.SetCurrentThreadId(event_thread)
+        except Exception:
+            pass
+
     # -- Process management ------------------------------------------------
 
     def attach(self, target: str) -> dict:
@@ -241,12 +305,7 @@ class DebugEngine:
 
         logger.info(f"Attaching to PID {pid}...")
         base.attach_proc(pid)
-
-        # Wait for initial break
-        try:
-            base.wait(timeout=10000)
-        except exception.DbgEngTimeout:
-            logger.warning("Timeout waiting for initial break, continuing anyway")
+        self._configure_target_context()
 
         self._target_pid = pid
         try:
@@ -320,10 +379,18 @@ class DebugEngine:
 
     def interrupt(self) -> dict:
         """Break into the debugger (interrupt execution)."""
-        # interrupt() can be called from any thread
-        if self._protected_base is not None:
-            self._protected_base._control.SetInterrupt(
-                DbgEng.DEBUG_INTERRUPT_ACTIVE)
+        return self._run_on_engine(self._interrupt_impl)
+
+    def _interrupt_impl(self) -> dict:
+        self._require_attached()
+        self._base._control.SetInterrupt(DbgEng.DEBUG_INTERRUPT_ACTIVE)
+        try:
+            self._base.wait(timeout=5000)
+        except exception.DbgEngTimeout as exc:
+            self._state = DebuggerState.RUNNING
+            self._executing = True
+            raise RuntimeError("Timed out waiting for debuggee to break") from exc
+        self._configure_target_context()
         self._state = DebuggerState.STOPPED
         self._executing = False
         return {"state": "stopped"}
@@ -365,11 +432,12 @@ class DebugEngine:
         self._require_attached()
         modules = []
         try:
-            for mod in self._base.module_list():
+            for names, params in self._base.module_list():
+                display_name = names[1] or names[0] or names[2] or "<unknown>"
                 modules.append(ModuleInfo(
-                    name=mod.name,
-                    runtime_base=mod.base,
-                    size=mod.size,
+                    name=display_name,
+                    runtime_base=params.Base,
+                    size=params.Size,
                 ))
         except Exception as e:
             logger.error(f"Error enumerating modules: {e}")
@@ -381,21 +449,46 @@ class DebugEngine:
 
     def _get_registers_impl(self) -> Dict[str, int]:
         self._require_stopped()
+        self._configure_target_context()
         regs = {}
         reg_obj = self._base.reg
-        # x86 general-purpose registers
-        for name in ["EAX", "EBX", "ECX", "EDX", "ESI", "EDI",
-                      "ESP", "EBP", "EIP"]:
+        try:
+            effective = self._base._control.GetEffectiveProcessorType()
+        except Exception:
+            effective = None
+
+        if effective == PE_MACHINE_I386:
+            reg_names = [
+                ("eax", "EAX"),
+                ("ebx", "EBX"),
+                ("ecx", "ECX"),
+                ("edx", "EDX"),
+                ("esi", "ESI"),
+                ("edi", "EDI"),
+                ("esp", "ESP"),
+                ("ebp", "EBP"),
+                ("eip", "EIP"),
+                ("efl", "EFLAGS"),
+            ]
+        else:
+            reg_names = [
+                ("rax", "RAX"),
+                ("rbx", "RBX"),
+                ("rcx", "RCX"),
+                ("rdx", "RDX"),
+                ("rsi", "RSI"),
+                ("rdi", "RDI"),
+                ("rsp", "RSP"),
+                ("rbp", "RBP"),
+                ("rip", "RIP"),
+                ("efl", "EFLAGS"),
+            ]
+
+        for source_name, label in reg_names:
             try:
-                val = reg_obj._get_register(name)
-                regs[name] = val
+                regs[label] = reg_obj._get_register(source_name)
             except Exception:
                 pass
-        # Flags
-        try:
-            regs["EFLAGS"] = reg_obj._get_register("efl")
-        except Exception:
-            pass
         return regs
 
     def read_memory(self, address: int, size: int) -> bytes:
@@ -404,6 +497,7 @@ class DebugEngine:
 
     def _read_memory_impl(self, address: int, size: int) -> bytes:
         self._require_stopped()
+        self._configure_target_context()
         return bytes(self._base.read(address, size))
 
     def read_dword(self, address: int) -> int:
@@ -421,6 +515,7 @@ class DebugEngine:
 
     def _get_stack_trace_impl(self, depth: int) -> List[dict]:
         self._require_stopped()
+        self._configure_target_context()
         frames = []
         try:
             for i, frame in enumerate(self._base.backtrace_list()):

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -17,17 +17,13 @@ import struct
 import threading
 import time
 from collections import namedtuple
+from contextlib import contextmanager, nullcontext
 from concurrent.futures import Future
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, cast
 
-_localappdata = os.environ.get("LOCALAPPDATA")
-if os.name == "nt" and _localappdata:
-    _pybag_cache = os.path.join(_localappdata, "pybag_cache")
-    if (
-        "WINDBG_DIR" not in os.environ
-        and os.path.exists(os.path.join(_pybag_cache, "dbgeng.dll"))
-    ):
-        os.environ["WINDBG_DIR"] = _pybag_cache
+from .windbg import ensure_windbg_dir
+
+ensure_windbg_dir()
 
 from pybag import pydbg, userdbg  # type: ignore
 from pybag.dbgeng import core as DbgEng  # type: ignore
@@ -39,12 +35,85 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 C = TypeVar("C", bound=Callable[..., Any])
+_IMAGE_FILE_MACHINE_I386 = 0x014C
+_IMAGE_FILE_MACHINE_AMD64 = 0x8664
 
-IMAGE_FILE_MACHINE_I386 = 0x014C
-DBGENG_PROCESSOR_X86 = getattr(DbgEng, "DEBUG_PROCESSOR_X86", 0)
-IMAGE_TO_DBGENG_PROCESSOR_TYPES = {
-    IMAGE_FILE_MACHINE_I386: DBGENG_PROCESSOR_X86,
-}
+
+def _normalize_pid_match(match: Any) -> int:
+    if isinstance(match, tuple):
+        if not match:
+            raise RuntimeError("Process lookup returned an empty match tuple")
+        match = match[0]
+    return int(match)
+
+
+def _module_info_from_pybag_entry(raw_module: Any) -> ModuleInfo:
+    if isinstance(raw_module, ModuleInfo):
+        return raw_module
+
+    if isinstance(raw_module, tuple) and len(raw_module) == 2:
+        name_info, params = raw_module
+        if isinstance(name_info, tuple):
+            image_path = str(name_info[0]) if len(name_info) > 0 and name_info[0] else ""
+            short_name = str(name_info[1]) if len(name_info) > 1 and name_info[1] else ""
+            loaded_name = str(name_info[2]) if len(name_info) > 2 and name_info[2] else ""
+            name = short_name or os.path.basename(image_path) or os.path.basename(loaded_name) or image_path or str(name_info)
+        else:
+            name = str(name_info)
+
+        runtime_base = getattr(params, "Base", getattr(params, "base", None))
+        size = getattr(params, "Size", getattr(params, "size", None))
+        if runtime_base is None or size is None:
+            raise ValueError(f"Unsupported pybag module tuple: {raw_module!r}")
+        return ModuleInfo(name=name, runtime_base=int(runtime_base), size=int(size))
+
+    name = getattr(raw_module, "name", None)
+    runtime_base = getattr(raw_module, "runtime_base", getattr(raw_module, "base", getattr(raw_module, "Base", None)))
+    size = getattr(raw_module, "size", getattr(raw_module, "Size", None))
+    if name is None or runtime_base is None or size is None:
+        raise ValueError(f"Unsupported pybag module entry: {raw_module!r}")
+    return ModuleInfo(name=str(name), runtime_base=int(runtime_base), size=int(size))
+
+
+def _register_query_plan(bitness: str) -> List[Tuple[str, str]]:
+    if bitness == "64":
+        return [
+            ("RAX", "rax"),
+            ("RBX", "rbx"),
+            ("RCX", "rcx"),
+            ("RDX", "rdx"),
+            ("RSI", "rsi"),
+            ("RDI", "rdi"),
+            ("RSP", "rsp"),
+            ("RBP", "rbp"),
+            ("RIP", "rip"),
+            ("R8", "r8"),
+            ("R9", "r9"),
+            ("R10", "r10"),
+            ("R11", "r11"),
+            ("R12", "r12"),
+            ("R13", "r13"),
+            ("R14", "r14"),
+            ("R15", "r15"),
+            ("EFLAGS", "efl"),
+        ]
+    return [
+        ("EAX", "eax"),
+        ("EBX", "ebx"),
+        ("ECX", "ecx"),
+        ("EDX", "edx"),
+        ("ESI", "esi"),
+        ("EDI", "edi"),
+        ("ESP", "esp"),
+        ("EBP", "ebp"),
+        ("EIP", "eip"),
+        ("EFLAGS", "efl"),
+    ]
+
+
+def _is_wow64_module_name(name: str) -> bool:
+    normalized = name.lower()
+    return normalized.startswith("wow64")
 
 
 # ---------------------------------------------------------------------------
@@ -158,9 +227,7 @@ class DebugEngine:
         self._target_pid: Optional[int] = None
         self._target_name: Optional[str] = None
         self._executing = False  # True when target is running
-        self._target_image_path: Optional[str] = None
-        self._target_pe_machine: Optional[int] = None
-        self._target_processor_type: Optional[int] = None
+        self._is_wow64 = False
         self._protected_base: Optional[AllDbg] = None
         self._events = EngineEventHandler()
 
@@ -229,81 +296,6 @@ class DebugEngine:
             return self._run_on_engine(func, *args, **kwargs)
         return cast(C, wrapper)
 
-    def _get_main_module_entry(self) -> Optional[Tuple[Tuple[str, str, str], Any]]:
-        try:
-            modules = self._base.module_list()
-        except Exception:
-            return None
-        return next(iter(modules), None)
-
-    def _read_pe_machine_from_file(self, image_path: str) -> Optional[int]:
-        try:
-            with open(image_path, "rb") as fh:
-                header = fh.read(0x1000)
-            if len(header) < 0x40 or header[:2] != b"MZ":
-                return None
-            pe_offset = struct.unpack_from("<I", header, 0x3C)[0]
-            if pe_offset + 6 <= len(header):
-                pe_header = header[pe_offset:pe_offset + 6]
-            else:
-                with open(image_path, "rb") as fh:
-                    fh.seek(pe_offset)
-                    pe_header = fh.read(6)
-            if len(pe_header) < 6 or pe_header[:4] != b"PE\x00\x00":
-                return None
-            return struct.unpack_from("<H", pe_header, 4)[0]
-        except OSError:
-            return None
-
-    def _detect_target_processor_type(self) -> None:
-        main_module = self._get_main_module_entry()
-        if main_module is None:
-            return
-
-        module_names, _ = main_module
-        image_path = next((
-            candidate
-            for candidate in module_names
-            if candidate and os.path.exists(candidate)
-        ), None)
-        if not image_path or image_path == self._target_image_path:
-            return
-
-        self._target_image_path = image_path
-        self._target_pe_machine = self._read_pe_machine_from_file(image_path)
-        self._target_processor_type = IMAGE_TO_DBGENG_PROCESSOR_TYPES.get(
-            self._target_pe_machine
-        )
-
-    def _apply_target_processor_type(self) -> None:
-        if self._target_processor_type is None:
-            return
-        base = self._base
-        try:
-            effective = base._control.GetEffectiveProcessorType()
-        except Exception:
-            effective = None
-        if effective != self._target_processor_type:
-            base._control.SetEffectiveProcessorType(self._target_processor_type)
-            logger.info(
-                "Switched effective processor to x86 for %s",
-                self._target_image_path or "<unknown>",
-            )
-
-    def _select_event_thread(self) -> None:
-        base = self._base
-        try:
-            event_thread = base._systems.GetEventThread()
-            base._systems.SetCurrentThreadId(event_thread)
-        except Exception:
-            pass
-
-    def _configure_target_context(self, detect_processor: bool = False) -> None:
-        if detect_processor:
-            self._detect_target_processor_type()
-        self._apply_target_processor_type()
-        self._select_event_thread()
-
     # -- Process management ------------------------------------------------
 
     def attach(self, target: str) -> dict:
@@ -322,28 +314,43 @@ class DebugEngine:
             raise RuntimeError(f"Cannot attach in state {self._state.value}")
 
         base = self._base
+        target_name = target
 
         # Resolve PID
         try:
             pid = int(target)
         except ValueError:
-            pids = base.pids_by_name(target)
-            if not pids:
+            matches = base.pids_by_name(target)
+            if not matches:
                 raise RuntimeError(f"No process found matching '{target}'")
-            pid = pids[0]
+            pid = _normalize_pid_match(matches[0])
+            if isinstance(matches[0], tuple) and len(matches[0]) > 1:
+                target_name = os.path.basename(str(matches[0][1])) or str(matches[0][1])
 
         logger.info(f"Attaching to PID {pid}...")
-        base.attach_proc(pid)
-        self._configure_target_context(detect_processor=True)
+        try:
+            base.attach_proc(pid)
+            raw_modules = self._wait_for_target_access_impl()
+            modules = [_module_info_from_pybag_entry(mod) for mod in raw_modules]
+        except Exception as exc:
+            try:
+                base.detach_proc()
+            except Exception as detach_exc:
+                logger.warning(f"Detach after failed attach raised: {detach_exc}")
+            self._target_pid = None
+            self._target_name = None
+            self._state = DebuggerState.DETACHED
+            self._executing = False
+            raise RuntimeError(
+                f"Attached to PID {pid} but the target never became queryable: {exc}"
+            ) from exc
 
         self._target_pid = pid
-        try:
-            self._target_name = base.get_name_by_offset(base.reg.get_pc())
-        except Exception:
-            self._target_name = target
+        self._is_wow64 = self._detect_wow64_target(modules)
+        self._target_name = modules[0].name if modules else target_name
         self._state = DebuggerState.STOPPED
+        self._executing = False
 
-        modules = self._get_modules_impl()
         logger.info(f"Attached to PID {pid}, {len(modules)} modules loaded")
         return {
             "pid": pid,
@@ -351,6 +358,55 @@ class DebugEngine:
             "module_count": len(modules),
             "state": self._state.value,
         }
+
+    def _wait_for_target_access_impl(self, timeout_seconds: float = 5.0) -> List[Any]:
+        deadline = time.monotonic() + timeout_seconds
+        last_error: Optional[Exception] = None
+
+        while time.monotonic() < deadline:
+            try:
+                self._base.reg.get_pc()
+                return list(self._base.module_list())
+            except Exception as exc:
+                last_error = exc
+                time.sleep(0.05)
+
+        if last_error is not None:
+            raise last_error
+        return []
+
+    def _detect_wow64_target(self, modules: List[ModuleInfo]) -> bool:
+        try:
+            actual_processor = self._base._control.GetActualProcessorType()
+        except Exception:
+            return False
+        if actual_processor != _IMAGE_FILE_MACHINE_AMD64:
+            return False
+        return any(_is_wow64_module_name(module.name) for module in modules)
+
+    @contextmanager
+    def _effective_processor_context(self, processor_type: Optional[int]) -> Iterator[None]:
+        if processor_type is None:
+            yield
+            return
+
+        control = self._base._control
+        previous_type: Optional[int] = None
+        changed = False
+        try:
+            previous_type = control.GetEffectiveProcessorType()
+            if previous_type != processor_type:
+                control.SetEffectiveProcessorType(processor_type)
+                changed = True
+            yield
+        finally:
+            if changed and previous_type is not None:
+                control.SetEffectiveProcessorType(previous_type)
+
+    def _wow64_x86_context(self) -> Iterator[None]:
+        if self._is_wow64:
+            return self._effective_processor_context(_IMAGE_FILE_MACHINE_I386)
+        return nullcontext()
 
     def detach(self) -> dict:
         """Detach from the target process."""
@@ -366,9 +422,7 @@ class DebugEngine:
         pid = self._target_pid
         self._target_pid = None
         self._target_name = None
-        self._target_image_path = None
-        self._target_pe_machine = None
-        self._target_processor_type = None
+        self._is_wow64 = False
         self._state = DebuggerState.DETACHED
         self._executing = False
         logger.info(f"Detached from PID {pid}")
@@ -411,18 +465,10 @@ class DebugEngine:
 
     def interrupt(self) -> dict:
         """Break into the debugger (interrupt execution)."""
-        return self._run_on_engine(self._interrupt_impl)
-
-    def _interrupt_impl(self) -> dict:
-        self._require_attached()
-        self._base._control.SetInterrupt(DbgEng.DEBUG_INTERRUPT_ACTIVE)
-        try:
-            self._base.wait(timeout=5000)
-        except exception.DbgEngTimeout as exc:
-            self._state = DebuggerState.RUNNING
-            self._executing = True
-            raise RuntimeError("Timed out waiting for debuggee to break") from exc
-        self._configure_target_context(detect_processor=True)
+        # interrupt() can be called from any thread
+        if self._protected_base is not None:
+            self._protected_base._control.SetInterrupt(
+                DbgEng.DEBUG_INTERRUPT_ACTIVE)
         self._state = DebuggerState.STOPPED
         self._executing = False
         return {"state": "stopped"}
@@ -434,7 +480,7 @@ class DebugEngine:
     def _step_into_impl(self, count: int) -> dict:
         self._require_stopped()
         self._base.stepi(count)
-        return {"state": "stopped", "pc": f"0x{self._base.reg.get_pc():08X}"}
+        return {"state": "stopped", "pc": f"0x{self._read_pc_impl():08X}"}
 
     def step_over(self, count: int = 1) -> dict:
         """Step over (proceed)."""
@@ -443,7 +489,7 @@ class DebugEngine:
     def _step_over_impl(self, count: int) -> dict:
         self._require_stopped()
         self._base.stepo(count)
-        return {"state": "stopped", "pc": f"0x{self._base.reg.get_pc():08X}"}
+        return {"state": "stopped", "pc": f"0x{self._read_pc_impl():08X}"}
 
     # -- State inspection --------------------------------------------------
 
@@ -464,13 +510,8 @@ class DebugEngine:
         self._require_attached()
         modules = []
         try:
-            for names, params in self._base.module_list():
-                display_name = names[1] or names[0] or names[2] or "<unknown>"
-                modules.append(ModuleInfo(
-                    name=display_name,
-                    runtime_base=params.Base,
-                    size=params.Size,
-                ))
+            for mod in self._base.module_list():
+                modules.append(_module_info_from_pybag_entry(mod))
         except Exception as e:
             logger.error(f"Error enumerating modules: {e}")
         return modules
@@ -481,47 +522,27 @@ class DebugEngine:
 
     def _get_registers_impl(self) -> Dict[str, int]:
         self._require_stopped()
-        self._configure_target_context()
+        return self._collect_registers_impl()
+
+    def _collect_registers_impl(self) -> Dict[str, int]:
         regs = {}
         reg_obj = self._base.reg
-        try:
-            effective = self._base._control.GetEffectiveProcessorType()
-        except Exception:
-            effective = None
-
-        if effective == DBGENG_PROCESSOR_X86:
-            reg_names = [
-                ("eax", "EAX"),
-                ("ebx", "EBX"),
-                ("ecx", "ECX"),
-                ("edx", "EDX"),
-                ("esi", "ESI"),
-                ("edi", "EDI"),
-                ("esp", "ESP"),
-                ("ebp", "EBP"),
-                ("eip", "EIP"),
-                ("efl", "EFLAGS"),
-            ]
-        else:
-            reg_names = [
-                ("rax", "RAX"),
-                ("rbx", "RBX"),
-                ("rcx", "RCX"),
-                ("rdx", "RDX"),
-                ("rsi", "RSI"),
-                ("rdi", "RDI"),
-                ("rsp", "RSP"),
-                ("rbp", "RBP"),
-                ("rip", "RIP"),
-                ("efl", "EFLAGS"),
-            ]
-
-        for source_name, label in reg_names:
-            try:
-                regs[label] = reg_obj._get_register(source_name)
-            except Exception:
-                pass
+        bitness = self._get_effective_bitness_impl()
+        with self._wow64_x86_context():
+            for result_name, query_name in _register_query_plan(bitness):
+                try:
+                    regs[result_name] = reg_obj._get_register(query_name)
+                except Exception:
+                    pass
         return regs
+
+    def _get_effective_bitness_impl(self) -> str:
+        if self._is_wow64:
+            return "32"
+        try:
+            return self._base.bitness()
+        except Exception:
+            return "32"
 
     def read_memory(self, address: int, size: int) -> bytes:
         """Read memory from the target."""
@@ -529,7 +550,6 @@ class DebugEngine:
 
     def _read_memory_impl(self, address: int, size: int) -> bytes:
         self._require_stopped()
-        self._configure_target_context()
         return bytes(self._base.read(address, size))
 
     def read_dword(self, address: int) -> int:
@@ -547,25 +567,25 @@ class DebugEngine:
 
     def _get_stack_trace_impl(self, depth: int) -> List[dict]:
         self._require_stopped()
-        self._configure_target_context()
         frames = []
         try:
-            for i, frame in enumerate(self._base.backtrace_list()):
-                if i >= depth:
-                    break
-                entry: dict = {
-                    "level": i,
-                    "instruction_offset": f"0x{frame.InstructionOffset:08X}",
-                    "return_offset": f"0x{frame.ReturnOffset:08X}",
-                    "stack_offset": f"0x{frame.StackOffset:08X}",
-                    "frame_offset": f"0x{frame.FrameOffset:08X}",
-                }
-                try:
-                    name = self._base.get_name_by_offset(frame.InstructionOffset)
-                    entry["symbol"] = name
-                except Exception:
-                    pass
-                frames.append(entry)
+            with self._wow64_x86_context():
+                for i, frame in enumerate(self._base.backtrace_list()):
+                    if i >= depth:
+                        break
+                    entry: dict = {
+                        "level": i,
+                        "instruction_offset": f"0x{frame.InstructionOffset:08X}",
+                        "return_offset": f"0x{frame.ReturnOffset:08X}",
+                        "stack_offset": f"0x{frame.StackOffset:08X}",
+                        "frame_offset": f"0x{frame.FrameOffset:08X}",
+                    }
+                    try:
+                        name = self._base.get_name_by_offset(frame.InstructionOffset)
+                        entry["symbol"] = name
+                    except Exception:
+                        pass
+                    frames.append(entry)
         except Exception as e:
             logger.error(f"Error reading stack trace: {e}")
         return frames
@@ -688,11 +708,19 @@ class DebugEngine:
 
     def get_pc(self) -> int:
         """Get current program counter."""
-        return self._run_on_engine(lambda: self._base.reg.get_pc())
+        return self._run_on_engine(self._read_pc_impl)
 
     def get_sp(self) -> int:
         """Get current stack pointer."""
-        return self._run_on_engine(lambda: self._base.reg.get_sp())
+        return self._run_on_engine(self._read_sp_impl)
+
+    def _read_pc_impl(self) -> int:
+        with self._wow64_x86_context():
+            return self._base.reg.get_pc()
+
+    def _read_sp_impl(self) -> int:
+        with self._wow64_x86_context():
+            return self._base.reg.get_sp()
 
     def resolve_symbol(self, address: int) -> Optional[str]:
         """Try to resolve an address to a symbol name."""

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -146,11 +146,17 @@ class RequestHandler(BaseHTTPRequestHandler):
     def _handle_status(self):
         ds = self._ds()
         engine = ds.engine
+        module_count = 0
+        if engine.get_state() != DebuggerState.DETACHED:
+            try:
+                module_count = len(engine.get_modules())
+            except Exception:
+                module_count = len(ds.mapper.get_all_modules())
         status = StatusResponse(
             state=engine.get_state(),
             target_pid=engine.get_target_pid(),
             target_name=engine.get_target_name(),
-            module_count=len(ds.mapper.get_all_modules()),
+            module_count=module_count,
             breakpoint_count=len(engine.list_breakpoints()) if engine.get_state() != DebuggerState.DETACHED else 0,
             active_traces=ds.tracer.active_count() if ds.tracer else 0,
             active_watches=ds.tracer.watch_count() if ds.tracer else 0,

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -134,12 +134,7 @@ class TraceSession:
                 if base is None:
                     return DbgEng.DEBUG_STATUS_GO_HANDLED
 
-                # Read registers directly (we're on the engine thread)
-                regs = {
-                    "ESP": base.reg.get_sp(),
-                    "ECX": base.reg._get_register("ECX"),
-                    "EDX": base.reg._get_register("EDX"),
-                }
+                regs = self._engine._collect_registers_impl()
 
                 args = read_args(regs, lambda a: struct.unpack("<I", base.read(a, 4))[0],
                                  convention, arg_count)
@@ -322,7 +317,7 @@ class TraceSession:
                 if base is None:
                     return DbgEng.DEBUG_STATUS_GO_HANDLED
 
-                pc = base.reg.get_pc()
+                pc = self._engine._read_pc_impl()
 
                 # Read the watched value
                 value = None

--- a/debugger/windbg.py
+++ b/debugger/windbg.py
@@ -1,0 +1,155 @@
+"""Helpers for resolving a usable WinDbg runtime for pybag."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+from pathlib import Path
+from typing import Iterable, MutableMapping, Optional
+
+try:
+    import winreg
+except ImportError:  # pragma: no cover - non-Windows test environments
+    winreg = None  # type: ignore[assignment]
+
+
+_REQUIRED_DLLS = ("dbgeng.dll", "dbghelp.dll", "dbgmodel.dll")
+_PACKAGE_REPOSITORY = (
+    r"Local Settings\Software\Microsoft\Windows\CurrentVersion"
+    r"\AppModel\PackageRepository\Packages"
+)
+
+
+def _sdk_arch_dir() -> str:
+    return "x64" if platform.architecture()[0] == "64bit" else "x86"
+
+
+def _store_arch_dir() -> str:
+    return "amd64" if platform.architecture()[0] == "64bit" else "x86"
+
+
+def has_required_dbgeng_dlls(path: Optional[Path | str]) -> bool:
+    if not path:
+        return False
+    candidate = Path(path)
+    return candidate.is_dir() and all((candidate / dll_name).is_file() for dll_name in _REQUIRED_DLLS)
+
+
+def _iter_sdk_candidates() -> Iterable[Path]:
+    seen: set[Path] = set()
+
+    def add(candidate: Optional[Path]) -> Iterable[Path]:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            yield candidate
+
+    if winreg is not None:
+        try:
+            roots_key = winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                r"SOFTWARE\Microsoft\Windows Kits\Installed Roots",
+            )
+            try:
+                kits_root = Path(winreg.QueryValueEx(roots_key, "KitsRoot10")[0])
+            finally:
+                winreg.CloseKey(roots_key)
+            yield from add(kits_root / "Debuggers" / _sdk_arch_dir())
+        except FileNotFoundError:
+            pass
+
+    for base in (
+        Path(r"C:\Program Files\Windows Kits\10"),
+        Path(r"C:\Program Files (x86)\Windows Kits\10"),
+    ):
+        yield from add(base / "Debuggers" / _sdk_arch_dir())
+
+
+def _find_store_install() -> Optional[Path]:
+    if winreg is None:
+        return None
+
+    packages_key = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, _PACKAGE_REPOSITORY)
+    try:
+        index = 0
+        while True:
+            try:
+                package_name = winreg.EnumKey(packages_key, index)
+            except OSError:
+                return None
+            index += 1
+            if "WinDbg" not in package_name or "_neutral_" in package_name:
+                continue
+            candidate = Path(r"C:\Program Files\WindowsApps") / package_name / _store_arch_dir()
+            if candidate.is_dir():
+                return candidate
+    finally:
+        winreg.CloseKey(packages_key)
+
+
+def _cache_store_install(store_dir: Path, localappdata: Optional[Path | str] = None) -> Path:
+    local_root = Path(localappdata) if localappdata else Path(os.environ.get("LOCALAPPDATA", ""))
+    if not local_root:
+        return store_dir
+
+    cache_dir = local_root / "ghidra_mcp_pybag_cache"
+    version_file = cache_dir / "version.txt"
+
+    def rebuild_cache() -> None:
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        for dll_name in _REQUIRED_DLLS:
+            shutil.copy2(store_dir / dll_name, cache_dir / dll_name)
+        version_file.write_text(str(store_dir), encoding="utf-8")
+
+    if not cache_dir.is_dir():
+        rebuild_cache()
+    else:
+        cached_source = version_file.read_text(encoding="utf-8") if version_file.is_file() else ""
+        if cached_source != str(store_dir) or not has_required_dbgeng_dlls(cache_dir):
+            rebuild_cache()
+
+    return cache_dir
+
+
+def resolve_windbg_dir(
+    env: Optional[MutableMapping[str, str]] = None,
+    sdk_candidates: Optional[Iterable[Path]] = None,
+    store_install: Optional[Path] = None,
+    localappdata: Optional[Path | str] = None,
+) -> Optional[Path]:
+    runtime_env = env if env is not None else os.environ
+
+    explicit = runtime_env.get("WINDBG_DIR")
+    if has_required_dbgeng_dlls(explicit):
+        return Path(explicit)
+
+    candidates = list(sdk_candidates) if sdk_candidates is not None else list(_iter_sdk_candidates())
+    for candidate in candidates:
+        if has_required_dbgeng_dlls(candidate):
+            return candidate
+
+    discovered_store = store_install if store_install is not None else _find_store_install()
+    if discovered_store and has_required_dbgeng_dlls(discovered_store):
+        return _cache_store_install(discovered_store, localappdata=localappdata)
+
+    return None
+
+
+def ensure_windbg_dir(
+    env: Optional[MutableMapping[str, str]] = None,
+    sdk_candidates: Optional[Iterable[Path]] = None,
+    store_install: Optional[Path] = None,
+    localappdata: Optional[Path | str] = None,
+) -> Optional[Path]:
+    runtime_env = env if env is not None else os.environ
+    resolved = resolve_windbg_dir(
+        env=runtime_env,
+        sdk_candidates=sdk_candidates,
+        store_install=store_install,
+        localappdata=localappdata,
+    )
+    if resolved is not None:
+        runtime_env["WINDBG_DIR"] = str(resolved)
+    return resolved

--- a/tests/unit/test_debugger_engine.py
+++ b/tests/unit/test_debugger_engine.py
@@ -1,0 +1,315 @@
+"""Unit tests for debugger/engine.py helpers and attach flow."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def import_engine_with_stubs():
+    for name in [
+        "debugger.engine",
+        "pybag",
+        "pybag.pydbg",
+        "pybag.userdbg",
+        "pybag.dbgeng",
+        "pybag.dbgeng.core",
+        "pybag.dbgeng.exception",
+    ]:
+        sys.modules.pop(name, None)
+
+    fake_pybag = types.ModuleType("pybag")
+
+    fake_pydbg = types.ModuleType("pybag.pydbg")
+
+    class FakeDebuggerBase:
+        pass
+
+    fake_pydbg.DebuggerBase = FakeDebuggerBase
+
+    fake_userdbg = types.ModuleType("pybag.userdbg")
+
+    class FakeUserDbg:
+        def proc_list(self):
+            return []
+
+        def ps(self):
+            return []
+
+        def pids_by_name(self, _name):
+            return []
+
+        def create(self, *_args, **_kwargs):
+            return None
+
+        def attach(self, *_args, **_kwargs):
+            return None
+
+        def detach(self, *_args, **_kwargs):
+            return None
+
+        def terminate(self, *_args, **_kwargs):
+            return None
+
+    fake_userdbg.UserDbg = FakeUserDbg
+
+    fake_dbgeng = types.ModuleType("pybag.dbgeng")
+    fake_core = types.ModuleType("pybag.dbgeng.core")
+    fake_core.DEBUG_INTERRUPT_ACTIVE = 1
+    fake_core.DEBUG_STATUS_GO = 2
+    fake_core.DEBUG_BREAKPOINT_CODE = 3
+    fake_core.DEBUG_BREAKPOINT_ENABLED = 4
+    fake_core.DEBUG_BREAKPOINT_ONE_SHOT = 8
+    fake_core.DEBUG_BREAKPOINT_DATA = 16
+    fake_core.DEBUG_STATUS_NO_CHANGE = 0
+
+    fake_exception = types.ModuleType("pybag.dbgeng.exception")
+
+    class FakeDbgEngTimeout(Exception):
+        pass
+
+    fake_exception.DbgEngTimeout = FakeDbgEngTimeout
+
+    fake_pybag.pydbg = fake_pydbg
+    fake_pybag.userdbg = fake_userdbg
+    fake_pybag.dbgeng = fake_dbgeng
+    fake_dbgeng.core = fake_core
+    fake_dbgeng.exception = fake_exception
+
+    sys.modules["pybag"] = fake_pybag
+    sys.modules["pybag.pydbg"] = fake_pydbg
+    sys.modules["pybag.userdbg"] = fake_userdbg
+    sys.modules["pybag.dbgeng"] = fake_dbgeng
+    sys.modules["pybag.dbgeng.core"] = fake_core
+    sys.modules["pybag.dbgeng.exception"] = fake_exception
+
+    return importlib.import_module("debugger.engine")
+
+
+def make_engine(engine_module, base, state):
+    engine = engine_module.DebugEngine.__new__(engine_module.DebugEngine)
+    engine._state = state
+    engine._target_pid = None
+    engine._target_name = None
+    engine._executing = False
+    engine._is_wow64 = False
+    engine._protected_base = base
+    engine._thread = threading.current_thread()
+    return engine
+
+
+class TestEngineHelpers:
+    def test_attach_uses_pid_from_pybag_match_and_skips_extra_wait(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeReg:
+            def get_pc(self):
+                return 0x140001000
+
+        class FakeBase:
+            def __init__(self):
+                self.reg = FakeReg()
+                self.attached = []
+                self.wait_calls = 0
+
+            def pids_by_name(self, _target):
+                return [(4321, r"C:\Windows\System32\ping.exe", "ping")]
+
+            def attach_proc(self, pid):
+                self.attached.append(pid)
+
+            def wait(self, _timeout=0):
+                self.wait_calls += 1
+
+            def module_list(self):
+                return [
+                    (
+                        (r"C:\Windows\System32\ping.exe", "ping", ""),
+                        types.SimpleNamespace(Base=0x140000000, Size=0x1000),
+                    )
+                ]
+
+        base = FakeBase()
+        engine = make_engine(engine_module, base, engine_module.DebuggerState.DETACHED)
+
+        result = engine._attach_impl("ping.exe")
+
+        assert base.attached == [4321]
+        assert base.wait_calls == 0
+        assert result["module_count"] == 1
+        assert result["name"] == "ping"
+        assert engine._state == engine_module.DebuggerState.STOPPED
+
+    def test_module_tuple_is_translated_to_module_info(self):
+        engine_module = import_engine_with_stubs()
+
+        module = engine_module._module_info_from_pybag_entry(
+            (
+                (r"C:\Windows\System32\ping.exe", "ping", ""),
+                types.SimpleNamespace(Base=0x140000000, Size=0x2000),
+            )
+        )
+
+        assert module.name == "ping"
+        assert module.runtime_base == 0x140000000
+        assert module.size == 0x2000
+
+    def test_registers_use_64bit_names_when_target_is_64bit(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeReg:
+            def __init__(self):
+                self.values = {
+                    "rax": 1,
+                    "rbx": 2,
+                    "rcx": 3,
+                    "rdx": 4,
+                    "rsi": 5,
+                    "rdi": 6,
+                    "rsp": 7,
+                    "rbp": 8,
+                    "rip": 9,
+                    "r8": 10,
+                    "r9": 11,
+                    "r10": 12,
+                    "r11": 13,
+                    "r12": 14,
+                    "r13": 15,
+                    "r14": 16,
+                    "r15": 17,
+                    "efl": 0x246,
+                }
+
+            def _get_register(self, name):
+                return self.values[name]
+
+        class FakeBase:
+            def __init__(self):
+                self.reg = FakeReg()
+
+            def bitness(self):
+                return "64"
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+        regs = engine._get_registers_impl()
+
+        assert regs["RAX"] == 1
+        assert regs["R15"] == 17
+        assert regs["RIP"] == 9
+        assert regs["EFLAGS"] == 0x246
+        assert "EAX" not in regs
+
+    def test_registers_use_32bit_names_when_target_is_wow64(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeControl:
+            def __init__(self):
+                self.effective = 0x8664
+                self.set_calls = []
+
+            def GetEffectiveProcessorType(self):
+                return self.effective
+
+            def SetEffectiveProcessorType(self, processor_type):
+                self.set_calls.append(processor_type)
+                self.effective = processor_type
+
+        class FakeReg:
+            def __init__(self):
+                self.values = {
+                    "eax": 1,
+                    "ebx": 2,
+                    "ecx": 3,
+                    "edx": 4,
+                    "esi": 5,
+                    "edi": 6,
+                    "esp": 7,
+                    "ebp": 8,
+                    "eip": 9,
+                    "efl": 0x202,
+                }
+
+            def _get_register(self, name):
+                return self.values[name]
+
+        class FakeBase:
+            def __init__(self):
+                self.reg = FakeReg()
+                self._control = FakeControl()
+
+            def bitness(self):
+                return "64"
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+        engine._is_wow64 = True
+        regs = engine._get_registers_impl()
+
+        assert regs["EAX"] == 1
+        assert regs["EIP"] == 9
+        assert regs["EFLAGS"] == 0x202
+        assert "RAX" not in regs
+        assert engine._protected_base._control.set_calls == [0x14C, 0x8664]
+
+    def test_get_pc_uses_32bit_effective_processor_on_wow64(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeControl:
+            def __init__(self):
+                self.effective = 0x8664
+                self.set_calls = []
+
+            def GetEffectiveProcessorType(self):
+                return self.effective
+
+            def SetEffectiveProcessorType(self, processor_type):
+                self.set_calls.append(processor_type)
+                self.effective = processor_type
+
+        class FakeReg:
+            def get_pc(self):
+                return 0x12345678
+
+        class FakeBase:
+            def __init__(self):
+                self.reg = FakeReg()
+                self._control = FakeControl()
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+        engine._is_wow64 = True
+
+        assert engine._read_pc_impl() == 0x12345678
+        assert engine._protected_base._control.set_calls == [0x14C, 0x8664]
+
+    def test_attach_failure_detaches_and_resets_state(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeReg:
+            def get_pc(self):
+                return 0x140001000
+
+        class FakeBase:
+            def __init__(self):
+                self.reg = FakeReg()
+                self.detached = False
+
+            def attach_proc(self, _pid):
+                return None
+
+            def detach_proc(self):
+                self.detached = True
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.DETACHED)
+        engine._wait_for_target_access_impl = lambda: (_ for _ in ()).throw(RuntimeError("not ready"))
+
+        with pytest.raises(RuntimeError, match="never became queryable"):
+            engine._attach_impl("1234")
+
+        assert engine._protected_base.detached is True
+        assert engine._state == engine_module.DebuggerState.DETACHED

--- a/tests/unit/test_windbg.py
+++ b/tests/unit/test_windbg.py
@@ -1,0 +1,65 @@
+"""Unit tests for debugger/windbg.py runtime resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from debugger.windbg import ensure_windbg_dir, has_required_dbgeng_dlls, resolve_windbg_dir
+
+
+def create_dbg_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    for dll_name in ("dbgeng.dll", "dbghelp.dll", "dbgmodel.dll"):
+        (path / dll_name).write_text(dll_name, encoding="utf-8")
+    return path
+
+
+def test_has_required_dbgeng_dlls(tmp_path):
+    valid = create_dbg_dir(tmp_path / "valid")
+    invalid = tmp_path / "invalid"
+    invalid.mkdir()
+    (invalid / "dbghelp.dll").write_text("dbghelp", encoding="utf-8")
+
+    assert has_required_dbgeng_dlls(valid) is True
+    assert has_required_dbgeng_dlls(invalid) is False
+
+
+def test_resolve_windbg_dir_skips_invalid_env_when_sdk_candidate_is_valid(tmp_path):
+    invalid_env = tmp_path / "invalid-env"
+    invalid_env.mkdir()
+    valid_sdk = create_dbg_dir(tmp_path / "sdk")
+
+    env = {"WINDBG_DIR": str(invalid_env)}
+    result = resolve_windbg_dir(env=env, sdk_candidates=[valid_sdk], store_install=None)
+
+    assert result == valid_sdk
+
+
+def test_resolve_windbg_dir_caches_store_install(tmp_path):
+    store_install = create_dbg_dir(tmp_path / "store")
+    localappdata = tmp_path / "localappdata"
+    localappdata.mkdir()
+
+    result = resolve_windbg_dir(
+        env={},
+        sdk_candidates=[],
+        store_install=store_install,
+        localappdata=localappdata,
+    )
+
+    assert result == localappdata / "ghidra_mcp_pybag_cache"
+    assert has_required_dbgeng_dlls(result)
+    assert (result / "version.txt").read_text(encoding="utf-8") == str(store_install)
+
+
+def test_ensure_windbg_dir_updates_environment(tmp_path):
+    valid_sdk = create_dbg_dir(tmp_path / "sdk")
+    env = {}
+
+    ensure_windbg_dir(env=env, sdk_candidates=[valid_sdk], store_install=None)
+
+    assert env["WINDBG_DIR"] == str(valid_sdk)


### PR DESCRIPTION
## Summary

This PR repairs the Windows debugger backend so it works reliably with both native x64 processes and Win32 targets under WOW64.

## What changed

- auto-resolves a usable WinDbg runtime for `pybag`, including Microsoft Store WinDbg fallback when the Windows Kits debugger directory is incomplete
- fixes the attach flow so the backend only reports success after the target is actually queryable
- parses `pybag` module enumeration tuples correctly and reports live module counts/status through the debugger API
- returns the correct x64 register set on native 64-bit targets
- switches dbgeng's effective processor to x86 for WOW64 register and stack-context reads so 32-bit targets return `EAX` / `ECX` / `ESP` / `EIP` instead of the host-side `R*` view
- carries that WOW64 x86 context through trace/watch helpers that depend on stack/register inspection
- adds targeted unit coverage for WinDbg runtime selection, attach/queryability handling, x64 register reads, and WOW64 register selection

## Validation

On Windows:

```powershell
pytest tests\unit -v -o addopts=
```

Live smoke tests:

- attached to `C:\Windows\System32\ping.exe` and verified modules, registers, and stack output for a native x64 target
- attached to `C:\Windows\SysWOW64\ping.exe` and verified modules, stack, and 32-bit register output (`EAX` / `EIP` / `ESP`) for a WOW64 target