### PR TITLE
feat(function): add 10 MCP endpoints for function tags

### DIFF
--- a/docs/prompts/TOOL_USAGE_GUIDE.md
+++ b/docs/prompts/TOOL_USAGE_GUIDE.md
@@ -332,6 +332,35 @@ Covers: `debugger_attach`, `debugger_status`, `debugger_step_{into,over,out}`, `
 
 Use for: ground-truth validation after static analysis. After emulation resolves a hash, set a breakpoint on the resolved API and confirm the process actually calls it.
 
+## Function Tagging
+
+Lightweight per-function labels (program-wide tag definitions, attached to any function). Useful for carving curated subsets across long analysis sessions — e.g. `crypto`, `parser`, `reviewed`, `todo`, `imported-from-dll`. Tags are stored in the Ghidra DB so they roundtrip through save/checkin and survive across sessions.
+
+Two layers:
+
+- **Tag definitions** (program-wide): `create_function_tag`, `delete_function_tag`, `set_function_tag_comment`, `list_function_tags`.
+- **Per-function attachment**: `add_function_tag`, `remove_function_tag`, `get_function_tags`, `search_functions_by_tag`. Attaching a tag by name auto-creates the definition if it doesn't already exist.
+
+Batch variants: `batch_add_function_tags` / `batch_remove_function_tags` take an array of `{function, tags}` objects and run the whole set in one transaction. Use these when tagging a sweep result — single-call instead of N round-trips.
+
+Worked pattern — sweep + curate:
+
+```python
+# After locating all crypto routines via detect_crypto_constants / search_byte_patterns,
+# tag them with one batch call:
+batch_add_function_tags(assignments=[
+    {"function": "0x401abc",  "tags": "crypto,aes"},
+    {"function": "0x401d40",  "tags": "crypto,sha256"},
+    # ...
+])
+
+# Later, recall the curated list:
+search_functions_by_tag(tag="crypto")
+# → returns {tag, total, functions: [{name, address}, ...]}
+```
+
+Tags are case-sensitive; `search_functions_by_tag` rejects unknown tag names (returns error rather than empty list) so you can detect typos.
+
 ## Security Environment Variables (v5.4.1+)
 
 GhidraMCP defaults to localhost-unauthenticated — safe on a single-user dev box. Configure these before binding beyond loopback:

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -3399,13 +3399,15 @@ public class FunctionService {
         final String tagComment = comment != null ? comment : "";
 
         FunctionTagManager mgr = program.getFunctionManager().getFunctionTagManager();
-        if (mgr.getFunctionTag(tagName) != null) {
-            return Response.err("Tag already exists: " + tagName);
-        }
 
         AtomicReference<FunctionTag> created = new AtomicReference<>();
+        AtomicReference<String> conflict = new AtomicReference<>();
         try {
             threadingStrategy.executeWrite(program, "Create function tag via HTTP", () -> {
+                if (mgr.getFunctionTag(tagName) != null) {
+                    conflict.set(tagName);
+                    return null;
+                }
                 created.set(mgr.createFunctionTag(tagName, tagComment));
                 return null;
             });
@@ -3414,6 +3416,7 @@ public class FunctionService {
             Msg.error(this, "Failed to create function tag", e);
             return Response.err("Failed to create tag: " + e.getMessage());
         }
+        if (conflict.get() != null) return Response.err("Tag already exists: " + conflict.get());
         FunctionTag tag = created.get();
         if (tag == null) return Response.err("createFunctionTag returned null");
         return Response.ok(JsonHelper.mapOf(

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -3199,4 +3199,481 @@ public class FunctionService {
     public Response validateBatchOperationResults(String functionAddress, Map<String, String> expectedRenames, Map<String, String> expectedTypes) {
         return validateBatchOperationResults(functionAddress, expectedRenames, expectedTypes, null);
     }
+
+    // ========================================================================
+    // Function tag methods
+    //
+    // Thin wrappers over Ghidra's FunctionTagManager / Function.addTag / removeTag.
+    // Tags are program-wide definitions (name + optional comment) that can be
+    // attached to any Function. Adding a tag by name to a Function auto-creates
+    // the tag definition if it does not already exist.
+    // ========================================================================
+
+    private static Map<String, Object> serializeTag(FunctionTag tag, Integer useCount) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", tag.getId());
+        m.put("name", tag.getName());
+        String comment = tag.getComment();
+        m.put("comment", comment != null ? comment : "");
+        if (useCount != null) m.put("use_count", useCount);
+        return m;
+    }
+
+    private static List<String> splitTagList(String raw) {
+        List<String> out = new ArrayList<>();
+        if (raw == null) return out;
+        for (String part : raw.split(",")) {
+            String t = part.trim();
+            if (!t.isEmpty()) out.add(t);
+        }
+        return out;
+    }
+
+    @McpTool(path = "/get_function_tags", description = "List all tags assigned to a specific function. Accepts either a function address or a function name.", category = "function")
+    public Response getFunctionTags(
+            @Param(value = "function", paramType = "address",
+                   description = "Function address (0x<hex> or <space>:<hex>) or function name") String functionRef,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (functionRef == null || functionRef.isEmpty()) {
+            return Response.err("function (address or name) is required");
+        }
+        Function func = ServiceUtils.resolveFunction(program, functionRef);
+        if (func == null) return Response.err("No function found for " + functionRef);
+
+        List<Map<String, Object>> tags = new ArrayList<>();
+        for (FunctionTag tag : func.getTags()) {
+            tags.add(serializeTag(tag, null));
+        }
+        tags.sort(Comparator.comparing(m -> ((String) m.get("name"))));
+        return Response.ok(JsonHelper.mapOf(
+                "function", func.getName(),
+                "address", func.getEntryPoint().toString(),
+                "tag_count", tags.size(),
+                "tags", tags));
+    }
+
+    @McpTool(path = "/add_function_tag", method = "POST",
+             description = "Attach one or more tags to a function. Tags are comma-separated and will be auto-created if they do not already exist.",
+             category = "function")
+    public Response addFunctionTag(
+            @Param(value = "function", source = ParamSource.BODY, paramType = "address",
+                   description = "Function address or function name") String functionRef,
+            @Param(value = "tags", source = ParamSource.BODY,
+                   description = "Comma-separated tag names to attach (e.g. \"syscall,lpe-surface\")") String tagsCsv,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (functionRef == null || functionRef.isEmpty()) return Response.err("function is required");
+        List<String> tagNames = splitTagList(tagsCsv);
+        if (tagNames.isEmpty()) return Response.err("tags is required (comma-separated list)");
+
+        Function func = ServiceUtils.resolveFunction(program, functionRef);
+        if (func == null) return Response.err("No function found for " + functionRef);
+
+        List<String> added = new ArrayList<>();
+        List<String> alreadyPresent = new ArrayList<>();
+        try {
+            threadingStrategy.executeWrite(program, "Add function tags via HTTP", () -> {
+                for (String name : tagNames) {
+                    if (func.addTag(name)) {
+                        added.add(name);
+                    } else {
+                        alreadyPresent.add(name);
+                    }
+                }
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Failed to add function tag(s)", e);
+            return Response.err("Failed to add tag(s): " + e.getMessage());
+        }
+
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "function", func.getName(),
+                "address", func.getEntryPoint().toString(),
+                "added", added,
+                "already_present", alreadyPresent));
+    }
+
+    @McpTool(path = "/remove_function_tag", method = "POST",
+             description = "Detach one or more tags from a function. Does not delete the program-wide tag definition — use delete_function_tag for that.",
+             category = "function")
+    public Response removeFunctionTag(
+            @Param(value = "function", source = ParamSource.BODY, paramType = "address",
+                   description = "Function address or function name") String functionRef,
+            @Param(value = "tags", source = ParamSource.BODY,
+                   description = "Comma-separated tag names to detach") String tagsCsv,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (functionRef == null || functionRef.isEmpty()) return Response.err("function is required");
+        List<String> tagNames = splitTagList(tagsCsv);
+        if (tagNames.isEmpty()) return Response.err("tags is required (comma-separated list)");
+
+        Function func = ServiceUtils.resolveFunction(program, functionRef);
+        if (func == null) return Response.err("No function found for " + functionRef);
+
+        Set<String> currentBefore = new HashSet<>();
+        for (FunctionTag t : func.getTags()) currentBefore.add(t.getName());
+
+        List<String> removed = new ArrayList<>();
+        List<String> notPresent = new ArrayList<>();
+        try {
+            threadingStrategy.executeWrite(program, "Remove function tags via HTTP", () -> {
+                for (String name : tagNames) {
+                    if (currentBefore.contains(name)) {
+                        func.removeTag(name);
+                        removed.add(name);
+                    } else {
+                        notPresent.add(name);
+                    }
+                }
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Failed to remove function tag(s)", e);
+            return Response.err("Failed to remove tag(s): " + e.getMessage());
+        }
+
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "function", func.getName(),
+                "address", func.getEntryPoint().toString(),
+                "removed", removed,
+                "not_present", notPresent));
+    }
+
+    @McpTool(path = "/list_function_tags",
+             description = "List all program-wide function tag definitions with their use counts.",
+             category = "function")
+    public Response listFunctionTags(
+            @Param(value = "offset", defaultValue = "0") int offset,
+            @Param(value = "limit", defaultValue = "500",
+                   description = "Maximum number of tags to return (default 500, which covers most programs in full)") int limit,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        FunctionTagManager mgr = program.getFunctionManager().getFunctionTagManager();
+        List<? extends FunctionTag> all = mgr.getAllFunctionTags();
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (FunctionTag tag : all) {
+            rows.add(serializeTag(tag, mgr.getUseCount(tag)));
+        }
+        rows.sort(Comparator.comparing(m -> ((String) m.get("name"))));
+
+        int total = rows.size();
+        int from = Math.max(0, offset);
+        int to = Math.min(total, from + Math.max(0, limit));
+        List<Map<String, Object>> page = from < to ? rows.subList(from, to) : List.of();
+        return Response.ok(JsonHelper.mapOf(
+                "total", total,
+                "offset", from,
+                "limit", limit,
+                "tags", page));
+    }
+
+    @McpTool(path = "/create_function_tag", method = "POST",
+             description = "Create a program-wide function tag definition with an optional comment. Use add_function_tag to attach it to functions.",
+             category = "function")
+    public Response createFunctionTag(
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Tag name (case-sensitive; Ghidra treats whitespace-trimmed names as unique)") String name,
+            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional description for the tag") String comment,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (name == null || name.trim().isEmpty()) return Response.err("name is required");
+        final String tagName = name.trim();
+        final String tagComment = comment != null ? comment : "";
+
+        FunctionTagManager mgr = program.getFunctionManager().getFunctionTagManager();
+        if (mgr.getFunctionTag(tagName) != null) {
+            return Response.err("Tag already exists: " + tagName);
+        }
+
+        AtomicReference<FunctionTag> created = new AtomicReference<>();
+        try {
+            threadingStrategy.executeWrite(program, "Create function tag via HTTP", () -> {
+                created.set(mgr.createFunctionTag(tagName, tagComment));
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Failed to create function tag", e);
+            return Response.err("Failed to create tag: " + e.getMessage());
+        }
+        FunctionTag tag = created.get();
+        if (tag == null) return Response.err("createFunctionTag returned null");
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "tag", serializeTag(tag, 0)));
+    }
+
+    @McpTool(path = "/delete_function_tag", method = "POST",
+             description = "Delete a program-wide function tag definition. This detaches the tag from every function that had it.",
+             category = "function")
+    public Response deleteFunctionTag(
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Tag name to delete program-wide") String name,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (name == null || name.isEmpty()) return Response.err("name is required");
+
+        FunctionTagManager mgr = program.getFunctionManager().getFunctionTagManager();
+        FunctionTag tag = mgr.getFunctionTag(name);
+        if (tag == null) return Response.err("Tag not found: " + name);
+
+        final int useCount = mgr.getUseCount(tag);
+        try {
+            threadingStrategy.executeWrite(program, "Delete function tag via HTTP", () -> {
+                tag.delete();
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Failed to delete function tag", e);
+            return Response.err("Failed to delete tag: " + e.getMessage());
+        }
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "name", name,
+                "detached_from_functions", useCount));
+    }
+
+    @McpTool(path = "/set_function_tag_comment", method = "POST",
+             description = "Update the comment/description on an existing program-wide function tag.",
+             category = "function")
+    public Response setFunctionTagComment(
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Tag name") String name,
+            @Param(value = "comment", source = ParamSource.BODY,
+                   description = "New comment text (pass an empty string to clear)") String comment,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (name == null || name.isEmpty()) return Response.err("name is required");
+
+        FunctionTagManager mgr = program.getFunctionManager().getFunctionTagManager();
+        FunctionTag tag = mgr.getFunctionTag(name);
+        if (tag == null) return Response.err("Tag not found: " + name);
+
+        final String newComment = comment != null ? comment : "";
+        try {
+            threadingStrategy.executeWrite(program, "Update function tag comment via HTTP", () -> {
+                tag.setComment(newComment);
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Failed to update tag comment", e);
+            return Response.err("Failed to update comment: " + e.getMessage());
+        }
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "tag", serializeTag(tag, mgr.getUseCount(tag))));
+    }
+
+    @McpTool(path = "/search_functions_by_tag",
+             description = "List all functions that have a specified tag attached. Returns name + entry address.",
+             category = "function")
+    public Response searchFunctionsByTag(
+            @Param(value = "tag", description = "Tag name to search for") String tagName,
+            @Param(value = "offset", defaultValue = "0") int offset,
+            @Param(value = "limit", defaultValue = "1000") int limit,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (tagName == null || tagName.isEmpty()) return Response.err("tag is required");
+
+        FunctionTagManager mgr = program.getFunctionManager().getFunctionTagManager();
+        if (mgr.getFunctionTag(tagName) == null) {
+            return Response.err("Tag not found: " + tagName);
+        }
+
+        List<Map<String, Object>> matches = new ArrayList<>();
+        for (Function func : program.getFunctionManager().getFunctions(true)) {
+            for (FunctionTag t : func.getTags()) {
+                if (t.getName().equals(tagName)) {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("name", func.getName());
+                    row.put("address", func.getEntryPoint().toString());
+                    matches.add(row);
+                    break;
+                }
+            }
+        }
+        matches.sort(Comparator.comparing(m -> ((String) m.get("address"))));
+        int total = matches.size();
+        int from = Math.max(0, offset);
+        int to = Math.min(total, from + Math.max(0, limit));
+        List<Map<String, Object>> page = from < to ? matches.subList(from, to) : List.of();
+        return Response.ok(JsonHelper.mapOf(
+                "tag", tagName,
+                "total", total,
+                "offset", from,
+                "limit", limit,
+                "functions", page));
+    }
+
+    @McpTool(path = "/batch_add_function_tags", method = "POST",
+             description = "Attach tags to many functions in one transaction. Body: [{\"function\":\"0x140200ae6\",\"tags\":\"syscall,lpe-surface\"}, ...]. Tags auto-create.",
+             category = "function")
+    public Response batchAddFunctionTags(
+            @Param(value = "assignments", source = ParamSource.BODY,
+                   description = "Array of {function, tags} objects. `function` may be an address or name; `tags` is a comma-separated list.") List<Map<String, String>> assignments,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (assignments == null || assignments.isEmpty()) return Response.err("assignments is required (non-empty array)");
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        AtomicInteger tagsAdded = new AtomicInteger(0);
+        AtomicInteger funcsTouched = new AtomicInteger(0);
+        try {
+            threadingStrategy.executeWrite(program, "Batch add function tags via HTTP", () -> {
+                for (Map<String, String> entry : assignments) {
+                    String ref = entry.get("function");
+                    String tagsCsv = entry.get("tags");
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("function", ref);
+                    if (ref == null || ref.isEmpty()) {
+                        row.put("status", "error");
+                        row.put("error", "missing function field");
+                        results.add(row);
+                        continue;
+                    }
+                    Function func = ServiceUtils.resolveFunction(program, ref);
+                    if (func == null) {
+                        row.put("status", "error");
+                        row.put("error", "function not found");
+                        results.add(row);
+                        continue;
+                    }
+                    List<String> names = splitTagList(tagsCsv);
+                    if (names.isEmpty()) {
+                        row.put("status", "error");
+                        row.put("error", "missing/empty tags field");
+                        results.add(row);
+                        continue;
+                    }
+                    List<String> added = new ArrayList<>();
+                    List<String> already = new ArrayList<>();
+                    for (String n : names) {
+                        if (func.addTag(n)) added.add(n);
+                        else already.add(n);
+                    }
+                    tagsAdded.addAndGet(added.size());
+                    if (!added.isEmpty()) funcsTouched.incrementAndGet();
+                    row.put("status", "success");
+                    row.put("address", func.getEntryPoint().toString());
+                    row.put("added", added);
+                    row.put("already_present", already);
+                    results.add(row);
+                }
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Batch add function tags failed", e);
+            return Response.err("Batch failed: " + e.getMessage());
+        }
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "functions_touched", funcsTouched.get(),
+                "tags_added", tagsAdded.get(),
+                "results", results));
+    }
+
+    @McpTool(path = "/batch_remove_function_tags", method = "POST",
+             description = "Detach tags from many functions in one transaction. Body shape matches /batch_add_function_tags.",
+             category = "function")
+    public Response batchRemoveFunctionTags(
+            @Param(value = "assignments", source = ParamSource.BODY,
+                   description = "Array of {function, tags} objects.") List<Map<String, String>> assignments,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+        if (assignments == null || assignments.isEmpty()) return Response.err("assignments is required (non-empty array)");
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        AtomicInteger tagsRemoved = new AtomicInteger(0);
+        AtomicInteger funcsTouched = new AtomicInteger(0);
+        try {
+            threadingStrategy.executeWrite(program, "Batch remove function tags via HTTP", () -> {
+                for (Map<String, String> entry : assignments) {
+                    String ref = entry.get("function");
+                    String tagsCsv = entry.get("tags");
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("function", ref);
+                    if (ref == null || ref.isEmpty()) {
+                        row.put("status", "error");
+                        row.put("error", "missing function field");
+                        results.add(row);
+                        continue;
+                    }
+                    Function func = ServiceUtils.resolveFunction(program, ref);
+                    if (func == null) {
+                        row.put("status", "error");
+                        row.put("error", "function not found");
+                        results.add(row);
+                        continue;
+                    }
+                    List<String> names = splitTagList(tagsCsv);
+                    if (names.isEmpty()) {
+                        row.put("status", "error");
+                        row.put("error", "missing/empty tags field");
+                        results.add(row);
+                        continue;
+                    }
+                    Set<String> have = new HashSet<>();
+                    for (FunctionTag t : func.getTags()) have.add(t.getName());
+                    List<String> removed = new ArrayList<>();
+                    List<String> notPresent = new ArrayList<>();
+                    for (String n : names) {
+                        if (have.contains(n)) {
+                            func.removeTag(n);
+                            removed.add(n);
+                        } else {
+                            notPresent.add(n);
+                        }
+                    }
+                    tagsRemoved.addAndGet(removed.size());
+                    if (!removed.isEmpty()) funcsTouched.incrementAndGet();
+                    row.put("status", "success");
+                    row.put("address", func.getEntryPoint().toString());
+                    row.put("removed", removed);
+                    row.put("not_present", notPresent);
+                    results.add(row);
+                }
+                return null;
+            });
+            program.flushEvents();
+        } catch (Exception e) {
+            Msg.error(this, "Batch remove function tags failed", e);
+            return Response.err("Batch failed: " + e.getMessage());
+        }
+        return Response.ok(JsonHelper.mapOf(
+                "status", "success",
+                "functions_touched", funcsTouched.get(),
+                "tags_removed", tagsRemoved.get(),
+                "results", results));
+    }
 }

--- a/src/test/java/com/xebyte/offline/FunctionTagEndpointsOfflineTest.java
+++ b/src/test/java/com/xebyte/offline/FunctionTagEndpointsOfflineTest.java
@@ -13,9 +13,9 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * Guard-rail for the v5.4.x function-tag endpoints added to
- * {@code FunctionService}. Locks in each tag tool's method, path, category, and
- * required-param set so a later refactor cannot silently drop one of them.
+ * Guard-rail for the function-tag endpoints in {@code FunctionService}.
+ * Locks in each tag tool's method, path, category, and required-param set so a
+ * later refactor cannot silently drop one of them.
  *
  * <p>Runs fully offline — shares the existing {@link ServiceFactory} stub wiring.
  */

--- a/src/test/java/com/xebyte/offline/FunctionTagEndpointsOfflineTest.java
+++ b/src/test/java/com/xebyte/offline/FunctionTagEndpointsOfflineTest.java
@@ -1,0 +1,111 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.AnnotationScanner;
+import com.xebyte.core.ProgramProvider;
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Guard-rail for the v5.4.x function-tag endpoints added to
+ * {@code FunctionService}. Locks in each tag tool's method, path, category, and
+ * required-param set so a later refactor cannot silently drop one of them.
+ *
+ * <p>Runs fully offline — shares the existing {@link ServiceFactory} stub wiring.
+ */
+public class FunctionTagEndpointsOfflineTest extends TestCase {
+
+    /** path -> expected (method, category, required params in any order). */
+    private static final Map<String, Expected> EXPECTED = new LinkedHashMap<>();
+    static {
+        EXPECTED.put("/get_function_tags",
+            new Expected("GET",  "function", "function", "program"));
+        EXPECTED.put("/add_function_tag",
+            new Expected("POST", "function", "function", "tags", "program"));
+        EXPECTED.put("/remove_function_tag",
+            new Expected("POST", "function", "function", "tags", "program"));
+        EXPECTED.put("/list_function_tags",
+            new Expected("GET",  "function", "offset", "limit", "program"));
+        EXPECTED.put("/create_function_tag",
+            new Expected("POST", "function", "name", "comment", "program"));
+        EXPECTED.put("/delete_function_tag",
+            new Expected("POST", "function", "name", "program"));
+        EXPECTED.put("/set_function_tag_comment",
+            new Expected("POST", "function", "name", "comment", "program"));
+        EXPECTED.put("/search_functions_by_tag",
+            new Expected("GET",  "function", "tag", "offset", "limit", "program"));
+        EXPECTED.put("/batch_add_function_tags",
+            new Expected("POST", "function", "assignments", "program"));
+        EXPECTED.put("/batch_remove_function_tags",
+            new Expected("POST", "function", "assignments", "program"));
+    }
+
+    private AnnotationScanner scanner;
+
+    @Override
+    protected void setUp() {
+        ProgramProvider provider = ServiceFactory.stubProvider();
+        scanner = new AnnotationScanner(provider, ServiceFactory.buildAllServices());
+    }
+
+    /** Each tag endpoint must be discovered by the scanner with the expected method + category. */
+    public void testEveryTagEndpointIsScannedWithCorrectMethodAndCategory() {
+        Map<String, AnnotationScanner.ToolDescriptor> byPath = new HashMap<>();
+        for (AnnotationScanner.ToolDescriptor d : scanner.getDescriptors()) {
+            byPath.put(d.path(), d);
+        }
+
+        for (Map.Entry<String, Expected> e : EXPECTED.entrySet()) {
+            String path = e.getKey();
+            Expected exp = e.getValue();
+            AnnotationScanner.ToolDescriptor d = byPath.get(path);
+            assertNotNull(path + " not discovered by AnnotationScanner", d);
+            assertEquals(path + " method mismatch", exp.method, d.method());
+            assertEquals(path + " category mismatch", exp.category, d.category());
+        }
+    }
+
+    /**
+     * Each tag endpoint must expose exactly the expected set of @Param names.
+     * Catches drift where a param is renamed, added, or dropped.
+     */
+    public void testEveryTagEndpointExposesExpectedParams() {
+        Map<String, AnnotationScanner.ToolDescriptor> byPath = new HashMap<>();
+        for (AnnotationScanner.ToolDescriptor d : scanner.getDescriptors()) {
+            byPath.put(d.path(), d);
+        }
+
+        for (Map.Entry<String, Expected> e : EXPECTED.entrySet()) {
+            String path = e.getKey();
+            Expected exp = e.getValue();
+            AnnotationScanner.ToolDescriptor tool = byPath.get(path);
+            assertNotNull(path + " not in scanner descriptors", tool);
+
+            Set<String> actual = new TreeSet<>();
+            for (AnnotationScanner.ParamDescriptor p : tool.params()) {
+                actual.add(p.name());
+            }
+            Set<String> expected = new TreeSet<>(exp.params);
+            assertEquals(path + " param set mismatch (expected " + expected
+                + ", got " + actual + ")", expected, actual);
+        }
+    }
+
+    private static final class Expected {
+        final String method;
+        final String category;
+        final Set<String> params;
+
+        Expected(String method, String category, String... params) {
+            this.method = method;
+            this.category = category;
+            this.params = new LinkedHashSet<>(Arrays.asList(params));
+        }
+    }
+}

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.7.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 231,
+  "total_endpoints": 241,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -20,6 +20,17 @@
     "emulation": "P-code emulation (run functions with controlled inputs)"
   },
   "endpoints": [
+    {
+      "path": "/add_function_tag",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "function",
+        "tags",
+        "program"
+      ],
+      "description": "Attach one or more tags to a function. Tags are comma-separated and will be auto-created if they do not already exist."
+    },
     {
       "path": "/add_struct_field",
       "method": "POST",
@@ -247,6 +258,16 @@
       "description": "Audit every global variable referenced from within a function in one call. Walks the function's instructions, collects unique data references, and returns the per-global audit (same shape as audit_global) plus a summary of how many are fully documented vs have issues. The killer per-function pre-flight tool — start every doc pass with this when the function has global xrefs."
     },
     {
+      "path": "/batch_add_function_tags",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "assignments",
+        "program"
+      ],
+      "description": "Attach tags to many functions in one transaction. Body: [{\"function\":\"0x140200ae6\",\"tags\":\"syscall,lpe-surface\"}, ...]. Tags auto-create."
+    },
+    {
       "path": "/batch_analyze_completeness",
       "method": "POST",
       "category": "analysis",
@@ -305,6 +326,16 @@
         "program"
       ],
       "description": "Delete multiple labels"
+    },
+    {
+      "path": "/batch_remove_function_tags",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "assignments",
+        "program"
+      ],
+      "description": "Detach tags from many functions in one transaction. Body shape matches /batch_add_function_tags."
     },
     {
       "path": "/batch_rename_function_components",
@@ -546,6 +577,17 @@
         "program"
       ],
       "description": "Create function signature type"
+    },
+    {
+      "path": "/create_function_tag",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "name",
+        "comment",
+        "program"
+      ],
+      "description": "Create a program-wide function tag definition with an optional comment. Use add_function_tag to attach it to functions."
     },
     {
       "path": "/create_label",
@@ -829,6 +871,16 @@
         "program"
       ],
       "description": "Delete function at address"
+    },
+    {
+      "path": "/delete_function_tag",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "name",
+        "program"
+      ],
+      "description": "Delete a program-wide function tag definition. This detaches the tag from every function that had it."
     },
     {
       "path": "/delete_label",
@@ -1316,6 +1368,16 @@
       "description": "Get function feature signature"
     },
     {
+      "path": "/get_function_tags",
+      "method": "GET",
+      "category": "function",
+      "params": [
+        "function",
+        "program"
+      ],
+      "description": "List all tags assigned to a specific function. Accepts either a function address or a function name."
+    },
+    {
       "path": "/get_function_variables",
       "method": "GET",
       "category": "getter",
@@ -1581,6 +1643,17 @@
         "program"
       ],
       "description": "List external locations"
+    },
+    {
+      "path": "/list_function_tags",
+      "method": "GET",
+      "category": "function",
+      "params": [
+        "offset",
+        "limit",
+        "program"
+      ],
+      "description": "List all program-wide function tag definitions with their use counts."
     },
     {
       "path": "/list_functions",
@@ -1853,6 +1926,17 @@
       "description": "Trigger full auto-analysis on a program"
     },
     {
+      "path": "/remove_function_tag",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "function",
+        "tags",
+        "program"
+      ],
+      "description": "Detach one or more tags from a function. Does not delete the program-wide tag definition — use delete_function_tag for that."
+    },
+    {
       "path": "/remove_struct_field",
       "method": "POST",
       "category": "datatype",
@@ -2049,6 +2133,18 @@
         "program"
       ],
       "description": "Search functions by name"
+    },
+    {
+      "path": "/search_functions_by_tag",
+      "method": "GET",
+      "category": "function",
+      "params": [
+        "tag",
+        "offset",
+        "limit",
+        "program"
+      ],
+      "description": "List all functions that have a specified tag attached. Returns name + entry address."
     },
     {
       "path": "/search_functions_enhanced",
@@ -2321,6 +2417,17 @@
         "program"
       ],
       "description": "Atomically apply name + type + plate-comment + array length to a global variable. Single-transaction; rejects on validation failure with no partial write. Replaces the 4-tool chain (apply_data_type → rename_data → batch_set_comments → create_label)."
+    },
+    {
+      "path": "/set_function_tag_comment",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "name",
+        "comment",
+        "program"
+      ],
+      "description": "Update the comment/description on an existing program-wide function tag."
     },
     {
       "path": "/set_image_base",


### PR DESCRIPTION
## Description

Adds 10 MCP endpoints for function tags. Lets you tag groups of functions and recall them later — e.g. tag all the crypto routines, all the parsers, anything you want to come back to as a set. Survives across sessions because tags live in the Ghidra DB.

Thin wrappers over Ghidra's `FunctionTagManager` / `Function.addTag` / `removeTag`. Two layers — program-wide tag definitions, and per-function attachment — plus batch ops so you can sweep a whole list in one transaction.

## Changes

- 10 new `@McpTool` endpoints in `FunctionService.java`:
  - per-function: `get_function_tags`, `add_function_tag`, `remove_function_tag`
  - program-wide: `list_function_tags`, `create_function_tag`, `delete_function_tag`, `set_function_tag_comment`
  - search: `search_functions_by_tag`
  - batch: `batch_add_function_tags`, `batch_remove_function_tags`
- Offline scanner contract test in `src/test/java/com/xebyte/offline/FunctionTagEndpointsOfflineTest.java` — verifies each tool registers with the right method/path/category/params
- New "Function Tagging" section in `docs/prompts/TOOL_USAGE_GUIDE.md` with worked example
- `tests/endpoints.json` regenerated from the annotation scanner

## Testing

- All 49 offline tests pass (`mvn test -Dtest='com.xebyte.offline.*Test'`); 2 of those are the new function-tag ones
- Used the endpoints day-to-day on a real binary while building this — create tag → batch-attach to a bunch of functions → search-by-tag → remove → delete all worked end-to-end

## Checklist

- [x] Tests added/updated (offline scanner contract test)
- [x] Documentation updated (`docs/prompts/TOOL_USAGE_GUIDE.md`)
- [x] No breaking changes — new endpoints only, nothing existing was touched
- [x] Live-Ghidra integration test — happy to add if you'd like, just wasn't sure the offline scanner test was enough on its own
