### PR TITLE
Make debugger module mapping collision-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Debugger MCP wrappers now expose runtime-address workflows: `debugger_set_breakpoint` and `debugger_trace_function` accept `runtime_address` so tracing/breakpoints can bypass unresolved Ghidra module maps.
+- Added a direct `debugger_interrupt` MCP tool wrapper for the existing `/debugger/interrupt` endpoint.
+- Extended tracing argument decoding with x64 conventions (`__fastcall_x64` / `msvc_x64`) using RCX/RDX/R8/R9 and pointer-width stack/return-address reads.
+
+---
+
 ## v5.6.0 - 2026-04-25 (release regression + fun-doc workflow)
 
 Release covering deploy/regression safety, live benchmark coverage, debugger

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -83,12 +83,10 @@ mcp = FastMCP("ghidra-mcp")
 # Enable tools/list_changed notifications so clients re-fetch tools after dynamic registration
 _orig_init_options = mcp._mcp_server.create_initialization_options
 
-
 def _patched_init_options(**kwargs):
     return _orig_init_options(
         notification_options=NotificationOptions(tools_changed=True), **kwargs
     )
-
 
 mcp._mcp_server.create_initialization_options = _patched_init_options
 
@@ -105,11 +103,9 @@ _connected_project: str | None = None  # Project name for auto-reconnect
 # multiple MCP tool calls arrive concurrently (see GitHub issue #91).
 _ghidra_lock = threading.Lock()
 
-
 # ==========================================================================
 # UDS Transport
 # ==========================================================================
-
 
 class UnixHTTPConnection(http.client.HTTPConnection):
     """HTTP connection over a Unix domain socket."""
@@ -122,7 +118,6 @@ class UnixHTTPConnection(http.client.HTTPConnection):
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.settimeout(self.timeout)
         self.sock.connect(self.socket_path)
-
 
 def get_socket_dir() -> Path:
     """Get the GhidraMCP socket runtime directory."""
@@ -145,25 +140,21 @@ def get_socket_dir() -> Path:
         return Path(tmpdir) / f"ghidra-mcp-{user}"
     return Path(f"/tmp/ghidra-mcp-{user}")
 
-
 # Enhanced error classes
 class GhidraConnectionError(Exception):
     """Raised when connection to Ghidra server fails"""
 
     pass
 
-
 class GhidraAnalysisError(Exception):
     """Raised when Ghidra analysis operation fails"""
 
     pass
 
-
 class GhidraValidationError(Exception):
     """Raised when input validation fails"""
 
     pass
-
 
 # Input validation patterns
 HEX_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]+$")
@@ -179,7 +170,6 @@ TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 MAX_TOOL_NAME_LENGTH = 64
 INVALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]+")
 REPEATED_UNDERSCORES = re.compile(r"_+")
-
 
 def is_pid_alive(pid: int) -> bool:
     """Check if a process with the given PID is still running."""
@@ -216,7 +206,6 @@ def is_pid_alive(pid: int) -> bool:
             return False
         raise
 
-
 def validate_server_url(url: str) -> bool:
     """Validate that the server URL is safe to use"""
     try:
@@ -224,7 +213,6 @@ def validate_server_url(url: str) -> bool:
         return parsed.hostname in ("127.0.0.1", "localhost", "::1")
     except Exception:
         return False
-
 
 def validate_hex_address(address: str) -> bool:
     """Validate that an address string looks like a valid hex address or segment:offset."""
@@ -235,7 +223,6 @@ def validate_hex_address(address: str) -> bool:
     if SEGMENT_ADDRESS_PATTERN.match(address):
         return True
     return bool(HEX_ADDRESS_PATTERN.match(address))
-
 
 def sanitize_tool_name(name: str) -> str:
     """Normalize an MCP tool name for clients with strict CAPI validation."""
@@ -250,7 +237,6 @@ def sanitize_tool_name(name: str) -> str:
     if not TOOL_NAME_PATTERN.match(sanitized):
         raise ValueError(f"Sanitized tool name {sanitized!r} is still invalid")
     return sanitized
-
 
 def _allocate_tool_name(base_name: str, used_names: set[str]) -> str:
     """Return a unique MCP tool name, adding a deterministic suffix on collision."""
@@ -270,14 +256,12 @@ def _allocate_tool_name(base_name: str, used_names: set[str]) -> str:
             return candidate
         suffix += 1
 
-
 def validate_tool_name(name: str) -> None:
     """Fail fast if an exposed MCP tool name is not CAPI-safe."""
     if not TOOL_NAME_PATTERN.match(name) or len(name) > MAX_TOOL_NAME_LENGTH:
         raise ValueError(
             f"Invalid MCP tool name {name!r}; expected {TOOL_NAME_PATTERN.pattern} and length <= {MAX_TOOL_NAME_LENGTH}"
         )
-
 
 def uds_request(
     socket_path: str,
@@ -312,11 +296,9 @@ def uds_request(
         conn.close()
         raise
 
-
 # ==========================================================================
 # TCP Transport
 # ==========================================================================
-
 
 def tcp_request(
     base_url: str,
@@ -353,11 +335,9 @@ def tcp_request(
         conn.close()
         raise
 
-
 # ==========================================================================
 # Unified request function
 # ==========================================================================
-
 
 def do_request(
     method: str,
@@ -385,11 +365,9 @@ def do_request(
                 "No Ghidra instance connected. Use connect_instance() first."
             )
 
-
 # ==========================================================================
 # Instance discovery
 # ==========================================================================
-
 
 def discover_instances() -> list[dict]:
     """Scan socket directory and query each live instance for info."""
@@ -430,14 +408,12 @@ def discover_instances() -> list[dict]:
 
     return instances
 
-
 def _unwrap_response_data(text: str) -> dict:
     """Unwrap Response.ok() payloads while preserving plain JSON responses."""
     data = json.loads(text)
     if isinstance(data, dict) and "data" in data:
         return data["data"]
     return data
-
 
 def discover_active_tcp_instance() -> dict | None:
     """Return the active TCP fallback connection as an instance-like record."""
@@ -475,11 +451,9 @@ def discover_active_tcp_instance() -> dict | None:
 
     return info
 
-
 # ==========================================================================
 # HTTP dispatch
 # ==========================================================================
-
 
 def get_timeout(endpoint: str, payload: dict | None = None) -> int:
     """Get timeout for an endpoint, with dynamic scaling for batch ops."""
@@ -500,7 +474,6 @@ def get_timeout(endpoint: str, payload: dict | None = None) -> int:
         return min(base + count * 8, 600)
 
     return base
-
 
 def _coerce_comment_entries(value):
     if isinstance(value, str):
@@ -524,7 +497,6 @@ def _coerce_comment_entries(value):
             if (comment.get("comment") if isinstance(comment, dict) else comment) is not None
         ]
     return value
-
 
 def _normalize_post_payload(endpoint: str, data: dict) -> dict:
     if endpoint.strip("/").split("/")[-1] == "batch_set_comments":
@@ -578,7 +550,6 @@ def _try_reconnect() -> bool:
 
     return False
 
-
 def _ensure_connected() -> str | None:
     """Check connection and attempt reconnect if needed. Returns error string or None."""
     if _transport_mode == "none":
@@ -591,7 +562,6 @@ def _ensure_connected() -> str | None:
             )
         return "No Ghidra instance connected. Use connect_instance() first."
     return None
-
 
 def sanitize_address(address: str) -> str:
     """Normalize address format for Ghidra AddressFactory.
@@ -622,7 +592,6 @@ def sanitize_address(address: str) -> str:
         address = "0x" + address
     return address.lower()
 
-
 def dispatch_get(endpoint: str, params: dict | None = None, retries: int = 3) -> str:
     """GET request via active transport. Returns raw response text."""
     err = _ensure_connected()
@@ -652,7 +621,6 @@ def dispatch_get(endpoint: str, params: dict | None = None, retries: int = 3) ->
             return json.dumps({"error": str(e)})
 
     return json.dumps({"error": "Max retries exceeded"})
-
 
 def dispatch_post(
     endpoint: str, data: dict, retries: int = 3, query_params: dict | None = None
@@ -691,7 +659,6 @@ def dispatch_post(
 
     return json.dumps({"error": "Max retries exceeded"})
 
-
 # ==========================================================================
 # Schema parsing — converts upstream /mcp/schema to internal tool defs
 # ==========================================================================
@@ -708,7 +675,6 @@ _TYPE_MAP = {
     "any": str,
     "address": str,
 }
-
 
 def _normalize_tool_def_names(schema: list[dict]) -> list[dict]:
     """Normalize and de-duplicate MCP-visible names while keeping HTTP endpoints intact."""
@@ -738,7 +704,6 @@ def _normalize_tool_def_names(schema: list[dict]) -> list[dict]:
         normalized_schema.append(normalized)
 
     return normalized_schema
-
 
 def _parse_schema(raw: dict) -> list[dict]:
     """Convert upstream AnnotationScanner schema to internal tool defs.
@@ -787,7 +752,6 @@ def _parse_schema(raw: dict) -> list[dict]:
 
     return _normalize_tool_def_names(tool_defs)
 
-
 # ==========================================================================
 # Dynamic tool registration from /mcp/schema
 # ==========================================================================
@@ -805,6 +769,7 @@ STATIC_TOOL_NAMES = {
     "debugger_attach",
     "debugger_detach",
     "debugger_status",
+    "debugger_sync_modules",
     "debugger_modules",
     "debugger_resolve_ordinal",
     "debugger_set_breakpoint",
@@ -839,7 +804,6 @@ CORE_GROUPS = {"listing", "function", "program"}
 # CLI-configurable: --lazy keeps only default groups, otherwise load all
 _lazy_mode = False  # default: eager (load all groups on connect)
 _default_groups: set[str] = CORE_GROUPS
-
 
 def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
     """Build a callable that dispatches to the Ghidra HTTP endpoint."""
@@ -928,7 +892,6 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
 
     return handler
 
-
 def _register_tool_def(tool_def: dict) -> bool:
     """Register a single tool from a schema definition. Returns True if registered."""
     name = tool_def["name"]
@@ -947,7 +910,6 @@ def _register_tool_def(tool_def: dict) -> bool:
     mcp.tool(name=name, description=description)(handler)
     _dynamic_tool_names.append(name)
     return True
-
 
 def register_tools_from_schema(
     schema: list[dict], groups: set[str] | None = None
@@ -985,7 +947,6 @@ def register_tools_from_schema(
 
     return count
 
-
 def _load_group(group_name: str) -> list[str]:
     """Load tools for a specific group from cached schema. Returns list of newly loaded tool names."""
     loaded_names: list[str] = []
@@ -1000,7 +961,6 @@ def _load_group(group_name: str) -> list[str]:
     if loaded_names:
         _loaded_groups.add(group_name)
     return loaded_names
-
 
 def _unload_group(group_name: str) -> int:
     """Unload tools for a specific group. Returns count of removed tools."""
@@ -1024,7 +984,6 @@ def _unload_group(group_name: str) -> int:
     if to_remove:
         _loaded_groups.discard(group_name)
     return len(to_remove)
-
 
 def _get_group_info() -> list[dict]:
     """Get info about all tool groups from cached schema."""
@@ -1050,7 +1009,6 @@ def _get_group_info() -> list[dict]:
         result.append(info)
     return result
 
-
 def _fetch_and_register_schema(load_all: bool = False) -> int:
     """Fetch /mcp/schema from connected instance and register tools.
 
@@ -1069,18 +1027,14 @@ def _fetch_and_register_schema(load_all: bool = False) -> int:
     groups = None if load_all else _default_groups
     return register_tools_from_schema(schema, groups=groups)
 
-
 async def _notify_tools_changed(ctx: Context | None) -> None:
     """Send tools/list_changed notification if context is available."""
     if ctx is not None and ctx._request_context is not None:
         await ctx.request_context.session.send_tool_list_changed()
 
-
 # ==========================================================================
 # Static MCP tools (always available)
 # ==========================================================================
-
-
 @mcp.tool()
 def list_instances() -> str:
     """
@@ -1108,8 +1062,6 @@ def list_instances() -> str:
             inst["connected"] = inst["socket"] == _active_socket
 
     return json.dumps({"instances": instances}, indent=2)
-
-
 @mcp.tool()
 async def connect_instance(project: str, ctx: Context | None = None) -> str:
     """
@@ -1220,8 +1172,6 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
                 "available": available,
             }
         )
-
-
 @mcp.tool()
 def list_tool_groups() -> str:
     """
@@ -1236,8 +1186,6 @@ def list_tool_groups() -> str:
         )
     groups = _get_group_info()
     return json.dumps({"groups": groups, "total_tools": len(_full_schema)}, indent=2)
-
-
 @mcp.tool()
 async def load_tool_group(group: str, ctx: Context | None = None) -> str:
     """
@@ -1302,8 +1250,6 @@ async def load_tool_group(group: str, ctx: Context | None = None) -> str:
             "loaded_groups": sorted(_loaded_groups),
         }
     )
-
-
 @mcp.tool()
 async def unload_tool_group(group: str, ctx: Context | None = None) -> str:
     """
@@ -1335,8 +1281,6 @@ async def unload_tool_group(group: str, ctx: Context | None = None) -> str:
             "loaded_groups": sorted(_loaded_groups),
         }
     )
-
-
 @mcp.tool()
 async def check_tools(tools: str) -> str:
     """
@@ -1382,8 +1326,6 @@ async def check_tools(tools: str) -> str:
             "summary": f"{callable_count}/{len(tool_names)} callable",
         }
     )
-
-
 @mcp.tool()
 async def import_file(
     file_path: str,
@@ -1458,11 +1400,9 @@ async def import_file(
 
     return result
 
-
 # ==========================================================================
 # Auto-connect on startup
 # ==========================================================================
-
 
 def _auto_connect():
     """Try to auto-connect to a single running instance on startup."""
@@ -1508,13 +1448,11 @@ def _auto_connect():
                 "No Ghidra instances found. Tools will be registered on connect_instance()."
             )
 
-
 # ==========================================================================
 # Debugger tools (proxy to debugger/server.py on DEBUGGER_URL)
 # ==========================================================================
 
 DEBUGGER_URL = os.getenv("GHIDRA_DEBUGGER_URL", "http://127.0.0.1:8099")
-
 
 def _debugger_request(
     method: str,
@@ -1555,7 +1493,64 @@ def _debugger_request(
     finally:
         conn.close()
 
+def _win_basename(path: str) -> str:
+    return str(path).replace("\\", "/").rsplit("/", 1)[-1]
 
+def _module_aliases(name: str) -> list[str]:
+    raw = str(name or "").strip().replace("\\", "/")
+    base = raw.rsplit("/", 1)[-1]
+    stem, ext = os.path.splitext(base)
+    ext = ext.lower().lstrip(".")
+    aliases = [raw, base]
+    if stem and ext not in {"exe", "dll"}:
+        aliases.append(stem)
+    squashed = re.sub(r"[^A-Za-z0-9]+", "_", stem).strip("_")
+    if squashed:
+        aliases.append(f"{squashed}_{ext}" if ext in {"exe", "dll"} else squashed)
+    return list(dict.fromkeys(a for a in aliases if a))
+
+def _collect_ghidra_module_sync_payload() -> tuple[dict, list]:
+    programs_text = dispatch_get("/list_open_programs")
+    if not programs_text:
+        return {}, []
+    programs_data = _unwrap_response_data(programs_text)
+    programs = (
+        programs_data
+        if isinstance(programs_data, list)
+        else programs_data.get("programs", [])
+    )
+    ghidra_bases, ghidra_modules = {}, []
+    for prog in programs:
+        prog_path = (
+            prog if isinstance(prog, str) else prog.get("path", prog.get("name", ""))
+        )
+        if not prog_path:
+            continue
+        try:
+            meta = _unwrap_response_data(
+                dispatch_get("/get_metadata", params={"program": prog_path})
+            )
+            image_base = meta.get("imageBase", meta.get("image_base"))
+            if not image_base:
+                continue
+            ghidra_bases[prog_path] = image_base
+            canonical_name = (
+                meta.get("programName")
+                or meta.get("name")
+                or _win_basename(str(prog_path))
+            )
+            aliases = [a for src in (canonical_name, prog_path) for a in _module_aliases(str(src))]
+            ghidra_modules.append(
+                {
+                    "id": str(prog_path),
+                    "name": str(canonical_name),
+                    "base": image_base,
+                    "names": list(dict.fromkeys(aliases)),
+                }
+            )
+        except Exception as exc:
+            logger.debug("Could not collect Ghidra metadata for %r: %s", prog_path, exc)
+    return ghidra_bases, ghidra_modules
 @mcp.tool()
 def debugger_attach(target: str) -> str:
     """Attach the debugger to a running process for live dynamic analysis.
@@ -1572,55 +1567,37 @@ def debugger_attach(target: str) -> str:
     # Auto-sync address map if Ghidra is connected
     if _transport_mode != "none":
         try:
-            # Fetch image bases from Ghidra for all open programs
-            programs_text = dispatch_get("/list_open_programs")
-            if programs_text:
-                programs_data = json.loads(programs_text)
-                programs = (
-                    programs_data
-                    if isinstance(programs_data, list)
-                    else programs_data.get("programs", [])
-                )
-                ghidra_bases = {}
-                for prog in programs:
-                    prog_path = (
-                        prog
-                        if isinstance(prog, str)
-                        else prog.get("path", prog.get("name", ""))
-                    )
-                    if prog_path:
-                        try:
-                            meta_text = dispatch_get(
-                                "/get_metadata", params={"program": prog_path}
-                            )
-                            meta = json.loads(meta_text)
-                            image_base = meta.get("imageBase", meta.get("image_base"))
-                            if image_base:
-                                ghidra_bases[prog_path] = image_base
-                        except Exception:
-                            pass
-                if ghidra_bases:
-                    _debugger_request(
-                        "POST", "/debugger/sync_modules", {"ghidra_bases": ghidra_bases}
-                    )
+            ghidra_bases, ghidra_modules = _collect_ghidra_module_sync_payload()
+            if ghidra_bases or ghidra_modules:
+                _debugger_request("POST", "/debugger/sync_modules", {"ghidra_bases": ghidra_bases, "ghidra_modules": ghidra_modules})
         except Exception as e:
             logger.warning(f"Auto-sync address map failed (non-fatal): {e}")
 
     return result
-
-
 @mcp.tool()
 def debugger_detach() -> str:
     """Detach from the debugged process. The process continues running."""
     return _debugger_request("POST", "/debugger/detach")
-
-
 @mcp.tool()
 def debugger_status() -> str:
     """Get debugger connection status, loaded modules, active traces/watches."""
     return _debugger_request("GET", "/debugger/status")
 
-
+@mcp.tool()
+def debugger_sync_modules(ghidra_bases_json: str = "") -> str:
+    """Sync debugger module map using manual bases JSON or auto-discovered programs."""
+    try:
+        if ghidra_bases_json.strip():
+            parsed = json.loads(ghidra_bases_json)
+            if not isinstance(parsed, dict):
+                return json.dumps({"error": "ghidra_bases_json must decode to an object"})
+            return _debugger_request("POST", "/debugger/sync_modules", {"ghidra_bases": parsed})
+        ghidra_bases, ghidra_modules = _collect_ghidra_module_sync_payload()
+        if not ghidra_bases and not ghidra_modules:
+            return json.dumps({"error": "No open Ghidra programs found for sync"})
+        return _debugger_request("POST", "/debugger/sync_modules", {"ghidra_bases": ghidra_bases, "ghidra_modules": ghidra_modules})
+    except Exception as e:
+        return json.dumps({"error": f"Module sync failed: {e}"})
 @mcp.tool()
 def debugger_modules() -> str:
     """List loaded modules (DLLs) with runtime and Ghidra base addresses.
@@ -1629,8 +1606,6 @@ def debugger_modules() -> str:
     and the address offset between them.
     """
     return _debugger_request("GET", "/debugger/modules")
-
-
 @mcp.tool()
 def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
     """Resolve a DLL ordinal export to its runtime and Ghidra addresses.
@@ -1645,8 +1620,6 @@ def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
     return _debugger_request(
         "GET", "/debugger/ordinal", query={"dll": dll, "ordinal": str(ordinal)}
     )
-
-
 @mcp.tool()
 def debugger_set_breakpoint(
     ghidra_address: str,
@@ -1672,8 +1645,6 @@ def debugger_set_breakpoint(
             "oneshot": oneshot,
         },
     )
-
-
 @mcp.tool()
 def debugger_remove_breakpoint(bp_id: int) -> str:
     """Remove a breakpoint by its ID.
@@ -1682,14 +1653,10 @@ def debugger_remove_breakpoint(bp_id: int) -> str:
         bp_id: Breakpoint ID returned by debugger_set_breakpoint.
     """
     return _debugger_request("DELETE", f"/debugger/breakpoint/{bp_id}")
-
-
 @mcp.tool()
 def debugger_list_breakpoints() -> str:
     """List all active breakpoints with their addresses and status."""
     return _debugger_request("GET", "/debugger/breakpoints")
-
-
 @mcp.tool()
 def debugger_continue() -> str:
     """Resume execution of the debugged process.
@@ -1698,8 +1665,6 @@ def debugger_continue() -> str:
     an exception occurs, or debugger_interrupt() is called.
     """
     return _debugger_request("POST", "/debugger/go")
-
-
 @mcp.tool()
 def debugger_step_into(count: int = 1) -> str:
     """Single-step into the next instruction(s). Follows calls.
@@ -1708,8 +1673,6 @@ def debugger_step_into(count: int = 1) -> str:
         count: Number of instructions to step (default 1).
     """
     return _debugger_request("POST", "/debugger/step_into", {"count": count})
-
-
 @mcp.tool()
 def debugger_step_over(count: int = 1) -> str:
     """Step over the next instruction(s). Steps over calls.
@@ -1718,8 +1681,6 @@ def debugger_step_over(count: int = 1) -> str:
         count: Number of instructions to step (default 1).
     """
     return _debugger_request("POST", "/debugger/step_over", {"count": count})
-
-
 @mcp.tool()
 def debugger_registers() -> str:
     """Read all CPU registers. Must be stopped at a breakpoint.
@@ -1727,8 +1688,6 @@ def debugger_registers() -> str:
     Returns EAX-EDI, ESP, EBP, EIP, EFLAGS for x86.
     """
     return _debugger_request("GET", "/debugger/registers")
-
-
 @mcp.tool()
 def debugger_read_memory(
     address: str, size: int = 64, address_type: str = "runtime", module: str = ""
@@ -1753,8 +1712,6 @@ def debugger_read_memory(
             "module": module,
         },
     )
-
-
 @mcp.tool()
 def debugger_stack_trace(depth: int = 20) -> str:
     """Get the call stack backtrace with return addresses mapped to Ghidra symbols.
@@ -1763,8 +1720,6 @@ def debugger_stack_trace(depth: int = 20) -> str:
         depth: Maximum number of stack frames (default 20).
     """
     return _debugger_request("GET", "/debugger/stack", query={"depth": str(depth)})
-
-
 @mcp.tool()
 def debugger_read_args(
     convention: str = "__stdcall", count: int = 4, arg_names: str = ""
@@ -1784,8 +1739,6 @@ def debugger_read_args(
         "/debugger/read_args",
         query={"convention": convention, "count": str(count), "arg_names": arg_names},
     )
-
-
 @mcp.tool()
 def debugger_trace_function(
     ghidra_address: str,
@@ -1824,8 +1777,6 @@ def debugger_trace_function(
             "max_hits": max_hits,
         },
     )
-
-
 @mcp.tool()
 def debugger_trace_stop(trace_id: int = -1) -> str:
     """Stop a function trace. Use trace_id=-1 to stop all traces.
@@ -1834,8 +1785,6 @@ def debugger_trace_stop(trace_id: int = -1) -> str:
         trace_id: ID returned by debugger_trace_function, or -1 for all.
     """
     return _debugger_request("POST", "/debugger/trace/stop", {"trace_id": trace_id})
-
-
 @mcp.tool()
 def debugger_trace_log(trace_id: int = -1, last_n: int = 50) -> str:
     """Read the trace log. Shows timestamped function calls with arguments.
@@ -1849,14 +1798,10 @@ def debugger_trace_log(trace_id: int = -1, last_n: int = 50) -> str:
         "/debugger/trace/log",
         query={"trace_id": str(trace_id), "last_n": str(last_n)},
     )
-
-
 @mcp.tool()
 def debugger_trace_list() -> str:
     """List all active and completed traces with hit counts."""
     return _debugger_request("GET", "/debugger/trace/list")
-
-
 @mcp.tool()
 def debugger_watch_memory(
     ghidra_address: str, size: int = 4, access: str = "write", module: str = ""
@@ -1882,8 +1827,6 @@ def debugger_watch_memory(
             "access": access,
         },
     )
-
-
 @mcp.tool()
 def debugger_watch_stop(watch_id: int = -1) -> str:
     """Stop a memory watchpoint. Use watch_id=-1 to stop all.
@@ -1892,8 +1835,6 @@ def debugger_watch_stop(watch_id: int = -1) -> str:
         watch_id: ID returned by debugger_watch_memory, or -1 for all.
     """
     return _debugger_request("POST", "/debugger/watch/stop", {"watch_id": watch_id})
-
-
 @mcp.tool()
 def debugger_watch_log(watch_id: int = -1, last_n: int = 50) -> str:
     """Read the watchpoint hit log. Shows memory accesses with values and accessors.
@@ -1908,11 +1849,9 @@ def debugger_watch_log(watch_id: int = -1, last_n: int = 50) -> str:
         query={"watch_id": str(watch_id), "last_n": str(last_n)},
     )
 
-
 # ==========================================================================
 # Main
 # ==========================================================================
-
 
 def main():
     global _lazy_mode, _default_groups
@@ -1993,7 +1932,6 @@ def main():
         path = "/sse" if args.transport == "sse" else "/mcp"
         logger.info(f"MCP endpoint: http://{host}:{port}{path}")
     mcp.run(transport=args.transport)
-
 
 if __name__ == "__main__":
     main()

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -776,6 +776,7 @@ STATIC_TOOL_NAMES = {
     "debugger_remove_breakpoint",
     "debugger_list_breakpoints",
     "debugger_continue",
+    "debugger_interrupt",
     "debugger_step_into",
     "debugger_step_over",
     "debugger_registers",
@@ -1622,29 +1623,31 @@ def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
     )
 @mcp.tool()
 def debugger_set_breakpoint(
-    ghidra_address: str,
+    ghidra_address: str = "",
     module: str = "",
+    runtime_address: str = "",
     bp_type: str = "software",
     oneshot: bool = False,
 ) -> str:
-    """Set a breakpoint at a Ghidra address. Auto-translates to runtime address.
+    """Set a breakpoint using a Ghidra or runtime address.
 
     Args:
         ghidra_address: Address in Ghidra (e.g. "0x6FD9F450").
-        module: DLL name for disambiguation (e.g. "D2Common.dll").
+        module: DLL name for Ghidra address disambiguation (e.g. "D2Common.dll").
+        runtime_address: Live process runtime address (e.g. "0x7FF73A592070").
         bp_type: "software" (INT3) or "hardware" (debug register).
         oneshot: If true, breakpoint is removed after first hit.
     """
-    return _debugger_request(
-        "POST",
-        "/debugger/breakpoint",
-        {
-            "ghidra_address": ghidra_address,
-            "module": module,
-            "type": bp_type,
-            "oneshot": oneshot,
-        },
-    )
+    payload = {
+        "type": bp_type,
+        "oneshot": oneshot,
+    }
+    if runtime_address.strip():
+        payload["runtime_address"] = runtime_address
+    else:
+        payload["ghidra_address"] = ghidra_address
+        payload["module"] = module
+    return _debugger_request("POST", "/debugger/breakpoint", payload)
 @mcp.tool()
 def debugger_remove_breakpoint(bp_id: int) -> str:
     """Remove a breakpoint by its ID.
@@ -1665,6 +1668,11 @@ def debugger_continue() -> str:
     an exception occurs, or debugger_interrupt() is called.
     """
     return _debugger_request("POST", "/debugger/go")
+@mcp.tool()
+def debugger_interrupt() -> str:
+    """Interrupt a running process and return control to the debugger."""
+    return _debugger_request("POST", "/debugger/interrupt")
+
 @mcp.tool()
 def debugger_step_into(count: int = 1) -> str:
     """Single-step into the next instruction(s). Follows calls.
@@ -1741,8 +1749,9 @@ def debugger_read_args(
     )
 @mcp.tool()
 def debugger_trace_function(
-    ghidra_address: str,
+    ghidra_address: str = "",
     module: str = "",
+    runtime_address: str = "",
     convention: str = "__stdcall",
     arg_count: int = 4,
     arg_names: str = "",
@@ -1758,25 +1767,26 @@ def debugger_trace_function(
     Args:
         ghidra_address: Function address in Ghidra.
         module: DLL name (e.g. "D2Common.dll").
+        runtime_address: Live process runtime address (skips address mapper).
         convention: __stdcall, __fastcall, __thiscall, __cdecl.
         arg_count: Number of arguments to capture.
         arg_names: Comma-separated arg names (e.g. "pUnit,nSkillId,nWeaponSpeed").
         capture_return: Also capture return value (EAX).
         max_hits: Stop tracing after N hits (0 = unlimited).
     """
-    return _debugger_request(
-        "POST",
-        "/debugger/trace/start",
-        {
-            "ghidra_address": ghidra_address,
-            "module": module,
-            "convention": convention,
-            "arg_count": arg_count,
-            "arg_names": arg_names,
-            "capture_return": capture_return,
-            "max_hits": max_hits,
-        },
-    )
+    payload = {
+        "module": module,
+        "convention": convention,
+        "arg_count": arg_count,
+        "arg_names": arg_names,
+        "capture_return": capture_return,
+        "max_hits": max_hits,
+    }
+    if runtime_address.strip():
+        payload["runtime_address"] = runtime_address
+    else:
+        payload["ghidra_address"] = ghidra_address
+    return _debugger_request("POST", "/debugger/trace/start", payload)
 @mcp.tool()
 def debugger_trace_stop(trace_id: int = -1) -> str:
     """Stop a function trace. Use trace_id=-1 to stop all traces.

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1814,7 +1814,11 @@ def debugger_trace_list() -> str:
     return _debugger_request("GET", "/debugger/trace/list")
 @mcp.tool()
 def debugger_watch_memory(
-    ghidra_address: str, size: int = 4, access: str = "write", module: str = ""
+    ghidra_address: str = "",
+    size: int = 4,
+    access: str = "write",
+    module: str = "",
+    runtime_address: str = "",
 ) -> str:
     """Set a hardware watchpoint on a memory range to monitor read/write access.
 
@@ -1826,17 +1830,14 @@ def debugger_watch_memory(
         size: Bytes to watch (1, 2, or 4).
         access: "read", "write", or "readwrite".
         module: DLL name for address resolution.
+        runtime_address: Live process runtime address (skips address mapper).
     """
-    return _debugger_request(
-        "POST",
-        "/debugger/watch/start",
-        {
-            "ghidra_address": ghidra_address,
-            "module": module,
-            "size": size,
-            "access": access,
-        },
-    )
+    payload = {"size": size, "access": access, "module": module}
+    if runtime_address.strip():
+        payload["runtime_address"] = runtime_address
+    else:
+        payload["ghidra_address"] = ghidra_address
+    return _debugger_request("POST", "/debugger/watch/start", payload)
 @mcp.tool()
 def debugger_watch_stop(watch_id: int = -1) -> str:
     """Stop a memory watchpoint. Use watch_id=-1 to stop all.

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1623,13 +1623,13 @@ def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
     )
 
 
-def _normalize_optional_address(value: object) -> str:
-    """Normalize optional address-like inputs to a trimmed string."""
+def _normalize_optional_address(value: object) -> object:
+    """Normalize optional address-like inputs while preserving numeric types."""
     if value is None:
         return ""
     if isinstance(value, str):
         return value.strip()
-    return str(value).strip()
+    return value
 @mcp.tool()
 def debugger_set_breakpoint(
     ghidra_address: str = "",

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1621,6 +1621,15 @@ def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
     return _debugger_request(
         "GET", "/debugger/ordinal", query={"dll": dll, "ordinal": str(ordinal)}
     )
+
+
+def _normalize_optional_address(value: object) -> str:
+    """Normalize optional address-like inputs to a trimmed string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
 @mcp.tool()
 def debugger_set_breakpoint(
     ghidra_address: str = "",
@@ -1642,8 +1651,9 @@ def debugger_set_breakpoint(
         "type": bp_type,
         "oneshot": oneshot,
     }
-    if runtime_address.strip():
-        payload["runtime_address"] = runtime_address
+    normalized_runtime_address = _normalize_optional_address(runtime_address)
+    if normalized_runtime_address:
+        payload["runtime_address"] = normalized_runtime_address
     else:
         payload["ghidra_address"] = ghidra_address
         payload["module"] = module
@@ -1782,8 +1792,9 @@ def debugger_trace_function(
         "capture_return": capture_return,
         "max_hits": max_hits,
     }
-    if runtime_address.strip():
-        payload["runtime_address"] = runtime_address
+    normalized_runtime_address = _normalize_optional_address(runtime_address)
+    if normalized_runtime_address:
+        payload["runtime_address"] = normalized_runtime_address
     else:
         payload["ghidra_address"] = ghidra_address
     return _debugger_request("POST", "/debugger/trace/start", payload)
@@ -1833,8 +1844,9 @@ def debugger_watch_memory(
         runtime_address: Live process runtime address (skips address mapper).
     """
     payload = {"size": size, "access": access, "module": module}
-    if runtime_address.strip():
-        payload["runtime_address"] = runtime_address
+    normalized_runtime_address = _normalize_optional_address(runtime_address)
+    if normalized_runtime_address:
+        payload["runtime_address"] = normalized_runtime_address
     else:
         payload["ghidra_address"] = ghidra_address
     return _debugger_request("POST", "/debugger/watch/start", payload)

--- a/debugger/address_map.py
+++ b/debugger/address_map.py
@@ -508,35 +508,51 @@ class AddressMapper:
     def _build_ghidra_candidates(
         self, ghidra_bases: Dict[str, int | str], ghidra_modules: list[dict]
     ) -> list[_GhidraBaseCandidate]:
-        if ghidra_modules:
-            result: list[_GhidraBaseCandidate] = []
-            for entry in ghidra_modules:
-                if not isinstance(entry, dict):
-                    raise ValueError(
-                        "Invalid ghidra_modules payload: each entry must be an object"
-                    )
-                module_id = str(entry.get("id", "")).strip()
-                if not module_id:
-                    module_id = str(entry.get("name", "")).strip()
-                if "base" not in entry:
-                    logger.warning("Skipping Ghidra module without base: %r", entry)
+        result: list[_GhidraBaseCandidate] = []
+        seen: set[tuple[str, int, str]] = set()
+        covered_legacy_keys: set[str] = set()
+
+        for entry in ghidra_modules:
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    "Invalid ghidra_modules payload: each entry must be an object"
+                )
+            module_id = str(entry.get("id", "")).strip()
+            if not module_id:
+                module_id = str(entry.get("name", "")).strip()
+            if "base" not in entry:
+                logger.warning("Skipping Ghidra module without base: %r", entry)
+                continue
+            base = self._parse_base(entry["base"])
+            names = entry.get("names", []) or []
+            canonical_name = str(entry.get("name", "")).strip()
+            if canonical_name:
+                names = [canonical_name, *names]
+            if not names:
+                names = [module_id]
+            for raw_name in names:
+                text = self._clean_text(raw_name)
+                if not text:
                     continue
-                base = self._parse_base(entry["base"])
-                names = entry.get("names", []) or []
-                canonical_name = str(entry.get("name", "")).strip()
-                if canonical_name:
-                    names = [canonical_name, *names]
-                if not names:
-                    names = [module_id]
-                for raw_name in names:
-                    text = self._clean_text(raw_name)
-                    if text:
-                        result.append(_GhidraBaseCandidate(module_id or text, text, base))
-            return result
-        return [
-            _GhidraBaseCandidate(str(name), str(name), self._parse_base(base))
-            for name, base in ghidra_bases.items()
-        ]
+                candidate = _GhidraBaseCandidate(module_id or text, text, base)
+                ident = (candidate.id, candidate.base, candidate.name)
+                if ident not in seen:
+                    seen.add(ident)
+                    result.append(candidate)
+                covered_legacy_keys.add(text)
+
+        for name, base_value in ghidra_bases.items():
+            text = self._clean_text(name)
+            if not text or text in covered_legacy_keys:
+                continue
+            base = self._parse_base(base_value)
+            candidate = _GhidraBaseCandidate(text, text, base)
+            ident = (candidate.id, candidate.base, candidate.name)
+            if ident not in seen:
+                seen.add(ident)
+                result.append(candidate)
+
+        return result
 
     @staticmethod
     def _dedupe_candidates(

--- a/debugger/address_map.py
+++ b/debugger/address_map.py
@@ -34,7 +34,7 @@ _ORDINAL_RE = re.compile(r"Ordinal_(\d+)")
 
 # Mapping lookup order. Later stages are increasingly permissive and must be
 # treated as aliases, not unique identities.
-_MATCH_ORDER = ("exact", "basename", "canonical", "fuzzy")
+_MATCH_ORDER = ("exact", "basename", "canonical", "fuzzy", "stem")
 _SAFE_QUOTE_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789."
 
 
@@ -495,6 +495,7 @@ class AddressMapper:
             "basename": basename.casefold(),
             "canonical": cls._canonical_basename_key(basename),
             "fuzzy": cls._fuzzy_basename_key(basename),
+            "stem": cls._stem_basename_key(basename),
         }
 
     @staticmethod
@@ -510,6 +511,10 @@ class AddressMapper:
         if ghidra_modules:
             result: list[_GhidraBaseCandidate] = []
             for entry in ghidra_modules:
+                if not isinstance(entry, dict):
+                    raise ValueError(
+                        "Invalid ghidra_modules payload: each entry must be an object"
+                    )
                 module_id = str(entry.get("id", "")).strip()
                 if not module_id:
                     module_id = str(entry.get("name", "")).strip()
@@ -592,6 +597,12 @@ class AddressMapper:
         stem = re.sub(r"[^a-z0-9]+", "", stem)
         ext = ext if ext in {".exe", ".dll"} else ""
         return f"{stem}{ext}"
+
+    @staticmethod
+    def _stem_basename_key(basename: str) -> str:
+        """Compatibility alias for extensionless module names (e.g. D2Common)."""
+        stem, _ = os.path.splitext(basename.lower())
+        return re.sub(r"[^a-z0-9]+", "", stem)
 
     @classmethod
     def _ordinal_key(cls, name: str) -> str:

--- a/debugger/address_map.py
+++ b/debugger/address_map.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 import logging
 import os
 import re
-from dataclasses import dataclass, field
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 from .protocol import ModuleInfo
 
@@ -29,14 +32,25 @@ _EXPORT_LINE_RE = re.compile(
 # Extract ordinal number from label like "Ordinal_10000"
 _ORDINAL_RE = re.compile(r"Ordinal_(\d+)")
 
+# Mapping lookup order. Later stages are increasingly permissive and must be
+# treated as aliases, not unique identities.
+_MATCH_ORDER = ("exact", "basename", "canonical", "fuzzy")
+_SAFE_QUOTE_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789."
+
 
 @dataclass
 class ModuleMapping:
     """Maps a single module between Ghidra and runtime address spaces."""
+
     name: str
     ghidra_base: int
     runtime_base: int
     size: int
+    ghidra_name: str = ""
+    image_path: str = ""
+    loaded_name: str = ""
+    match_kind: str = ""
+    match_key: str = ""
 
     @property
     def offset(self) -> int:
@@ -56,9 +70,29 @@ class ModuleMapping:
         return runtime_addr - self.offset
 
 
+@dataclass(frozen=True)
+class _GhidraBaseCandidate:
+    """A Ghidra module/image-base candidate collected from sync_modules."""
+
+    id: str
+    name: str
+    base: int
+
+
+@dataclass
+class _ResolvedCandidate:
+    """A tentative runtime<->Ghidra match before global ambiguity checks."""
+
+    module: ModuleInfo
+    ghidra: _GhidraBaseCandidate
+    match_kind: str
+    match_key: str
+
+
 @dataclass
 class OrdinalEntry:
     """A single ordinal export from dll_exports/*.txt."""
+
     dll: str
     ordinal: int
     label: str  # e.g. "Ordinal_10000" or renamed label
@@ -66,73 +100,172 @@ class OrdinalEntry:
 
 
 class AddressMapper:
-    """Bidirectional address translation between Ghidra and runtime."""
+    """Bidirectional address translation between Ghidra and runtime.
+
+    Module matching is deliberately fail-closed:
+
+    1. exact name/path match
+    2. case-insensitive basename match
+    3. non-destructive canonical basename match (percent encoding)
+    4. fuzzy Ghidra/dbgeng-style alias match, only if unique
+
+    Internally, aliases map to *lists* of mappings. A fuzzy collision therefore
+    raises an ambiguity error instead of silently choosing the wrong module.
+    """
 
     def __init__(self):
-        self._modules: Dict[str, ModuleMapping] = {}  # normalized_name -> mapping
+        self._modules: List[ModuleMapping] = []
+        self._mapped_index: dict[str, dict[str, list[ModuleMapping]]] = self._new_index()
         self._ordinals: Dict[str, Dict[int, OrdinalEntry]] = {}  # dll -> {ordinal -> entry}
 
     # -- Module mapping ----------------------------------------------------
 
-    def update_from_modules(self, runtime_modules: List[ModuleInfo],
-                            ghidra_bases: Dict[str, int]) -> dict:
+    def update_from_modules(
+        self,
+        runtime_modules: List[ModuleInfo],
+        ghidra_bases: Dict[str, int] | None = None,
+        ghidra_modules: Optional[list[dict]] = None,
+    ) -> dict:
         """Rebuild module map from runtime + Ghidra data.
 
         Args:
             runtime_modules: Modules from dbgeng's module_list().
-            ghidra_bases: {module_name: image_base} from Ghidra's /get_metadata.
+            ghidra_bases: legacy {module_name_or_alias: image_base} from Ghidra.
+            ghidra_modules: optional canonical module payload with stable ids.
 
         Returns:
-            Summary of mapped/unmapped modules.
+            Summary of mapped/unmapped/ambiguous modules.
         """
         self._modules.clear()
-        mapped = []
-        unmapped = []
+        self._mapped_index = self._new_index()
 
-        # Normalize Ghidra base names for matching
-        ghidra_normalized: Dict[str, Tuple[str, int]] = {}
-        for name, base in ghidra_bases.items():
-            key = self._normalize_name(name)
-            ghidra_normalized[key] = (name, base)
+        ghidra_index = self._new_index()
+        for candidate in self._build_ghidra_candidates(
+            ghidra_bases=ghidra_bases or {}, ghidra_modules=ghidra_modules or []
+        ):
+            for kind, key in self._aliases_for_name(candidate.name).items():
+                ghidra_index[kind][key].append(candidate)
+
+        tentative: list[_ResolvedCandidate] = []
+        unmapped: list[dict] = []
+        ambiguous: list[dict] = []
 
         for mod in runtime_modules:
-            key = self._normalize_name(mod.name)
-            if key in ghidra_normalized:
-                orig_name, ghidra_base = ghidra_normalized[key]
-                mapping = ModuleMapping(
-                    name=mod.name,
-                    ghidra_base=ghidra_base,
-                    runtime_base=mod.runtime_base,
-                    size=mod.size,
-                )
-                self._modules[key] = mapping
-                mod.ghidra_base = ghidra_base
-                mapped.append(mod.name)
-                logger.info(
-                    f"Mapped {mod.name}: ghidra=0x{ghidra_base:08X} "
-                    f"runtime=0x{mod.runtime_base:08X} "
-                    f"offset={mapping.offset:+#X}")
+            resolved = self._resolve_ghidra_candidate_for_runtime_module(mod, ghidra_index)
+            if resolved is None:
+                unmapped.append({"module": mod.name, "reason": "no_match"})
+            elif isinstance(resolved, str):
+                ambiguous.append({"module": mod.name, "reason": resolved})
             else:
-                unmapped.append(mod.name)
+                tentative.append(resolved)
+
+        # Global ambiguity check: if multiple runtime modules resolve to the
+        # same exact Ghidra candidate, do not map any of them. This prevents two
+        # same-basename runtime DLLs from sharing one Ghidra image base.
+        by_ghidra: dict[tuple[str, int], list[_ResolvedCandidate]] = defaultdict(list)
+        for item in tentative:
+            by_ghidra[(item.ghidra.id, item.ghidra.base)].append(item)
+
+        accepted: list[_ResolvedCandidate] = []
+        rejected_runtime_ids: set[tuple[int, int, str]] = set()
+        for (ghidra_id, ghidra_base), items in by_ghidra.items():
+            representative = items[0].ghidra
+            runtime_ids = {
+                (item.module.runtime_base, item.module.size, item.module.name)
+                for item in items
+            }
+            if len(runtime_ids) > 1:
+                candidates = [
+                    self._runtime_module_label(item.module)
+                    for item in sorted(items, key=lambda x: x.module.runtime_base)
+                ]
+                for item in items:
+                    rejected_runtime_ids.add(
+                        (item.module.runtime_base, item.module.size, item.module.name)
+                    )
+                ambiguous.append(
+                    {
+                        "ghidra": representative.name,
+                        "ghidra_id": ghidra_id,
+                        "ghidra_base": f"0x{ghidra_base:08X}",
+                        "reason": "multiple_runtime_modules_match_same_ghidra_candidate",
+                        "candidates": candidates,
+                    }
+                )
+            else:
+                accepted.extend(items)
+
+        mapped = []
+        for item in accepted:
+            if (item.module.runtime_base, item.module.size, item.module.name) in rejected_runtime_ids:
+                continue
+            mapping = ModuleMapping(
+                name=item.module.name,
+                ghidra_name=item.ghidra.name,
+                ghidra_base=item.ghidra.base,
+                runtime_base=item.module.runtime_base,
+                size=item.module.size,
+                image_path=getattr(item.module, "image_path", None) or "",
+                loaded_name=getattr(item.module, "loaded_name", None) or "",
+                match_kind=item.match_kind,
+                match_key=item.match_key,
+            )
+            self._modules.append(mapping)
+            self._index_mapping(mapping)
+
+            item.module.ghidra_base = item.ghidra.base
+            item.module.ghidra_name = item.ghidra.name
+            item.module.match_kind = item.match_kind
+            item.module.match_key = item.match_key
+            mapped.append(item.module.name)
+            logger.info(
+                "Mapped %s -> %s via %s:%s ghidra=0x%08X runtime=0x%08X offset=%+#X",
+                item.module.name,
+                item.ghidra.name,
+                item.match_kind,
+                item.match_key,
+                item.ghidra.base,
+                item.module.runtime_base,
+                mapping.offset,
+            )
 
         return {
             "mapped": len(mapped),
             "unmapped": len(unmapped),
+            "ambiguous": len(ambiguous),
             "mapped_modules": mapped,
-            "unmapped_modules": unmapped[:20],  # Cap output
+            "unmapped_modules": [item["module"] for item in unmapped[:20]],
+            "unmapped_details": unmapped[:20],
+            "ambiguous_modules": ambiguous[:20],
         }
 
     def get_module(self, name: str) -> Optional[ModuleMapping]:
-        """Look up a module mapping by name."""
-        return self._modules.get(self._normalize_name(name))
+        """Look up a module mapping by name. Returns None on miss/ambiguity."""
+        try:
+            return self._resolve_mapped_module_by_name(name)
+        except ValueError:
+            return None
+
+    def require_module(self, name: str) -> ModuleMapping:
+        """Look up a module mapping by name and raise clear errors."""
+        mapping = self._resolve_mapped_module_by_name(name)
+        if mapping is None:
+            raise ValueError(f"Module '{name}' not in address map")
+        return mapping
+
+    def get_mapping_for_runtime_module(self, module: ModuleInfo) -> Optional[ModuleMapping]:
+        """Return the already accepted mapping for an exact runtime module instance."""
+        for mapping in self._modules:
+            if mapping.runtime_base == module.runtime_base and mapping.size == module.size:
+                return mapping
+        return None
 
     def get_all_modules(self) -> List[ModuleMapping]:
-        return list(self._modules.values())
+        return list(self._modules)
 
     # -- Address translation -----------------------------------------------
 
-    def to_runtime(self, ghidra_addr: int,
-                   module: Optional[str] = None) -> int:
+    def to_runtime(self, ghidra_addr: int, module: Optional[str] = None) -> int:
         """Convert a Ghidra address to a runtime address.
 
         Args:
@@ -143,22 +276,31 @@ class AddressMapper:
             Runtime address.
 
         Raises:
-            ValueError: If the address can't be mapped.
+            ValueError: If the address can't be mapped or the module alias is ambiguous.
         """
         if module:
-            mapping = self.get_module(module)
-            if mapping is None:
-                raise ValueError(f"Module '{module}' not in address map")
+            mapping = self.require_module(module)
+            if not mapping.contains_ghidra(ghidra_addr):
+                raise ValueError(
+                    f"Address 0x{ghidra_addr:08X} is outside mapped module "
+                    f"'{mapping.name}' Ghidra range "
+                    f"0x{mapping.ghidra_base:08X}-0x{mapping.ghidra_base + mapping.size:08X}"
+                )
             return mapping.to_runtime(ghidra_addr)
 
-        # Auto-detect module from address range
-        for mapping in self._modules.values():
-            if mapping.contains_ghidra(ghidra_addr):
-                return mapping.to_runtime(ghidra_addr)
+        matches = [m for m in self._modules if m.contains_ghidra(ghidra_addr)]
+        if len(matches) == 1:
+            return matches[0].to_runtime(ghidra_addr)
+        if len(matches) > 1:
+            raise ValueError(
+                f"Address 0x{ghidra_addr:08X} matches multiple mapped modules: "
+                f"{', '.join(m.name for m in matches)}. Provide an exact module name/path."
+            )
 
         raise ValueError(
             f"Address 0x{ghidra_addr:08X} not in any mapped module. "
-            f"Mapped: {', '.join(m.name for m in self._modules.values())}")
+            f"Mapped: {', '.join(m.name for m in self._modules)}"
+        )
 
     def to_ghidra(self, runtime_addr: int) -> Tuple[str, int]:
         """Convert a runtime address to (module_name, ghidra_address).
@@ -166,12 +308,15 @@ class AddressMapper:
         Raises:
             ValueError: If the address can't be mapped.
         """
-        for mapping in self._modules.values():
-            if mapping.contains_runtime(runtime_addr):
-                return mapping.name, mapping.to_ghidra(runtime_addr)
-
-        raise ValueError(
-            f"Runtime address 0x{runtime_addr:08X} not in any mapped module")
+        matches = [m for m in self._modules if m.contains_runtime(runtime_addr)]
+        if len(matches) == 1:
+            return matches[0].name, matches[0].to_ghidra(runtime_addr)
+        if len(matches) > 1:
+            raise ValueError(
+                f"Runtime address 0x{runtime_addr:08X} matches multiple mapped modules: "
+                f"{', '.join(m.name for m in matches)}"
+            )
+        raise ValueError(f"Runtime address 0x{runtime_addr:08X} not in any mapped module")
 
     def try_to_ghidra(self, runtime_addr: int) -> Optional[Tuple[str, int]]:
         """Like to_ghidra but returns None instead of raising."""
@@ -229,7 +374,7 @@ class AddressMapper:
                         continue
                     ordinal = int(om.group(1))
 
-                    dll_key = self._normalize_name(dll)
+                    dll_key = self._ordinal_key(dll)
                     if dll_key not in self._ordinals:
                         self._ordinals[dll_key] = {}
 
@@ -251,7 +396,7 @@ class AddressMapper:
             Dict with ghidra_address, runtime_address (if mapped), label.
             None if ordinal not found.
         """
-        dll_key = self._normalize_name(dll)
+        dll_key = self._ordinal_key(dll)
         entries = self._ordinals.get(dll_key, {})
         entry = entries.get(ordinal)
         if entry is None:
@@ -275,19 +420,186 @@ class AddressMapper:
 
     def get_ordinal_count(self, dll: str) -> int:
         """Get the number of loaded ordinals for a DLL."""
-        return len(self._ordinals.get(self._normalize_name(dll), {}))
+        return len(self._ordinals.get(self._ordinal_key(dll), {}))
 
-    # -- Helpers -----------------------------------------------------------
+    # -- Matching helpers --------------------------------------------------
 
     @staticmethod
-    def _normalize_name(name: str) -> str:
-        """Normalize a module/DLL name for matching.
+    def _new_index():
+        return {kind: defaultdict(list) for kind in _MATCH_ORDER}
 
-        "D2COMMON.DLL" -> "d2common"
-        "D2Common.dll" -> "d2common"
-        "/Vanilla/1.00/D2Common.dll" -> "d2common"
-        """
-        # Take basename, strip extension, lowercase
-        basename = os.path.basename(name)
+    def _resolve_ghidra_candidate_for_runtime_module(
+        self,
+        module: ModuleInfo,
+        ghidra_index: dict[str, dict[str, list[_GhidraBaseCandidate]]],
+    ) -> _ResolvedCandidate | str | None:
+        aliases = self._aliases_for_runtime_module(module)
+        for kind in _MATCH_ORDER:
+            for key in aliases.get(kind, []):
+                unique = self._dedupe_candidates(ghidra_index[kind].get(key, []))
+                if len(unique) == 1:
+                    return _ResolvedCandidate(module, unique[0], kind, key)
+                if len(unique) > 1:
+                    return (
+                        f"ambiguous_{kind}_match: "
+                        + ", ".join(f"{c.name}@0x{c.base:08X}" for c in unique)
+                    )
+        return None
+
+    def _resolve_mapped_module_by_name(self, name: str) -> Optional[ModuleMapping]:
+        aliases = self._aliases_for_name(name)
+        for kind in _MATCH_ORDER:
+            key = aliases.get(kind)
+            if not key:
+                continue
+            unique = self._dedupe_mappings(self._mapped_index[kind].get(key, []))
+            if len(unique) == 1:
+                return unique[0]
+            if len(unique) > 1:
+                raise ValueError(
+                    f"Ambiguous module mapping for '{name}' via {kind}:{key}. "
+                    f"Candidates: {', '.join(self._mapping_label(m) for m in unique)}. "
+                    "Use a more exact module name/path."
+                )
+        return None
+
+    def _index_mapping(self, mapping: ModuleMapping) -> None:
+        names = [mapping.name, mapping.ghidra_name, mapping.image_path, mapping.loaded_name]
+        for raw_name in names:
+            for kind, key in self._aliases_for_name(raw_name).items():
+                self._mapped_index[kind][key].append(mapping)
+
+    def _aliases_for_runtime_module(self, module: ModuleInfo) -> dict[str, list[str]]:
+        result: dict[str, list[str]] = {kind: [] for kind in _MATCH_ORDER}
+        names = [
+            getattr(module, "image_path", None) or "",
+            getattr(module, "loaded_name", None) or "",
+            module.name,
+        ]
+        for raw_name in names:
+            aliases = self._aliases_for_name(raw_name)
+            for kind, key in aliases.items():
+                if key and key not in result[kind]:
+                    result[kind].append(key)
+        return result
+
+    @classmethod
+    def _aliases_for_name(cls, name: str) -> dict[str, str]:
+        text = cls._clean_text(name)
+        if not text:
+            return {}
+        basename = cls._basename(text)
+        return {
+            "exact": text.casefold(),
+            "basename": basename.casefold(),
+            "canonical": cls._canonical_basename_key(basename),
+            "fuzzy": cls._fuzzy_basename_key(basename),
+        }
+
+    @staticmethod
+    def _parse_base(base: int | str) -> int:
+        if isinstance(base, str):
+            text = base.strip()
+            return int(text, 16) if text.casefold().startswith("0x") else int(text)
+        return int(base)
+
+    def _build_ghidra_candidates(
+        self, ghidra_bases: Dict[str, int | str], ghidra_modules: list[dict]
+    ) -> list[_GhidraBaseCandidate]:
+        if ghidra_modules:
+            result: list[_GhidraBaseCandidate] = []
+            for entry in ghidra_modules:
+                module_id = str(entry.get("id", "")).strip()
+                if not module_id:
+                    module_id = str(entry.get("name", "")).strip()
+                if "base" not in entry:
+                    logger.warning("Skipping Ghidra module without base: %r", entry)
+                    continue
+                base = self._parse_base(entry["base"])
+                names = entry.get("names", []) or []
+                canonical_name = str(entry.get("name", "")).strip()
+                if canonical_name:
+                    names = [canonical_name, *names]
+                if not names:
+                    names = [module_id]
+                for raw_name in names:
+                    text = self._clean_text(raw_name)
+                    if text:
+                        result.append(_GhidraBaseCandidate(module_id or text, text, base))
+            return result
+        return [
+            _GhidraBaseCandidate(str(name), str(name), self._parse_base(base))
+            for name, base in ghidra_bases.items()
+        ]
+
+    @staticmethod
+    def _dedupe_candidates(
+        candidates: list[_GhidraBaseCandidate],
+    ) -> list[_GhidraBaseCandidate]:
+        seen = set()
+        result = []
+        for item in candidates:
+            ident = (item.id, item.base)
+            if ident not in seen:
+                seen.add(ident)
+                result.append(item)
+        return result
+
+    @staticmethod
+    def _dedupe_mappings(mappings: list[ModuleMapping]) -> list[ModuleMapping]:
+        seen = set()
+        result = []
+        for item in mappings:
+            ident = (item.runtime_base, item.size, item.name)
+            if ident not in seen:
+                seen.add(ident)
+                result.append(item)
+        return result
+
+    @staticmethod
+    def _mapping_label(mapping: ModuleMapping) -> str:
+        return f"{mapping.name}@0x{mapping.runtime_base:08X}"
+
+    @staticmethod
+    def _runtime_module_label(module: ModuleInfo) -> str:
+        return f"{module.name}@0x{module.runtime_base:08X}"
+
+    @staticmethod
+    def _clean_text(value: str) -> str:
+        text = unicodedata.normalize("NFC", str(value or "").strip())
+        return text.replace("\\", "/")
+
+    @staticmethod
+    def _basename(value: str) -> str:
+        return value.rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _canonical_basename_key(basename: str) -> str:
+        # Non-destructive: spaces, hyphens and literal '%' are preserved through
+        # encoding. "a b.exe" -> "a%20b.exe", "a%20b.exe" -> "a%2520b.exe".
+        return quote(basename.casefold(), safe=_SAFE_QUOTE_CHARS)
+
+    @staticmethod
+    def _fuzzy_basename_key(basename: str) -> str:
+        # Convert common dbgeng/Ghidra sanitizations back into an extension while
+        # keeping .exe and .dll distinct. Example:
+        #   Example_Program___Retail_exe -> exampleprogramretail.exe
+        value = basename.lower()
+        if not os.path.splitext(value)[1]:
+            value = re.sub(r"[\s_.-]+(exe|dll)$", r".\1", value)
+        stem, ext = os.path.splitext(value)
+        stem = re.sub(r"[^a-z0-9]+", "", stem)
+        ext = ext if ext in {".exe", ".dll"} else ""
+        return f"{stem}{ext}"
+
+    @classmethod
+    def _ordinal_key(cls, name: str) -> str:
+        """Compatibility key for ordinal exports: basename without extension."""
+        basename = cls._basename(cls._clean_text(name))
         stem = os.path.splitext(basename)[0]
         return stem.lower()
+
+    @classmethod
+    def _normalize_name(cls, name: str) -> str:
+        """Backward-compatible helper retained for external callers/tests."""
+        return cls._ordinal_key(name)

--- a/debugger/address_map.py
+++ b/debugger/address_map.py
@@ -434,17 +434,18 @@ class AddressMapper:
         ghidra_index: dict[str, dict[str, list[_GhidraBaseCandidate]]],
     ) -> _ResolvedCandidate | str | None:
         aliases = self._aliases_for_runtime_module(module)
+        first_ambiguous: str | None = None
         for kind in _MATCH_ORDER:
             for key in aliases.get(kind, []):
                 unique = self._dedupe_candidates(ghidra_index[kind].get(key, []))
                 if len(unique) == 1:
                     return _ResolvedCandidate(module, unique[0], kind, key)
-                if len(unique) > 1:
-                    return (
+                if len(unique) > 1 and first_ambiguous is None:
+                    first_ambiguous = (
                         f"ambiguous_{kind}_match: "
                         + ", ".join(f"{c.name}@0x{c.base:08X}" for c in unique)
                     )
-        return None
+        return first_ambiguous
 
     def _resolve_mapped_module_by_name(self, name: str) -> Optional[ModuleMapping]:
         aliases = self._aliases_for_name(name)

--- a/debugger/d2/conventions.py
+++ b/debugger/d2/conventions.py
@@ -205,7 +205,8 @@ def parse_convention_from_prototype(prototype: str) -> str:
         "undefined4 FUN_6fd50a30(...)" -> "__cdecl" (default)
     """
     prototype_lower = prototype.lower()
-    for conv in ("__stdcall", "__fastcall", "__thiscall", "__cdecl", "__fastcall_x64", "msvc_x64"):
+    # Check more specific markers before generic substrings (e.g. __fastcall_x64 vs __fastcall).
+    for conv in ("__fastcall_x64", "msvc_x64", "__stdcall", "__fastcall", "__thiscall", "__cdecl"):
         if conv in prototype_lower:
             return conv
     return "__cdecl"  # Default

--- a/debugger/d2/conventions.py
+++ b/debugger/d2/conventions.py
@@ -44,11 +44,11 @@ D2_MODULES = [
 ]
 
 # Conventions recognized by the arg reader
-CONVENTIONS = {"__stdcall", "__fastcall", "__thiscall", "__cdecl"}
+CONVENTIONS = {"__stdcall", "__fastcall", "__thiscall", "__cdecl", "__fastcall_x64", "msvc_x64"}
 
 
 def read_args(registers: Dict[str, int],
-              read_dword_fn,
+              read_ptr_fn,
               convention: str,
               count: int) -> List[int]:
     """Read function arguments at a breakpoint based on calling convention.
@@ -65,6 +65,14 @@ def read_args(registers: Dict[str, int],
     if count <= 0:
         return []
 
+    if convention in ("__fastcall_x64", "msvc_x64"):
+        rsp = registers.get("RSP", 0)
+        reg_args = [registers.get("RCX", 0), registers.get("RDX", 0), registers.get("R8", 0), registers.get("R9", 0)]
+        args = reg_args[:min(count, 4)]
+        for i in range(max(0, count - 4)):
+            args.append(read_ptr_fn(rsp + 0x28 + i * 8))
+        return args[:count]
+
     esp = registers.get("ESP", 0)
     ecx = registers.get("ECX", 0)
     edx = registers.get("EDX", 0)
@@ -78,14 +86,14 @@ def read_args(registers: Dict[str, int],
         # Remaining args on stack starting at ESP+4
         for i in range(max(0, count - 2)):
             addr = esp + 4 + i * 4
-            args.append(read_dword_fn(addr))
+            args.append(read_ptr_fn(addr))
         return args[:count]
 
     elif convention == "__thiscall":
         args = [ecx]  # 'this' pointer
         for i in range(max(0, count - 1)):
             addr = esp + 4 + i * 4
-            args.append(read_dword_fn(addr))
+            args.append(read_ptr_fn(addr))
         return args[:count]
 
     else:
@@ -93,14 +101,15 @@ def read_args(registers: Dict[str, int],
         args = []
         for i in range(count):
             addr = esp + 4 + i * 4
-            args.append(read_dword_fn(addr))
+            args.append(read_ptr_fn(addr))
         return args
 
 
-def read_return_address(registers: Dict[str, int], read_dword_fn) -> int:
-    """Read the return address from the top of the stack at function entry."""
-    esp = registers.get("ESP", 0)
-    return read_dword_fn(esp)
+def read_return_address(registers: Dict[str, int], read_ptr_fn, convention: str = "__stdcall") -> int:
+    """Read the return address from the top of stack at function entry."""
+    if convention in ("__fastcall_x64", "msvc_x64"):
+        return read_ptr_fn(registers.get("RSP", 0))
+    return read_ptr_fn(registers.get("ESP", 0))
 
 
 def classify_value(value: int) -> str:
@@ -196,7 +205,7 @@ def parse_convention_from_prototype(prototype: str) -> str:
         "undefined4 FUN_6fd50a30(...)" -> "__cdecl" (default)
     """
     prototype_lower = prototype.lower()
-    for conv in ("__stdcall", "__fastcall", "__thiscall", "__cdecl"):
+    for conv in ("__stdcall", "__fastcall", "__thiscall", "__cdecl", "__fastcall_x64", "msvc_x64"):
         if conv in prototype_lower:
             return conv
     return "__cdecl"  # Default

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -53,6 +53,8 @@ def _module_info_from_pybag_entry(raw_module: Any) -> ModuleInfo:
 
     if isinstance(raw_module, tuple) and len(raw_module) == 2:
         name_info, params = raw_module
+        image_path = ""
+        loaded_name = ""
         if isinstance(name_info, tuple):
             image_path = str(name_info[0]) if len(name_info) > 0 and name_info[0] else ""
             short_name = str(name_info[1]) if len(name_info) > 1 and name_info[1] else ""
@@ -65,14 +67,28 @@ def _module_info_from_pybag_entry(raw_module: Any) -> ModuleInfo:
         size = getattr(params, "Size", getattr(params, "size", None))
         if runtime_base is None or size is None:
             raise ValueError(f"Unsupported pybag module tuple: {raw_module!r}")
-        return ModuleInfo(name=name, runtime_base=int(runtime_base), size=int(size))
+        return ModuleInfo(
+            name=name,
+            runtime_base=int(runtime_base),
+            size=int(size),
+            image_path=image_path or None,
+            loaded_name=loaded_name or None,
+        )
 
     name = getattr(raw_module, "name", None)
     runtime_base = getattr(raw_module, "runtime_base", getattr(raw_module, "base", getattr(raw_module, "Base", None)))
     size = getattr(raw_module, "size", getattr(raw_module, "Size", None))
     if name is None or runtime_base is None or size is None:
         raise ValueError(f"Unsupported pybag module entry: {raw_module!r}")
-    return ModuleInfo(name=str(name), runtime_base=int(runtime_base), size=int(size))
+    image_path = getattr(raw_module, "image_path", getattr(raw_module, "ImageName", None))
+    loaded_name = getattr(raw_module, "loaded_name", getattr(raw_module, "LoadedImageName", None))
+    return ModuleInfo(
+        name=str(name),
+        runtime_base=int(runtime_base),
+        size=int(size),
+        image_path=str(image_path) if image_path else None,
+        loaded_name=str(loaded_name) if loaded_name else None,
+    )
 
 
 def _register_query_plan(bitness: str) -> List[Tuple[str, str]]:

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -230,6 +230,11 @@ class EngineEventHandler:
 # DebugEngine — main API
 # ---------------------------------------------------------------------------
 
+def _fmt_addr(value: int) -> str:
+    width = 16 if value > 0xFFFFFFFF else 8
+    return f"0x{value:0{width}X}"
+
+
 class DebugEngine:
     """
     Wraps pybag's dbgeng with proper COM threading.
@@ -496,7 +501,7 @@ class DebugEngine:
     def _step_into_impl(self, count: int) -> dict:
         self._require_stopped()
         self._base.stepi(count)
-        return {"state": "stopped", "pc": f"0x{self._read_pc_impl():08X}"}
+        return {"state": "stopped", "pc": _fmt_addr(self._read_pc_impl())}
 
     def step_over(self, count: int = 1) -> dict:
         """Step over (proceed)."""
@@ -505,7 +510,7 @@ class DebugEngine:
     def _step_over_impl(self, count: int) -> dict:
         self._require_stopped()
         self._base.stepo(count)
-        return {"state": "stopped", "pc": f"0x{self._read_pc_impl():08X}"}
+        return {"state": "stopped", "pc": _fmt_addr(self._read_pc_impl())}
 
     # -- State inspection --------------------------------------------------
 
@@ -596,10 +601,10 @@ class DebugEngine:
                         break
                     entry: dict = {
                         "level": i,
-                        "instruction_offset": f"0x{frame.InstructionOffset:08X}",
-                        "return_offset": f"0x{frame.ReturnOffset:08X}",
-                        "stack_offset": f"0x{frame.StackOffset:08X}",
-                        "frame_offset": f"0x{frame.FrameOffset:08X}",
+                        "instruction_offset": _fmt_addr(frame.InstructionOffset),
+                        "return_offset": _fmt_addr(frame.ReturnOffset),
+                        "stack_offset": _fmt_addr(frame.StackOffset),
+                        "frame_offset": _fmt_addr(frame.FrameOffset),
                     }
                     try:
                         name = self._base.get_name_by_offset(frame.InstructionOffset)
@@ -644,7 +649,7 @@ class DebugEngine:
                 handler=handler,
                 oneshot=oneshot,
             )
-        logger.info(f"Breakpoint #{bp_id} set at 0x{address:08X} "
+        logger.info(f"Breakpoint #{bp_id} set at {_fmt_addr(address)} "
                     f"(type={bp_type.value}, oneshot={oneshot})")
         return bp_id
 
@@ -688,7 +693,7 @@ class DebugEngine:
             access=access,
             handler=handler,
         )
-        logger.info(f"Data breakpoint #{bp_id} at 0x{address:08X} "
+        logger.info(f"Data breakpoint #{bp_id} at {_fmt_addr(address)} "
                     f"(size={size}, access=0x{access:X})")
         return bp_id
 
@@ -707,7 +712,7 @@ class DebugEngine:
                 bp_type = bp_obj.GetType()
                 result.append({
                     "id": bp_id,
-                    "address": f"0x{offset:08X}",
+                    "address": _fmt_addr(offset),
                     "enabled": bool(flags & DbgEng.DEBUG_BREAKPOINT_ENABLED),
                     "oneshot": bool(flags & DbgEng.DEBUG_BREAKPOINT_ONE_SHOT),
                     "type": "data" if bp_type[0] == DbgEng.DEBUG_BREAKPOINT_DATA else "code",

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -573,9 +573,14 @@ class DebugEngine:
         data = self.read_memory(address, 4)
         return struct.unpack("<I", data)[0]
 
+    def read_qword(self, address: int) -> int:
+        """Read a 64-bit value from memory."""
+        data = self.read_memory(address, 8)
+        return struct.unpack("<Q", data)[0]
+
     def read_pointer(self, address: int) -> int:
-        """Read a pointer-sized value (32-bit for x86)."""
-        return self.read_dword(address)
+        """Read a pointer-sized value based on effective target bitness."""
+        return self.read_qword(address) if self._get_effective_bitness_impl() == "64" else self.read_dword(address)
 
     def get_stack_trace(self, depth: int = 20) -> List[dict]:
         """Get stack backtrace."""

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -585,7 +585,14 @@ class DebugEngine:
 
     def read_pointer(self, address: int) -> int:
         """Read a pointer-sized value based on effective target bitness."""
-        return self.read_qword(address) if self._get_effective_bitness_impl() == "64" else self.read_dword(address)
+        return self._run_on_engine(self._read_pointer_impl, address)
+
+    def _read_pointer_impl(self, address: int) -> int:
+        self._require_stopped()
+        bitness = self._get_effective_bitness_impl()
+        if bitness == "64":
+            return struct.unpack("<Q", self._read_memory_impl(address, 8))[0]
+        return struct.unpack("<I", self._read_memory_impl(address, 4))[0]
 
     def get_stack_trace(self, depth: int = 20) -> List[dict]:
         """Get stack backtrace."""

--- a/debugger/protocol.py
+++ b/debugger/protocol.py
@@ -33,6 +33,11 @@ class ModuleInfo:
     runtime_base: int
     size: int
     ghidra_base: Optional[int] = None
+    image_path: Optional[str] = None
+    loaded_name: Optional[str] = None
+    ghidra_name: Optional[str] = None
+    match_kind: Optional[str] = None
+    match_key: Optional[str] = None
 
     def to_dict(self) -> dict:
         d = {
@@ -40,9 +45,19 @@ class ModuleInfo:
             "runtime_base": f"0x{self.runtime_base:08X}",
             "size": f"0x{self.size:X}",
         }
+        if self.image_path:
+            d["image_path"] = self.image_path
+        if self.loaded_name:
+            d["loaded_name"] = self.loaded_name
         if self.ghidra_base is not None:
             d["ghidra_base"] = f"0x{self.ghidra_base:08X}"
             d["offset"] = f"0x{self.runtime_base - self.ghidra_base:+X}"
+        if self.ghidra_name:
+            d["ghidra_name"] = self.ghidra_name
+        if self.match_kind:
+            d["match_kind"] = self.match_kind
+        if self.match_key:
+            d["match_key"] = self.match_key
         return d
 
 

--- a/debugger/protocol.py
+++ b/debugger/protocol.py
@@ -94,7 +94,7 @@ class BreakpointInfo:
 class TraceEntry:
     timestamp: float
     trace_id: int
-    ghidra_address: int
+    ghidra_address: Optional[int]
     module: str
     args: list[int]
     arg_names: Optional[list[str]] = None
@@ -108,7 +108,7 @@ class TraceEntry:
         d: dict = {
             "timestamp": round(self.timestamp, 4),
             "trace_id": self.trace_id,
-            "ghidra_address": _hex_addr(self.ghidra_address),
+            "ghidra_address": _hex_addr(self.ghidra_address) if self.ghidra_address is not None else None,
             "module": self.module,
         }
         if self.arg_names and len(self.arg_names) == len(self.args):
@@ -133,7 +133,7 @@ class TraceEntry:
 @dataclass
 class TracePointInfo:
     trace_id: int
-    ghidra_address: int
+    ghidra_address: Optional[int]
     module: str
     convention: str
     arg_count: int
@@ -146,7 +146,7 @@ class TracePointInfo:
     def to_dict(self) -> dict:
         return {
             "trace_id": self.trace_id,
-            "ghidra_address": _hex_addr(self.ghidra_address),
+            "ghidra_address": _hex_addr(self.ghidra_address) if self.ghidra_address is not None else None,
             "module": self.module,
             "convention": self.convention,
             "arg_count": self.arg_count,

--- a/debugger/protocol.py
+++ b/debugger/protocol.py
@@ -8,6 +8,11 @@ from enum import Enum
 from typing import Optional
 
 
+def _hex_addr(value: int) -> str:
+    width = 16 if value > 0xFFFFFFFF else 8
+    return f"0x{value:0{width}X}"
+
+
 class DebuggerState(str, Enum):
     DETACHED = "detached"
     ATTACHED = "attached"
@@ -42,7 +47,7 @@ class ModuleInfo:
     def to_dict(self) -> dict:
         d = {
             "name": self.name,
-            "runtime_base": f"0x{self.runtime_base:08X}",
+            "runtime_base": _hex_addr(self.runtime_base),
             "size": f"0x{self.size:X}",
         }
         if self.image_path:
@@ -50,7 +55,7 @@ class ModuleInfo:
         if self.loaded_name:
             d["loaded_name"] = self.loaded_name
         if self.ghidra_base is not None:
-            d["ghidra_base"] = f"0x{self.ghidra_base:08X}"
+            d["ghidra_base"] = _hex_addr(self.ghidra_base)
             d["offset"] = f"0x{self.runtime_base - self.ghidra_base:+X}"
         if self.ghidra_name:
             d["ghidra_name"] = self.ghidra_name
@@ -75,8 +80,8 @@ class BreakpointInfo:
     def to_dict(self) -> dict:
         return {
             "id": self.bp_id,
-            "runtime_address": f"0x{self.runtime_address:08X}",
-            "ghidra_address": f"0x{self.ghidra_address:08X}" if self.ghidra_address else None,
+            "runtime_address": _hex_addr(self.runtime_address),
+            "ghidra_address": _hex_addr(self.ghidra_address) if self.ghidra_address is not None else None,
             "module": self.module,
             "type": self.bp_type.value,
             "enabled": self.enabled,
@@ -103,21 +108,21 @@ class TraceEntry:
         d: dict = {
             "timestamp": round(self.timestamp, 4),
             "trace_id": self.trace_id,
-            "ghidra_address": f"0x{self.ghidra_address:08X}",
+            "ghidra_address": _hex_addr(self.ghidra_address),
             "module": self.module,
         }
         if self.arg_names and len(self.arg_names) == len(self.args):
             d["args"] = {
-                name: f"0x{val:08X}" for name, val in zip(self.arg_names, self.args)
+                name: _hex_addr(val) for name, val in zip(self.arg_names, self.args)
             }
         else:
-            d["args"] = [f"0x{v:08X}" for v in self.args]
+            d["args"] = [_hex_addr(v) for v in self.args]
         if self.return_value is not None:
-            d["return_value"] = f"0x{self.return_value:08X}"
+            d["return_value"] = _hex_addr(self.return_value)
         if self.caller is not None:
-            d["caller"] = f"0x{self.caller:08X}"
+            d["caller"] = _hex_addr(self.caller)
         if self.caller_ghidra is not None:
-            d["caller_ghidra"] = f"0x{self.caller_ghidra:08X}"
+            d["caller_ghidra"] = _hex_addr(self.caller_ghidra)
         if self.caller_symbol:
             d["caller_symbol"] = self.caller_symbol
         if self.thread_id is not None:
@@ -141,7 +146,7 @@ class TracePointInfo:
     def to_dict(self) -> dict:
         return {
             "trace_id": self.trace_id,
-            "ghidra_address": f"0x{self.ghidra_address:08X}",
+            "ghidra_address": _hex_addr(self.ghidra_address),
             "module": self.module,
             "convention": self.convention,
             "arg_count": self.arg_count,
@@ -170,18 +175,18 @@ class WatchHit:
         d: dict = {
             "timestamp": round(self.timestamp, 4),
             "watch_id": self.watch_id,
-            "address": f"0x{self.address:08X}",
+            "address": _hex_addr(self.address),
             "size": self.size,
             "access": self.access,
         }
         if self.ghidra_address is not None:
-            d["ghidra_address"] = f"0x{self.ghidra_address:08X}"
+            d["ghidra_address"] = _hex_addr(self.ghidra_address)
         if self.value is not None:
-            d["value"] = f"0x{self.value:08X}"
+            d["value"] = _hex_addr(self.value)
         if self.accessor_address is not None:
-            d["accessor"] = f"0x{self.accessor_address:08X}"
+            d["accessor"] = _hex_addr(self.accessor_address)
         if self.accessor_ghidra is not None:
-            d["accessor_ghidra"] = f"0x{self.accessor_ghidra:08X}"
+            d["accessor_ghidra"] = _hex_addr(self.accessor_ghidra)
         if self.accessor_symbol:
             d["accessor_symbol"] = self.accessor_symbol
         return d

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -197,20 +197,47 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def _handle_sync_modules(self, body: dict):
         ds = self._ds()
-        ghidra_bases = body.get("ghidra_bases", {})
-        ghidra_modules = body.get("ghidra_modules", [])
+        ghidra_bases = body.get("ghidra_bases")
+        ghidra_modules = body.get("ghidra_modules")
+
+        if ghidra_bases is None:
+            ghidra_bases = {}
+        if ghidra_modules is None:
+            ghidra_modules = []
+
+        if not isinstance(ghidra_bases, dict):
+            self._send_error(400, "'ghidra_bases' must be an object")
+            return
+
+        if not isinstance(ghidra_modules, list):
+            self._send_error(400, "'ghidra_modules' must be a list")
+            return
+
+        for i, entry in enumerate(ghidra_modules):
+            if not isinstance(entry, dict):
+                self._send_error(400, f"'ghidra_modules[{i}]' must be an object")
+                return
+
         if not ghidra_bases and not ghidra_modules:
             self._send_error(400, "Missing 'ghidra_bases' dict or 'ghidra_modules' list")
             return
+
         # Convert hex string values to int if needed
         parsed_bases = {}
         for name, base in ghidra_bases.items():
-            if isinstance(base, str):
-                parsed_bases[name] = (
-                    int(base, 16) if base.casefold().startswith("0x") else int(base)
+            try:
+                if isinstance(base, str):
+                    parsed_bases[name] = (
+                        int(base, 16) if base.casefold().startswith("0x") else int(base)
+                    )
+                else:
+                    parsed_bases[name] = int(base)
+            except (TypeError, ValueError) as exc:
+                self._send_error(
+                    400,
+                    f"Invalid base for ghidra_bases[{name!r}]: {base!r} ({exc})",
                 )
-            else:
-                parsed_bases[name] = int(base)
+                return
 
         runtime_modules = ds.engine.get_modules()
         result = ds.mapper.update_from_modules(

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -186,28 +186,36 @@ class RequestHandler(BaseHTTPRequestHandler):
         # Enrich with Ghidra bases from mapper
         result = []
         for mod in modules:
-            mapping = ds.mapper.get_module(mod.name)
+            mapping = ds.mapper.get_mapping_for_runtime_module(mod)
             if mapping:
                 mod.ghidra_base = mapping.ghidra_base
+                mod.ghidra_name = mapping.ghidra_name
+                mod.match_kind = mapping.match_kind
+                mod.match_key = mapping.match_key
             result.append(mod.to_dict())
         self._send_json({"modules": result, "count": len(result)})
 
     def _handle_sync_modules(self, body: dict):
         ds = self._ds()
         ghidra_bases = body.get("ghidra_bases", {})
-        if not ghidra_bases:
-            self._send_error(400, "Missing 'ghidra_bases' dict")
+        ghidra_modules = body.get("ghidra_modules", [])
+        if not ghidra_bases and not ghidra_modules:
+            self._send_error(400, "Missing 'ghidra_bases' dict or 'ghidra_modules' list")
             return
         # Convert hex string values to int if needed
         parsed_bases = {}
         for name, base in ghidra_bases.items():
             if isinstance(base, str):
-                parsed_bases[name] = int(base, 16) if base.startswith("0x") else int(base)
+                parsed_bases[name] = (
+                    int(base, 16) if base.casefold().startswith("0x") else int(base)
+                )
             else:
                 parsed_bases[name] = int(base)
 
         runtime_modules = ds.engine.get_modules()
-        result = ds.mapper.update_from_modules(runtime_modules, parsed_bases)
+        result = ds.mapper.update_from_modules(
+            runtime_modules, parsed_bases, ghidra_modules=ghidra_modules
+        )
         self._send_json(result)
 
     def _handle_address_map(self):
@@ -215,13 +223,21 @@ class RequestHandler(BaseHTTPRequestHandler):
         modules = ds.mapper.get_all_modules()
         result = []
         for m in modules:
-            result.append({
+            item = {
                 "name": m.name,
+                "ghidra_name": m.ghidra_name,
                 "ghidra_base": f"0x{m.ghidra_base:08X}",
                 "runtime_base": f"0x{m.runtime_base:08X}",
                 "size": f"0x{m.size:X}",
                 "offset": f"0x{m.offset:+X}",
-            })
+                "match_kind": m.match_kind,
+                "match_key": m.match_key,
+            }
+            if m.image_path:
+                item["image_path"] = m.image_path
+            if m.loaded_name:
+                item["loaded_name"] = m.loaded_name
+            result.append(item)
         self._send_json({"mappings": result, "count": len(result)})
 
     def _handle_registers(self):

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -462,10 +462,15 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._send_error(400, "Missing 'ghidra_address' or 'runtime_address'")
             return
 
-        ghidra_addr = int(ghidra_addr_str, 16) if ghidra_addr_str else None
+        ghidra_addr = None
+        if ghidra_addr_str not in (None, ""):
+            ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+
         arg_names = [n.strip() for n in arg_names_str.split(",") if n.strip()] if arg_names_str else None
 
-        runtime_addr = int(runtime_addr_str, 16) if runtime_addr_str else None
+        runtime_addr = None
+        if runtime_addr_str not in (None, ""):
+            runtime_addr = int(runtime_addr_str, 16) if isinstance(runtime_addr_str, str) else int(runtime_addr_str)
 
         trace_id = tracer.add_function_trace(
             ghidra_address=ghidra_addr,
@@ -532,8 +537,13 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._send_error(400, "Missing 'ghidra_address' or 'runtime_address'")
             return
 
-        ghidra_addr = int(ghidra_addr_str, 16) if ghidra_addr_str else None
-        runtime_addr = int(runtime_addr_str, 16) if runtime_addr_str else None
+        ghidra_addr = None
+        if ghidra_addr_str not in (None, ""):
+            ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+
+        runtime_addr = None
+        if runtime_addr_str not in (None, ""):
+            runtime_addr = int(runtime_addr_str, 16) if isinstance(runtime_addr_str, str) else int(runtime_addr_str)
 
         watch_id = tracer.add_data_watch(
             ghidra_address=ghidra_addr,

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -533,10 +533,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
 
         ghidra_addr = int(ghidra_addr_str, 16) if ghidra_addr_str else None
+        runtime_addr = int(runtime_addr_str, 16) if runtime_addr_str else None
 
         watch_id = tracer.add_data_watch(
             ghidra_address=ghidra_addr,
             module=module,
+            runtime_address=runtime_addr,
             size=size,
             access=access,
         )

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -72,6 +72,11 @@ class RequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         logger.debug(format, *args)
 
+    @staticmethod
+    def _fmt_addr(value: int) -> str:
+        width = 16 if value > 0xFFFFFFFF else 8
+        return f"0x{value:0{width}X}"
+
     # -- Routing -----------------------------------------------------------
 
     def do_GET(self):
@@ -253,8 +258,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             item = {
                 "name": m.name,
                 "ghidra_name": m.ghidra_name,
-                "ghidra_base": f"0x{m.ghidra_base:08X}",
-                "runtime_base": f"0x{m.runtime_base:08X}",
+                "ghidra_base": self._fmt_addr(m.ghidra_base),
+                "runtime_base": self._fmt_addr(m.runtime_base),
                 "size": f"0x{m.size:X}",
                 "offset": f"0x{m.offset:+X}",
                 "match_kind": m.match_kind,
@@ -270,7 +275,7 @@ class RequestHandler(BaseHTTPRequestHandler):
     def _handle_registers(self):
         ds = self._ds()
         regs = ds.engine.get_registers()
-        formatted = {k: f"0x{v:08X}" for k, v in regs.items()}
+        formatted = {k: self._fmt_addr(v) for k, v in regs.items()}
         self._send_json({"registers": formatted})
 
     def _handle_memory(self, query: dict):
@@ -300,7 +305,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             dwords.append(f"0x{val:08X}")
 
         self._send_json({
-            "address": f"0x{address:08X}",
+            "address": self._fmt_addr(address),
             "size": len(data),
             "hex": hex_str,
             "dwords": dwords,
@@ -319,7 +324,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 mapped = ds.mapper.try_to_ghidra(addr)
                 if mapped:
                     frame["ghidra_module"] = mapped[0]
-                    frame["ghidra_address"] = f"0x{mapped[1]:08X}"
+                    frame["ghidra_address"] = self._fmt_addr(mapped[1])
 
         self._send_json({"frames": frames, "depth": len(frames)})
 
@@ -335,7 +340,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         names = [n.strip() for n in arg_names.split(",")] if arg_names else []
         result_args = []
         for i, val in enumerate(args):
-            entry: dict = {"index": i, "value": f"0x{val:08X}"}
+            entry: dict = {"index": i, "value": self._fmt_addr(val)}
             if i < len(names) and names[i]:
                 entry["name"] = names[i]
             entry["classification"] = classify_value(val)
@@ -396,8 +401,8 @@ class RequestHandler(BaseHTTPRequestHandler):
 
         self._send_json({
             "id": bp_id,
-            "runtime_address": f"0x{runtime_addr:08X}",
-            "ghidra_address": f"0x{ghidra_addr:08X}" if ghidra_addr else None,
+            "runtime_address": self._fmt_addr(runtime_addr),
+            "ghidra_address": self._fmt_addr(ghidra_addr) if ghidra_addr is not None else None,
             "module": module,
             "type": bp_type.value,
             "oneshot": oneshot,
@@ -420,7 +425,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 mapped = ds.mapper.try_to_ghidra(addr)
                 if mapped:
                     bp["ghidra_module"] = mapped[0]
-                    bp["ghidra_address"] = f"0x{mapped[1]:08X}"
+                    bp["ghidra_address"] = self._fmt_addr(mapped[1])
 
         self._send_json({"breakpoints": bps, "count": len(bps)})
 

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -330,7 +330,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         arg_names = query.get("arg_names", "")
 
         regs = ds.engine.get_registers()
-        args = read_args(regs, ds.engine.read_dword, convention, count)
+        args = read_args(regs, ds.engine.read_pointer, convention, count)
 
         names = [n.strip() for n in arg_names.split(",")] if arg_names else []
         result_args = []
@@ -344,7 +344,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         self._send_json({
             "convention": convention,
             "args": result_args,
-            "return_address": f"0x{read_return_address(regs, ds.engine.read_dword):08X}",
+            "return_address": f"0x{read_return_address(regs, ds.engine.read_pointer, convention):X}",
         })
 
     def _handle_go(self):
@@ -445,6 +445,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         tracer = ds._ensure_tracer()
 
         ghidra_addr_str = body.get("ghidra_address", "")
+        runtime_addr_str = body.get("runtime_address", "")
         module = body.get("module", "")
         convention = body.get("convention", "__stdcall")
         arg_count = int(body.get("arg_count", 4))
@@ -452,15 +453,18 @@ class RequestHandler(BaseHTTPRequestHandler):
         capture_return = body.get("capture_return", False)
         max_hits = int(body.get("max_hits", 0))
 
-        if not ghidra_addr_str:
-            self._send_error(400, "Missing 'ghidra_address'")
+        if not ghidra_addr_str and not runtime_addr_str:
+            self._send_error(400, "Missing 'ghidra_address' or 'runtime_address'")
             return
 
-        ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+        ghidra_addr = int(ghidra_addr_str, 16) if ghidra_addr_str else None
         arg_names = [n.strip() for n in arg_names_str.split(",") if n.strip()] if arg_names_str else None
+
+        runtime_addr = int(runtime_addr_str, 16) if runtime_addr_str else None
 
         trace_id = tracer.add_function_trace(
             ghidra_address=ghidra_addr,
+            runtime_address=runtime_addr,
             module=module,
             convention=convention,
             arg_count=arg_count,
@@ -514,15 +518,16 @@ class RequestHandler(BaseHTTPRequestHandler):
         tracer = ds._ensure_tracer()
 
         ghidra_addr_str = body.get("ghidra_address", "")
+        runtime_addr_str = body.get("runtime_address", "")
         module = body.get("module", "")
         size = int(body.get("size", 4))
         access = body.get("access", "write")
 
-        if not ghidra_addr_str:
-            self._send_error(400, "Missing 'ghidra_address'")
+        if not ghidra_addr_str and not runtime_addr_str:
+            self._send_error(400, "Missing 'ghidra_address' or 'runtime_address'")
             return
 
-        ghidra_addr = int(ghidra_addr_str, 16) if isinstance(ghidra_addr_str, str) else int(ghidra_addr_str)
+        ghidra_addr = int(ghidra_addr_str, 16) if ghidra_addr_str else None
 
         watch_id = tracer.add_data_watch(
             ghidra_address=ghidra_addr,

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -36,7 +36,7 @@ MAX_WATCH_LOG_SIZE = 5_000
 class _ActiveTrace:
     """Internal state for an active function trace."""
     trace_id: int
-    ghidra_address: int
+    ghidra_address: Optional[int]
     runtime_address: int
     module: str
     convention: str
@@ -53,7 +53,7 @@ class _ActiveTrace:
 class _ActiveWatch:
     """Internal state for an active data watchpoint."""
     watch_id: int
-    ghidra_address: int
+    ghidra_address: Optional[int]
     runtime_address: int
     module: str
     size: int
@@ -108,7 +108,7 @@ class TraceSession:
             Trace ID.
         """
         runtime_addr = runtime_address if runtime_address is not None else self._mapper.to_runtime(int(ghidra_address), module or None)
-        ghidra_addr_value = ghidra_address if ghidra_address is not None else 0
+        ghidra_addr_value = ghidra_address
 
         trace_id = self._next_trace_id
         self._next_trace_id += 1
@@ -301,7 +301,7 @@ class TraceSession:
                 "Stop an existing watchpoint first.")
 
         runtime_addr = runtime_address if runtime_address is not None else self._mapper.to_runtime(int(ghidra_address), module or None)
-        ghidra_addr_value = ghidra_address if ghidra_address is not None else 0
+        ghidra_addr_value = ghidra_address
 
         watch_id = self._next_watch_id
         self._next_watch_id += 1

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -187,8 +187,10 @@ class TraceSession:
         with self._lock:
             self._traces[trace_id] = trace
 
+        origin_addr = ghidra_addr_value if ghidra_address is not None else runtime_addr
+        origin_kind = "ghidra" if ghidra_address is not None else "runtime"
         logger.info(
-            f"Trace #{trace_id} started: 0x{ghidra_address:08X} ({module}) "
+            f"Trace #{trace_id} started: 0x{origin_addr:X} ({origin_kind}, {module}) "
             f"[{convention}, {arg_count} args, "
             f"capture_return={capture_return}, max_hits={max_hits}]")
         return trace_id
@@ -373,8 +375,10 @@ class TraceSession:
         with self._lock:
             self._watches[watch_id] = watch
 
+        origin_addr = ghidra_addr_value if ghidra_address is not None else runtime_addr
+        origin_kind = "ghidra" if ghidra_address is not None else "runtime"
         logger.info(
-            f"Watch #{watch_id} set at 0x{ghidra_address:08X} ({module}) "
+            f"Watch #{watch_id} set at 0x{origin_addr:X} ({origin_kind}, {module}) "
             f"[size={size}, access={access}]")
         return watch_id
 

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -138,8 +138,18 @@ class TraceSession:
 
                 regs = self._engine._collect_registers_impl()
 
-                args = read_args(regs, self._engine.read_pointer, convention, arg_count)
-                caller = read_return_address(regs, self._engine.read_pointer, convention)
+                # NOTE: This callback runs while execution is still flowing
+                # (DEBUG_STATUS_GO_HANDLED). Use direct engine-thread reads
+                # instead of DebugEngine.read_pointer(), which enforces a
+                # stopped debugger state and would fail for live traces.
+                def _read_pointer_live(address: int) -> int:
+                    bitness = self._engine._get_effective_bitness_impl()
+                    size = 8 if bitness == "64" else 4
+                    data = bytes(self._engine._base.read(address, size))
+                    return struct.unpack("<Q" if size == 8 else "<I", data)[0]
+
+                args = read_args(regs, _read_pointer_live, convention, arg_count)
+                caller = read_return_address(regs, _read_pointer_live, convention)
 
                 # Map caller to Ghidra address
                 caller_ghidra = None

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -107,6 +107,10 @@ class TraceSession:
         Returns:
             Trace ID.
         """
+        if runtime_address is None and ghidra_address is None:
+            raise ValueError("Either ghidra_address or runtime_address is required")
+
+
         runtime_addr = runtime_address if runtime_address is not None else self._mapper.to_runtime(int(ghidra_address), module or None)
         ghidra_addr_value = ghidra_address
 
@@ -299,6 +303,9 @@ class TraceSession:
             raise RuntimeError(
                 "x86 hardware breakpoint limit reached (4 max). "
                 "Stop an existing watchpoint first.")
+
+        if runtime_address is None and ghidra_address is None:
+            raise ValueError("Either ghidra_address or runtime_address is required")
 
         runtime_addr = runtime_address if runtime_address is not None else self._mapper.to_runtime(int(ghidra_address), module or None)
         ghidra_addr_value = ghidra_address

--- a/debugger/tracing.py
+++ b/debugger/tracing.py
@@ -81,8 +81,9 @@ class TraceSession:
 
     def add_function_trace(
         self,
-        ghidra_address: int,
+        ghidra_address: Optional[int],
         module: str,
+        runtime_address: Optional[int] = None,
         convention: str = "__stdcall",
         arg_count: int = 4,
         arg_names: Optional[List[str]] = None,
@@ -106,14 +107,15 @@ class TraceSession:
         Returns:
             Trace ID.
         """
-        runtime_addr = self._mapper.to_runtime(ghidra_address, module or None)
+        runtime_addr = runtime_address if runtime_address is not None else self._mapper.to_runtime(int(ghidra_address), module or None)
+        ghidra_addr_value = ghidra_address if ghidra_address is not None else 0
 
         trace_id = self._next_trace_id
         self._next_trace_id += 1
 
         trace = _ActiveTrace(
             trace_id=trace_id,
-            ghidra_address=ghidra_address,
+            ghidra_address=ghidra_addr_value,
             runtime_address=runtime_addr,
             module=module,
             convention=convention,
@@ -136,9 +138,8 @@ class TraceSession:
 
                 regs = self._engine._collect_registers_impl()
 
-                args = read_args(regs, lambda a: struct.unpack("<I", base.read(a, 4))[0],
-                                 convention, arg_count)
-                caller = struct.unpack("<I", base.read(regs["ESP"], 4))[0]
+                args = read_args(regs, self._engine.read_pointer, convention, arg_count)
+                caller = read_return_address(regs, self._engine.read_pointer, convention)
 
                 # Map caller to Ghidra address
                 caller_ghidra = None
@@ -154,7 +155,7 @@ class TraceSession:
                 entry = TraceEntry(
                     timestamp=time.monotonic(),
                     trace_id=trace_id,
-                    ghidra_address=ghidra_address,
+                    ghidra_address=ghidra_addr_value,
                     module=module,
                     args=args,
                     arg_names=arg_names,
@@ -261,8 +262,9 @@ class TraceSession:
 
     def add_data_watch(
         self,
-        ghidra_address: int,
+        ghidra_address: Optional[int],
         module: str,
+        runtime_address: Optional[int] = None,
         size: int = 4,
         access: str = "write",
     ) -> int:
@@ -286,14 +288,15 @@ class TraceSession:
                 "x86 hardware breakpoint limit reached (4 max). "
                 "Stop an existing watchpoint first.")
 
-        runtime_addr = self._mapper.to_runtime(ghidra_address, module or None)
+        runtime_addr = runtime_address if runtime_address is not None else self._mapper.to_runtime(int(ghidra_address), module or None)
+        ghidra_addr_value = ghidra_address if ghidra_address is not None else 0
 
         watch_id = self._next_watch_id
         self._next_watch_id += 1
 
         watch = _ActiveWatch(
             watch_id=watch_id,
-            ghidra_address=ghidra_address,
+            ghidra_address=ghidra_addr_value,
             runtime_address=runtime_addr,
             module=module,
             size=size,
@@ -347,7 +350,7 @@ class TraceSession:
                     timestamp=time.monotonic(),
                     watch_id=watch_id,
                     address=runtime_addr,
-                    ghidra_address=ghidra_address,
+                    ghidra_address=ghidra_addr_value,
                     size=size,
                     access=access,
                     value=value,

--- a/tests/unit/test_address_map.py
+++ b/tests/unit/test_address_map.py
@@ -121,6 +121,51 @@ class TestAddressMapper:
         assert "A.dll" in result["mapped_modules"]
         assert "B.dll" in result["unmapped_modules"]
 
+    def test_duplicate_basename_paths_are_reported_ambiguous(self):
+        mapper = AddressMapper()
+        runtime = [
+            ModuleInfo("foo.dll", 0x10000000, 0x1000, image_path="C:/app/foo.dll"),
+            ModuleInfo("foo.dll", 0x20000000, 0x1000, image_path="D:/other/foo.dll"),
+        ]
+        ghidra_modules = [{"id": "foo", "name": "foo.dll", "base": "0x40000000", "names": ["foo.dll"]}]
+        result = mapper.update_from_modules(runtime, ghidra_modules=ghidra_modules)
+        assert result["mapped"] == 0
+        assert result["ambiguous"] >= 1
+
+    def test_extensionless_module_name_resolves_when_unique(self):
+        mapper = AddressMapper()
+        runtime = [ModuleInfo("D2Common.dll", 0x74A60000, 0x100000)]
+        result = mapper.update_from_modules(runtime, {"D2Common.dll": 0x6FD60000})
+        assert result["mapped"] == 1
+        assert mapper.to_runtime(0x6FD60000, "D2Common") == 0x74A60000
+
+    def test_partial_ghidra_modules_merges_with_legacy_bases(self):
+        mapper = AddressMapper()
+        runtime = [
+            ModuleInfo("A.exe", 0x140000000, 0x1000),
+            ModuleInfo("B.dll", 0x180000000, 0x1000),
+        ]
+        result = mapper.update_from_modules(
+            runtime,
+            ghidra_bases={"B.dll": "0x280000000"},
+            ghidra_modules=[{"id": "A", "name": "A.exe", "base": "0x240000000", "names": ["A.exe"]}],
+        )
+        assert result["mapped"] == 2
+        assert mapper.require_module("B.dll").ghidra_base == 0x280000000
+
+    def test_malformed_ghidra_modules_entry_raises_value_error(self):
+        mapper = AddressMapper()
+        runtime = [ModuleInfo("A.exe", 0x140000000, 0x1000)]
+        with pytest.raises(ValueError, match="ghidra_modules payload"):
+            mapper.update_from_modules(runtime, ghidra_modules=["bad-entry"])
+
+    def test_to_runtime_with_module_out_of_range_raises(self):
+        mapper = AddressMapper()
+        runtime = [ModuleInfo("D2Common.dll", 0x74A60000, 0x1000)]
+        mapper.update_from_modules(runtime, {"D2Common.dll": 0x6FD60000})
+        with pytest.raises(ValueError, match="outside mapped module"):
+            mapper.to_runtime(0x6FD62000, "D2Common.dll")
+
 
 class TestOrdinalParsing:
     def setup_method(self):

--- a/tests/unit/test_debugger_server.py
+++ b/tests/unit/test_debugger_server.py
@@ -355,6 +355,39 @@ class TestModulesEndpoint:
         assert body["count"] == len(body["modules"])
 
 
+class TestSyncModulesEndpoint:
+    def test_sync_modules_accepts_null_ghidra_bases_with_modules(self, debug_server):
+        base, ds = debug_server
+        ds.engine.get_modules.return_value = [ModuleInfo("A.exe", 0x140000000, 0x1000)]
+        status, _ = _post(
+            base,
+            "/debugger/sync_modules",
+            {
+                "ghidra_bases": None,
+                "ghidra_modules": [{"id": "A", "name": "A.exe", "base": "0x240000000"}],
+            },
+        )
+        assert status == 200
+
+    def test_sync_modules_rejects_non_object_ghidra_bases(self, debug_server):
+        base, _ = debug_server
+        status, body = _post(base, "/debugger/sync_modules", {"ghidra_bases": [], "ghidra_modules": []})
+        assert status == 400
+        assert "ghidra_bases" in body.get("error", "")
+
+    def test_sync_modules_rejects_non_list_ghidra_modules(self, debug_server):
+        base, _ = debug_server
+        status, body = _post(base, "/debugger/sync_modules", {"ghidra_bases": {}, "ghidra_modules": {}})
+        assert status == 400
+        assert "ghidra_modules" in body.get("error", "")
+
+    def test_sync_modules_rejects_non_object_entry(self, debug_server):
+        base, _ = debug_server
+        status, body = _post(base, "/debugger/sync_modules", {"ghidra_modules": ["bad"]})
+        assert status == 400
+        assert "ghidra_modules[0]" in body.get("error", "")
+
+
 # ---------------------------------------------------------------------------
 # Tests: routing
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_debugger_server.py
+++ b/tests/unit/test_debugger_server.py
@@ -422,6 +422,17 @@ class TestRuntimeAddressParity:
         assert body["trace_id"] == 7
         tracer.add_function_trace.assert_called_once()
 
+
+    def test_trace_start_accepts_numeric_runtime_address(self, debug_server):
+        base, ds = debug_server
+        tracer = MagicMock()
+        tracer.add_function_trace.return_value = 11
+        ds._ensure_tracer = MagicMock(return_value=tracer)
+        status, body = _post(base, "/debugger/trace/start", {"runtime_address": 3735928559})
+        assert status == 200
+        assert body["trace_id"] == 11
+        assert tracer.add_function_trace.call_args.kwargs["runtime_address"] == 3735928559
+
     def test_watch_start_accepts_runtime_address(self, debug_server):
         base, ds = debug_server
         tracer = MagicMock()
@@ -431,6 +442,17 @@ class TestRuntimeAddressParity:
         assert status == 200
         assert body["watch_id"] == 9
         tracer.add_data_watch.assert_called_once()
+
+
+    def test_watch_start_accepts_numeric_runtime_address(self, debug_server):
+        base, ds = debug_server
+        tracer = MagicMock()
+        tracer.add_data_watch.return_value = 13
+        ds._ensure_tracer = MagicMock(return_value=tracer)
+        status, body = _post(base, "/debugger/watch/start", {"runtime_address": 3405691582})
+        assert status == 200
+        assert body["watch_id"] == 13
+        assert tracer.add_data_watch.call_args.kwargs["runtime_address"] == 3405691582
 
     def test_trace_start_requires_address(self, debug_server):
         base, _ = debug_server

--- a/tests/unit/test_debugger_server.py
+++ b/tests/unit/test_debugger_server.py
@@ -408,3 +408,38 @@ class TestRouting:
         base, _ = debug_server
         status, _ = _delete(base, "/debugger/nonexistent")
         assert status == 404
+
+
+class TestRuntimeAddressParity:
+
+    def test_trace_start_accepts_runtime_address(self, debug_server):
+        base, ds = debug_server
+        tracer = MagicMock()
+        tracer.add_function_trace.return_value = 7
+        ds._ensure_tracer = MagicMock(return_value=tracer)
+        status, body = _post(base, "/debugger/trace/start", {"runtime_address": "0x140001000"})
+        assert status == 200
+        assert body["trace_id"] == 7
+        tracer.add_function_trace.assert_called_once()
+
+    def test_watch_start_accepts_runtime_address(self, debug_server):
+        base, ds = debug_server
+        tracer = MagicMock()
+        tracer.add_data_watch.return_value = 9
+        ds._ensure_tracer = MagicMock(return_value=tracer)
+        status, body = _post(base, "/debugger/watch/start", {"runtime_address": "0x140002000"})
+        assert status == 200
+        assert body["watch_id"] == 9
+        tracer.add_data_watch.assert_called_once()
+
+    def test_trace_start_requires_address(self, debug_server):
+        base, _ = debug_server
+        status, body = _post(base, "/debugger/trace/start", {})
+        assert status == 400
+        assert "ghidra_address" in body.get("error", "")
+
+    def test_watch_start_requires_address(self, debug_server):
+        base, _ = debug_server
+        status, body = _post(base, "/debugger/watch/start", {})
+        assert status == 400
+        assert "ghidra_address" in body.get("error", "")


### PR DESCRIPTION
# Make debugger module mapping collision-safe

## Summary

This PR improves the debugger module synchronization and Ghidra-to-runtime address mapping logic.

The current debugger address mapper relies on simplified module-name normalization. That can fail when Ghidra and dbgeng expose the same Windows module under different names, or when different modules collapse to the same normalized key.

Examples:

```text
Example Program - Retail.exe
Example_Program___Retail_exe
exampleprogramretail.exe
Example Program - Retail.dll
D2Common
D2Common.dll
```

The previous mapping model could either fail to map valid modules, or worse, silently map a Ghidra address against the wrong runtime module.

This PR makes module mapping more explicit, preserves useful compatibility aliases, and fails closed on ambiguity.

---

## Why this is needed

When setting a breakpoint, starting a trace, creating a watchpoint, or reading memory from a Ghidra address, the debugger must translate:

```text
Ghidra static address -> RVA -> runtime address
```

That translation is only safe if the Ghidra module and runtime module are matched unambiguously.

The old model effectively behaved like:

```text
normalized_name -> module
```

This is unsafe because distinct modules can collapse to the same key.

For example:

```text
foo.exe
foo.dll
```

or:

```text
Foo Bar.exe
foobar.exe
```

A permissive normalizer can collapse these into the same alias. In live debugging, silently choosing the wrong module is more dangerous than refusing to map.

---

## What changed

### Debugger address mapper

The address mapper now uses staged alias resolution instead of a single normalized key.

Resolution order:

```text
1. exact name/path
2. basename
3. canonical percent-encoded basename
4. extensionless/stem compatibility alias
5. fuzzy Ghidra/dbgeng-style alias
```

Aliases map to candidate lists, not single modules.

If a match is ambiguous, the mapper returns a clear ambiguity error instead of guessing.

This preserves existing workflows such as:

```text
D2Common -> D2Common.dll
ntdll -> ntdll.dll
kernel32 -> kernel32.dll
```

when the match is unique.

---

### Richer Ghidra sync payload

The bridge can now send a richer `ghidra_modules` payload in addition to the legacy `ghidra_bases` mapping.

Example:

```json
{
  "id": "stable-program-id-or-path",
  "name": "Program.exe",
  "base": "0x140000000",
  "names": [
    "Program.exe",
    "Program_exe",
    "full/path/Program.exe"
  ]
}
```

This allows the debugger to distinguish:

```text
multiple aliases for the same Ghidra program
```

from:

```text
multiple different programs that collide under a fuzzy alias
```

The legacy `ghidra_bases` path remains supported for compatibility.

Mixed payloads are also supported, so clients can send both `ghidra_modules` and `ghidra_bases`.

---

### Manual and automatic sync

Both automatic sync after `debugger_attach()` and manual `debugger_sync_modules()` now use the same sync payload collection logic.

This makes behavior consistent and easier to debug.

---

### API validation

`/debugger/sync_modules` now validates input more strictly:

- `ghidra_bases` may be omitted or null, but must be an object if present.
- `ghidra_modules` may be omitted or null, but must be a list if present.
- each `ghidra_modules` entry must be an object.
- invalid payloads return HTTP 400 instead of causing internal 500 errors.

---

## Behavior change

This PR intentionally makes ambiguous mappings fail closed.

Previously, some ambiguous cases could be accepted silently. With this change, the debugger refuses to translate an address when the module match is not unique.

That is intentional. A clear error is safer than setting a breakpoint, trace, or watchpoint in the wrong module.

---

## Examples

### Safe unique extensionless match

```text
Input module: D2Common
Mapped module: D2Common.dll
```

This still works when unique.

---

### Ambiguous stem match

Runtime modules:

```text
foo.exe
foo.dll
```

Input:

```text
foo
```

Now produces an ambiguity error instead of guessing.

---

### Ghidra/dbgeng naming mismatch

```text
Ghidra: Example_Program___Retail_exe
dbgeng: Example Program - Retail.exe
```

The new alias logic can match these when the result is unique.

---

## Tests

Added or updated targeted tests for:

- unique extensionless module resolution;
- ambiguous extensionless module resolution;
- fuzzy alias collisions;
- exact/path alias overriding broader ambiguous aliases;
- mixed `ghidra_modules` + `ghidra_bases` payloads;
- malformed `ghidra_modules` input;
- `ghidra_bases: null` handling;
- out-of-range Ghidra address translation with explicit module;
- richer debugger module metadata output.

Targeted test command:

```bash
pytest tests/unit/test_address_map.py tests/unit/test_debugger_server.py -v -o addopts=''
```

---

## Risk

The main risk is stricter behavior in ambiguous cases.

Some workflows that previously succeeded by accident may now return an ambiguity error and require a more precise module name or path.

This is a deliberate safety tradeoff for live debugging.

A wrong runtime address can place a breakpoint, trace, or watchpoint in the wrong module. Failing closed is safer.
