### PR TITLE
Add GUI toggle for function name enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Added
+
+- **GUI-configurable function-name enforcement** — the **Strict Function Name
+  Enforcement** Ghidra Tool Option controls whether
+  `rename_function_by_address` hard-rejects names that fail the verb-tier or
+  token-subset gates. The default remains strict. When disabled, the rename
+  proceeds while returning the same issues as warnings. No endpoint schema
+  change is required.
+
+---
+
 ## v5.7.0 - 2026-05-05 (globals quality, scope guard, archive integration)
 
 Release headline is bringing global variables up to the same documentation

--- a/README.md
+++ b/README.md
@@ -350,6 +350,13 @@ GhidraMCP is designed for **localhost-only development**. The default configurat
 | `GHIDRA_MCP_ALLOW_SCRIPTS` | Set to `1`, `true`, or `yes` to enable `/run_script_inline` and `/run_ghidra_script`. **Off by default as of v5.4.1** — these endpoints execute arbitrary Java against the Ghidra process. |
 | `GHIDRA_MCP_FILE_ROOT` | When set to a directory path, filesystem-path endpoints (`/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. Prevents path-traversal. |
 
+Function-name quality enforcement is separate from security. By default,
+`rename_function_by_address` rejects names that fail the built-in quality
+gate. Disable the hard-reject layer with **Edit > Tool Options > GhidraMCP
+HTTP Server > Strict Function Name Enforcement**. The Tool Options setting is
+read when the MCP server starts or restarts. Convention warnings are still
+returned when enforcement is disabled.
+
 ### Example: exposing to a private LAN with auth
 
 ```bash

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -7,6 +7,14 @@ For the full version history, see [CHANGELOG.md](../../CHANGELOG.md) in the proj
 For the release preparation runbook, see
 [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md).
 
+## Unreleased
+
+- **GUI-configurable function-name enforcement** — the **Strict Function Name
+  Enforcement** Ghidra Tool Option controls whether
+  `rename_function_by_address` hard-rejects names that fail the verb-tier or
+  token-subset gates. The default remains strict; disabling the option lets
+  noncompliant names proceed while returning the same issues as warnings.
+
 ## Current Releases
 
 ### v5.7.0 (Latest) — globals quality, scope guard, archive integration

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -66,6 +66,7 @@ import com.xebyte.core.AnnotationScanner;
 import com.xebyte.core.EndpointDef;
 import com.xebyte.core.FrontEndProgramProvider;
 import com.xebyte.core.JsonHelper;
+import com.xebyte.core.NamingPolicy;
 import com.xebyte.core.ServerManager;
 
 import ghidra.framework.main.ApplicationLevelPlugin;
@@ -187,6 +188,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     private static final int DEFAULT_PORT = 8089;
     private static final String UDS_ENABLED_OPTION = "Enable UDS Transport";
     private static final String TCP_ENABLED_OPTION = "Enable TCP Transport";
+    private static final String STRICT_FUNCTION_NAMES_OPTION = "Strict Function Name Enforcement";
     private static final boolean DEFAULT_UDS_ENABLED = !System.getProperty("os.name", "").toLowerCase().contains("win");
     private static final boolean DEFAULT_TCP_ENABLED = System.getProperty("os.name", "").toLowerCase().contains("win");
 
@@ -291,6 +293,13 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
             "Enable Unix Domain Socket transport for local multi-instance support.");
         options.registerOption(TCP_ENABLED_OPTION, DEFAULT_TCP_ENABLED, null,
             "Enable TCP transport for remote/network access.");
+        options.registerOption(STRICT_FUNCTION_NAMES_OPTION,
+            NamingPolicy.defaultStrictFunctionNames(), null,
+            "Reject rename_function_by_address names that fail the built-in " +
+            "function-name quality checks. Disable when your naming convention " +
+            "does not match the built-in heuristic; convention warnings are still returned. " +
+            "Takes effect when the MCP server starts or restarts.");
+        refreshNamingPolicyFromOptions();
 
         boolean udsEnabled = options.getBoolean(UDS_ENABLED_OPTION, DEFAULT_UDS_ENABLED);
         boolean tcpEnabled = options.getBoolean(TCP_ENABLED_OPTION, DEFAULT_TCP_ENABLED);
@@ -340,6 +349,14 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         return server != null;
     }
 
+    private void refreshNamingPolicyFromOptions() {
+        Options options = tool.getOptions(OPTION_CATEGORY_NAME);
+        boolean strict = options.getBoolean(STRICT_FUNCTION_NAMES_OPTION,
+            NamingPolicy.defaultStrictFunctionNames());
+        NamingPolicy.getInstance().setStrictFunctionNames(strict, "tool_options");
+        Msg.info(this, "GhidraMCP strict function-name enforcement: " + strict);
+    }
+
     private void stopServer() {
         if (server != null) {
             Msg.info(this, "Stopping GhidraMCP HTTP server...");
@@ -366,6 +383,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
             @Override
             public void actionPerformed(ActionContext context) {
                 Options opts = tool.getOptions(OPTION_CATEGORY_NAME);
+                refreshNamingPolicyFromOptions();
                 boolean uds = opts.getBoolean(UDS_ENABLED_OPTION, DEFAULT_UDS_ENABLED);
                 boolean tcp = opts.getBoolean(TCP_ENABLED_OPTION, DEFAULT_TCP_ENABLED);
                 StringBuilder started = new StringBuilder();
@@ -433,6 +451,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
                 String message = "GhidraMCP Server Status\n\n" +
                     "UDS: " + udsStatus + "\n" +
                     "TCP: " + tcpStatus + "\n" +
+                    "Strict function names: " + NamingPolicy.getInstance().isStrictFunctionNames() + "\n" +
                     "Version: " + VersionInfo.getFullVersion() + "\n" +
                     "Endpoints: " + VersionInfo.getEndpointCount();
                 Msg.showInfo(getClass(), null, "GhidraMCP", message);
@@ -451,6 +470,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     private void startServer() throws IOException {
         // Read the configured port
         Options options = tool.getOptions(OPTION_CATEGORY_NAME);
+        refreshNamingPolicyFromOptions();
         int port = options.getInt(PORT_OPTION_NAME, DEFAULT_PORT);
 
         // Stop existing server if running (e.g., if plugin is reloaded)

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -804,6 +804,9 @@ public class FunctionService {
             return Response.err("No function found for " + functionAddrStr);
         }
 
+        boolean enforceStrictFunctionNames = NamingPolicy.getInstance().isStrictFunctionNames();
+        List<String> enforcementWarnings = new ArrayList<>();
+
         // ---- Q1-Q5 validator gate (defense in depth) ----------------------
         // Hard-reject names that fail verb-tier specificity (Q2/Q4) or
         // collide via token-subset with another function in this program
@@ -813,14 +816,11 @@ public class FunctionService {
             NamingConventions.NameQualityResult quality =
                     NamingConventions.checkFunctionNameQuality(newName);
             if (!quality.ok) {
-                return Response.ok(JsonHelper.mapOf(
-                        "status", "rejected",
-                        "error", "name_quality",
-                        "issue", quality.issue,
-                        "rejected_name", newName,
-                        "message", quality.message,
-                        "suggestion", quality.suggestion
-                ));
+                Map<String, Object> rejection = nameQualityRejection(newName, quality);
+                if (enforceStrictFunctionNames) {
+                    return Response.ok(rejection);
+                }
+                enforcementWarnings.add(disabledEnforcementWarning(rejection));
             }
             // Token-subset collision check against every function in the
             // program. Iteration is read-only and fast enough for in-line
@@ -834,21 +834,11 @@ public class FunctionService {
             String collidesWith =
                     NamingConventions.findTokenSubsetCollision(newName, existingNames);
             if (collidesWith != null) {
-                return Response.ok(JsonHelper.mapOf(
-                        "status", "rejected",
-                        "error", "name_collision",
-                        "issue", "token_subset_duplicate",
-                        "rejected_name", newName,
-                        "conflicts_with", collidesWith,
-                        "message", "Token-subset collision: '" + newName + "' shares the same token set "
-                                + "as existing function '" + collidesWith + "' in this program. "
-                                + "Names that differ only by an added/removed trailing token are usually "
-                                + "a sign that the function needs a more meaningful distinguisher.",
-                        "suggestion", "Pick a name with a distinguishing token that captures *why* this "
-                                + "function differs from '" + collidesWith + "' (e.g., add 'Broadcast', "
-                                + "'Local', 'ByIndex', 'ForPlayer', 'WithRetry', ...) rather than just "
-                                + "trimming/extending '" + collidesWith + "'."
-                ));
+                Map<String, Object> rejection = tokenSubsetCollisionRejection(newName, collidesWith);
+                if (enforceStrictFunctionNames) {
+                    return Response.ok(rejection);
+                }
+                enforcementWarnings.add(disabledEnforcementWarning(rejection));
             }
         }
 
@@ -871,19 +861,56 @@ public class FunctionService {
 
         String text = resultMsg.length() > 0 ? resultMsg.toString() : "Error: Unknown failure";
         if (success.get()) {
-            List<String> nameWarnings = NamingConventions.validateFunctionName(newName, false);
-            if (nameWarnings.isEmpty()) {
-                return Response.ok(JsonHelper.mapOf("status", "success", "message", text));
-            } else {
-                return Response.ok(JsonHelper.mapOf("status", "success", "message", text,
-                        "warnings", nameWarnings));
+            List<String> nameWarnings = new ArrayList<>(NamingConventions.validateFunctionName(newName, false));
+            nameWarnings.addAll(enforcementWarnings);
+            Map<String, Object> data = JsonHelper.mapOf("status", "success", "message", text);
+            if (!nameWarnings.isEmpty()) {
+                data.put("warnings", nameWarnings);
             }
+            return Response.ok(data);
         }
         return Response.err(text.startsWith("Error: ") ? text.substring(7) : text);
     }
 
     public Response renameFunctionByAddress(String functionAddrStr, String newName) {
         return renameFunctionByAddress(functionAddrStr, newName, null);
+    }
+
+    private static Map<String, Object> nameQualityRejection(
+            String rejectedName, NamingConventions.NameQualityResult quality) {
+        return JsonHelper.mapOf(
+                "status", "rejected",
+                "error", "name_quality",
+                "issue", quality.issue,
+                "rejected_name", rejectedName,
+                "message", quality.message,
+                "suggestion", quality.suggestion
+        );
+    }
+
+    private static Map<String, Object> tokenSubsetCollisionRejection(
+            String rejectedName, String collidesWith) {
+        return JsonHelper.mapOf(
+                "status", "rejected",
+                "error", "name_collision",
+                "issue", "token_subset_duplicate",
+                "rejected_name", rejectedName,
+                "conflicts_with", collidesWith,
+                "message", "Token-subset collision: '" + rejectedName + "' shares the same token set "
+                        + "as existing function '" + collidesWith + "' in this program. "
+                        + "Names that differ only by an added/removed trailing token are usually "
+                        + "a sign that the function needs a more meaningful distinguisher.",
+                "suggestion", "Pick a name with a distinguishing token that captures *why* this "
+                        + "function differs from '" + collidesWith + "' (e.g., add 'Broadcast', "
+                        + "'Local', 'ByIndex', 'ForPlayer', 'WithRetry', ...) rather than just "
+                        + "trimming/extending '" + collidesWith + "'."
+        );
+    }
+
+    private static String disabledEnforcementWarning(Map<String, Object> rejection) {
+        return "Strict function-name enforcement disabled: would have rejected "
+                + rejection.get("error") + "/" + rejection.get("issue") + " - "
+                + rejection.get("message");
     }
 
     // ========================================================================

--- a/src/main/java/com/xebyte/core/NamingPolicy.java
+++ b/src/main/java/com/xebyte/core/NamingPolicy.java
@@ -1,0 +1,46 @@
+package com.xebyte.core;
+
+/**
+ * Runtime policy for naming-convention enforcement.
+ *
+ * <p>The default is intentionally strict to preserve the v5.6.0 behavior:
+ * {@code rename_function_by_address} rejects low-quality function names before
+ * mutating the program. GUI users can disable the hard reject layer through
+ * Tool Options when the built-in heuristic does not match their naming
+ * convention. Warning-only validation still runs in that mode.
+ */
+public final class NamingPolicy {
+
+    private static final NamingPolicy INSTANCE = new NamingPolicy();
+    private static final boolean DEFAULT_STRICT_FUNCTION_NAMES = true;
+
+    private volatile boolean strictFunctionNames;
+    private volatile String source;
+
+    private NamingPolicy() {
+        this.strictFunctionNames = DEFAULT_STRICT_FUNCTION_NAMES;
+        this.source = "default";
+    }
+
+    public static NamingPolicy getInstance() {
+        return INSTANCE;
+    }
+
+    public static boolean defaultStrictFunctionNames() {
+        return DEFAULT_STRICT_FUNCTION_NAMES;
+    }
+
+    public synchronized void setStrictFunctionNames(boolean strictFunctionNames, String source) {
+        this.strictFunctionNames = strictFunctionNames;
+        this.source = source != null && !source.isBlank() ? source : "runtime";
+    }
+
+    public boolean isStrictFunctionNames() {
+        return strictFunctionNames;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+}

--- a/src/test/java/com/xebyte/offline/NamingPolicyTest.java
+++ b/src/test/java/com/xebyte/offline/NamingPolicyTest.java
@@ -1,0 +1,31 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.NamingPolicy;
+import junit.framework.TestCase;
+
+/**
+ * Pure-logic tests for the function-name enforcement policy.
+ */
+public class NamingPolicyTest extends TestCase {
+
+    public void testDefaultPreservesStrictBehavior() {
+        assertTrue(NamingPolicy.defaultStrictFunctionNames());
+    }
+
+    public void testGlobalSettingCanBeUpdatedAndRestored() {
+        NamingPolicy policy = NamingPolicy.getInstance();
+        boolean originalValue = policy.isStrictFunctionNames();
+        String originalSource = policy.getSource();
+
+        try {
+            policy.setStrictFunctionNames(false, "test");
+            assertFalse(policy.isStrictFunctionNames());
+            assertEquals("test", policy.getSource());
+
+            policy.setStrictFunctionNames(true, "test");
+            assertTrue(policy.isStrictFunctionNames());
+        } finally {
+            policy.setStrictFunctionNames(originalValue, originalSource);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Ghidra Tool Options toggle for strict function-name enforcement
- keep strict enforcement as the default behavior
- when disabled, allow noncompliant renames while returning warnings
- leave MCP schema and endpoint catalog unchanged

## Tests
- mvn -Dghidra.version=12.0.3 -Dtest=com.xebyte.offline.NamingPolicyTest,com.xebyte.offline.EndpointsJsonParityTest,com.xebyte.offline.NamingConventionsTest test
- env XONSH_HISTORY_BACKEND=dummy python3 -m pytest tests/unit/test_endpoint_catalog.py -q --no-cov