### PR TITLE
Fix OSError exception when finding maven cmd on windows

### DIFF
--- a/tools/setup/maven.py
+++ b/tools/setup/maven.py
@@ -106,8 +106,10 @@ def candidate_maven_commands() -> list[Path]:
 
     m2_home = os.environ.get("M2_HOME")
     if m2_home:
-        candidates.append(Path(m2_home) / "bin" / "mvn")
-        candidates.append(Path(m2_home) / "bin" / "mvn.cmd")
+        if sys.platform == "win32":
+            candidates.append(Path(m2_home) / "bin" / "mvn.cmd")
+        else:
+            candidates.append(Path(m2_home) / "bin" / "mvn")
 
     candidates.extend(
         [


### PR DESCRIPTION
This PR is a proposal to fix an error when installing ghidra-mcp with a M2_HOME env variable on windows.

When running the commands :

- `python -m tools.setup build`
- `python -m tools.setup install-ghidra-deps --ghidra-path "C:\path\to\ghidra_12.0.4_PUBLIC"`

on windows, if we are on windows using M2_HOME variable to point to the maven binaries, `find_maven_command()` returns `C:\\paht\\to\\apache-maven-3.9.15\\bin\\mvn` which end up with this exception :


```
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
                             # no special security
                             ^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
                             cwd,
                             ^^^^
                             startupinfo)
                             ^^^^^^^^^^^^
OSError: [WinError 193] %1 is not a valid Win32 application
```

Applying this change solve the issue. We ensure that if we use M2_HOME and if we are running on windows, we search for `mvn.cmd`
