### PR TITLE
fix: align list_functions_enhanced thunk detection with analyze_function_completeness

### DIFF
--- a/src/main/java/com/xebyte/core/ListingService.java
+++ b/src/main/java/com/xebyte/core/ListingService.java
@@ -297,7 +297,7 @@ public class ListingService {
             Map<String, Object> funcItem = new LinkedHashMap<>();
             funcItem.putAll(ServiceUtils.addressToJson(func.getEntryPoint(), program));
             funcItem.put("name", func.getName());
-            funcItem.put("isThunk", func.isThunk());
+            funcItem.put("isThunk", "thunk".equals(AnalysisService.classifyFunction(func, program)));
             funcItem.put("isExternal", func.isExternal());
             functions.add(funcItem);
             count++;


### PR DESCRIPTION
## Problem
`list_functions_enhanced` returned `isThunk: false` for functions that
`analyze_function_completeness` correctly classified as `"thunk"`.
The discrepancy came from using two different detection strategies:
  - `list_functions_enhanced` called `func.isThunk()` — Ghidra's native tag only
  - `analyze_function_completeness` called `AnalysisService.classifyFunction()`,
    which checks `func.isThunk()` **and** a single-JMP instruction heuristic
  Any function Ghidra didn't explicitly tag as a thunk but consisting of a single
  `JMP` instruction would be classified as `"thunk"` by one tool and reported as
  `isThunk: false` by the other.

## Fix
Replace `func.isThunk()` in `listFunctionsEnhanced` with the same `AnalysisService.classifyFunction()` call used by `analyze_function_completeness`. This makes `isThunk` in `list_functions_enhanced` agree with `classification` from `analyze_function_completeness` for all functions.

Fixes #163 
  
## Impact
  - Single-JMP thunks (not Ghidra-tagged) now correctly surface as `isThunk: true` in `list_functions_enhanced`
  - No schema or endpoint changes
  - No behavior change for functions Ghidra has already tagged as thunks