### PR TITLE
Prepare 5.6.0 release regression

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,12 @@ GHIDRA_PATH=
 # setup/deploy. Windows-only; ignored on Linux and macOS.
 # Values: true/false, 1/0, yes/no, on/off
 INSTALL_DEBUGGER_DEPS=false
+
+# Optional Python executable for Ghidra Trace RMI debugger launchers.
+# Useful on Windows when PATH points at a Python version incompatible with
+# Ghidra's bundled dbgeng wheels. Example:
+# GHIDRA_DEBUGGER_PYTHON=C:\Users\you\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\python.exe
+GHIDRA_DEBUGGER_PYTHON=
 # =============================================================================
 # Server Configuration
 # =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -372,6 +372,7 @@ allure-results/
 allure-report/
 junit/
 reports/
+live-all-mcp-tools-report.json
 
 # Performance and profiling
 *.prof

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.5.0
+- **Version**: 5.6.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
-- **Key feature**: 199 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
+- **Key feature**: 225 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 
 ## Directory Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## v5.6.0 - 2026-04-25 (release regression)
+
+Release focused on deploy safety, live benchmark regression coverage, and
+debugger endpoint validation.
+
+### Added
+
+- **Live deploy release regression** - deploy can now opt into benchmark-backed
+  read/write, multi-program, negative-contract, and debugger-live regression
+  tiers with `--test ...` or local `GHIDRA_MCP_DEPLOY_TESTS`.
+- **Benchmark debugger fixture** - `fun-doc/benchmark` now builds
+  `BenchmarkDebug.exe` alongside `Benchmark.dll` so debugger MCP endpoints can
+  be exercised against a real launched process.
+- **Scoped prompt policy endpoint** - `/prompt_policy` temporarily handles a
+  narrow allow-list of known Ghidra automation dialogs during deploy/regression
+  runs while leaving normal interactive prompts untouched.
+
+### Changed
+
+- **Deploy lifecycle** - deploy now saves all open programs, attempts graceful
+  Ghidra exit, force-kills matching leftovers when needed, installs the
+  extension, starts Ghidra, waits for MCP/project readiness, and runs schema
+  smoke checks.
+- **Benchmark project reset** - benchmark tiers reset `/testing/benchmark` in
+  the active project, import both benchmark binaries, auto-analyze them, and
+  clear restored benchmark tool state before startup.
+
 ## v5.5.0 - 2026-04-23 (maintenance)
 
 Maintenance release focused on cleanup and release readiness after the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-MCP server bridging Ghidra reverse engineering with AI tools. 222 MCP tools for binary analysis.
+MCP server bridging Ghidra reverse engineering with AI tools. 225 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.5.0 | **Java**: 21 LTS | **Ghidra**: 12.0.4
+- **Package**: `com.xebyte` | **Version**: 5.6.0 | **Java**: 21 LTS | **Ghidra**: 12.0.4
 
 ## Boil the ocean
 
@@ -32,7 +32,7 @@ Services use constructor injection: `ProgramProvider` + `ThreadingStrategy`.
 
 Do not try to keep the full tool list in this file.
 
-- **Authoritative repo snapshot**: `tests/endpoints.json` (222 endpoints, categories, descriptions)
+- **Authoritative repo snapshot**: `tests/endpoints.json` (225 endpoints, categories, descriptions)
 - **Authoritative runtime schema**: `/mcp/schema` from the running server
 - **Usage patterns / operator guide**: `docs/prompts/TOOL_USAGE_GUIDE.md`
 
@@ -72,6 +72,24 @@ python -m tools.setup deploy         --ghidra-path F:\ghidra_12.0.4_PUBLIC
 - `tools.setup` delegates to Maven by default; set `TOOLS_SETUP_BACKEND=gradle` to route the same commands to Gradle
 - Deploy handles: build, extension install, FrontEndTool.xml patching, Ghidra restart
 - Migration plan: `docs/project-management/GRADLE_MIGRATION_CHECKLIST.md`
+
+## Releases
+
+Use `docs/releases/RELEASE_CHECKLIST.md` as the canonical release runbook. Do
+not duplicate the whole checklist here; keep this file light enough to fit in
+agent context.
+
+Release floor before tagging or publishing:
+
+```text
+python -m tools.setup verify-version
+python -m tools.setup build
+pytest tests/unit/ -v --no-cov
+python -m tools.setup deploy --ghidra-path F:\ghidra_12.0.4_PUBLIC --test release
+```
+
+Run UI-touching deploy/regression only after confirming the current Ghidra UI
+state when modal dialogs may be present.
 
 ## Running the MCP Server
 
@@ -117,15 +135,87 @@ When building new tools or modifying existing ones, wire validation through `Nam
 
 ## Testing
 
-- **Offline (no Ghidra required)**:
-  - Java (Gradle): `./gradlew test --tests 'com.xebyte.offline.*' -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC`
-  - Java (Maven): `mvn test -Dtest='com.xebyte.offline.*Test'` -- annotation scanner + `tests/endpoints.json` parity (~0.5s, 11 tests)
-  - Python: `pytest tests/performance/test_selector_invariants.py tests/performance/test_state_atomicity.py`
-- **Integration (Ghidra required on port 8089)**:
-  - Java (Gradle): `./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC`
-  - Java (Maven): `mvn test` -- runs everything including endpoint registration tests
-  - Python: `pytest tests/`
-- **Catalog drift**: if `EndpointsJsonParityTest` fails after adding/modifying an `@McpTool`, run `mvn test -Dtest=RegenerateEndpointsJson -Dregenerate=true` to rewrite `tests/endpoints.json` from the scanner (preserves hand-authored descriptions and hand-registered routes).
+Three tiers by cost and prerequisites:
+
+1. **Unit** (`pytest tests/unit/`) — pure Python, no Ghidra, no side effects. Covers bridge utils, debugger engine, setup CLI, catalog/schema consistency. Fast (<5s).
+2. **Offline** — Java scanner/parity + Python regression tests that don't hit Ghidra on 8089. Fast (<10s).
+3. **Integration** (`pytest tests/` + `mvn test`) — requires live Ghidra on port 8089 with a binary open. Slow and stateful.
+
+### Match change → tests
+
+Find the file(s) you edited below; run everything in that row. Always include the tier-1 Unit + Offline row as a floor unless noted.
+
+| Change location | Run |
+| --- | --- |
+| `src/main/java/com/xebyte/core/*Service.java` (any service class) | Offline (Java) + Integration (Java) + `tests/integration/test_readonly_endpoints.py` |
+| `src/main/java/com/xebyte/core/NamingConventions.java` | Offline (Java) + `tests/integration/test_safe_write_endpoints.py` + fun-doc benchmark (`--mock --tier fast --compare`) |
+| Add/modify `@McpTool` / `@Param` annotation | Offline (Java) first — `EndpointsJsonParityTest` will fail if `tests/endpoints.json` is stale. Regenerate: `mvn test -Dtest=RegenerateEndpointsJson -Dregenerate=true`. Then Integration (Java). |
+| `src/main/java/com/xebyte/GhidraMCPPlugin.java` (HTTP routes) | Offline (Java) + `EndpointRegistrationTest` (integration) + `tests/performance/test_http_concurrency.py` |
+| `src/main/java/com/xebyte/headless/*` | Offline (Java) + `tests/unit/test_setup_ghidra.py` + Integration (Java) headless run |
+| `bridge_mcp_ghidra.py` | `tests/unit/test_bridge_utils.py tests/unit/test_mcp_tools.py tests/unit/test_mcp_tool_functions.py tests/unit/test_response_schemas.py tests/unit/test_endpoint_catalog.py` |
+| `fun-doc/fun_doc.py` — state, sessions, locking, selector, scoring | `tests/performance/test_state_atomicity.py tests/performance/test_state_lock_reentrant.py tests/performance/test_selector_invariants.py tests/performance/test_event_bus_drain.py` + fun-doc benchmark (`--mock --tier fast --compare`) |
+| `fun-doc/fun_doc.py` — provider routing, prompt construction | `tests/performance/test_provider_selection.py tests/performance/test_ghidra_offline.py` + fun-doc benchmark |
+| `fun-doc/web.py` — worker loop, heartbeats, dashboard | `tests/performance/test_state_atomicity.py tests/performance/test_worker_watchdog.py tests/performance/test_dashboard_single_instance.py` |
+| `fun-doc/event_bus.py` / `event_log.py` | `tests/performance/test_event_bus_drain.py` |
+| `fun-doc/audit/*` | `tests/performance/test_audit_rules.py tests/performance/test_audit_registry.py` |
+| `fun-doc/benchmark/scorer.py` or `truth/*.yaml` or `src/*.c` | `tests/performance/test_benchmark_scorer.py tests/performance/test_benchmark_extract_truth.py tests/performance/test_benchmark_haiku_judge.py tests/performance/test_benchmark_ghidra_bridge.py` + rerun the benchmark itself |
+| `debugger/*` | `tests/unit/test_address_map.py tests/unit/test_d2_conventions.py tests/unit/test_debugger_engine.py tests/unit/test_debugger_server.py tests/unit/test_windbg.py` |
+| `tools/setup/*`, `build.gradle`, `pom.xml` | `tests/unit/test_setup_cli.py tests/unit/test_setup_ghidra.py tests/unit/test_gradle_tasks.py tests/unit/test_version_bump.py tests/unit/test_project_consistency.py` |
+| `tests/endpoints.json` hand-edit | Offline (Java) — `EndpointsJsonParityTest` verifies every `@McpTool` is listed and hand-authored descriptions are preserved |
+| CLI: `bridge_mcp_ghidra.py --transport`, `tools.setup` subcommands | `tests/unit/test_setup_cli.py` + manual invocation |
+
+### Commands
+
+**Unit (always cheap, run by default):**
+
+```text
+pytest tests/unit/ --no-cov
+```
+
+**Offline Java (scanner + endpoints.json parity, ~11 tests, <1s):**
+
+```text
+# Gradle
+./gradlew test --tests 'com.xebyte.offline.*' -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+# Maven
+mvn test -Dtest='com.xebyte.offline.*Test'
+```
+
+**Offline Python (no Ghidra needed — the whole performance/ dir minus 4 integration-flavored files):**
+
+```text
+pytest tests/performance/ \
+  --ignore=tests/performance/test_batch_scoring_consistency.py \
+  --ignore=tests/performance/test_health_endpoint.py \
+  --ignore=tests/performance/test_http_concurrency.py \
+  --ignore=tests/performance/test_listing_consistency.py \
+  --no-cov
+```
+
+(The four excluded files hit `http://127.0.0.1:8089` and need live Ghidra.)
+
+**Integration (Ghidra running on 8089 with a binary open):**
+
+```text
+# Java
+./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC   # or: mvn test
+# Python — subset by marker
+pytest tests/ -m readonly          # safe, no writes
+pytest tests/ -m safe_write        # identity writes only
+pytest tests/                      # full suite, includes mutating tests
+```
+
+### Known pre-existing failures
+
+- `tests/performance/test_worker_watchdog.py` — three tests reference `WorkerManager._watchdog_stop`, which no longer exists. Failures are unrelated to most changes; ignore unless editing the watchdog itself.
+
+### Catalog drift
+
+If `EndpointsJsonParityTest` fails after `@McpTool` edits, regenerate `tests/endpoints.json` from the scanner (preserves hand-authored descriptions and hand-registered routes):
+
+```text
+mvn test -Dtest=RegenerateEndpointsJson -Dregenerate=true
+```
 
 ## Key Gotchas
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 >
 > If Ghidra MCP saves you time, consider [sponsoring the project](https://github.com/sponsors/bethington). One-time and recurring support both help fund compatibility updates, production hardening, docs, and new tooling.
 
-A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **222 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
+A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **225 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
 
 ## Why Ghidra MCP?
 
 Most Ghidra MCP implementations give you a handful of read-only tools and call it a day. This project is different — it was built by a reverse engineer who uses it daily on real binaries, not as a demo.
 
-- **222 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
+- **225 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
 - **Battle-tested AI workflows** — Proven documentation workflows (V5) refined across hundreds of functions. Includes step-by-step prompts, Hungarian notation reference, batch processing guides, and orphaned code discovery.
 - **Production-grade reliability** — Atomic transactions, batch operations (93% API call reduction), configurable timeouts, and graceful error handling. No silent failures.
 - **Cross-binary documentation transfer** — SHA-256 function hash matching propagates documentation across binary versions automatically. Document once, apply everywhere.
@@ -55,7 +55,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 ### Core MCP Integration
 - **Full MCP Compatibility** — Complete implementation of Model Context Protocol
-- **222 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
+- **225 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
 - **Production-Ready Reliability** — Atomic transactions, batch operations, configurable timeouts
 - **Real-time Analysis** — Live integration with Ghidra's analysis engine
 
@@ -125,8 +125,11 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
    python -m tools.setup ensure-prereqs --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
    python -m tools.setup build
    python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
-   python -m tools.setup start-ghidra --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
    ```
+
+   `deploy` saves/closes an already-running matching Ghidra instance when
+   needed, installs the extension, starts Ghidra, waits for MCP health, and runs
+   schema smoke checks.
 
 4. **Optional strict/manual mode** (advanced):
    ```text
@@ -455,7 +458,7 @@ python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.0.4_PUBLIC
 
 ## 📊 Production Performance
 
-- **MCP Tools**: 222 tools fully implemented
+- **MCP Tools**: 225 tools fully implemented
 - **Speed**: Sub-second response for most operations
 - **Efficiency**: 93% reduction in API calls via batch operations
 - **Reliability**: Atomic transactions with all-or-nothing semantics
@@ -696,7 +699,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ### Components
 
-- **bridge_mcp_ghidra.py** — Python MCP server that translates MCP protocol to HTTP calls (222 tools)
+- **bridge_mcp_ghidra.py** — Python MCP server that translates MCP protocol to HTTP calls (225 catalog entries)
 - **GhidraMCP.jar** — Ghidra plugin that exposes analysis capabilities via HTTP (175 GUI endpoints)
 - **GhidraMCPHeadlessServer** — Standalone headless server — 183 endpoints, no GUI required
 - **ghidra_scripts/** — Collection of automation scripts for common tasks
@@ -742,13 +745,15 @@ Common flags accepted by most commands:
 | `--force` | Reinstall Ghidra JARs even if already present (`install-ghidra-deps`, `ensure-prereqs`). |
 | `--with-debugger` | Force-install debugger Python requirements (Windows only). |
 | `--use-debugger-toggle` | Read `INSTALL_DEBUGGER_DEPS` from `.env` to decide whether to install debugger deps. |
+| `--test TIER` | (`deploy` only) Opt into live deploy regression tiers such as `release` or `debugger-live`. |
 | `--strict` | (`preflight` only) Also check network reachability for Maven Central and PyPI. |
 
 Deploy test tiers are opt-in because benchmark tiers can import/reset
-`Benchmark.dll` in the active Ghidra project. Use `--test release` before
-cutting releases, or set `GHIDRA_MCP_DEPLOY_TESTS=release` in a local `.env`
-when you want every deploy on your machine to run the live benchmark
-regression. See [Testing and Release Regression](docs/TESTING.md).
+`Benchmark.dll` and `BenchmarkDebug.exe` in the active Ghidra project. Use
+`--test release` before cutting releases, or set
+`GHIDRA_MCP_DEPLOY_TESTS=release` in a local `.env` when you want every deploy
+on your machine to run the live benchmark regression. See
+[Testing and Release Regression](docs/TESTING.md).
 
 ```text
 # Standard first-time setup and deploy
@@ -760,7 +765,7 @@ python -m tools.setup deploy --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
 python -m tools.setup preflight --strict --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
 
 # Version bump and tag
-python -m tools.setup bump-version --new 5.5.0 --tag
+python -m tools.setup bump-version --new 5.6.0 --tag
 
 # Run offline Java tests
 python -m tools.setup run-tests
@@ -772,17 +777,17 @@ python -m tools.setup --help
 ### Project Structure
 ```
 ghidra-mcp/
-├── bridge_mcp_ghidra.py     # MCP server (Python, 222 tools)
+├── bridge_mcp_ghidra.py     # MCP server (Python, 225 catalog entries)
 ├── src/main/java/           # Ghidra plugin + headless server (Java)
 │   └── com/xebyte/
-│       ├── GhidraMCPPlugin.java         # GUI plugin (175 endpoints)
+│       ├── GhidraMCPPlugin.java         # GUI plugin (177 endpoints)
 │       ├── headless/                    # Headless server (183 endpoints)
 │       └── core/                        # Shared service layer (12 services)
 ├── debugger/                # Optional standalone debugger server (port 8099)
 ├── ghidra_scripts/          # Automation scripts for batch workflows
 ├── tests/                   # Python unit tests + endpoint catalog
 │   ├── unit/               # Catalog consistency, schema, tool function tests
-│   └── endpoints.json      # Endpoint specification (222 entries)
+│   └── endpoints.json      # Endpoint specification (225 entries)
 ├── docs/                    # Documentation
 │   ├── prompts/            # AI workflow prompts (V5 documentation workflows)
 │   ├── releases/           # Version release notes
@@ -889,7 +894,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.5.0
+# Connection OK - GhidraMCP Headless Server v5.6.0
 ```
 
 ### Headless API Workflow
@@ -955,9 +960,9 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.5.0 |
-| **MCP Tools** | 222 fully implemented |
-| **GUI Endpoints** | 198 (GhidraMCPPlugin) |
+| **Version** | 5.6.0 |
+| **MCP Tools** | 225 fully implemented |
+| **GUI Endpoints** | 177 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |
 | **Compilation** | ✅ 100% success |
 | **Batch Efficiency** | 93% API call reduction |

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -28,7 +28,7 @@ SECURITY.md                  — Security guidelines and reporting (future)
 Organized reference documentation also uses **UPPERCASE**:
 
 ```
-docs/TOOL_REFERENCE.md           — Authoritative endpoint catalog (222 tools)
+docs/TOOL_REFERENCE.md           — Authoritative endpoint catalog (225 tools)
 docs/ERROR_CODES.md              — Error catalog and troubleshooting guide
 docs/PERFORMANCE_BASELINES.md    — Performance metrics and optimization
 docs/ARCHITECTURE.md             — System architecture and design

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,7 +8,7 @@ This project has two different testing surfaces:
   exercise MCP endpoints against a benchmark binary inside an active project.
 
 The live tests are intentionally opt-in because they can add or reset
-`Benchmark.dll` in the current Ghidra project.
+`Benchmark.dll` and `BenchmarkDebug.exe` in the current Ghidra project.
 
 ## Quick Commands
 
@@ -45,8 +45,9 @@ repository default.
 A plain deploy:
 
 1. Detects matching running Ghidra processes for the target install.
-2. Requests `save_program`.
-3. Requests graceful `exit_ghidra`.
+2. Requests `save_all_programs`.
+3. Requests graceful `exit_ghidra`, which saves open programs and debugger
+   traces before closing.
 4. Force-kills remaining matching Ghidra processes if graceful exit did not
    finish.
 5. Installs the extension and bridge files.
@@ -55,8 +56,8 @@ A plain deploy:
 8. Waits for a project-backed endpoint to confirm the active project is ready.
 9. Runs MCP schema smoke checks.
 
-A plain deploy does **not** import `Benchmark.dll` unless the user opts in with
-`--test ...` or `GHIDRA_MCP_DEPLOY_TESTS`.
+A plain deploy does **not** import `Benchmark.dll` or `BenchmarkDebug.exe`
+unless the user opts in with `--test ...` or `GHIDRA_MCP_DEPLOY_TESTS`.
 
 ## Live Test Tiers
 
@@ -70,7 +71,8 @@ Pass one or more `--test` values to `python -m tools.setup deploy`.
 | `benchmark-write` | Imports/resets benchmark, writes test metadata | Runs reversible write smoke checks against the benchmark. |
 | `multi-program` | Imports/resets benchmark | Confirms project-path targeting works when multiple programs are open. |
 | `negative-contract` | Imports/resets benchmark | Asserts important error cases return actionable messages. |
-| `release` | Imports/resets benchmark, writes test metadata | Runs the release-grade suite. |
+| `debugger-live` | Imports/resets benchmark, launches test process | Launches `BenchmarkDebug.exe` through MCP debugger endpoints and reads live trace state. |
+| `release` | Imports/resets benchmark, writes test metadata, launches test process | Runs the release-grade suite. |
 
 The `release` tier currently runs:
 
@@ -79,8 +81,14 @@ The `release` tier currently runs:
 3. Extended benchmark read checks.
 4. Multi-program targeting checks.
 5. Negative/error-shape checks.
+6. Debugger live launch/status/module/register/stack checks.
 
 Default deploy also runs the schema smoke check before any selected tier.
+
+When a benchmark tier runs, deploy temporarily enables the `/prompt_policy`
+endpoint. This narrowly-scoped prompt policy only responds to known automation
+dialogs for the benchmark flow, such as benchmark analysis prompts, modified
+file saves, and tool-layout save prompts. Unknown dialogs are left alone.
 
 ## Benchmark Fixture
 
@@ -89,21 +97,30 @@ active Ghidra project at:
 
 ```text
 /testing/benchmark/Benchmark.dll
+/testing/benchmark/BenchmarkDebug.exe
 ```
 
-The filesystem build artifact stays at:
+The filesystem build artifacts stay at:
 
 ```text
 fun-doc/benchmark/build/Benchmark.dll
+fun-doc/benchmark/build/BenchmarkDebug.exe
 ```
 
 Before benchmark tiers run, the deploy harness deletes any existing benchmark
 project file at the legacy and current benchmark paths, recreates the
-`/testing/benchmark` folder, imports the current binary, and waits for analysis
-to become idle.
+`/testing/benchmark` folder, imports the current binaries, and waits for
+analysis to become idle. It also removes restored benchmark CodeBrowser or
+Debugger tool state from the active project before startup so old benchmark
+windows do not trigger first-open dialogs before MCP is ready.
 
 This reset is why benchmark tiers are opt-in: users should not get a test binary
 added to their project merely because they deployed the extension.
+
+The debugger live tier is Windows-only today and uses Ghidra's Trace RMI
+debugger launcher. If the default Python on `PATH` is not compatible with the
+Ghidra debugger wheels, set `GHIDRA_DEBUGGER_PYTHON` in local `.env` to the
+Python executable Ghidra should use for debugger launches.
 
 ## GitHub Actions
 
@@ -194,7 +211,11 @@ as proving the installed GUI plugin works in a real user project.
 
 ## What To Run Before a Release
 
-Recommended release checklist:
+For the full release runbook, including versioning, documentation, PR, tagging,
+and post-release steps, see
+[`docs/releases/RELEASE_CHECKLIST.md`](releases/RELEASE_CHECKLIST.md).
+
+Minimum local verification:
 
 ```text
 python -m tools.setup preflight --ghidra-path "F:\ghidra_12.0.4_PUBLIC"

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,14 +4,25 @@ This directory contains version-specific release documentation for the Ghidra MC
 
 For the full version history, see [CHANGELOG.md](../../CHANGELOG.md) in the project root.
 
+For the release preparation runbook, see
+[RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md).
+
 ## Current Releases
 
-### v5.5.0 (Latest) — maintenance release
+### v5.6.0 (Latest) — release regression
+
+- **Live deploy regression tiers** — `tools.setup deploy` can run selected contract, benchmark read/write, multi-program, negative-contract, debugger-live, and release-grade suites.
+- **Benchmark debugger fixture** — `fun-doc/benchmark` now builds `BenchmarkDebug.exe` alongside `Benchmark.dll` so debugger endpoints can be exercised against a real launched process.
+- **Scoped prompt policy** — `/prompt_policy` temporarily handles known automation dialogs during deploy/regression runs while leaving normal interactive prompts untouched.
+- **Safer deploy lifecycle** — deploy saves open programs/traces, exits or force-kills matching Ghidra processes, starts Ghidra, waits for MCP/project readiness, and runs schema smoke checks.
+- See [CHANGELOG.md](../../CHANGELOG.md) for full details.
+
+### v5.5.0 — maintenance release
 
 - **Decompiler lifecycle fixes** — `FunctionService` now disposes owned `DecompInterface` instances across success, early-return, and exception paths instead of leaking subprocesses in long-running sessions.
 - **Bridge compatibility fix** — Python tool-name sanitization now enforces Claude/CAPI's 64-character limit and valid-character rules during collision handling.
 - **Bundled script hardening** — script-side `DecompInterface` ownership was normalized to scoped cleanup, and Claude-invoking scripts now use bounded waits with terminate/kill fallback.
-- **Contributor guidance** — `CONTRIBUTING.md` now includes a release-relevant resource-ownership checklist for disposables, transactions, child-process handling, and timeout expectations.
+- **Contributor guidance** — `CONTRIBUTING.md` includes a release-relevant resource-ownership checklist for disposables, transactions, child-process handling, and timeout expectations.
 - **Release metadata refresh** — Maven/package metadata, headless/plugin fallback versions, endpoint catalog version, and release docs were updated to `5.5.0`.
 - See [CHANGELOG.md](../../CHANGELOG.md) for full details.
 

--- a/docs/releases/RELEASE_CHECKLIST.md
+++ b/docs/releases/RELEASE_CHECKLIST.md
@@ -1,0 +1,163 @@
+# Release Checklist
+
+Use this checklist when preparing a stable release or pre-release. It is written
+for humans working with Claude Code, Codex, or another coding agent: keep the
+agent focused on one phase at a time, make it show command results, and do not
+let it tag or publish until the verification gates are complete.
+
+## Release Owner Rules
+
+- Keep this file as the canonical release checklist.
+- Keep `CLAUDE.md` and `AGENTS.md` as short pointers to this file, not full
+  copies of the runbook.
+- Use `python -m tools.setup bump-version --new X.Y.Z` for version changes.
+- Do not create a release tag until the release branch is merged to `main` or
+  the release workflow is intentionally creating the tag from the selected
+  branch.
+- Do not run deploy/live regression from an agent session without confirming
+  the current Ghidra UI state when modal dialogs may be present.
+
+## 1. Decide Version Scope
+
+- [ ] Identify the release type:
+  - Patch: bug fixes only, no new behavior.
+  - Minor: backward-compatible features, new endpoints, new tests, workflow
+    improvements.
+  - Major: breaking endpoint behavior, removed tools, or incompatible config.
+- [ ] Confirm the target version does not already exist as a tag:
+
+```text
+git tag --list "v*" --sort=-v:refname
+```
+
+- [ ] Update the version:
+
+```text
+python -m tools.setup bump-version --new X.Y.Z
+```
+
+- [ ] Verify version consistency:
+
+```text
+python -m tools.setup verify-version
+```
+
+## 2. Documentation and Metadata
+
+- [ ] Update `CHANGELOG.md` with a new top entry for the release.
+- [ ] Update `docs/releases/README.md` so the latest release summary is current.
+- [ ] Update user-facing docs for any changed commands, defaults, side effects,
+  endpoints, or environment variables.
+- [ ] Confirm `README.md` examples and version references are current.
+- [ ] If endpoint annotations changed, update `tests/endpoints.json`.
+
+For agent-assisted releases, ask the agent to search for stale version and tool
+count references before committing:
+
+```text
+rg -n "OLD_VERSION|NEW_VERSION|MCP Tools|GUI Endpoints|Headless Endpoints|total_endpoints" README.md CHANGELOG.md docs tests src pom.xml
+```
+
+## 3. Local Verification
+
+Run the cheap gates before any live Ghidra work:
+
+```text
+python -m tools.setup preflight --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup build
+pytest tests/unit/ -v --no-cov
+git diff --check
+git diff --cached --check
+```
+
+For setup/version/catalog changes, also run:
+
+```text
+pytest tests/unit/test_version_bump.py tests/unit/test_endpoint_catalog.py tests/unit/test_setup_cli.py tests/unit/test_setup_ghidra.py -v --no-cov
+```
+
+For Java endpoint/catalog changes, run the offline Java scanner/parity tests:
+
+```text
+mvn test -Dtest='com.xebyte.offline.*Test'
+```
+
+## 4. Live Ghidra Regression
+
+Live regression is required before merging risky deploy, GUI plugin, debugger,
+benchmark, or endpoint behavior changes.
+
+- [ ] Confirm the current Ghidra UI has no blocking modal dialogs.
+- [ ] Run the release-grade deploy regression:
+
+```text
+python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC" --test release
+```
+
+- [ ] Record whether the release regression passed.
+- [ ] If the run required manual dialog intervention, document the popup and
+  decide whether the deploy/prompt-policy automation needs another fix before
+  release.
+
+## 5. Commit and Pull Request
+
+- [ ] Review staged files:
+
+```text
+git status --short --branch
+git diff --cached --stat
+git diff --cached --check
+```
+
+- [ ] Commit with a release-appropriate message.
+- [ ] Push the branch.
+- [ ] Open or update the PR with:
+  - Version number.
+  - Summary of user-facing changes.
+  - Tests run and live regression result.
+  - Known risks or intentionally deferred items.
+- [ ] Confirm GitHub `tests.yml` checks pass.
+- [ ] For high-risk Ghidra changes, add the `live-ghidra-regression` PR label
+  if a self-hosted runner is available.
+
+## 6. Merge and Publish
+
+- [ ] Merge the PR to `main`.
+- [ ] Confirm `main` contains the intended version:
+
+```text
+git fetch origin
+git checkout main
+git pull --ff-only
+python -m tools.setup verify-version
+```
+
+- [ ] Publish using the GitHub **Create Release** workflow, or create/push an
+  annotated tag and let `release.yml` run:
+
+```text
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+- [ ] Enable `run_live_regression` in the release workflow when the
+  self-hosted Windows runner is available.
+- [ ] Verify release assets include `GhidraMCP-X.Y.Z.zip`.
+- [ ] Download the release ZIP and sanity-check that it installs or at least
+  contains the expected extension payload.
+
+## 7. Post-Release
+
+- [ ] Confirm GitHub release notes are accurate.
+- [ ] Confirm the latest release badge points at the new release.
+- [ ] Close or update issues/PRs covered by the release.
+- [ ] If the release exposed follow-up work, create issues before moving on.
+
+## Agent Usage Notes
+
+- Ask the agent to execute one checklist phase at a time.
+- Require exact command results in the final PR/release summary.
+- Keep secrets, local `.env`, and generated runtime reports out of commits.
+- Prefer deterministic repo tools over hand editing version metadata.
+- For UI-touching Ghidra actions, pause for a screenshot/checkpoint if the
+  agent cannot inspect the Ghidra window directly.

--- a/fun-doc/benchmark/build.py
+++ b/fun-doc/benchmark/build.py
@@ -200,6 +200,17 @@ def _cl_executable(tc: dict) -> str:
     return tc.get("cl_path", "cl.exe")
 
 
+def _run_command(command: list[str], env: dict[str, str], failure_label: str) -> None:
+    print(f"[build][cmd]  {' '.join(command)}")
+    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    if result.returncode != 0:
+        raise RuntimeError(f"{failure_label} failed (exit {result.returncode}).")
+
+
 def build(toolchain_name: str, clean: bool = False) -> Path:
     if toolchain_name not in TOOLCHAINS:
         raise ValueError(
@@ -211,7 +222,8 @@ def build(toolchain_name: str, clean: bool = False) -> Path:
         shutil.rmtree(BUILD_DIR)
     BUILD_DIR.mkdir(parents=True, exist_ok=True)
 
-    sources = sorted(SRC_DIR.glob("*.c"))
+    harness_source = SRC_DIR / "benchmark_debug.c"
+    sources = sorted(s for s in SRC_DIR.glob("*.c") if s.name != harness_source.name)
     if not sources:
         raise RuntimeError(f"No .c sources found in {SRC_DIR}")
 
@@ -255,14 +267,7 @@ def build(toolchain_name: str, clean: bool = False) -> Path:
     # Drop /LD from compile-only cmd — it's a linker flag that cl.exe
     # passes through when linking; harmless but confusing in a /c cmd.
     compile_cmd = [x for x in compile_cmd if x != "/LD"]
-    print(f"[build][cl]   {' '.join(compile_cmd)}")
-    result = subprocess.run(compile_cmd, env=env, capture_output=True, text=True)
-    if result.stdout:
-        print(result.stdout)
-    if result.stderr:
-        print(result.stderr, file=sys.stderr)
-    if result.returncode != 0:
-        raise RuntimeError(f"Compile failed (exit {result.returncode}).")
+    _run_command(compile_cmd, env, "Compile")
 
     # --- Step 2: link the .objs into the DLL ---
     objs = sorted(BUILD_DIR.glob("*.obj"))
@@ -295,16 +300,31 @@ def build(toolchain_name: str, clean: bool = False) -> Path:
         # happy to delegate. No /ENTRY override needed.
         *[str(o) for o in objs],
     ]
-    print(f"[build][link] {' '.join(link_cmd)}")
-    result = subprocess.run(link_cmd, env=env, capture_output=True, text=True)
-    if result.stdout:
-        print(result.stdout)
-    if result.stderr:
-        print(result.stderr, file=sys.stderr)
-    if result.returncode != 0:
-        raise RuntimeError(f"Link failed (exit {result.returncode}).")
+    _run_command(link_cmd, env, "Link")
     if not out_dll.is_file():
         raise RuntimeError(f"Link succeeded but {out_dll} not produced")
+
+    out_exe = BUILD_DIR / "BenchmarkDebug.exe"
+    if harness_source.is_file():
+        exe_cmd = [
+            cl,
+            "/nologo",
+            "/W3",
+            "/O2",
+            "/GF",
+            "/MT",
+            "/GS-",
+            "/Gy",
+            f"/Fe{out_exe}",
+            str(harness_source),
+            "/link",
+            "/NOLOGO",
+            "/MACHINE:X86",
+            "/SUBSYSTEM:CONSOLE,4.00",
+        ]
+        _run_command(exe_cmd, env, "Debug harness build")
+        if not out_exe.is_file():
+            raise RuntimeError(f"Build succeeded but {out_exe} not produced")
 
     # Write a small manifest so downstream tools can read which toolchain
     # produced the binary — useful for the run record to include and for
@@ -314,12 +334,15 @@ def build(toolchain_name: str, clean: bool = False) -> Path:
         "description": tc["description"],
         "sources": [s.name for s in sources],
         "dll": out_dll.name,
+        "debug_exe": out_exe.name if out_exe.is_file() else None,
         "map": out_map.name,
     }
     (BUILD_DIR / "build_manifest.json").write_text(
         json.dumps(manifest, indent=2), encoding="utf-8"
     )
     print(f"[build] ok — {out_dll} ({out_dll.stat().st_size} bytes)")
+    if out_exe.is_file():
+        print(f"[build] ok - {out_exe} ({out_exe.stat().st_size} bytes)")
     return out_dll
 
 

--- a/fun-doc/benchmark/src/benchmark_debug.c
+++ b/fun-doc/benchmark/src/benchmark_debug.c
@@ -1,0 +1,150 @@
+/*
+ * benchmark_debug.c - tiny live-debug harness for Benchmark.dll.
+ *
+ * This EXE intentionally calls a handful of exported benchmark functions in a
+ * repeatable loop so Ghidra debugger regression tests have a stable process to
+ * launch, interrupt, inspect, and terminate.
+ */
+
+#include <windows.h>
+#include <stdio.h>
+
+#define D2_STAT_LIST_MAGIC 0x01020304
+#define SIMPLE_STAT_LIST_MAGIC 0x54415453
+
+typedef unsigned short (__stdcall *calc_crc16_fn)(const unsigned char *data, unsigned int length);
+typedef unsigned int (__stdcall *compute_gcd_fn)(unsigned int a, unsigned int b);
+typedef int (__stdcall *get_stat_list_flags_fn)(int *pStatList);
+typedef unsigned int (__stdcall *get_stat_list_layer_fn)(const unsigned char *pStatList);
+typedef int (__stdcall *get_stat_list_owner_guid_fn)(int *pStatList);
+typedef int (__stdcall *get_stat_list_prev_link_fn)(int *pStatList);
+typedef int (__stdcall *advance_parser_state_fn)(int current_state, unsigned char input);
+typedef unsigned int (__stdcall *compute_str_len_fn)(const char *str);
+
+struct StatEntry {
+    unsigned short stat_id;
+    unsigned short flags;
+    int value;
+};
+
+struct StatList {
+    unsigned int magic;
+    unsigned int list_flags;
+    unsigned int entry_count;
+    struct StatEntry entries[16];
+};
+
+typedef int (__stdcall *stat_list_add_fn)(
+    struct StatList *list,
+    unsigned short id,
+    unsigned short flags,
+    int value);
+
+static volatile LONG g_debug_heartbeat = 0;
+static volatile DWORD g_debug_last_result = 0;
+
+static FARPROC require_export(HMODULE module, const char *name)
+{
+    FARPROC proc = GetProcAddress(module, name);
+    if (proc == NULL) {
+        fprintf(stderr, "missing export: %s\n", name);
+        ExitProcess(2);
+    }
+    return proc;
+}
+
+static void build_sibling_path(char *buffer, DWORD buffer_size, const char *file_name)
+{
+    DWORD length = GetModuleFileNameA(NULL, buffer, buffer_size);
+    char *cursor;
+
+    if (length == 0 || length >= buffer_size) {
+        fprintf(stderr, "GetModuleFileNameA failed\n");
+        ExitProcess(2);
+    }
+
+    cursor = buffer + length;
+    while (cursor > buffer && cursor[-1] != '\\' && cursor[-1] != '/') {
+        cursor--;
+    }
+    lstrcpynA(cursor, file_name, (int)(buffer_size - (cursor - buffer)));
+}
+
+int main(int argc, char **argv)
+{
+    char dll_path[MAX_PATH];
+    HMODULE benchmark;
+    calc_crc16_fn calc_crc16;
+    compute_gcd_fn compute_gcd;
+    get_stat_list_flags_fn get_stat_list_flags;
+    get_stat_list_layer_fn get_stat_list_layer;
+    get_stat_list_owner_guid_fn get_stat_list_owner_guid;
+    get_stat_list_prev_link_fn get_stat_list_prev_link;
+    advance_parser_state_fn advance_parser_state;
+    compute_str_len_fn compute_str_len;
+    stat_list_add_fn stat_list_add;
+    DWORD runtime_ms = 300000;
+    DWORD started = GetTickCount();
+    unsigned char payload[] = { 'D', '2', 'M', 'C', 'P', 0x13, 0x37 };
+    int d2_stat_list[16] = { 0 };
+    struct StatList simple_list;
+    int parser_state = 0;
+
+    if (argc >= 3 && lstrcmpiA(argv[1], "--seconds") == 0) {
+        runtime_ms = (DWORD)(strtoul(argv[2], NULL, 10) * 1000);
+    }
+
+    d2_stat_list[0] = D2_STAT_LIST_MAGIC;
+    d2_stat_list[1] = 7;
+    d2_stat_list[4] = 0x20;
+    d2_stat_list[8] = 0x12345678;
+    d2_stat_list[13] = 0x00ABCDEF;
+
+    ZeroMemory(&simple_list, sizeof(simple_list));
+    simple_list.magic = SIMPLE_STAT_LIST_MAGIC;
+    simple_list.list_flags = 0x400;
+
+    build_sibling_path(dll_path, sizeof(dll_path), "Benchmark.dll");
+    benchmark = LoadLibraryA(dll_path);
+    if (benchmark == NULL) {
+        fprintf(stderr, "LoadLibraryA failed for %s (error=%lu)\n", dll_path, GetLastError());
+        return 2;
+    }
+
+    calc_crc16 = (calc_crc16_fn)require_export(benchmark, "calc_crc16");
+    compute_gcd = (compute_gcd_fn)require_export(benchmark, "compute_gcd");
+    get_stat_list_flags = (get_stat_list_flags_fn)require_export(benchmark, "get_stat_list_flags");
+    get_stat_list_layer = (get_stat_list_layer_fn)require_export(benchmark, "get_stat_list_layer");
+    get_stat_list_owner_guid =
+        (get_stat_list_owner_guid_fn)require_export(benchmark, "get_stat_list_owner_guid");
+    get_stat_list_prev_link =
+        (get_stat_list_prev_link_fn)require_export(benchmark, "get_stat_list_prev_link");
+    advance_parser_state = (advance_parser_state_fn)require_export(benchmark, "advance_parser_state");
+    compute_str_len = (compute_str_len_fn)require_export(benchmark, "compute_str_len");
+    stat_list_add = (stat_list_add_fn)require_export(benchmark, "stat_list_add");
+
+    printf("BenchmarkDebug.exe pid=%lu dll=%s\n", GetCurrentProcessId(), dll_path);
+    fflush(stdout);
+
+    while (GetTickCount() - started < runtime_ms) {
+        DWORD result = 0;
+        LONG heartbeat = InterlockedIncrement(&g_debug_heartbeat);
+
+        result += calc_crc16(payload, sizeof(payload));
+        result += compute_gcd(heartbeat + 144, 84);
+        result += get_stat_list_flags(d2_stat_list);
+        result += get_stat_list_layer((const unsigned char *)d2_stat_list);
+        result += get_stat_list_owner_guid(d2_stat_list);
+        result += get_stat_list_prev_link(d2_stat_list);
+        parser_state = advance_parser_state(parser_state, (unsigned char)('a' + (heartbeat % 26)));
+        result += (DWORD)parser_state;
+        result += compute_str_len("diablo2 benchmark debugger harness");
+        result += stat_list_add(&simple_list, (unsigned short)(heartbeat & 0xffff), 1, result);
+
+        g_debug_last_result = result;
+        Sleep(100);
+    }
+
+    FreeLibrary(benchmark);
+    return (int)(g_debug_last_result & 0xff);
+}

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -761,6 +761,55 @@ def end_session(state):
         state["current_session"] = None
 
 
+_SESSION_UPDATE_MISSING = object()
+
+
+def finalize_worker_session(session, *, active_binary=_SESSION_UPDATE_MISSING):
+    """Atomically merge a worker's finished session into the latest on-disk state.
+
+    Read-modify-write under `_state_lock`: re-reads state.json, sets
+    `session["ended"]`, appends to `state["sessions"]`, clears
+    `state["current_session"]` when it still points at this session, and
+    optionally updates `state["active_binary"]`. Writes atomically.
+
+    Replaces the `end_session(state); save_state(state)` pattern in worker
+    loops. A full-state save there would write the functions dict that was
+    loaded at iteration start, clobbering per-function updates made
+    concurrently by other workers through update_function_state().
+
+    `session` is the worker's local session dict (as returned by
+    start_session). If None or falsy, only active_binary handling runs.
+
+    `active_binary` uses a sentinel: pass a string to set, pass None to
+    clear (pop the key), or omit to leave whatever is on disk alone.
+    """
+    with _state_lock:
+        # Re-read latest state from disk using the same backup/raise behavior
+        # as normal loads, so a transient worker finish cannot overwrite a
+        # recoverable corrupt state file with a fresh default state.
+        latest = load_state()
+
+        if session:
+            session["ended"] = datetime.now().isoformat()
+            latest.setdefault("sessions", []).append(session)
+            # Only clear current_session if it still references this worker's
+            # session (match on the "started" timestamp, which is unique per
+            # start_session call). Another worker's concurrent session should
+            # stay untouched.
+            cur = latest.get("current_session")
+            if isinstance(cur, dict) and cur.get("started") == session.get("started"):
+                latest["current_session"] = None
+
+        if active_binary is not _SESSION_UPDATE_MISSING:
+            if active_binary is None:
+                latest.pop("active_binary", None)
+            else:
+                latest["active_binary"] = active_binary
+
+        _atomic_write_state(latest)
+    bus_emit("state_changed")
+
+
 # ---------------------------------------------------------------------------
 # Ghidra data fetching
 # ---------------------------------------------------------------------------

--- a/fun-doc/web.py
+++ b/fun-doc/web.py
@@ -231,10 +231,9 @@ class WorkerManager:
         try:
             from fun_doc import (
                 load_state,
-                save_state,
                 get_next_functions,
                 start_session,
-                end_session,
+                finalize_worker_session,
                 process_function,
                 refresh_candidate_scores,
                 load_priority_queue,
@@ -558,13 +557,15 @@ class WorkerManager:
 
                 self._emit_status()
 
-            end_session(state)
+            # Persist session + optional active_binary restore via a
+            # read-modify-write that leaves state["functions"] alone. A
+            # full-state save here would write the functions snapshot this
+            # worker loaded, clobbering per-function updates written
+            # concurrently by other workers via update_function_state().
             if worker["binary"] and original_binary != worker["binary"]:
-                if original_binary:
-                    state["active_binary"] = original_binary
-                else:
-                    state.pop("active_binary", None)
-            save_state(state)
+                finalize_worker_session(session, active_binary=original_binary)
+            else:
+                finalize_worker_session(session)
 
         except Exception as e:
             self._bus.emit(

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.5.0</version>
+    <version>5.6.0</version>
     <name>Ghidra MCP Server</name>
-    <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. v5.5.0 maintenance release: decompiler lifecycle fixes in FunctionService, Claude/CAPI-compatible bridge tool-name sanitization, bundled-script resource ownership cleanup, bounded Claude subprocess waits, and refreshed release metadata on top of the v5.4.x security and debugger/emulation feature set.</description>
+    <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. v5.6.0 release: live deploy regression tiers, BenchmarkDebug debugger fixture, scoped prompt-policy automation, safer Ghidra deploy lifecycle, and benchmark project reset improvements on top of the v5.5.x maintenance baseline.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>
     <properties>
         <maven.compiler.release>21</maven.compiler.release>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -25,6 +25,7 @@ import ghidra.app.decompiler.DecompInterface;
 import ghidra.app.decompiler.DecompileResults;
 import ghidra.app.plugin.PluginCategoryNames;
 import ghidra.app.services.CodeViewerService;
+import ghidra.app.services.DebuggerTraceManagerService;
 import ghidra.app.services.GoToService;
 
 import ghidra.app.script.GhidraScriptUtil;
@@ -41,6 +42,7 @@ import ghidra.framework.plugintool.util.PluginStatus;
 import ghidra.program.util.ProgramLocation;
 import ghidra.util.Msg;
 import ghidra.util.task.ConsoleTaskMonitor;
+import ghidra.trace.model.Trace;
 import ghidra.program.model.pcode.HighVariable;
 import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.DataTypeManager;
@@ -92,6 +94,7 @@ import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -99,12 +102,12 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.5.0"; // Default fallback
+    private static String VERSION = "5.6.0"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven
     private static String BUILD_NUMBER = "0"; // Will be replaced by Maven
-    private static final int ENDPOINT_COUNT = 175;
+    private static final int ENDPOINT_COUNT = 177;
 
     static {
         // v5.4.2: loading "/version.properties" from the classpath root was
@@ -163,7 +166,7 @@ class VersionInfo {
     category = PluginCategoryNames.COMMON,
     shortDescription = "GhidraMCP - HTTP server plugin",
     description = "GhidraMCP - Starts an embedded HTTP server to expose program data via REST API and MCP bridge. " +
-                  "Provides 165 endpoints for reverse engineering automation. " +
+                  "Provides 177 endpoints for reverse engineering automation. " +
                   "Port configurable via Tool Options. " +
                   "Features: function analysis, decompilation, symbol management, cross-references, label operations, " +
                   "high-performance batch data analysis, field-level structure analysis, advanced call graph analysis, " +
@@ -235,6 +238,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     private final com.xebyte.core.ProgramScriptService programScriptService;
     private final com.xebyte.core.EmulationService emulationService;
     private final com.xebyte.core.DebuggerService debuggerService;
+    private final com.xebyte.core.PromptPolicyService promptPolicyService;
 
     public GhidraMCPPlugin(PluginTool tool) {
         super(tool);
@@ -256,6 +260,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         this.programScriptService = new com.xebyte.core.ProgramScriptService(programProvider, threadingStrategy);
         this.emulationService = new com.xebyte.core.EmulationService(programProvider, threadingStrategy);
         this.debuggerService = new com.xebyte.core.DebuggerService(programProvider, threadingStrategy, tool);
+        this.promptPolicyService = new com.xebyte.core.PromptPolicyService();
         Msg.info(this, "============================================");
         Msg.info(this, "GhidraMCP " + VersionInfo.getFullVersion());
         Msg.info(this, "Endpoints: " + VersionInfo.getEndpointCount());
@@ -486,7 +491,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
             listingService, functionService, commentService, symbolLabelService,
             xrefCallGraphService, dataTypeService, analysisService,
             documentationHashService, malwareSecurityService, programScriptService,
-            emulationService, debuggerService);
+            emulationService, debuggerService, promptPolicyService);
 
         for (EndpointDef ep : scanner.getEndpoints()) {
             server.createContext(ep.path(), safeHandler(exchange -> {
@@ -653,15 +658,18 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
 
         server.createContext("/exit_ghidra", safeHandler(exchange -> {
             try {
-                // Save first, then exit
-                String saveResult = saveCurrentProgram(null);
-                sendResponse(exchange, "{\"success\": true, \"message\": \"Saving and exiting Ghidra\", \"save\": " + saveResult + "}");
+                promptPolicyService.enableFor("exit_ghidra", 30);
+                Map<String, Object> saveResult = saveEverythingBeforeExit();
+                sendResponse(exchange, JsonHelper.toJson(JsonHelper.mapOf(
+                    "success", true,
+                    "message", "Saving all open programs and traces, then exiting Ghidra",
+                    "save", saveResult
+                )));
                 // Schedule exit after response is sent
                 new Thread(() -> {
                     try { Thread.sleep(500); } catch (InterruptedException ignored) {}
                     SwingUtilities.invokeLater(() -> {
-                        PluginTool t = getTool();
-                        if (t != null) t.close();
+                        closeGhidraWithoutSavingToolLayouts();
                     });
                 }).start();
             } catch (Throwable e) {
@@ -1733,6 +1741,113 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
      */
     private String saveCurrentProgram(String programName) {
         return programScriptService.saveCurrentProgram(programName).toJson();
+    }
+
+    private Map<String, Object> saveEverythingBeforeExit() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("programs", JsonHelper.parseJson(programScriptService.saveAllOpenPrograms().toJson()));
+        result.put("traces", saveAllOpenDebuggerTraces());
+        return result;
+    }
+
+    private void closeGhidraWithoutSavingToolLayouts() {
+        PluginTool currentTool = getTool();
+        if (currentTool == null) {
+            return;
+        }
+
+        Set<PluginTool> tools = Collections.newSetFromMap(new IdentityHashMap<>());
+        tools.add(currentTool);
+        try {
+            Project project = currentTool.getProject();
+            if (project != null && project.getToolManager() != null) {
+                for (PluginTool runningTool : project.getToolManager().getRunningTools()) {
+                    if (runningTool != null) {
+                        tools.add(runningTool);
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            Msg.warn(this, "Unable to enumerate running tools before exit: " + e.getMessage());
+        }
+
+        for (PluginTool tool : tools) {
+            try {
+                tool.setConfigChanged(false);
+            } catch (Throwable e) {
+                Msg.warn(this, "Unable to clear tool layout change flag: " + e.getMessage());
+            }
+        }
+
+        currentTool.close();
+    }
+
+    private Map<String, Object> saveAllOpenDebuggerTraces() {
+        List<Map<String, Object>> saved = new ArrayList<>();
+        List<Map<String, Object>> errors = new ArrayList<>();
+        Set<Trace> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        PluginTool currentTool = getTool();
+        if (currentTool == null || currentTool.getProject() == null) {
+            return JsonHelper.mapOf(
+                "success", true,
+                "saved_count", 0,
+                "traces", saved,
+                "errors", errors,
+                "message", "No project/tool available for trace save"
+            );
+        }
+
+        List<PluginTool> tools = new ArrayList<>();
+        tools.add(currentTool);
+        try {
+            ghidra.framework.model.ToolManager tm = currentTool.getProject().getToolManager();
+            if (tm != null) {
+                for (PluginTool runningTool : tm.getRunningTools()) {
+                    if (runningTool != null && !tools.contains(runningTool)) {
+                        tools.add(runningTool);
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            errors.add(JsonHelper.mapOf(
+                "error", "Unable to enumerate running tools: " +
+                    (e.getMessage() != null ? e.getMessage() : e.toString())
+            ));
+        }
+
+        for (PluginTool runningTool : tools) {
+            DebuggerTraceManagerService traceMgr = runningTool.getService(DebuggerTraceManagerService.class);
+            if (traceMgr == null) {
+                continue;
+            }
+            List<Trace> traces = new ArrayList<>(traceMgr.getOpenTraces());
+            for (Trace trace : traces) {
+                if (trace == null || !seen.add(trace)) {
+                    continue;
+                }
+
+                Map<String, Object> info = new LinkedHashMap<>();
+                info.put("trace", trace.getName());
+                info.put("tool", runningTool.getName());
+                try {
+                    traceMgr.saveTrace(trace).get(30, TimeUnit.SECONDS);
+                    traceMgr.closeTraceNoConfirm(trace);
+                    saved.add(info);
+                } catch (Throwable e) {
+                    info.put("error", e.getMessage() != null ? e.getMessage() : e.toString());
+                    errors.add(info);
+                    Msg.error(this, "Error saving debugger trace " + trace.getName(), e);
+                }
+            }
+        }
+
+        return JsonHelper.mapOf(
+            "success", errors.isEmpty(),
+            "saved_count", saved.size(),
+            "traces", saved,
+            "errors", errors
+        );
     }
 
     private String listOpenPrograms() {

--- a/src/main/java/com/xebyte/core/DebuggerService.java
+++ b/src/main/java/com/xebyte/core/DebuggerService.java
@@ -5,11 +5,19 @@ import ghidra.app.services.DebuggerStaticMappingService;
 import ghidra.app.services.DebuggerTargetService;
 import ghidra.app.services.DebuggerTraceManagerService;
 import ghidra.app.services.TraceRmiLauncherService;
+import ghidra.debug.api.ValStr;
 import ghidra.debug.api.target.ActionName;
 import ghidra.debug.api.target.Target;
+import ghidra.debug.api.tracermi.LaunchParameter;
+import ghidra.debug.api.tracermi.TraceRmiLaunchOffer;
+import ghidra.debug.api.tracermi.TraceRmiLaunchOffer.LaunchConfigurator;
+import ghidra.debug.api.tracermi.TraceRmiLaunchOffer.LaunchResult;
+import ghidra.debug.api.tracermi.TraceRmiLaunchOffer.RelPrompt;
 import ghidra.debug.api.tracemgr.DebuggerCoordinates;
 import ghidra.framework.model.Project;
 import ghidra.framework.model.ToolManager;
+import ghidra.framework.model.ToolTemplate;
+import ghidra.framework.model.Workspace;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressFactory;
@@ -33,11 +41,14 @@ import ghidra.util.Msg;
 import ghidra.util.task.ConsoleTaskMonitor;
 import ghidra.util.task.TaskMonitor;
 
+import javax.swing.SwingUtilities;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
@@ -98,6 +109,53 @@ public class DebuggerService {
         return null;
     }
 
+    private PluginTool startDebuggerTool() {
+        Project project = frontEndTool.getProject();
+        if (project == null) return null;
+        ToolManager tm = project.getToolManager();
+        if (tm == null) return null;
+        try {
+            Workspace workspace = tm.getActiveWorkspace();
+            if (workspace == null) return null;
+            for (String templateName : List.of("Debugger", "CodeBrowser")) {
+                ToolTemplate template = project.getLocalToolChest().getToolTemplate(templateName);
+                if (template == null) {
+                    continue;
+                }
+                AtomicReference<PluginTool> launched = new AtomicReference<>();
+                AtomicReference<Exception> launchError = new AtomicReference<>();
+                Runnable launcher = () -> {
+                    try {
+                        launched.set(workspace.runTool(template));
+                    } catch (Exception e) {
+                        launchError.set(e);
+                    }
+                };
+                if (SwingUtilities.isEventDispatchThread()) {
+                    launcher.run();
+                } else {
+                    SwingUtilities.invokeAndWait(launcher);
+                }
+                if (launchError.get() != null) {
+                    throw launchError.get();
+                }
+                PluginTool tool = launched.get();
+                if (tool == null) {
+                    continue;
+                }
+                for (int i = 0; i < 20; i++) {
+                    if (tool.getService(DebuggerTraceManagerService.class) != null) {
+                        return tool;
+                    }
+                    Thread.sleep(250);
+                }
+            }
+        } catch (Exception e) {
+            Msg.warn(this, "Failed to launch debugger tool: " + e.getMessage());
+        }
+        return null;
+    }
+
     private PluginTool getDebuggerTool() {
         PluginTool cached = cachedDebuggerTool;
         if (cached != null) {
@@ -115,6 +173,25 @@ public class DebuggerService {
         return found;
     }
 
+    private PluginTool getOrStartDebuggerTool(int timeoutSeconds) throws TimeoutException {
+        PluginTool tool = getDebuggerTool();
+        if (tool != null) {
+            return tool;
+        }
+        CompletableFuture<PluginTool> future = CompletableFuture.supplyAsync(this::startDebuggerTool);
+        try {
+            tool = future.get(Math.max(1, timeoutSeconds), TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw e;
+        } catch (Exception e) {
+            Msg.warn(this, "Failed to auto-start debugger tool: " + e.getMessage());
+            return null;
+        }
+        cachedDebuggerTool = tool;
+        return tool;
+    }
+
     private <T> T getService(Class<T> serviceClass) {
         PluginTool tool = getDebuggerTool();
         if (tool == null) return null;
@@ -122,8 +199,9 @@ public class DebuggerService {
     }
 
     private Response noDebugger() {
-        return Response.err("Debugger not active. Open a CodeBrowser and enable the Debugger " +
-                "(Window > Debugger), then attach to your target process.");
+        return Response.err("Debugger not active and GhidraMCP could not auto-start a " +
+                "Debugger tool. Open the Debugger tool or enable Window > Debugger in CodeBrowser, " +
+                "then attach to your target process.");
     }
 
     private Response noTrace() {
@@ -185,6 +263,201 @@ public class DebuggerService {
     // ========================================================================
     // Session management
     // ========================================================================
+
+    private TraceRmiLaunchOffer selectLaunchOffer(Collection<TraceRmiLaunchOffer> offers,
+                                                  String preferredOffer) {
+        List<TraceRmiLaunchOffer> candidates = offers.stream()
+                .filter(TraceRmiLaunchOffer::supportsImage)
+                .toList();
+        if (candidates.isEmpty()) {
+            candidates = List.copyOf(offers);
+        }
+        if (preferredOffer != null && !preferredOffer.isBlank()) {
+            String needle = preferredOffer.trim().toLowerCase(Locale.ROOT);
+            for (TraceRmiLaunchOffer offer : candidates) {
+                if (offer.getTitle().equalsIgnoreCase(preferredOffer) ||
+                        offer.getConfigName().equalsIgnoreCase(preferredOffer)) {
+                    return offer;
+                }
+            }
+            for (TraceRmiLaunchOffer offer : candidates) {
+                if (offer.getTitle().toLowerCase(Locale.ROOT).contains(needle) ||
+                        offer.getConfigName().toLowerCase(Locale.ROOT).contains(needle)) {
+                    return offer;
+                }
+            }
+        }
+        for (TraceRmiLaunchOffer offer : candidates) {
+            if ("dbgeng".equalsIgnoreCase(offer.getTitle()) ||
+                    offer.getConfigName().toLowerCase(Locale.ROOT).contains("local-dbgeng")) {
+                return offer;
+            }
+        }
+        return candidates.isEmpty() ? null : candidates.get(0);
+    }
+
+    private ValStr<?> decodeLaunchValue(LaunchParameter<?> param, String value) {
+        return param.decode(value);
+    }
+
+    private void setLaunchArgument(Map<String, ValStr<?>> args,
+                                   Map<String, LaunchParameter<?>> parameters,
+                                   String name,
+                                   String value) {
+        LaunchParameter<?> param = parameters.get(name);
+        if (param != null) {
+            args.put(name, decodeLaunchValue(param, value));
+        }
+    }
+
+    private List<Map<String, Object>> describeLaunchParameters(TraceRmiLaunchOffer offer) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map.Entry<String, LaunchParameter<?>> entry : offer.getParameters().entrySet()) {
+            LaunchParameter<?> param = entry.getValue();
+            Map<String, Object> info = new LinkedHashMap<>();
+            info.put("name", entry.getKey());
+            info.put("display", param.display());
+            info.put("type", param.type().getSimpleName());
+            info.put("required", param.required());
+            info.put("default", param.defaultValue() != null ? param.defaultValue().str() : null);
+            result.add(info);
+        }
+        return result;
+    }
+
+    private Map<String, Target.ActionEntry> collectTargetActions(Target target,
+                                                                 ActionName actionName) {
+        return target.collectActions(actionName, null,
+                Target.ObjectArgumentPolicy.CURRENT_AND_RELATED);
+    }
+
+    private void invokeTargetAction(Target.ActionEntry action) throws Exception {
+        if (action.requiresPrompt()) {
+            throw new IllegalStateException("Action requires a Ghidra UI prompt: " +
+                    action.display());
+        }
+        action.invokeAsync(false).get(ACTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @McpTool(path = "/debugger/launch", method = "POST",
+            description = "Launch an executable through Ghidra's Trace RMI debugger launcher")
+    public Response launch(
+            @Param(value = "executable_path", source = ParamSource.BODY,
+                    description = "Absolute path to the executable to launch") String executablePath,
+            @Param(value = "args", source = ParamSource.BODY, defaultValue = "",
+                    description = "Command-line arguments to pass to the executable") String args,
+            @Param(value = "cwd", source = ParamSource.BODY, defaultValue = "",
+                    description = "Working directory hint for launchers that expose one") String cwd,
+            @Param(value = "timeout_seconds", source = ParamSource.BODY, defaultValue = "60",
+                    description = "Maximum seconds to wait for the debugger trace") int timeoutSeconds,
+            @Param(value = "program", source = ParamSource.BODY, defaultValue = "",
+                    description = "Program path/name to use for static mapping") String programName,
+            @Param(value = "offer", source = ParamSource.BODY, defaultValue = "",
+                    description = "Optional launcher title or config name, e.g. dbgeng") String preferredOffer,
+            @Param(value = "python_executable", source = ParamSource.BODY, defaultValue = "",
+                    description = "Optional Python executable for Python-backed debugger launchers") String pythonExecutable) {
+        PluginTool tool;
+        try {
+            tool = getOrStartDebuggerTool(20);
+        } catch (TimeoutException e) {
+            return Response.err("Timed out while auto-starting Ghidra's Debugger tool. " +
+                    "Open the Debugger tool manually, then retry debugger_launch.");
+        }
+        if (tool == null) return noDebugger();
+
+        TraceRmiLauncherService launcherSvc =
+                tool.getService(TraceRmiLauncherService.class);
+        if (launcherSvc == null) {
+            return Response.err("Trace RMI launcher service not available. Open CodeBrowser, " +
+                    "enable Window > Debugger, and make sure the debugger launcher plugins are loaded.");
+        }
+
+        try {
+            ghidra.program.model.listing.Program program =
+                    programProvider.resolveProgram(programName);
+            Collection<TraceRmiLaunchOffer> offers = launcherSvc.getOffers(program);
+            if (offers.isEmpty()) {
+                return Response.err("No debugger launch offers are available for " +
+                        (program != null ? program.getName() : "the current program") +
+                        ". Install/enable a backend such as Ghidra's dbgeng agent and " +
+                        "open the executable in CodeBrowser first.");
+            }
+
+            TraceRmiLaunchOffer offer = selectLaunchOffer(offers, preferredOffer);
+            if (offer == null) {
+                return Response.err("No debugger launch offer could be selected. Available offers: " +
+                        offers.stream().map(TraceRmiLaunchOffer::getTitle).collect(Collectors.joining(", ")));
+            }
+
+            LaunchParameter<?> imageParam = offer.imageParameter();
+            if (imageParam == null) {
+                return Response.err("Selected launcher '" + offer.getTitle() +
+                        "' does not expose an image/executable parameter. Available parameters: " +
+                        offer.getParameters().keySet());
+            }
+
+            int waitSeconds = Math.max(1, timeoutSeconds);
+            ConsoleTaskMonitor monitor = new ConsoleTaskMonitor();
+            CompletableFuture<LaunchResult> future = CompletableFuture.supplyAsync(() ->
+                    offer.launchProgram(monitor, new LaunchConfigurator() {
+                        @Override
+                        public Map<String, ValStr<?>> configureLauncher(
+                                TraceRmiLaunchOffer launchOffer,
+                                Map<String, ValStr<?>> launchArgs,
+                                RelPrompt relPrompt) {
+                            Map<String, ValStr<?>> configured = new LinkedHashMap<>(launchArgs);
+                            configured.put(imageParam.name(), decodeLaunchValue(imageParam, executablePath));
+                            if (args != null && !args.isBlank()) {
+                                setLaunchArgument(configured, launchOffer.getParameters(), "args", args);
+                                setLaunchArgument(configured, launchOffer.getParameters(), "env:OPT_TARGET_ARGS", args);
+                            }
+                            if (cwd != null && !cwd.isBlank()) {
+                                setLaunchArgument(configured, launchOffer.getParameters(), "cwd", cwd);
+                                setLaunchArgument(configured, launchOffer.getParameters(), "env:CWD", cwd);
+                                setLaunchArgument(configured, launchOffer.getParameters(), "env:OPT_CWD", cwd);
+                                setLaunchArgument(configured, launchOffer.getParameters(), "env:OPT_TARGET_DIR", cwd);
+                            }
+                            if (pythonExecutable != null && !pythonExecutable.isBlank()) {
+                                setLaunchArgument(configured, launchOffer.getParameters(),
+                                        "env:OPT_PYTHON_EXE", pythonExecutable);
+                            }
+                            return configured;
+                        }
+                    }));
+
+            LaunchResult result;
+            try {
+                result = future.get(waitSeconds, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                monitor.cancel();
+                return Response.err("Debugger launch timed out after " + waitSeconds +
+                        "s waiting for a Trace RMI connection. Check the launcher terminal, " +
+                        "Python debugger dependencies, and dbgeng/WinDbg installation.");
+            }
+
+            if (result.exception() != null) {
+                return Response.err("Debugger launch failed using '" + offer.getTitle() + "': " +
+                        result.exception().getMessage() +
+                        ". Check Ghidra's launcher terminal and debugger backend setup.");
+            }
+            if (result.trace() == null) {
+                return Response.err("Debugger launch did not produce an active trace using '" +
+                        offer.getTitle() + "'. Check Ghidra's launcher terminal for backend errors.");
+            }
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("status", "launched");
+            response.put("offer_title", offer.getTitle());
+            response.put("offer_config_name", offer.getConfigName());
+            response.put("trace_name", result.trace().getName());
+            response.put("executable_path", executablePath);
+            response.put("args", args);
+            response.put("program", program != null ? program.getName() : null);
+            return Response.ok(response);
+        } catch (Exception e) {
+            return Response.err("Debugger launch failed: " + e.getMessage());
+        }
+    }
 
     @McpTool(path = "/debugger/status",
             description = "Get debugger status: active trace, thread, execution state, module count")
@@ -292,13 +565,13 @@ public class DebuggerService {
 
         try {
             Map<String, Target.ActionEntry> actions =
-                    target.collectActions(ActionName.RESUME, null, null);
+                    collectTargetActions(target, ActionName.RESUME);
             if (actions.isEmpty()) {
                 return Response.err("Resume action not available in current state");
             }
             // Execute the first available resume action
             Target.ActionEntry action = actions.values().iterator().next();
-            action.run(true);
+            invokeTargetAction(action);
             return Response.ok(Map.of("status", "resumed"));
         } catch (Exception e) {
             return Response.err("Resume failed: " + e.getMessage());
@@ -315,12 +588,12 @@ public class DebuggerService {
 
         try {
             Map<String, Target.ActionEntry> actions =
-                    target.collectActions(ActionName.INTERRUPT, null, null);
+                    collectTargetActions(target, ActionName.INTERRUPT);
             if (actions.isEmpty()) {
                 return Response.err("Interrupt action not available in current state");
             }
             Target.ActionEntry action = actions.values().iterator().next();
-            action.run(true);
+            invokeTargetAction(action);
             return Response.ok(Map.of("status", "interrupted"));
         } catch (Exception e) {
             return Response.err("Interrupt failed: " + e.getMessage());
@@ -337,12 +610,12 @@ public class DebuggerService {
 
         try {
             Map<String, Target.ActionEntry> actions =
-                    target.collectActions(ActionName.STEP_INTO, null, null);
+                    collectTargetActions(target, ActionName.STEP_INTO);
             if (actions.isEmpty()) {
                 return Response.err("Step into not available in current state");
             }
             Target.ActionEntry action = actions.values().iterator().next();
-            action.run(true);
+            invokeTargetAction(action);
             return Response.ok(Map.of("status", "stepped"));
         } catch (Exception e) {
             return Response.err("Step into failed: " + e.getMessage());
@@ -359,12 +632,12 @@ public class DebuggerService {
 
         try {
             Map<String, Target.ActionEntry> actions =
-                    target.collectActions(ActionName.STEP_OVER, null, null);
+                    collectTargetActions(target, ActionName.STEP_OVER);
             if (actions.isEmpty()) {
                 return Response.err("Step over not available in current state");
             }
             Target.ActionEntry action = actions.values().iterator().next();
-            action.run(true);
+            invokeTargetAction(action);
             return Response.ok(Map.of("status", "stepped"));
         } catch (Exception e) {
             return Response.err("Step over failed: " + e.getMessage());
@@ -381,12 +654,12 @@ public class DebuggerService {
 
         try {
             Map<String, Target.ActionEntry> actions =
-                    target.collectActions(ActionName.STEP_OUT, null, null);
+                    collectTargetActions(target, ActionName.STEP_OUT);
             if (actions.isEmpty()) {
                 return Response.err("Step out not available in current state");
             }
             Target.ActionEntry action = actions.values().iterator().next();
-            action.run(true);
+            invokeTargetAction(action);
             return Response.ok(Map.of("status", "stepped_out"));
         } catch (Exception e) {
             return Response.err("Step out failed: " + e.getMessage());
@@ -849,6 +1122,10 @@ public class DebuggerService {
                 info.put("description", offer.getDescription());
                 info.put("icon", offer.getIcon() != null
                         ? offer.getIcon().toString() : null);
+                info.put("config_name", offer.getConfigName());
+                info.put("supports_image", offer.supportsImage());
+                info.put("requires_image", offer.requiresImage());
+                info.put("parameters", describeLaunchParameters(offer));
                 result.add(info);
             }
             return Response.ok(result);

--- a/src/main/java/com/xebyte/core/EndpointRegistry.java
+++ b/src/main/java/com/xebyte/core/EndpointRegistry.java
@@ -1150,8 +1150,8 @@ public class EndpointRegistry {
             (q, b) -> programScriptService.runGhidraScript(bodyStr(b, "script_path"), bodyStr(b, "args"), str(q, "program")));
 
         post("/run_script_inline", "Execute inline Ghidra script code",
-            params(bStr("code"), bStrOpt("args")),
-            (q, b) -> programScriptService.runGhidraScript(bodyStr(b, "code"), bodyStr(b, "args")));
+              params(bStr("code"), bStrOpt("args"), pProg()),
+              (q, b) -> programScriptService.runScriptInline(bodyStr(b, "code"), bodyStr(b, "args"), str(q, "program")));
 
         post("/run_ghidra_script", "Execute script with output capture and timeout",
             params(bStr("script_name"), bStrOpt("args"), bInt("timeout_seconds", 300),

--- a/src/main/java/com/xebyte/core/EndpointRegistry.java
+++ b/src/main/java/com/xebyte/core/EndpointRegistry.java
@@ -1113,6 +1113,10 @@ public class EndpointRegistry {
             params(pProg()),
             (q, b) -> programScriptService.saveCurrentProgram(str(q, "program")));
 
+        get("/save_all_programs", "Save all open programs",
+            params(),
+            (q, b) -> programScriptService.saveAllOpenPrograms());
+
         get("/list_open_programs", "List all open programs",
             params(),
             (q, b) -> programScriptService.listOpenPrograms());

--- a/src/main/java/com/xebyte/core/FrontEndProgramProvider.java
+++ b/src/main/java/com/xebyte/core/FrontEndProgramProvider.java
@@ -378,6 +378,57 @@ public class FrontEndProgramProvider implements ProgramProvider {
     }
 
     /**
+     * Release a cached program opened directly by this provider.
+     *
+     * @param nameOrPath Program name or project path
+     * @return true if a cached program reference was released
+     */
+    public boolean releaseCachedProgram(String nameOrPath) {
+        if (nameOrPath == null || nameOrPath.trim().isEmpty()) {
+            return false;
+        }
+
+        String search = nameOrPath.trim();
+        List<String> keys = new ArrayList<>();
+        String directKey = pathToName.get(search);
+        if (directKey != null) {
+            keys.add(directKey);
+        }
+        keys.add(search);
+
+        for (Map.Entry<String, Program> entry : openPrograms.entrySet()) {
+            Program program = entry.getValue();
+            if (program.getName().equalsIgnoreCase(search) ||
+                    (program.getDomainFile() != null &&
+                            program.getDomainFile().getPathname().equalsIgnoreCase(search))) {
+                keys.add(entry.getKey());
+            }
+        }
+
+        boolean released = false;
+        for (String key : new ArrayList<>(keys)) {
+            Program program = openPrograms.remove(key);
+            if (program == null) {
+                continue;
+            }
+            try {
+                program.release(consumer);
+                released = true;
+                if (program == currentProgram) {
+                    currentProgram = null;
+                }
+                Msg.info(this, "Released cached program: " + key);
+            } catch (Exception e) {
+                Msg.warn(this, "Error releasing cached program " + key + ": " + e.getMessage());
+            }
+        }
+
+        pathToName.entrySet().removeIf(entry -> keys.contains(entry.getValue()) ||
+                entry.getKey().equalsIgnoreCase(search));
+        return released;
+    }
+
+    /**
      * Get the underlying PluginTool.
      *
      * @return The PluginTool

--- a/src/main/java/com/xebyte/core/ListingService.java
+++ b/src/main/java/com/xebyte/core/ListingService.java
@@ -297,7 +297,7 @@ public class ListingService {
             Map<String, Object> funcItem = new LinkedHashMap<>();
             funcItem.putAll(ServiceUtils.addressToJson(func.getEntryPoint(), program));
             funcItem.put("name", func.getName());
-            funcItem.put("isThunk", func.isThunk());
+            funcItem.put("isThunk", "thunk".equals(AnalysisService.classifyFunction(func, program)));
             funcItem.put("isExternal", func.isExternal());
             functions.add(funcItem);
             count++;

--- a/src/main/java/com/xebyte/core/ListingService.java
+++ b/src/main/java/com/xebyte/core/ListingService.java
@@ -297,7 +297,7 @@ public class ListingService {
             Map<String, Object> funcItem = new LinkedHashMap<>();
             funcItem.putAll(ServiceUtils.addressToJson(func.getEntryPoint(), program));
             funcItem.put("name", func.getName());
-            funcItem.put("isThunk", "thunk".equals(AnalysisService.classifyFunction(func, program)));
+            funcItem.put("isThunk", func.isThunk());
             funcItem.put("isExternal", func.isExternal());
             functions.add(funcItem);
             count++;

--- a/src/main/java/com/xebyte/core/ProgramProvider.java
+++ b/src/main/java/com/xebyte/core/ProgramProvider.java
@@ -55,6 +55,19 @@ public interface ProgramProvider {
     void setCurrentProgram(Program program);
 
     /**
+     * Close a program when the provider owns the program lifecycle.
+     *
+     * <p>GUI providers usually close through Ghidra's ProgramManager, so the
+     * default is a no-op. Headless providers should override this.
+     *
+     * @param program The program to close
+     * @return true if the provider closed the program
+     */
+    default boolean closeProgram(Program program) {
+        return false;
+    }
+
+    /**
      * Check if any program is currently open.
      *
      * @return true if at least one program is open

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -1038,7 +1038,8 @@ public class ProgramScriptService {
     @McpTool(path = "/run_script_inline", method = "POST", description = "Execute inline Ghidra script code. Pass the full Java source as the 'code' body parameter. Gated by GHIDRA_MCP_ALLOW_SCRIPTS=1 (v5.4.1+).", category = "program")
     public Response runScriptInline(
             @Param(value = "code", source = ParamSource.BODY) String code,
-            @Param(value = "args", source = ParamSource.BODY, defaultValue = "") String args) {
+            @Param(value = "args", source = ParamSource.BODY, defaultValue = "") String args,
+            @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         if (!SecurityConfig.getInstance().areScriptsAllowed()) {
             return Response.err("Script execution disabled. Set GHIDRA_MCP_ALLOW_SCRIPTS=1 "
                 + "(and GHIDRA_MCP_AUTH_TOKEN if exposing beyond loopback) to enable. "
@@ -1125,7 +1126,7 @@ public class ProgramScriptService {
             }
 
             java.nio.file.Files.writeString(tempScript.toPath(), scriptCode);
-            responseHolder[0] = runGhidraScript(tempScript.getAbsolutePath(), args);
+            responseHolder[0] = runGhidraScript(tempScript.getAbsolutePath(), args, programName);
             return responseHolder[0];
         } catch (Exception e) {
             return Response.err("Failed to create inline script: " + e.getMessage());

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -18,6 +18,7 @@ import javax.swing.SwingUtilities;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -29,6 +30,7 @@ public class ProgramScriptService {
 
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
+    private static final String AUTO_ANALYSIS_COMPLETION_MESSAGE = "Auto-analysis completed";
 
     public ProgramScriptService(ProgramProvider programProvider, ThreadingStrategy threadingStrategy) {
         this.programProvider = programProvider;
@@ -50,6 +52,46 @@ public class ProgramScriptService {
             return mtp.getActiveTool();
         }
         return null;
+    }
+
+    private boolean runAutoAnalysisAndPersistFlags(Program program, boolean force) {
+        if (program == null) {
+            return false;
+        }
+        try {
+            ghidra.program.util.GhidraProgramUtilities.markProgramNotToAskToAnalyze(program);
+            AutoAnalysisManager mgr = AutoAnalysisManager.getAnalysisManager(program);
+            if (force) {
+                mgr.reAnalyzeAll(null);
+            }
+            mgr.startAnalysis(ghidra.util.task.TaskMonitor.DUMMY);
+            mgr.waitForAnalysis(null, ghidra.util.task.TaskMonitor.DUMMY);
+            ghidra.program.util.GhidraProgramUtilities.markProgramAnalyzed(program);
+            persistProgram(program, AUTO_ANALYSIS_COMPLETION_MESSAGE);
+            return true;
+        } catch (Exception e) {
+            Msg.warn(this, "Auto-analysis failed: " + e.getMessage());
+            try {
+                suppressAnalysisPrompt(program);
+            } catch (Exception ignored) {
+                // Preserve the original analysis failure in the log.
+            }
+            return false;
+        }
+    }
+
+    private void suppressAnalysisPrompt(Program program) throws IOException, ghidra.util.exception.CancelledException {
+        ghidra.program.util.GhidraProgramUtilities.markProgramNotToAskToAnalyze(program);
+        persistProgram(program, "Suppress analysis prompt");
+    }
+
+    private void persistProgram(Program program, String reason)
+            throws IOException, ghidra.util.exception.CancelledException {
+        if (program == null || !program.canSave()) {
+            return;
+        }
+        program.flushEvents();
+        program.save(reason, ghidra.util.task.TaskMonitor.DUMMY);
     }
 
     // ========================================================================
@@ -156,6 +198,73 @@ public class ProgramScriptService {
     }
 
     /**
+     * Save every currently open program. This is intended for automation paths
+     * such as deploy shutdown where Ghidra would otherwise prompt for each
+     * modified domain object on exit.
+     */
+    @McpTool(path = "/save_all_programs", description = "Save all open programs", category = "program")
+    public Response saveAllOpenPrograms() {
+        Program[] programs = programProvider.getAllOpenPrograms();
+        if (programs == null || programs.length == 0) {
+            return Response.ok(JsonHelper.mapOf(
+                "success", true,
+                "saved_count", 0,
+                "programs", List.of(),
+                "errors", List.of(),
+                "message", "No open programs to save"
+            ));
+        }
+
+        final AtomicReference<List<Map<String, Object>>> saved = new AtomicReference<>(new ArrayList<>());
+        final AtomicReference<List<Map<String, Object>>> errors = new AtomicReference<>(new ArrayList<>());
+
+        Runnable saveTask = () -> {
+            Set<Program> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (Program program : programs) {
+                if (program == null || !seen.add(program)) {
+                    continue;
+                }
+
+                Map<String, Object> info = new LinkedHashMap<>();
+                info.put("program", program.getName());
+                try {
+                    ghidra.framework.model.DomainFile df = program.getDomainFile();
+                    if (df == null) {
+                        info.put("error", "Program has no domain file");
+                        errors.get().add(info);
+                        continue;
+                    }
+                    info.put("path", df.getPathname());
+                    df.save(new ConsoleTaskMonitor());
+                    saved.get().add(info);
+                } catch (Throwable e) {
+                    info.put("error", e.getMessage() != null ? e.getMessage() : e.toString());
+                    errors.get().add(info);
+                    Msg.error(this, "Error saving program " + program.getName(), e);
+                }
+            }
+        };
+
+        try {
+            if (SwingUtilities.isEventDispatchThread()) {
+                saveTask.run();
+            } else {
+                SwingUtilities.invokeAndWait(saveTask);
+            }
+        } catch (Throwable e) {
+            return Response.err("Failed to save all programs: " +
+                    (e.getMessage() != null ? e.getMessage() : e.toString()));
+        }
+
+        return Response.ok(JsonHelper.mapOf(
+            "success", errors.get().isEmpty(),
+            "saved_count", saved.get().size(),
+            "programs", saved.get(),
+            "errors", errors.get()
+        ));
+    }
+
+    /**
      * List all currently open programs in Ghidra.
      */
     @McpTool(path = "/list_open_programs", description = "List all open programs. If more than one program is listed, always pass the program name explicitly in subsequent tool calls — omitting it will silently target the active program, which may not be the intended one.", category = "program")
@@ -188,6 +297,64 @@ public class ProgramScriptService {
             "programs", programList,
             "count", programs.length,
             "current_program", currentProgram != null ? currentProgram.getName() : ""
+        ));
+    }
+
+    @McpTool(path = "/close_program", method = "POST",
+             description = "Close an open program by project path or name", category = "program")
+    public Response closeProgram(
+            @Param(value = "name", source = ParamSource.BODY,
+                    description = "Program name or project path") String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return Response.err("Program name or path is required");
+        }
+
+        String search = name.trim();
+        AtomicInteger closedCount = new AtomicInteger(0);
+        AtomicReference<String> error = new AtomicReference<>();
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    for (ProgramManager pm : findAllProgramManagers()) {
+                        for (Program program : pm.getAllOpenPrograms()) {
+                            if (programMatches(program, search)) {
+                                pm.closeProgram(program, false);
+                                closedCount.incrementAndGet();
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    error.set(e.getMessage() != null ? e.getMessage() : e.toString());
+                }
+            });
+        } catch (Exception e) {
+            return Response.err("Failed to close program: " +
+                    (e.getMessage() != null ? e.getMessage() : e.toString()));
+        }
+
+        if (closedCount.get() == 0) {
+            for (Program program : programProvider.getAllOpenPrograms()) {
+                if (programMatches(program, search) && programProvider.closeProgram(program)) {
+                    closedCount.incrementAndGet();
+                }
+            }
+        }
+
+        if (error.get() != null) {
+            return Response.err("Failed to close program: " + error.get());
+        }
+
+        boolean releasedCache = false;
+        if (programProvider instanceof FrontEndProgramProvider fpp) {
+            releasedCache = fpp.releaseCachedProgram(search);
+        }
+
+        return Response.ok(JsonHelper.mapOf(
+            "success", true,
+            "closed_count", closedCount.get(),
+            "released_cache", releasedCache,
+            "name", search
         ));
     }
 
@@ -534,6 +701,11 @@ public class ProgramScriptService {
         for (Program prog : openPrograms) {
             if (prog.getDomainFile().getPathname().equals(path)) {
                 // Already open, just switch to it
+                try {
+                    suppressAnalysisPrompt(prog);
+                } catch (Exception e) {
+                    Msg.warn(this, "Failed to save analysis prompt flags: " + e.getMessage());
+                }
                 programProvider.setCurrentProgram(prog);
                 return Response.ok(JsonHelper.mapOf(
                     "success", true,
@@ -558,22 +730,25 @@ public class ProgramScriptService {
                 return Response.err("Failed to open program: " + path);
             }
 
-            // Add to tool and set as current
-            pm.openProgram(program);
-            pm.setCurrentProgram(program);
+            ghidra.program.util.GhidraProgramUtilities.markProgramNotToAskToAnalyze(program);
 
-            // Optionally trigger auto-analysis
             boolean analyzed = false;
             if (autoAnalyze) {
+                analyzed = runAutoAnalysisAndPersistFlags(program, true);
+            } else {
                 try {
-                    AutoAnalysisManager mgr = AutoAnalysisManager.getAnalysisManager(program);
-                    mgr.reAnalyzeAll(null);
-                    mgr.startAnalysis(ghidra.util.task.TaskMonitor.DUMMY);
-                    analyzed = true;
-                } catch (Exception ae) {
-                    Msg.warn(this, "Auto-analysis failed: " + ae.getMessage());
+                    suppressAnalysisPrompt(program);
+                } catch (Exception e) {
+                    Msg.warn(this, "Failed to save analysis prompt flags: " + e.getMessage());
                 }
             }
+
+            // Open after the analysis flags are persisted so CodeBrowser does not prompt.
+            Program finalProgram = program;
+            SwingUtilities.invokeAndWait(() -> {
+                pm.openProgram(finalProgram);
+                pm.setCurrentProgram(finalProgram);
+            });
 
             return Response.ok(JsonHelper.mapOf(
                 "success", true,
@@ -657,7 +832,6 @@ public class ProgramScriptService {
                 }
                 // Save to project folder (creates DomainFile)
                 loaded.save(ghidra.util.task.TaskMonitor.DUMMY);
-                loaded.release(this);
             } else {
                 // Auto-detect format
                 LoadResults<Program> loadResults = AutoImporter.importByUsingBestGuess(
@@ -673,40 +847,41 @@ public class ProgramScriptService {
                 }
                 // Save to project folder before releasing (prevents "Database is closed")
                 loadResults.save(ghidra.util.task.TaskMonitor.DUMMY);
-                loadResults.release(this);
             }
 
             // Suppress the "Analysis Options" dialog — we handle analysis programmatically
             ghidra.program.util.GhidraProgramUtilities.markProgramNotToAskToAnalyze(program);
 
-            // Open in CodeBrowser
+            boolean autoAnalyzed = false;
+            if (autoAnalyze) {
+                autoAnalyzed = runAutoAnalysisAndPersistFlags(program, false);
+            } else {
+                try {
+                    suppressAnalysisPrompt(program);
+                } catch (Exception e) {
+                    Msg.warn(this, "Failed to save analysis prompt flags: " + e.getMessage());
+                }
+            }
+
+            // Open after the analysis flags are persisted so CodeBrowser does not prompt.
             ProgramManager pm = findOrCreateProgramManager(tool);
             if (pm == null) {
                 return Response.err("Could not find or create a CodeBrowser tool");
             }
 
-            pm.openProgram(program);
-            pm.setCurrentProgram(program);
-
-            // Optionally trigger auto-analysis
-            boolean analyzing = false;
-            if (autoAnalyze) {
-                try {
-                    AutoAnalysisManager mgr = AutoAnalysisManager.getAnalysisManager(program);
-                    mgr.reAnalyzeAll(null);
-                    mgr.startAnalysis(ghidra.util.task.TaskMonitor.DUMMY);
-                    analyzing = true;
-                } catch (Exception ae) {
-                    Msg.warn(this, "Auto-analysis failed: " + ae.getMessage());
-                }
-            }
+            Program finalProgram = program;
+            SwingUtilities.invokeAndWait(() -> {
+                pm.openProgram(finalProgram);
+                pm.setCurrentProgram(finalProgram);
+            });
 
             return Response.ok(JsonHelper.mapOf(
                 "success", true,
                 "name", program.getName(),
                 "path", program.getDomainFile().getPathname(),
                 "language", program.getLanguageID().getIdAsString(),
-                "analyzing", analyzing
+                "analyzing", false,
+                "auto_analyzed", autoAnalyzed
             ));
         } catch (Exception e) {
             String msg = e.getMessage();
@@ -731,14 +906,13 @@ public class ProgramScriptService {
         Program program = pe.program();
 
         try {
-            AutoAnalysisManager mgr = AutoAnalysisManager.getAnalysisManager(program);
-            mgr.reAnalyzeAll(null);
-            mgr.startAnalysis(ghidra.util.task.TaskMonitor.DUMMY);
+            boolean analyzed = runAutoAnalysisAndPersistFlags(program, true);
             return Response.ok(JsonHelper.mapOf(
-                "success", true,
+                "success", analyzed,
                 "name", program.getName(),
-                "analyzing", true,
-                "message", "Auto-analysis started for " + program.getName()
+                "analyzing", false,
+                "message", analyzed ? AUTO_ANALYSIS_COMPLETION_MESSAGE + " for " + program.getName()
+                    : "Auto-analysis failed for " + program.getName()
             ));
         } catch (Exception e) {
             return Response.err("Failed to start analysis: " + e.getMessage());
@@ -760,15 +934,21 @@ public class ProgramScriptService {
                 continue;
             }
             boolean analyzing = false;
+            boolean analyzed = false;
+            boolean shouldAskToAnalyze = false;
             try {
                 AutoAnalysisManager mgr = AutoAnalysisManager.getAnalysisManager(prog);
                 analyzing = mgr.isAnalyzing();
+                analyzed = ghidra.program.util.GhidraProgramUtilities.isAnalyzed(prog);
+                shouldAskToAnalyze = ghidra.program.util.GhidraProgramUtilities.shouldAskToAnalyze(prog);
             } catch (Exception e) {
                 // May not have an analysis manager in headless mode
             }
             results.add(JsonHelper.mapOf(
                 "name", prog.getName(),
                 "analyzing", analyzing,
+                "analyzed", analyzed,
+                "should_ask_to_analyze", shouldAskToAnalyze,
                 "function_count", prog.getFunctionManager().getFunctionCount()
             ));
         }
@@ -800,6 +980,48 @@ public class ProgramScriptService {
 
     // ========================================================================
     // Script Execution
+    private List<ProgramManager> findAllProgramManagers() {
+        List<ProgramManager> managers = new ArrayList<>();
+        Set<PluginTool> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        PluginTool activeTool = getToolFromProvider();
+        if (activeTool != null) {
+            seen.add(activeTool);
+            ProgramManager pm = activeTool.getService(ProgramManager.class);
+            if (pm != null) {
+                managers.add(pm);
+            }
+
+            try {
+                ghidra.framework.model.Project project = activeTool.getProject();
+                if (project != null) {
+                    ghidra.framework.model.ToolManager tm = project.getToolManager();
+                    if (tm != null) {
+                        for (PluginTool runningTool : tm.getRunningTools()) {
+                            if (!seen.add(runningTool)) {
+                                continue;
+                            }
+                            ProgramManager runningPm = runningTool.getService(ProgramManager.class);
+                            if (runningPm != null) {
+                                managers.add(runningPm);
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                Msg.warn(this, "Error scanning for ProgramManager services: " + e.getMessage());
+            }
+        }
+
+        if (programProvider instanceof MultiToolProgramProvider mtp) {
+            ProgramManager pm = mtp.findProgramManager();
+            if (pm != null && !managers.contains(pm)) {
+                managers.add(pm);
+            }
+        }
+        return managers;
+    }
+
     /**
      * Find an existing ProgramManager or launch a new CodeBrowser to get one.
      */

--- a/src/main/java/com/xebyte/core/PromptPolicyService.java
+++ b/src/main/java/com/xebyte/core/PromptPolicyService.java
@@ -1,0 +1,224 @@
+package com.xebyte.core;
+
+import ghidra.util.Msg;
+
+import javax.swing.AbstractButton;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Window;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Scoped automation prompt handler for known Ghidra dialogs produced by MCP
+ * deploy/regression workflows.
+ *
+ * This is intentionally narrow: it only runs for a short explicit window and
+ * only responds to exact known prompts. Unknown dialogs are left untouched so
+ * normal interactive Ghidra work retains its safety prompts.
+ */
+public class PromptPolicyService {
+    private final Object lock = new Object();
+    private final Set<Window> handledWindows = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+    private final List<Map<String, Object>> actions = new ArrayList<>();
+    private Timer timer;
+    private long enabledUntilMillis = 0;
+    private String reason = "";
+
+    public void enableFor(String reason, int seconds) {
+        int durationSeconds = Math.max(1, Math.min(seconds, 300));
+        synchronized (lock) {
+            this.reason = reason != null ? reason : "automation";
+            this.enabledUntilMillis = System.currentTimeMillis() + durationSeconds * 1000L;
+        }
+        SwingUtilities.invokeLater(this::ensureTimer);
+    }
+
+    public void disable() {
+        synchronized (lock) {
+            enabledUntilMillis = 0;
+            reason = "";
+            handledWindows.clear();
+        }
+        SwingUtilities.invokeLater(() -> {
+            if (timer != null) {
+                timer.stop();
+            }
+        });
+    }
+
+    public Map<String, Object> status() {
+        synchronized (lock) {
+            long remaining = Math.max(0, enabledUntilMillis - System.currentTimeMillis());
+            return JsonHelper.mapOf(
+                "enabled", remaining > 0,
+                "remaining_ms", remaining,
+                "reason", reason,
+                "actions", new ArrayList<>(actions)
+            );
+        }
+    }
+
+    @McpTool(path = "/prompt_policy", method = "POST",
+            description = "Temporarily enable, disable, or query scoped automation prompt handling",
+            category = "system")
+    public Response configure(
+            @Param(value = "action", source = ParamSource.BODY, defaultValue = "status",
+                    description = "One of: enable, disable, status") String action,
+            @Param(value = "reason", source = ParamSource.BODY, defaultValue = "automation",
+                    description = "Short reason recorded in prompt-policy logs") String reason,
+            @Param(value = "seconds", source = ParamSource.BODY, defaultValue = "120",
+                    description = "How long to keep the prompt policy active") int seconds) {
+        if ("enable".equalsIgnoreCase(action)) {
+            enableFor(reason, seconds);
+        } else if ("disable".equalsIgnoreCase(action)) {
+            disable();
+        }
+        return Response.ok(status());
+    }
+
+    private void ensureTimer() {
+        if (timer == null) {
+            timer = new Timer(250, e -> scanDialogs());
+            timer.setRepeats(true);
+        }
+        if (!timer.isRunning()) {
+            timer.start();
+        }
+        scanDialogs();
+    }
+
+    private boolean isEnabled() {
+        synchronized (lock) {
+            return System.currentTimeMillis() < enabledUntilMillis;
+        }
+    }
+
+    private void scanDialogs() {
+        if (!isEnabled()) {
+            if (timer != null) {
+                timer.stop();
+            }
+            handledWindows.clear();
+            return;
+        }
+        handledWindows.removeIf(window -> !window.isDisplayable());
+        for (Window window : Window.getWindows()) {
+            if (!(window instanceof JDialog dialog) || !dialog.isShowing()) {
+                continue;
+            }
+            if (handledWindows.contains(dialog)) {
+                continue;
+            }
+            maybeHandle(dialog);
+        }
+    }
+
+    private void maybeHandle(JDialog dialog) {
+        String title = dialog.getTitle() != null ? dialog.getTitle() : "";
+        String text = collectText(dialog.getContentPane()).toLowerCase();
+
+        if (title.equals("Save Tool Changes?") && text.contains("tool chest")) {
+            if (selectRadio(dialog.getContentPane(), "None") && clickButton(dialog.getContentPane(), "OK")) {
+                record(dialog, "selected None and clicked OK");
+            }
+            return;
+        }
+
+        if (title.equals("Save Modified Files")) {
+            if (clickButton(dialog.getContentPane(), "Save")) {
+                record(dialog, "clicked Save");
+            }
+            return;
+        }
+
+        if (title.equals("Analyze?")
+                && text.contains("has not been analyzed")
+                && (text.contains("benchmark.dll") || text.contains("benchmarkdebug.exe"))) {
+            if (clickButton(dialog.getContentPane(), "No (Don't ask again)")) {
+                record(dialog, "clicked No (Don't ask again)");
+            }
+        }
+    }
+
+    private void record(JDialog dialog, String action) {
+        handledWindows.add(dialog);
+        Map<String, Object> entry = JsonHelper.mapOf(
+            "title", dialog.getTitle(),
+            "action", action,
+            "time_ms", System.currentTimeMillis(),
+            "reason", reason
+        );
+        synchronized (lock) {
+            actions.add(entry);
+            if (actions.size() > 50) {
+                actions.remove(0);
+            }
+        }
+        Msg.info(this, "GhidraMCP prompt policy: " + entry);
+    }
+
+    private String collectText(Component component) {
+        StringBuilder builder = new StringBuilder();
+        collectText(component, builder);
+        return builder.toString();
+    }
+
+    private void collectText(Component component, StringBuilder builder) {
+        if (component instanceof JLabel label && label.getText() != null) {
+            builder.append(' ').append(label.getText());
+        }
+        if (component instanceof AbstractButton button && button.getText() != null) {
+            builder.append(' ').append(button.getText());
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                collectText(child, builder);
+            }
+        }
+    }
+
+    private boolean selectRadio(Component component, String text) {
+        if (component instanceof AbstractButton button
+                && !(component instanceof JButton)
+                && text.equals(stripMnemonic(button.getText()))) {
+            button.setSelected(true);
+            return true;
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                if (selectRadio(child, text)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean clickButton(Component component, String text) {
+        if (component instanceof JButton button && text.equals(stripMnemonic(button.getText()))) {
+            button.doClick();
+            return true;
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                if (clickButton(child, text)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private String stripMnemonic(String text) {
+        return text == null ? "" : text.replace("&", "").trim();
+    }
+}

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -52,7 +52,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.5.0-headless";
+    private static final String VERSION = "5.6.0-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/java/com/xebyte/headless/HeadlessManagementService.java
+++ b/src/main/java/com/xebyte/headless/HeadlessManagementService.java
@@ -44,17 +44,6 @@ public class HeadlessManagementService {
         return Response.err("Failed to load program from: " + filePath);
     }
 
-    @McpTool(path = "/close_program", method = "POST", description = "Close a loaded program and free its resources", category = "headless")
-    public Response closeProgram(
-            @Param(value = "name", source = ParamSource.BODY, description = "Program name (as shown by list_open_programs)") String name) {
-        Program program = programProvider.getProgram(name);
-        if (program == null) {
-            return Response.err("Program not found: " + (name != null ? name : "current"));
-        }
-        programProvider.closeProgram(program);
-        return Response.text("{\"success\": true, \"closed\": \"" + ServiceUtils.escapeJson(program.getName()) + "\"}");
-    }
-
     // ========================================================================
     // Project management
     // ========================================================================

--- a/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
+++ b/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
@@ -210,9 +210,10 @@ public class HeadlessProgramProvider implements ProgramProvider {
      *
      * @param program The program to close
      */
-    public void closeProgram(Program program) {
+    @Override
+    public boolean closeProgram(Program program) {
         if (program == null) {
-            return;
+            return false;
         }
 
         openPrograms.remove(program.getName());
@@ -228,6 +229,7 @@ public class HeadlessProgramProvider implements ProgramProvider {
         } catch (Exception e) {
             Msg.warn(this, "Error releasing program: " + e.getMessage());
         }
+        return true;
     }
 
     /**

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.5.0
+Plugin-Version: 5.6.0
 Plugin-Author: Ben Ethington
-Plugin-Description: GhidraMCP - HTTP server plugin with 222 MCP tools for reverse engineering automation
+Plugin-Description: GhidraMCP - HTTP server plugin with 225 MCP tools for reverse engineering automation

--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -1,5 +1,5 @@
 name=GhidraMCP
-description=A plugin that runs an embedded HTTP server to expose program data. Provides 222 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
+description=A plugin that runs an embedded HTTP server to expose program data. Provides 225 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
 author=Ben Ethington
 createdOn=2025-03-22
 version=${ghidra.version}

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 222,
+  "total_endpoints": 225,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -391,11 +391,11 @@
     {
       "path": "/close_program",
       "method": "POST",
-      "category": "headless",
+      "category": "program",
       "params": [
         "name"
       ],
-      "description": "Close a loaded program and free its resources"
+      "description": "Close an open program by project path or name"
     },
     {
       "path": "/close_project",
@@ -608,6 +608,21 @@
         "program"
       ],
       "description": "List available debugger launch/attach options for the current program"
+    },
+    {
+      "path": "/debugger/launch",
+      "method": "POST",
+      "category": "debugger",
+      "params": [
+        "executable_path",
+        "args",
+        "cwd",
+        "timeout_seconds",
+        "program",
+        "offer",
+        "python_executable"
+      ],
+      "description": "Launch an executable through Ghidra's Trace RMI debugger launcher"
     },
     {
       "path": "/debugger/list_breakpoints",
@@ -1743,6 +1758,17 @@
       "description": "Get detailed project info including running tools and open programs"
     },
     {
+      "path": "/prompt_policy",
+      "method": "POST",
+      "category": "system",
+      "params": [
+        "action",
+        "reason",
+        "seconds"
+      ],
+      "description": "Temporarily enable, disable, or query scoped automation prompt handling"
+    },
+    {
       "path": "/read_memory",
       "method": "GET",
       "category": "analysis",
@@ -1917,6 +1943,13 @@
         "program"
       ],
       "description": "Save current program"
+    },
+    {
+      "path": "/save_all_programs",
+      "method": "GET",
+      "category": "program",
+      "params": [],
+      "description": "Save all open programs"
     },
     {
       "path": "/search_byte_patterns",

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1904,7 +1904,8 @@
       "category": "script",
       "params": [
         "code",
-        "args"
+        "args",
+        "program"
       ],
       "description": "Run inline script code"
     },

--- a/tests/performance/test_state_atomicity.py
+++ b/tests/performance/test_state_atomicity.py
@@ -204,6 +204,115 @@ def test_update_function_state_preserves_concurrent_other_keys(isolated_state):
     assert final["functions"][key_b]["last_result"] == "B"
 
 
+def test_finalize_worker_session_does_not_clobber_concurrent_function_updates(
+    isolated_state,
+):
+    """Worker-loop end-of-run persistence must not reintroduce the lost-update
+    race that update_function_state exists to solve.
+
+    Scenario: worker A loads state, worker B concurrently commits a per-function
+    update via update_function_state, worker A finalizes its session. If worker
+    A's finalize writes the full in-memory state, worker B's update is lost.
+    finalize_worker_session does RMW, so B's update survives.
+    """
+    fun_doc, path = isolated_state
+
+    fun_doc.save_state(_sample_state(10))
+
+    # Worker A loads state (stale snapshot from here on)
+    worker_a_state = fun_doc.load_state()
+    session_a = fun_doc.start_session(worker_a_state)
+    session_a["completed"] = 3
+    session_a["functions"] = ["prog::addr0001", "prog::addr0002", "prog::addr0003"]
+
+    # Worker B commits a per-function update — invisible to A's cached state
+    key_b = "prog::addr0007"
+    on_disk = json.loads(path.read_text())
+    func_b = {**on_disk["functions"][key_b], "score": 88, "last_result": "B"}
+    fun_doc.update_function_state(key_b, func_b)
+
+    # Worker A finalizes its session. Must NOT clobber B's update.
+    fun_doc.finalize_worker_session(session_a)
+
+    final = json.loads(path.read_text())
+    assert (
+        final["functions"][key_b]["score"] == 88
+    ), "finalize_worker_session clobbered a concurrent per-function update"
+    assert final["functions"][key_b]["last_result"] == "B"
+
+    # Session was recorded with ended timestamp
+    assert len(final["sessions"]) == 1
+    archived = final["sessions"][0]
+    assert archived["completed"] == 3
+    assert archived["functions"] == ["prog::addr0001", "prog::addr0002", "prog::addr0003"]
+    assert archived.get("ended")
+
+
+def test_finalize_worker_session_handles_active_binary_restore(isolated_state):
+    """active_binary override path: pass a value to set, pass None to clear,
+    omit to leave the on-disk value untouched."""
+    fun_doc, path = isolated_state
+
+    # Seed: active_binary already set on disk (e.g., by dashboard)
+    seed = _sample_state(3)
+    seed["active_binary"] = "dashboard_binary"
+    fun_doc.save_state(seed)
+
+    # Worker finishes, no override: on-disk active_binary must be preserved
+    session = {"started": "2026-04-24T10:00:00", "completed": 1}
+    fun_doc.finalize_worker_session(session)
+    assert json.loads(path.read_text())["active_binary"] == "dashboard_binary"
+
+    # Worker restores a prior original_binary
+    session2 = {"started": "2026-04-24T11:00:00", "completed": 1}
+    fun_doc.finalize_worker_session(session2, active_binary="original")
+    assert json.loads(path.read_text())["active_binary"] == "original"
+
+    # Worker clears (original was None)
+    session3 = {"started": "2026-04-24T12:00:00", "completed": 1}
+    fun_doc.finalize_worker_session(session3, active_binary=None)
+    assert "active_binary" not in json.loads(path.read_text())
+
+
+def test_finalize_worker_session_only_clears_matching_current_session(isolated_state):
+    """current_session must only be cleared if it still references this worker's
+    session. Another worker's concurrent session should stay untouched."""
+    fun_doc, path = isolated_state
+
+    # Seed state with another worker's current_session already recorded
+    seed = _sample_state(3)
+    other_session = {"started": "2026-04-24T09:00:00", "completed": 0}
+    seed["current_session"] = other_session
+    fun_doc.save_state(seed)
+
+    my_session = {"started": "2026-04-24T10:00:00", "completed": 2}
+    fun_doc.finalize_worker_session(my_session)
+
+    final = json.loads(path.read_text())
+    # Other worker's current_session untouched
+    assert final["current_session"] == other_session
+    # My session archived
+    assert len(final["sessions"]) == 1
+    assert final["sessions"][0]["started"] == "2026-04-24T10:00:00"
+
+
+def test_finalize_worker_session_uses_backup_when_state_is_corrupt(isolated_state):
+    """Worker finalization should preserve recoverable history by loading the
+    same backup that load_state() would use instead of writing a fresh default."""
+    fun_doc, path = isolated_state
+    bak_path = path.with_suffix(".json.bak")
+    good = _sample_state(2)
+    good["current_session"] = {"started": "2026-04-24T10:00:00", "completed": 0}
+    bak_path.write_text(json.dumps(good))
+    path.write_text('{"functions": {"foo": {"classificat')
+
+    fun_doc.finalize_worker_session({"started": "2026-04-24T10:00:00", "completed": 1})
+
+    final = json.loads(path.read_text())
+    assert len(final["functions"]) == 2
+    assert final["sessions"][-1]["completed"] == 1
+
+
 def test_save_state_truncation_corruption_is_recoverable(isolated_state, tmp_path):
     """End-to-end: simulate the exact failure mode we hit — a truncated
     state.json where a function entry is cut off mid-value. The recovery

--- a/tests/unit/test_setup_ghidra.py
+++ b/tests/unit/test_setup_ghidra.py
@@ -33,6 +33,7 @@ def test_patch_frontend_tool_config_adds_plugin_to_self_closing_utility_block():
     assert modified is True
     assert PLUGIN_CLASS in updated
     assert '<PACKAGE NAME="Utility">' in updated
+    assert '<EXTENSION NAME="GhidraMCP" />' in updated
 
 
 def test_patch_frontend_tool_config_removes_stale_package_and_inserts_plugin():
@@ -51,6 +52,7 @@ def test_patch_frontend_tool_config_removes_stale_package_and_inserts_plugin():
     assert 'PACKAGE NAME="GhidraMCP"' not in updated
     assert PLUGIN_CLASS in updated
     assert updated.count(PLUGIN_CLASS) == 1
+    assert '<EXTENSION NAME="GhidraMCP" />' in updated
 
 
 def test_patch_codebrowser_tcd_removes_ghidra_mcp_package_block():
@@ -67,6 +69,7 @@ def test_patch_codebrowser_tcd_removes_ghidra_mcp_package_block():
     assert modified is True
     assert PLUGIN_CLASS not in updated
     assert 'PACKAGE NAME="GhidraMCP"' not in updated
+    assert '<EXTENSION NAME="GhidraMCP" />' in updated
 
 
 def test_resolve_ghidra_user_dir_prefers_matching_public_dir(tmp_path: Path):
@@ -359,10 +362,15 @@ def test_run_deploy_tests_dispatches_release_tier(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(ghidra, "run_benchmark_read_test", lambda *args: calls.append("read"))
     monkeypatch.setattr(ghidra, "run_benchmark_write_test", lambda *args: calls.append("write"))
     monkeypatch.setattr(ghidra, "run_release_regression_tests", lambda *args: calls.append("release"))
+    monkeypatch.setattr(
+        ghidra,
+        "_mcp_request",
+        lambda *args, **kwargs: calls.append("prompt_policy") or (200, {"enabled": True}),
+    )
 
     run_deploy_tests(Path("C:/repo"), "http://127.0.0.1:8089", ["release"])
 
-    assert calls == ["smoke", "release"]
+    assert calls == ["smoke", "prompt_policy", "release"]
 
 
 def test_run_deploy_tests_default_does_not_import_benchmark(monkeypatch: pytest.MonkeyPatch):

--- a/tools/setup/cli.py
+++ b/tools/setup/cli.py
@@ -179,6 +179,7 @@ def build_parser() -> argparse.ArgumentParser:
         choices=[
             "benchmark-read",
             "benchmark-write",
+            "debugger-live",
             "endpoint-catalog",
             "multi-program",
             "negative-contract",

--- a/tools/setup/ghidra.py
+++ b/tools/setup/ghidra.py
@@ -12,6 +12,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from .envfile import load_env_file
@@ -47,14 +48,24 @@ REQUIRED_GHIDRA_JARS: tuple[tuple[str, str], ...] = (
 )
 
 PLUGIN_CLASS = "com.xebyte.GhidraMCPPlugin"
+PLUGIN_EXTENSION_NAME = "GhidraMCP"
 DEFAULT_MCP_URL = "http://127.0.0.1:8089"
 DEFAULT_MCP_WAIT_SECONDS = 120
 DEFAULT_GHIDRA_EXIT_WAIT_SECONDS = 15
 DEFAULT_BENCHMARK_DLL = Path("fun-doc") / "benchmark" / "build" / "Benchmark.dll"
+DEFAULT_BENCHMARK_DEBUG_EXE = Path("fun-doc") / "benchmark" / "build" / "BenchmarkDebug.exe"
 LEGACY_BENCHMARK_PROGRAM = "/benchmark/Benchmark.dll"
 DEFAULT_BENCHMARK_FOLDER = "/testing/benchmark"
 DEFAULT_BENCHMARK_PROGRAM = f"{DEFAULT_BENCHMARK_FOLDER}/Benchmark.dll"
+DEFAULT_BENCHMARK_DEBUG_PROGRAM = f"{DEFAULT_BENCHMARK_FOLDER}/BenchmarkDebug.exe"
 DEFAULT_BENCHMARK_FUNCTION = "calc_crc16"
+BENCHMARK_DEPLOY_TEST_MODES = {
+    "benchmark-read",
+    "benchmark-write",
+    "release",
+    "debugger-live",
+    "multi-program",
+}
 SMOKE_REQUIRED_TOOLS = {
     "decompile_function",
     "get_function_variables",
@@ -62,13 +73,16 @@ SMOKE_REQUIRED_TOOLS = {
     "batch_set_comments",
     "set_local_variable_type",
     "rename_variables",
+    "prompt_policy",
     "save_program",
+    "save_all_programs",
     "set_function_prototype",
     "rename_function_by_address",
     "search_data_types",
     "create_struct",
     "get_struct_layout",
     "list_open_programs",
+    "debugger/launch",
 }
 RELEASE_CONTRACT_TOOLS = SMOKE_REQUIRED_TOOLS | {
     "analysis_status",
@@ -82,6 +96,9 @@ RELEASE_CONTRACT_TOOLS = SMOKE_REQUIRED_TOOLS | {
     "list_imports",
     "list_exports",
     "list_strings",
+    "debugger/launch",
+    "debugger/status",
+    "debugger/modules",
 }
 
 
@@ -152,6 +169,7 @@ def patch_frontend_tool_config(content: str) -> tuple[str, bool]:
         )
 
     if PLUGIN_CLASS in updated:
+        updated = mark_extension_known_in_tool_config(updated, PLUGIN_EXTENSION_NAME)
         return updated, updated != original
 
     utility_self_closing = '<PACKAGE NAME="Utility" />'
@@ -162,6 +180,7 @@ def patch_frontend_tool_config(content: str) -> tuple[str, bool]:
             "            </PACKAGE>"
         )
         updated = updated.replace(utility_self_closing, replacement, 1)
+        updated = mark_extension_known_in_tool_config(updated, PLUGIN_EXTENSION_NAME)
         return updated, True
 
     utility_block = '<PACKAGE NAME="Utility">'
@@ -171,6 +190,7 @@ def patch_frontend_tool_config(content: str) -> tuple[str, bool]:
             f'                <INCLUDE CLASS="{PLUGIN_CLASS}" />'
         )
         updated = updated.replace(utility_block, replacement, 1)
+        updated = mark_extension_known_in_tool_config(updated, PLUGIN_EXTENSION_NAME)
         return updated, True
 
     root_node = "<ROOT_NODE"
@@ -182,18 +202,58 @@ def patch_frontend_tool_config(content: str) -> tuple[str, bool]:
             "<ROOT_NODE"
         )
         updated = updated.replace(root_node, insertion, 1)
+        updated = mark_extension_known_in_tool_config(updated, PLUGIN_EXTENSION_NAME)
         return updated, True
 
+    updated = mark_extension_known_in_tool_config(updated, PLUGIN_EXTENSION_NAME)
     return updated, updated != original
 
 
-def patch_codebrowser_tcd(content: str) -> tuple[str, bool]:
+def mark_extension_known_in_tool_config(content: str, extension_name: str) -> str:
+    """Record an installed extension as known to suppress Ghidra's first-run plugin dialog."""
+    if re.search(
+        rf'<EXTENSION\s+(?:[^>]*\s)?NAME="{re.escape(extension_name)}"',
+        content,
+    ):
+        return content
+
+    extension_entry = f'            <EXTENSION NAME="{extension_name}" />\n'
+    empty_extensions = re.compile(r"(?m)^([ \t]*)<EXTENSIONS\s*/>\s*$")
+    if empty_extensions.search(content):
+        return empty_extensions.sub(
+            rf"\1<EXTENSIONS>\n{extension_entry}\1</EXTENSIONS>",
+            content,
+            count=1,
+        )
+
+    extensions_open = re.compile(r"(?m)^([ \t]*)<EXTENSIONS>\s*$")
+    match = extensions_open.search(content)
+    if match:
+        insert_at = match.end()
+        return content[:insert_at] + "\n" + extension_entry + content[insert_at:]
+
+    if "</TOOL>" not in content:
+        return content
+    return content.replace(
+        "</TOOL>",
+        f"        <EXTENSIONS>\n{extension_entry}        </EXTENSIONS>\n    </TOOL>",
+        1,
+    )
+
+
+def patch_tool_tcd(content: str) -> tuple[str, bool]:
+    original = content
     updated = re.sub(
         rf'\s*<PACKAGE NAME="GhidraMCP">\s*<INCLUDE CLASS="{re.escape(PLUGIN_CLASS)}"\s*/>\s*</PACKAGE>',
         "",
         content,
     )
-    return updated, updated != content
+    updated = mark_extension_known_in_tool_config(updated, PLUGIN_EXTENSION_NAME)
+    return updated, updated != original
+
+
+def patch_codebrowser_tcd(content: str) -> tuple[str, bool]:
+    return patch_tool_tcd(content)
 
 
 def _write_text_file(path: Path, content: str) -> None:
@@ -216,15 +276,15 @@ def patch_ghidra_user_configs(user_base_dir: Path, *, dry_run: bool = False) -> 
         _write_text_file(front_end_file, updated)
         print(f"Patched FrontEnd config {front_end_file}")
 
-    for tcd_file in sorted(user_base_dir.glob("*/tools/_code_browser.tcd")):
-        updated, modified = patch_codebrowser_tcd(tcd_file.read_text(encoding="utf-8"))
+    for tcd_file in sorted(user_base_dir.glob("*/tools/*.tcd")):
+        updated, modified = patch_tool_tcd(tcd_file.read_text(encoding="utf-8"))
         if not modified:
             continue
         if dry_run:
             print(f"DRY RUN: patch {tcd_file}")
             continue
         _write_text_file(tcd_file, updated)
-        print(f"Cleaned CodeBrowser config {tcd_file}")
+        print(f"Patched tool config {tcd_file}")
 
 
 def _find_plugin_jar(repo_root: Path) -> Path | None:
@@ -478,6 +538,79 @@ def _terminate_process(pid: int) -> None:
         os.kill(pid, signal.SIGKILL)
 
 
+def _terminate_processes_by_name(process_name: str) -> None:
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/IM", process_name, "/F"], check=False)
+        return
+    subprocess.run(["pkill", "-f", process_name], check=False)
+
+
+def _project_state_path_from_gpr(project_path: str) -> Path | None:
+    if not project_path:
+        return None
+    gpr = Path(project_path)
+    if gpr.suffix.lower() != ".gpr":
+        return None
+    return gpr.with_suffix(".rep") / "projectState"
+
+
+def _deploy_tests_use_benchmark(test_modes: list[str]) -> bool:
+    return any(mode in BENCHMARK_DEPLOY_TEST_MODES for mode in test_modes)
+
+
+def clear_restored_benchmark_tools(repo_root: Path, *, dry_run: bool = False) -> int:
+    env_values = load_env_file(repo_root / ".env")
+    project_state = _project_state_path_from_gpr(env_values.get("GHIDRA_PROJECT_PATH", "").strip())
+    if project_state is None or not project_state.is_file():
+        return 0
+
+    try:
+        tree = ET.parse(project_state)
+    except ET.ParseError as exc:
+        print(f"WARNING: Could not parse Ghidra project state {project_state}: {exc}")
+        return 0
+
+    root = tree.getroot()
+    parent_by_child = {child: parent for parent in root.iter() for child in parent}
+    removed = 0
+    benchmark_state_markers = (
+        f'VALUE="{DEFAULT_BENCHMARK_PROGRAM}"',
+        f'VALUE="diablo2:{DEFAULT_BENCHMARK_PROGRAM}"',
+        f'VALUE="{DEFAULT_BENCHMARK_DEBUG_PROGRAM}"',
+        f'VALUE="diablo2:{DEFAULT_BENCHMARK_DEBUG_PROGRAM}"',
+        f'VALUE="{LEGACY_BENCHMARK_PROGRAM}"',
+        "/testing/benchmark/",
+        "/New Traces/pydbg/BenchmarkDebug.exe",
+    )
+    for tool in list(root.iter("RUNNING_TOOL")):
+        if tool.attrib.get("TOOL_NAME") not in {"CodeBrowser", "Debugger"}:
+            continue
+        tool_xml = ET.tostring(tool, encoding="unicode")
+        if not any(marker in tool_xml for marker in benchmark_state_markers):
+            continue
+        parent = parent_by_child.get(tool)
+        if parent is None:
+            continue
+        if dry_run:
+            removed += 1
+            continue
+        parent.remove(tool)
+        removed += 1
+
+    if removed == 0:
+        return 0
+    if dry_run:
+        print(f"DRY RUN: remove {removed} restored benchmark CodeBrowser tool(s) from {project_state}")
+        return removed
+
+    backup_path = project_state.with_name(project_state.name + ".GhidraMCP.bak")
+    shutil.copy2(project_state, backup_path)
+    tree.write(project_state, encoding="utf-8", xml_declaration=True)
+    print(f"Removed {removed} restored benchmark CodeBrowser tool(s) from {project_state}")
+    print(f"Backed up previous project state to {backup_path}")
+    return removed
+
+
 def close_running_ghidra_for_deploy(
     repo_root: Path,
     ghidra_path: Path,
@@ -493,17 +626,22 @@ def close_running_ghidra_for_deploy(
     for proc in matches:
         print(f"Detected running Ghidra PID {proc['pid']}: {proc['command']}")
     if dry_run:
-        print(f"DRY RUN: save via {mcp_url}/save_program")
+        print(f"DRY RUN: save all open programs via {mcp_url}/save_all_programs")
         print(f"DRY RUN: graceful exit via {mcp_url}/exit_ghidra")
         for proc in matches:
             print(f"DRY RUN: force-kill PID {proc['pid']} if still running")
         return True
 
     try:
-        _mcp_request(repo_root, mcp_url, "/save_program", timeout=60)
-        print("Requested Ghidra program save.")
+        _mcp_request(repo_root, mcp_url, "/save_all_programs", timeout=60)
+        print("Requested save for all open Ghidra programs.")
     except Exception as exc:
-        print(f"WARNING: save_program failed before deploy: {exc}")
+        print(f"WARNING: save_all_programs failed before deploy: {exc}")
+        try:
+            _mcp_request(repo_root, mcp_url, "/save_program", timeout=60)
+            print("Requested fallback Ghidra program save.")
+        except Exception as fallback_exc:
+            print(f"WARNING: fallback save_program failed before deploy: {fallback_exc}")
     try:
         _mcp_request(repo_root, mcp_url, "/exit_ghidra", timeout=10)
         print("Requested graceful Ghidra exit.")
@@ -615,25 +753,54 @@ def run_default_smoke_test(repo_root: Path, mcp_url: str) -> None:
     print(f"MCP smoke passed: schema exposes {len(tools)} tools.")
 
 
+def _close_and_delete_project_file(repo_root: Path, mcp_url: str, program_path: str) -> None:
+    deadline = time.monotonic() + 90
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            _mcp_request(
+                repo_root,
+                mcp_url,
+                "/close_program",
+                data={"name": program_path},
+                method="POST",
+                timeout=30,
+            )
+            _status, payload = _mcp_request(
+                repo_root,
+                mcp_url,
+                "/delete_file",
+                data={"filePath": program_path},
+                method="POST",
+                timeout=30,
+            )
+            _ensure_mcp_ok("/delete_file", payload)
+            return
+        except Exception as exc:
+            last_error = str(exc)
+            if "in use" not in last_error.lower() and "background" not in last_error.lower():
+                raise
+            time.sleep(3)
+    raise RuntimeError(f"Timed out deleting {program_path}: {last_error}")
+
+
 def reset_benchmark_fixture(repo_root: Path, mcp_url: str) -> None:
     benchmark_dll = repo_root / DEFAULT_BENCHMARK_DLL
-    if not benchmark_dll.is_file():
-        print(f"Benchmark.dll missing at {benchmark_dll}; building it now.")
+    benchmark_debug_exe = repo_root / DEFAULT_BENCHMARK_DEBUG_EXE
+    _terminate_processes_by_name("BenchmarkDebug.exe")
+    if not benchmark_dll.is_file() or not benchmark_debug_exe.is_file():
+        print("Benchmark binary output missing; building it now.")
         subprocess.run(
             [sys.executable, str(repo_root / "fun-doc" / "benchmark" / "build.py")],
             cwd=repo_root,
             check=True,
         )
-    for program_path in (LEGACY_BENCHMARK_PROGRAM, DEFAULT_BENCHMARK_PROGRAM):
-        _status, payload = _mcp_request(
-            repo_root,
-            mcp_url,
-            "/delete_file",
-            data={"filePath": program_path},
-            method="POST",
-            timeout=30,
-        )
-        _ensure_mcp_ok("/delete_file", payload)
+    for program_path in (
+        LEGACY_BENCHMARK_PROGRAM,
+        DEFAULT_BENCHMARK_PROGRAM,
+        DEFAULT_BENCHMARK_DEBUG_PROGRAM,
+    ):
+        _close_and_delete_project_file(repo_root, mcp_url, program_path)
     _status, payload = _mcp_request(
         repo_root,
         mcp_url,
@@ -650,8 +817,19 @@ def reset_benchmark_fixture(repo_root: Path, mcp_url: str) -> None:
         data={
             "file_path": str(benchmark_dll),
             "project_folder": DEFAULT_BENCHMARK_FOLDER,
-            "language": "x86:LE:32:default",
-            "compiler_spec": "windows",
+            "auto_analyze": True,
+        },
+        method="POST",
+        timeout=120,
+    )
+    _ensure_mcp_ok("/import_file", payload)
+    _status, payload = _mcp_request(
+        repo_root,
+        mcp_url,
+        "/import_file",
+        data={
+            "file_path": str(benchmark_debug_exe),
+            "project_folder": DEFAULT_BENCHMARK_FOLDER,
             "auto_analyze": True,
         },
         method="POST",
@@ -669,9 +847,25 @@ def reset_benchmark_fixture(repo_root: Path, mcp_url: str) -> None:
                 timeout=10,
             )
             _ensure_mcp_ok("/analysis_status", status)
+            _status, exe_status = _mcp_request(
+                repo_root,
+                mcp_url,
+                "/analysis_status",
+                params={"program": DEFAULT_BENCHMARK_DEBUG_PROGRAM},
+                timeout=10,
+            )
+            _ensure_mcp_ok("/analysis_status", exe_status)
             state = (status.get("state") or status.get("status")) if isinstance(status, dict) else None
+            exe_state = (
+                (exe_status.get("state") or exe_status.get("status"))
+                if isinstance(exe_status, dict)
+                else None
+            )
             is_idle = isinstance(status, dict) and status.get("analyzing") is False
-            if is_idle or state in {"complete", "done", "idle", "finished"}:
+            exe_idle = isinstance(exe_status, dict) and exe_status.get("analyzing") is False
+            if (is_idle or state in {"complete", "done", "idle", "finished"}) and (
+                exe_idle or exe_state in {"complete", "done", "idle", "finished"}
+            ):
                 print(f"Benchmark fixture reset at {DEFAULT_BENCHMARK_PROGRAM}.")
                 return
         except Exception:
@@ -707,7 +901,59 @@ def _list_benchmark_functions(repo_root: Path, mcp_url: str) -> list[tuple[str, 
     return functions
 
 
-def _has_non_phantom_local(repo_root: Path, mcp_url: str, address: str) -> bool:
+def _list_benchmark_exports(repo_root: Path, mcp_url: str) -> list[tuple[str, str]]:
+    _status, payload = _mcp_request(
+        repo_root,
+        mcp_url,
+        "/list_exports",
+        params={"program": DEFAULT_BENCHMARK_PROGRAM},
+        timeout=60,
+    )
+    _ensure_mcp_ok("/list_exports", payload)
+    exports: list[tuple[str, str]] = []
+    if isinstance(payload, str):
+        for line in payload.splitlines():
+            match = re.match(r"(.+?)\s+->\s+([0-9a-fA-Fx]+)\s*$", line.strip())
+            if match:
+                exports.append((match.group(1), match.group(2)))
+    return exports
+
+
+def _ensure_benchmark_function(repo_root: Path, mcp_url: str, address: str, name: str) -> None:
+    _status, payload = _mcp_request(
+        repo_root,
+        mcp_url,
+        "/get_function_by_address",
+        params={"program": DEFAULT_BENCHMARK_PROGRAM, "address": address},
+        timeout=30,
+    )
+    if isinstance(payload, dict) and "error" not in payload:
+        return
+    _status, payload = _mcp_request(
+        repo_root,
+        mcp_url,
+        "/create_function",
+        params={"program": DEFAULT_BENCHMARK_PROGRAM},
+        data={
+            "address": address,
+            "name": re.sub(r"[^A-Za-z0-9_]", "_", name).strip("_") or "BenchmarkFunction",
+            "disassemble_first": True,
+        },
+        method="POST",
+        timeout=60,
+    )
+    _ensure_mcp_ok("/create_function", payload)
+
+
+def _has_editable_variable(repo_root: Path, mcp_url: str, address: str) -> bool:
+    _status, decompile_payload = _mcp_request(
+        repo_root,
+        mcp_url,
+        "/decompile_function",
+        params={"program": DEFAULT_BENCHMARK_PROGRAM, "address": address},
+        timeout=60,
+    )
+    _ensure_mcp_ok("/decompile_function", decompile_payload)
     _status, variables = _mcp_request(
         repo_root,
         mcp_url,
@@ -718,13 +964,13 @@ def _has_non_phantom_local(repo_root: Path, mcp_url: str, address: str) -> bool:
     _ensure_mcp_ok("/get_function_variables", variables)
     if not isinstance(variables, dict):
         return False
-    for local in variables.get("locals") or []:
-        if isinstance(local, dict) and local.get("name") and not local.get("is_phantom"):
+    for variable in (variables.get("locals") or []) + (variables.get("parameters") or []):
+        if isinstance(variable, dict) and variable.get("name") and not variable.get("is_phantom"):
             return True
     return False
 
 
-def _find_benchmark_function(repo_root: Path, mcp_url: str, *, require_local: bool = False) -> str:
+def _find_benchmark_function(repo_root: Path, mcp_url: str, *, require_variable: bool = False) -> str:
     _status, payload = _mcp_request(
         repo_root,
         mcp_url,
@@ -741,20 +987,33 @@ def _find_benchmark_function(repo_root: Path, mcp_url: str, *, require_local: bo
         _ensure_mcp_ok("/search_functions", payload)
         functions = payload.get("results") or payload.get("functions") or []
     for function in functions:
-        if isinstance(function, dict) and function.get("name") == DEFAULT_BENCHMARK_FUNCTION:
+        if isinstance(function, dict) and DEFAULT_BENCHMARK_FUNCTION in str(function.get("name") or ""):
             address = function.get("address") or function.get("entry_point")
-            if address and (not require_local or _has_non_phantom_local(repo_root, mcp_url, str(address))):
+            if address and (not require_variable or _has_editable_variable(repo_root, mcp_url, str(address))):
                 return str(address)
 
     fallback_functions = _list_benchmark_functions(repo_root, mcp_url)
-    if require_local:
+    if require_variable:
         for _name, address in fallback_functions:
-            if _has_non_phantom_local(repo_root, mcp_url, address):
+            if _has_editable_variable(repo_root, mcp_url, address):
                 return address
     elif fallback_functions:
         return fallback_functions[0][1]
 
-    suffix = " with a non-phantom local" if require_local else ""
+    for name, address in _list_benchmark_exports(repo_root, mcp_url):
+        if name.startswith("Ordinal_") or name == "entry":
+            continue
+        if DEFAULT_BENCHMARK_FUNCTION not in name and not fallback_functions:
+            continue
+        _ensure_benchmark_function(repo_root, mcp_url, address, name)
+        if not require_variable:
+            return address
+        for _ in range(5):
+            if _has_editable_variable(repo_root, mcp_url, address):
+                return address
+            time.sleep(1)
+
+    suffix = " with an editable variable" if require_variable else ""
     raise RuntimeError(f"Could not find a benchmark function{suffix} in {DEFAULT_BENCHMARK_PROGRAM}")
 
 
@@ -820,7 +1079,7 @@ def run_benchmark_extended_read_test(repo_root: Path, mcp_url: str) -> None:
 
 
 def run_benchmark_write_test(repo_root: Path, mcp_url: str) -> None:
-    address = _find_benchmark_function(repo_root, mcp_url, require_local=True)
+    address = _find_benchmark_function(repo_root, mcp_url, require_variable=True)
     _status, variables = _mcp_request(
         repo_root,
         mcp_url,
@@ -829,14 +1088,14 @@ def run_benchmark_write_test(repo_root: Path, mcp_url: str) -> None:
         timeout=30,
     )
     _ensure_mcp_ok("/get_function_variables", variables)
-    local_name = None
+    variable_name = None
     if isinstance(variables, dict):
-        for local in variables.get("locals") or []:
-            if isinstance(local, dict) and local.get("name") and not local.get("is_phantom"):
-                local_name = str(local["name"])
+        for variable in (variables.get("locals") or []) + (variables.get("parameters") or []):
+            if isinstance(variable, dict) and variable.get("name") and not variable.get("is_phantom"):
+                variable_name = str(variable["name"])
                 break
-    if not local_name:
-        raise RuntimeError("No benchmark local variable available for write smoke")
+    if not variable_name:
+        raise RuntimeError("No benchmark editable variable available for write smoke")
     write_calls = [
         (
             "/batch_set_comments",
@@ -850,7 +1109,7 @@ def run_benchmark_write_test(repo_root: Path, mcp_url: str) -> None:
             "/set_local_variable_type",
             {
                 "function_address": address,
-                "variable_name": local_name,
+                "variable_name": variable_name,
                 "new_type": "uint",
             },
         ),
@@ -858,7 +1117,7 @@ def run_benchmark_write_test(repo_root: Path, mcp_url: str) -> None:
             "/rename_variables",
             {
                 "function_address": address,
-                "variable_renames": {local_name: "dwDeploySmoke"},
+                "variable_renames": {variable_name: "dwDeploySmoke"},
                 "force_individual": True,
             },
         ),
@@ -893,7 +1152,7 @@ def run_benchmark_write_test(repo_root: Path, mcp_url: str) -> None:
 
 
 def run_negative_contract_test(repo_root: Path, mcp_url: str) -> None:
-    address = _find_benchmark_function(repo_root, mcp_url, require_local=True)
+    address = _find_benchmark_function(repo_root, mcp_url, require_variable=True)
     _status, payload = _mcp_request(
         repo_root,
         mcp_url,
@@ -978,6 +1237,80 @@ def run_multi_program_targeting_test(repo_root: Path, mcp_url: str) -> None:
     print("Multi-program targeting test passed.")
 
 
+def run_debugger_live_test(repo_root: Path, mcp_url: str) -> None:
+    if os.name != "nt":
+        raise RuntimeError("Debugger live regression is currently Windows-only.")
+    benchmark_debug_exe = repo_root / DEFAULT_BENCHMARK_DEBUG_EXE
+    if not benchmark_debug_exe.is_file():
+        raise RuntimeError(f"BenchmarkDebug.exe not found at {benchmark_debug_exe}")
+
+    env_values = load_env_file(repo_root / ".env")
+    python_executable = (
+        os.environ.get("GHIDRA_DEBUGGER_PYTHON", "").strip()
+        or env_values.get("GHIDRA_DEBUGGER_PYTHON", "").strip()
+    )
+    launch_data: dict[str, object] = {
+        "program": DEFAULT_BENCHMARK_DEBUG_PROGRAM,
+        "executable_path": str(benchmark_debug_exe),
+        "args": "--seconds 180",
+        "cwd": str(benchmark_debug_exe.parent),
+        "timeout_seconds": 90,
+        "offer": "BATCH_FILE:local-dbgeng.bat",
+    }
+    if python_executable:
+        launch_data["python_executable"] = python_executable
+
+    try:
+        _status, launch = _mcp_request(
+            repo_root,
+            mcp_url,
+            "/debugger/launch",
+            data=launch_data,
+            method="POST",
+            timeout=120,
+        )
+        _ensure_mcp_ok("/debugger/launch", launch)
+
+        deadline = time.monotonic() + 45
+        status_payload: object = {}
+        while time.monotonic() < deadline:
+            _status, status_payload = _mcp_request(
+                repo_root,
+                mcp_url,
+                "/debugger/status",
+                timeout=20,
+            )
+            _ensure_mcp_ok("/debugger/status", status_payload)
+            if (
+                isinstance(status_payload, dict)
+                and status_payload.get("trace_active") is True
+                and status_payload.get("target_connected") is True
+                and status_payload.get("thread")
+            ):
+                break
+            time.sleep(2)
+        else:
+            raise RuntimeError(f"Debugger did not report an active target: {status_payload}")
+
+        for path, params in (
+            ("/debugger/traces", {}),
+            ("/debugger/modules", {}),
+            ("/debugger/registers", {}),
+            ("/debugger/stack_trace", {"depth": 8}),
+        ):
+            _status, payload = _mcp_request(
+                repo_root,
+                mcp_url,
+                path,
+                params=params,
+                timeout=30,
+            )
+            _ensure_mcp_ok(path, payload)
+        print("Debugger live test passed: launched BenchmarkDebug.exe and read trace state.")
+    finally:
+        _terminate_processes_by_name("BenchmarkDebug.exe")
+
+
 def run_endpoint_catalog_test(repo_root: Path, mcp_url: str) -> None:
     _status, schema = _mcp_request(repo_root, mcp_url, "/mcp/schema", timeout=20)
     live_tools = _schema_tools(schema)
@@ -1041,11 +1374,21 @@ def run_release_regression_tests(repo_root: Path, mcp_url: str) -> None:
     run_benchmark_extended_read_test(repo_root, mcp_url)
     run_multi_program_targeting_test(repo_root, mcp_url)
     run_negative_contract_test(repo_root, mcp_url)
+    run_debugger_live_test(repo_root, mcp_url)
     print("Release regression tier passed.")
 
 
 def run_deploy_tests(repo_root: Path, mcp_url: str, test_modes: list[str]) -> None:
     run_default_smoke_test(repo_root, mcp_url)
+    if _deploy_tests_use_benchmark(test_modes):
+        _mcp_request(
+            repo_root,
+            mcp_url,
+            "/prompt_policy",
+            data={"action": "enable", "reason": "deploy_tests", "seconds": 300},
+            method="POST",
+            timeout=10,
+        )
     for mode in test_modes:
         if mode == "endpoint-catalog":
             run_endpoint_catalog_test(repo_root, mcp_url)
@@ -1063,6 +1406,9 @@ def run_deploy_tests(repo_root: Path, mcp_url: str, test_modes: list[str]) -> No
             run_multi_program_targeting_test(repo_root, mcp_url)
         elif mode == "selected-contract":
             run_selected_endpoint_contract_test(repo_root, mcp_url)
+        elif mode == "debugger-live":
+            reset_benchmark_fixture(repo_root, mcp_url)
+            run_debugger_live_test(repo_root, mcp_url)
         elif mode == "release":
             run_release_regression_tests(repo_root, mcp_url)
 
@@ -1234,7 +1580,9 @@ def deploy_to_ghidra(
             )
         install_user_extension(repo_root, ghidra_path, archive_path, dry_run=True)
         patch_ghidra_user_configs(user_base_dir, dry_run=True)
-        start_ghidra(ghidra_path, dry_run=True)
+        if _deploy_tests_use_benchmark(test_modes):
+            clear_restored_benchmark_tools(repo_root, dry_run=True)
+        start_ghidra(ghidra_path, repo_root=repo_root, dry_run=True)
         print(f"DRY RUN: wait up to {DEFAULT_MCP_WAIT_SECONDS}s for MCP at {mcp_url}")
         print(f"DRY RUN: wait up to {DEFAULT_MCP_WAIT_SECONDS}s for active project")
         print("DRY RUN: run default MCP smoke test")
@@ -1267,7 +1615,9 @@ def deploy_to_ghidra(
 
     install_user_extension(repo_root, ghidra_path, archive_path)
     patch_ghidra_user_configs(user_base_dir)
-    start_ghidra(ghidra_path)
+    if _deploy_tests_use_benchmark(test_modes):
+        clear_restored_benchmark_tools(repo_root)
+    start_ghidra(ghidra_path, repo_root=repo_root)
     wait_for_mcp(repo_root, mcp_url, timeout_seconds=DEFAULT_MCP_WAIT_SECONDS)
     wait_for_project(repo_root, mcp_url, timeout_seconds=DEFAULT_MCP_WAIT_SECONDS)
     run_deploy_tests(repo_root, mcp_url, test_modes)
@@ -1275,12 +1625,17 @@ def deploy_to_ghidra(
     return 0
 
 
-def start_ghidra(ghidra_path: Path, *, dry_run: bool = False) -> int:
+def start_ghidra(ghidra_path: Path, *, repo_root: Path | None = None, dry_run: bool = False) -> int:
     executable = find_ghidra_executable(ghidra_path)
+    env_root = repo_root if repo_root is not None else Path.cwd()
+    env_values = load_env_file(env_root / ".env")
+    project_path = env_values.get("GHIDRA_PROJECT_PATH", "").strip()
     if executable.suffix.lower() in {".bat", ".cmd"}:
         command = [os.environ.get("COMSPEC", "cmd.exe"), "/c", str(executable)]
     else:
         command = [str(executable)]
+    if project_path:
+        command.append(project_path)
 
     if dry_run:
         print("DRY RUN:", end=" ")


### PR DESCRIPTION
## Summary

Prepares the 5.6.0 release and expands the deploy/release regression path:

- Adds live benchmark-backed release regression coverage, including debugger-live validation against `BenchmarkDebug.exe`.
- Adds scoped `/prompt_policy` handling for known Ghidra automation dialogs during deploy/regression runs.
- Makes deploy safer by saving open programs/traces, gracefully exiting matching Ghidra, force-killing leftovers when needed, starting Ghidra, and running MCP smoke checks.
- Improves benchmark fixture reset/import behavior for `/testing/benchmark/Benchmark.dll` and `/testing/benchmark/BenchmarkDebug.exe`.
- Updates release/version metadata to 5.6.0 and adds a canonical release checklist at `docs/releases/RELEASE_CHECKLIST.md`.

## Verification

- `python -m tools.setup verify-version`
- `pytest tests/unit/test_version_bump.py tests/unit/test_endpoint_catalog.py tests/unit/test_setup_cli.py -v --no-cov` — 103 passed
- `pytest tests/unit/ -v --no-cov` — 295 passed earlier in this branch
- `python -m tools.setup build` — produced `target/GhidraMCP-5.6.0.zip`
- `git diff --check` / `git diff --cached --check`

## Release / Merge Note

The code is ready for PR review. Before merging to `main`, I recommend one live Ghidra deploy regression pass with `--test release`, using a UI screenshot/checkpoint first because this branch specifically touches popup/deploy behavior.