### PR TITLE
fix: resolve 421 Misdirected Request when --mcp-host is set to a non-localhost address

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -32,6 +32,7 @@ from urllib.parse import urlencode, urlparse
 
 from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.lowlevel.server import NotificationOptions
+from mcp.server.transport_security import TransportSecuritySettings
 
 # ==========================================================================
 # Configuration
@@ -1942,6 +1943,28 @@ def main():
     mcp.settings.host = args.mcp_host
     if args.mcp_port:
         mcp.settings.port = args.mcp_port
+
+    # The MCP SDK's DNS rebinding protection is configured at FastMCP construction
+    # time, before --mcp-host is known.  Patch it now based on the resolved host so
+    # that non-localhost binds don't get a 421 Misdirected Request.
+    _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
+    _WILDCARD_HOSTS = {"0.0.0.0", "::"}
+    _host = args.mcp_host
+    if _host not in _LOCALHOST_HOSTS:
+        if _host in _WILDCARD_HOSTS:
+            # Operator is explicitly binding to all interfaces; disable rebinding
+            # protection — network-level isolation is the intended security boundary.
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=False,
+            )
+        else:
+            # Explicit non-localhost host: keep protection on but allow that host.
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=[f"{_host}:*", "localhost:*", "127.0.0.1:*"],
+                allowed_origins=[f"http://{_host}:*", "http://localhost:*", "http://127.0.0.1:*"],
+            )
+
     logger.info(f"Starting MCP bridge ({args.transport})")
     if args.transport in ("sse", "streamable-http"):
         host = args.mcp_host


### PR DESCRIPTION
### Problem
  When starting the bridge with `--mcp-host 0.0.0.0` (or any non-localhost address) and an HTTP transport (`--transport streamable-http` and possibly `--transport sse`), every incoming request is rejected with this error message:

```bash
python bridge_mcp_ghidra.py --transport streamable-http --mcp-host 0.0.0.0 --mcp-port 8081
....
mcp.server.transport_security - WARNING - Invalid Host header: <host>
INFO: "POST /mcp HTTP/1.1" 421 Misdirected Request
```

### Root Cause
`mcp >= 1.24` introduced DNS rebinding protection ([python-sdk #861](https://github.com/modelcontextprotocol/python-sdk/pull/861)). `FastMCP.__init__` auto-configures `TransportSecuritySettings` only when the host passed to the constructor is `127.0.0.1`, `localhost`, or `::1`. For any other host (including `0.0.0.0`) the middleware is enabled with `allowed_hosts=[]`, so **every request from every host fails**.

Because the bridge constructs `FastMCP` at module load time and applies `--mcp-host` later via `mcp.settings.host`, the constructor's auto-configure logic never sees the user-supplied host, leaving protection active with an empty allowlist.

### Fix
After `mcp.settings.host` is patched in `main()`, we now also patch `mcp.settings.transport_security` according to the resolved bind address:
| Host value | Behavior |
|---|---|
| `127.0.0.1`, `localhost`, `::1` | No change — SDK default is correct |
| `0.0.0.0` / `::` | Disable DNS rebinding protection; operator controls the network boundary |
| Any other explicit host | Keep protection enabled; add the host to `allowed_hosts` with wildcard port (`host:*`) |
 
Fixes #161 

### References
- [modelcontextprotocol/python-sdk#1798](https://github.com/modelcontextprotocol/python-sdk/issues/1798) — community guide on the 421 issue
- [jlowin/fastmcp #873](https://github.com/jlowin/fastmcp/issues/873) — host option not supported with streamable-http