### PR TITLE
feat(search_functions_enhanced): add isThunk/isExternal fields and filters

### DIFF
--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -3121,9 +3121,10 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
      * NEW v1.6.0: Enhanced function search with filtering and sorting
      */
     private String searchFunctionsEnhanced(String namePattern, Integer minXrefs, Integer maxXrefs,
-                                          String callingConvention, Boolean hasCustomName, boolean regex,
+                                          String callingConvention, Boolean hasCustomName,
+                                          Boolean isThunk, Boolean isExternal, boolean regex,
                                           String sortBy, int offset, int limit, String programName) {
-        return analysisService.searchFunctionsEnhanced(namePattern, minXrefs, maxXrefs, callingConvention, hasCustomName, regex, sortBy, offset, limit, programName).toJson();
+        return analysisService.searchFunctionsEnhanced(namePattern, minXrefs, maxXrefs, callingConvention, hasCustomName, isThunk, isExternal, regex, sortBy, offset, limit, programName).toJson();
     }
 
     /**

--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -2285,6 +2285,8 @@ public class AnalysisService {
             @Param(value = "max_xrefs", description = "Maximum xref count filter (omit for no maximum)", defaultValue = "") Integer maxXrefs,
             @Param(value = "calling_convention", description = "Calling convention filter (omit for any)", defaultValue = "") String callingConvention,
             @Param(value = "has_custom_name", description = "Filter by whether function has a user-defined name (omit for any)", defaultValue = "") Boolean hasCustomName,
+            @Param(value = "is_thunk", description = "Filter by thunk classification (true=only thunks, false=exclude thunks, omit for any)", defaultValue = "") Boolean isThunkFilter,
+            @Param(value = "is_external", description = "Filter by external classification (true=only external, false=exclude external, omit for any)", defaultValue = "") Boolean isExternalFilter,
             @Param(value = "regex", defaultValue = "false", description = "Use regex matching") boolean regex,
             @Param(value = "sort_by", defaultValue = "address", description = "Sort field") String sortBy,
             @Param(value = "offset", defaultValue = "0") int offset,
@@ -2346,11 +2348,24 @@ public class AnalysisService {
                             continue;
                         }
 
+                        // Classify once: classifyFunction walks instructions, so reuse for both filter and output
+                        boolean funcIsThunk = "thunk".equals(AnalysisService.classifyFunction(func, program));
+                        boolean funcIsExternal = func.isExternal();
+
+                        if (isThunkFilter != null && funcIsThunk != isThunkFilter) {
+                            continue;
+                        }
+                        if (isExternalFilter != null && funcIsExternal != isExternalFilter) {
+                            continue;
+                        }
+
                         // Create match entry
                         Map<String, Object> match = new LinkedHashMap<>();
                         match.put("name", func.getName());
                         match.putAll(ServiceUtils.addressToJson(func.getEntryPoint(), program));
                         match.put("xref_count", xrefCount);
+                        match.put("isThunk", funcIsThunk);
+                        match.put("isExternal", funcIsExternal);
                         matches.add(match);
                     }
 

--- a/src/main/java/com/xebyte/core/EndpointRegistry.java
+++ b/src/main/java/com/xebyte/core/EndpointRegistry.java
@@ -998,11 +998,13 @@ public class EndpointRegistry {
         get("/search_functions_enhanced", "Advanced function search with filtering",
             params(qStr("name_pattern", "Name pattern"), qNullInt("min_xrefs"), qNullInt("max_xrefs"),
                 qStr("calling_convention", "Calling convention filter"), qNullBool("has_custom_name"),
+                qNullBool("is_thunk"), qNullBool("is_external"),
                 qBool("regex", false, "Use regex matching"), qStr("sort_by", "Sort field"),
                 qInt("offset", 0), qInt("limit", 100), pProg()),
             (q, b) -> analysisService.searchFunctionsEnhanced(str(q, "name_pattern"),
                 nullableInt(q, "min_xrefs"), nullableInt(q, "max_xrefs"),
                 str(q, "calling_convention"), nullableBool(q, "has_custom_name"),
+                nullableBool(q, "is_thunk"), nullableBool(q, "is_external"),
                 bool(q, "regex"), str(q, "sort_by", "address"),
                 num(q, "offset", 0), num(q, "limit", 100), str(q, "program")));
     }

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -1182,9 +1182,10 @@ public class HeadlessEndpointHandler {
      * Enhanced function search with multiple filter options.
      */
     public String searchFunctionsEnhanced(String namePattern, Integer minXrefs, Integer maxXrefs,
-                                          Boolean hasCustomName, boolean regex, String sortBy,
+                                          Boolean hasCustomName, Boolean isThunk, Boolean isExternal,
+                                          boolean regex, String sortBy,
                                           int offset, int limit, String programName) {
-        return analysisService.searchFunctionsEnhanced(namePattern, minXrefs, maxXrefs, null, hasCustomName, regex, sortBy, offset, limit, programName).toJson();
+        return analysisService.searchFunctionsEnhanced(namePattern, minXrefs, maxXrefs, null, hasCustomName, isThunk, isExternal, regex, sortBy, offset, limit, programName).toJson();
     }
 
     /**

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -2060,6 +2060,8 @@
         "max_xrefs",
         "calling_convention",
         "has_custom_name",
+        "is_thunk",
+        "is_external",
         "regex",
         "sort_by",
         "offset",

--- a/tests/integration/test_phase2_endpoints.py
+++ b/tests/integration/test_phase2_endpoints.py
@@ -80,15 +80,20 @@ class TestSearchFunctionsEnhanced:
 
     @pytest.mark.requires_program
     def test_search_functions_enhanced_basic(self, http_client):
-        """Test basic enhanced search."""
+        """Test basic enhanced search and verify isThunk/isExternal fields."""
         response = http_client.get("/search_functions_enhanced", params={
             "name_pattern": "FUN_",
             "limit": 10
         })
         assert response.status_code == 200
-        # Should return JSON with total and results
-        text = response.text
-        assert "total" in text or "results" in text or "error" in text.lower()
+        data = response.json()
+        assert "total" in data
+        assert "results" in data
+        for item in data["results"]:
+            assert "isThunk" in item, f"missing isThunk: {item}"
+            assert "isExternal" in item, f"missing isExternal: {item}"
+            assert isinstance(item["isThunk"], bool)
+            assert isinstance(item["isExternal"], bool)
 
     @pytest.mark.requires_program
     def test_search_functions_enhanced_with_filters(self, http_client):
@@ -110,6 +115,70 @@ class TestSearchFunctionsEnhanced:
             "limit": 5
         })
         assert response.status_code == 200
+
+    @pytest.mark.requires_program
+    def test_search_functions_enhanced_filter_is_thunk_true(self, http_client):
+        """is_thunk=true should return only thunks."""
+        response = http_client.get("/search_functions_enhanced", params={
+            "is_thunk": "true",
+            "limit": 50
+        })
+        assert response.status_code == 200
+        data = response.json()
+        for item in data["results"]:
+            assert item["isThunk"] is True, f"non-thunk leaked through is_thunk=true: {item}"
+
+    @pytest.mark.requires_program
+    def test_search_functions_enhanced_filter_is_thunk_false(self, http_client):
+        """is_thunk=false should exclude thunks."""
+        response = http_client.get("/search_functions_enhanced", params={
+            "is_thunk": "false",
+            "limit": 50
+        })
+        assert response.status_code == 200
+        data = response.json()
+        for item in data["results"]:
+            assert item["isThunk"] is False, f"thunk leaked through is_thunk=false: {item}"
+
+    @pytest.mark.requires_program
+    def test_search_functions_enhanced_filter_is_external_true(self, http_client):
+        """is_external=true should return only externals (or nothing if fixture has none)."""
+        response = http_client.get("/search_functions_enhanced", params={
+            "is_external": "true",
+            "limit": 50
+        })
+        assert response.status_code == 200
+        data = response.json()
+        for item in data["results"]:
+            assert item["isExternal"] is True, f"non-external leaked through is_external=true: {item}"
+
+    @pytest.mark.requires_program
+    def test_search_functions_enhanced_filter_is_external_false(self, http_client):
+        """is_external=false should exclude externals."""
+        response = http_client.get("/search_functions_enhanced", params={
+            "is_external": "false",
+            "limit": 50
+        })
+        assert response.status_code == 200
+        data = response.json()
+        for item in data["results"]:
+            assert item["isExternal"] is False, f"external leaked through is_external=false: {item}"
+
+    @pytest.mark.requires_program
+    def test_search_functions_enhanced_filter_combined(self, http_client):
+        """Combined is_thunk=false + is_external=false + min_xrefs filter composes correctly."""
+        response = http_client.get("/search_functions_enhanced", params={
+            "is_thunk": "false",
+            "is_external": "false",
+            "min_xrefs": 1,
+            "limit": 25
+        })
+        assert response.status_code == 200
+        data = response.json()
+        for item in data["results"]:
+            assert item["isThunk"] is False
+            assert item["isExternal"] is False
+            assert item["xref_count"] >= 1
 
 
 class TestAnalyzeFunctionComplete:


### PR DESCRIPTION
## Summary

- Add `isThunk` and `isExternal` boolean fields to every `/search_functions_enhanced` result item, matching `/list_functions_enhanced`.
- Add tri-state Boolean filters `is_thunk` and `is_external` (mirroring the existing `has_custom_name` parameter on the same endpoint).
- Classify each candidate once per loop iteration and reuse the booleans for both filtering and output, so `classifyFunction`'s instruction walk runs at most once per function.

## Changes

- `src/main/java/com/xebyte/core/AnalysisService.java` -  `searchFunctionsEnhanced`: two new `@Param`s, filter checks, two new output fields.
- `src/main/java/com/xebyte/core/EndpointRegistry.java` - `qNullBool("is_thunk")` / `qNullBool("is_external")` wired into the route binding.
- `src/main/java/com/xebyte/GhidraMCPPlugin.java` & `src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java` - pass-through wrappers widened to the new 12-arg service signature so the plugin and headless server still compile.
- `tests/endpoints.json` - `is_thunk` / `is_external` inserted into the params catalog in declaration order. (Will be a no-op when `RegenerateEndpointsJson` runs next.)
- `tests/integration/test_phase2_endpoints.py` - extended `test_search_functions_enhanced_basic` with field-presence assertions; added five new cases covering each filter direction and a combined-filter case.

Implements #177

## Notes

- Keeps the existing parameter shape backwards-compatible - new params are nullable Booleans defaulting to "no filter."
- The two pass-through wrappers (`GhidraMCPPlugin.searchFunctionsEnhanced`, `HeadlessEndpointHandler.searchFunctionsEnhanced`) appear to be dead code from before `AnnotationScanner` took over dispatch - left in place and updated to compile, rather than expanding scope by deleting them.
- Pre-existing bug spotted while editing: `calling_convention` is declared on `searchFunctionsEnhanced` but never applied in the filter loop. Not addressed here - separate issue.