### PR TITLE
fix(triage): #180 headless crash + #184 8051 addresses + #183 docker version

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -597,8 +597,8 @@ def sanitize_address(address: str) -> str:
     """Normalize address format for Ghidra AddressFactory.
 
     Handles:
-    - space:0xHEX  -> space:HEX   (strip 0x from offset; AddressFactory rejects 0x after colon)
-    - SPACE:HEX    -> space:HEX   (lowercase space name; AddressFactory is case-sensitive)
+    - space:0xHEX  -> space:HEX   (strip 0x; AddressFactory rejects 0x after colon)
+    - SPACE:HEX    -> SPACE:HEX   (preserve case — AddressFactory is case-sensitive; see #184)
     - 0xHEX        -> 0xhex       (lowercase)
     - HEX          -> 0xHEX       (add 0x prefix)
     """
@@ -609,13 +609,11 @@ def sanitize_address(address: str) -> str:
     # Step 1: handle space:0xHEX form (checked first — 'x' not in [0-9a-fA-F])
     m = SEGMENT_ADDR_WITH_0X_PATTERN.match(address)
     if m:
-        # Lowercase space name; preserve offset case (AddressFactory handles hex case)
-        return f"{m.group(1).lower()}:{m.group(2)}"
+        return f"{m.group(1)}:{m.group(2)}"  # case preserved (#184)
 
-    # Step 2: normalize valid space:HEX form (lowercase space name only)
+    # Step 2: valid space:HEX — pass through unchanged (#184)
     if SEGMENT_ADDRESS_PATTERN.match(address):
-        space, offset = address.split(":", 1)
-        return f"{space.lower()}:{offset}"
+        return address
 
     # Step 3: plain hex normalization (unchanged logic)
     if not address.startswith(("0x", "0X")):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,14 @@
 FROM eclipse-temurin:21-jdk AS builder
 
 # Build arguments
-ARG GHIDRA_VERSION=12.0.3
-ARG GHIDRA_DATE=20260210
+# IMPORTANT: keep GHIDRA_VERSION in sync with pom.xml's <ghidra.version>.
+# The Maven build resolves ghidra:* artifacts at this exact version, and the
+# install-file step below stamps that version onto the JARs we extract from
+# the Ghidra release zip. A mismatch means Maven can't resolve dependencies
+# (see #183). GHIDRA_DATE must match the asset filename of the chosen
+# version on the upstream NSA/ghidra GitHub release.
+ARG GHIDRA_VERSION=12.0.4
+ARG GHIDRA_DATE=20260303
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -375,11 +375,12 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
         });
 
         // --- Project Organization ---
-
-        safeContext("/create_folder", exchange -> {
-            Map<String, String> params = parsePostParams(exchange);
-            sendResponse(exchange, endpointHandler.createFolder(params.get("path"), params.get("program")));
-        });
+        // Note: /create_folder and /delete_file are NOT registered here because
+        // they are already registered via @McpTool annotations on
+        // ProgramScriptService.{createFolder,deleteFile} which the
+        // AnnotationScanner picks up. Re-registering them manually causes
+        // "cannot add context to list" on headless startup (see #180).
+        // /move_file and /move_folder have no annotation, so they stay manual.
 
         safeContext("/move_file", exchange -> {
             Map<String, String> params = parsePostParams(exchange);
@@ -389,11 +390,6 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
         safeContext("/move_folder", exchange -> {
             Map<String, String> params = parsePostParams(exchange);
             sendResponse(exchange, endpointHandler.moveFolder(params.get("sourcePath"), params.get("destPath")));
-        });
-
-        safeContext("/delete_file", exchange -> {
-            Map<String, String> params = parsePostParams(exchange);
-            sendResponse(exchange, endpointHandler.deleteFile(params.get("filePath")));
         });
 
         // --- Server Endpoints ---
@@ -517,8 +513,9 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
     private int countEndpoints() {
         // registeredEndpointCount = annotation-scanned (shared services + HeadlessManagementService)
-        // 31 = infrastructure + schema + remaining manual createContext registrations
-        return registeredEndpointCount + 31;
+        // 29 = infrastructure + schema + remaining manual createContext registrations
+        // (was 31; -2 after #180 dropped /create_folder + /delete_file as duplicates)
+        return registeredEndpointCount + 29;
     }
 
     public void stop() {

--- a/tests/test_address_spaces.py
+++ b/tests/test_address_spaces.py
@@ -27,18 +27,32 @@ class TestSanitizeAddress:
         """Critical for word-addressed spaces where 0x00ff != 0xff."""
         assert sanitize_address("mem:0x00ff") == "mem:00ff"
 
-    def test_lowercase_space_name_with_0x(self):
-        assert sanitize_address("MEM:0x00FF") == "mem:00FF"
+    def test_preserves_uppercase_space_name_with_0x(self):
+        """Issue #184: 8051 architecture declares uppercase RAM/CODE/INTMEM/EXTMEM
+        space names; AddressFactory resolves them case-sensitively. The bridge
+        must NOT lowercase the space name."""
+        assert sanitize_address("MEM:0x00FF") == "MEM:00FF"
 
     def test_uppercase_x_in_0X(self):
         assert sanitize_address("code:0X1A2B") == "code:1A2B"
 
-    # Step 2 path: space:HEX (existing pattern, now lowercases space name)
-    def test_lowercases_space_name(self):
-        assert sanitize_address("MEM:1000") == "mem:1000"
+    # Step 2 path: space:HEX (passes through unchanged — see #184)
+    def test_preserves_uppercase_space_name(self):
+        """Issue #184 regression — preserve whatever case the caller used."""
+        assert sanitize_address("MEM:1000") == "MEM:1000"
 
     def test_idempotent_already_normalized(self):
         assert sanitize_address("mem:1000") == "mem:1000"
+
+    # Issue #184: 8051 specifically — must round-trip without case mangling
+    def test_8051_code_space_preserved(self):
+        assert sanitize_address("CODE:123") == "CODE:123"
+
+    def test_8051_intmem_space_preserved(self):
+        assert sanitize_address("INTMEM:0x42") == "INTMEM:42"
+
+    def test_8051_extmem_space_preserved(self):
+        assert sanitize_address("EXTMEM:0xfeed") == "EXTMEM:feed"
 
     # Plain hex path (unchanged behaviour)
     def test_plain_hex_lowercase(self):
@@ -82,7 +96,10 @@ class TestBuildToolFunctionSanitization:
         properties = {}
         required_list = list(address_params)
         for p in address_params:
-            properties[p] = {"type": "string", "paramType": "address"}
+            # The bridge gates address sanitization on `param_type` (snake_case);
+            # the original test set `paramType` (camelCase) which silently
+            # disabled sanitization on this code path. See #184 cleanup.
+            properties[p] = {"type": "string", "param_type": "address"}
         # Add a non-address param for contrast
         properties["label"] = {"type": "string"}
 
@@ -103,7 +120,10 @@ class TestBuildToolFunctionSanitization:
             calls.append(("GET", endpoint, dict(params) if params else {}))
             return "{}"
 
-        def mock_post(endpoint, data=None):
+        def mock_post(endpoint, data=None, query_params=None):
+            # query_params kwarg was added when POST endpoints gained
+            # @Param(source=ParamSource.QUERY) support; the mock now mirrors
+            # the live signature so tests don't fail with TypeError.
             calls.append(("POST", endpoint, dict(data) if data else {}))
             return "{}"
 
@@ -132,7 +152,10 @@ class TestBuildToolFunctionSanitization:
             handler(address="MEM:FF00", label="test")
             assert len(calls) == 1
             _, _, body = calls[0]
-            assert body["address"] == "mem:FF00"
+            # Issue #184: case must be preserved — Ghidra's AddressFactory is
+            # case-sensitive on space names and some architectures (8051 etc.)
+            # declare them uppercase.
+            assert body["address"] == "MEM:FF00"
         finally:
             bridge.dispatch_get = orig_get
             bridge.dispatch_post = orig_post
@@ -148,13 +171,16 @@ class TestBuildToolFunctionSanitization:
             bridge.dispatch_get = orig_get
             bridge.dispatch_post = orig_post
 
-    def test_uppercase_space_name_lowercased(self):
+    def test_uppercase_space_name_preserved(self):
+        """Issue #184: 8051 / other architectures with uppercase space names —
+        the bridge must NOT lowercase them. AddressFactory is case-sensitive
+        and those targets only know about CODE/RAM/INTMEM/EXTMEM as declared."""
         handler, calls, (orig_get, orig_post, bridge) = \
             self._make_test_handler(method="GET")
         try:
             handler(address="CODE:abcd")
             _, _, params = calls[0]
-            assert params["address"] == "code:abcd"
+            assert params["address"] == "CODE:abcd"
         finally:
             bridge.dispatch_get = orig_get
             bridge.dispatch_post = orig_post


### PR DESCRIPTION
## Summary

Triage of three issues that surfaced after v5.7.0 was tagged. All three have user-supplied diagnoses; this PR turns those into fixes + regression coverage.

## Fixes

### #180 — Headless startup crash: "cannot add context to list"

`/create_folder` and `/delete_file` were registered three times in headless mode (annotation scan + EndpointRegistry + manual `safeContext`), tripping `HttpServerImpl.createContext` with `IllegalArgumentException`. Server crashed before serving any request — affecting every Docker/headless user.

Fix: drop the manual `safeContext` calls in `GhidraMCPHeadlessServer.registerEndpoints()`. The `@McpTool`-annotated methods on `ProgramScriptService` already handle these endpoints. `/move_file` and `/move_folder` have no annotation and stay manual. Updated `countEndpoints()` (-2).

Originally diagnosed by @MMOStars in the issue body.

### #184 — Address-space name lowercasing breaks 8051 (and similar)

`bridge_mcp_ghidra.py::sanitize_address` was lowercasing the space-name component of `SPACE:HEX` and `SPACE:0xHEX` addresses. Ghidra's `AddressFactory` is case-sensitive, and the 8051 architecture (and others) declare uppercase space names — `RAM`, `CODE`, `INTMEM`, `EXTMEM`. So `CODE:123` became `code:123` and Ghidra rejected it.

Fix: pass the space name through unchanged. Still strip the `0x` prefix from the offset (Ghidra rejects `0x` after a colon).

Tests updated to match. Three regression tests added covering the 8051 spaces (`CODE:123`, `INTMEM:0x42`, `EXTMEM:0xfeed`). Two unrelated pre-existing test scaffolding bugs cleaned up too — `paramType` (camelCase) → `param_type` (snake_case) so the GET-path test scaffolding actually triggers sanitization, and `mock_post()` now accepts `query_params=` to match `dispatch_post`'s real signature. Test file goes 18 → 21 passing tests.

### #183 — Docker build can't resolve Ghidra Maven artifacts

`docker/Dockerfile`'s `GHIDRA_VERSION` ARG defaulted to `12.0.3` from the v5.6.0 era, but `pom.xml` bumped to `12.0.4` in v5.7.0. The build downloaded Ghidra 12.0.3, installed JARs as `ghidra:*:12.0.3`, then Maven failed to resolve `ghidra:*:12.0.4` matching `RocketMaDev`'s reported error verbatim.

Fix: bump `GHIDRA_VERSION=12.0.4` + `GHIDRA_DATE=20260303` to match upstream. Added a comment flagging this as a release-time sync point with `pom.xml` so it doesn't drift again on the next bump.

## Verification

- `mvn test -Dtest='com.xebyte.offline.*Test'`: ✅ 84/84 pass (incl. `EndpointsJsonParityTest` — the catalog still aligns with `@McpTool` annotations after the registration changes)
- `pytest tests/unit/ tests/test_address_spaces.py`: ✅ all pass; `test_address_spaces.py` goes 18 → 21
- `git diff --check`: ✅ clean

Live Docker rebuild not run locally — the `Dockerfile` change is mechanical (ARG default bump) and the build steps are otherwise unchanged. CI's docker workflow will exercise it.

## Test plan

- [x] Java offline tests
- [x] Python unit tests + address-space tests
- [x] git diff --check
- [ ] CI green
- [ ] Post-merge: confirm `docker build` against the new Dockerfile succeeds end-to-end
- [ ] Post-merge: a headless deployment (without GUI) should now start without the "cannot add context to list" crash

Closes #180, #183, #184.
