### PR TITLE
Extend naming enforcement toggle to globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Changed
+
+- **Strict Naming Enforcement covers global name-quality gates.**
+  The existing Ghidra Tool Option remains strict by default, but when disabled
+  it now downgrades the hard name-quality rejects in `rename_data`,
+  `rename_global_variable`, `set_global`, and the `apply_data_type`
+  prefix/type guard to warnings, matching `rename_function_by_address`. No
+  endpoint schema changes are required. Existing saved values from the legacy
+  **Strict Function Name Enforcement** option are migrated automatically.
+
 ## v5.7.1 - 2026-05-08 (community contributions + post-release triage)
 
 Patch release bundling five community-contributed PRs that landed on `main`

--- a/README.md
+++ b/README.md
@@ -350,12 +350,14 @@ GhidraMCP is designed for **localhost-only development**. The default configurat
 | `GHIDRA_MCP_ALLOW_SCRIPTS` | Set to `1`, `true`, or `yes` to enable `/run_script_inline` and `/run_ghidra_script`. **Off by default as of v5.4.1** — these endpoints execute arbitrary Java against the Ghidra process. |
 | `GHIDRA_MCP_FILE_ROOT` | When set to a directory path, filesystem-path endpoints (`/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. Prevents path-traversal. |
 
-Function-name quality enforcement is separate from security. By default,
-`rename_function_by_address` rejects names that fail the built-in quality
-gate. Disable the hard-reject layer with **Edit > Tool Options > GhidraMCP
-HTTP Server > Strict Function Name Enforcement**. The Tool Options setting is
-read when the MCP server starts or restarts. Convention warnings are still
-returned when enforcement is disabled.
+Name-quality enforcement is separate from security. By default,
+`rename_function_by_address` and global write endpoints reject names that fail
+the built-in quality gates. Disable the hard-reject layer with **Edit > Tool
+Options > GhidraMCP HTTP Server > Strict Naming Enforcement**. The same
+Tool Options checkbox covers `rename_data`, `rename_global_variable`,
+`set_global`, and the `apply_data_type` prefix/type guard. The setting is read
+when the MCP server starts or restarts. Convention warnings are still returned
+when enforcement is disabled.
 
 ### Example: exposing to a private LAN with auth
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -7,6 +7,16 @@ For the full version history, see [CHANGELOG.md](../../CHANGELOG.md) in the proj
 For the release preparation runbook, see
 [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md).
 
+## Unreleased
+
+- **Strict Naming Enforcement covers global name-quality gates** — the
+  existing Ghidra Tool Option remains strict by default, but disabling it now
+  lets `rename_data`, `rename_global_variable`, `set_global`, and the
+  `apply_data_type` prefix/type guard proceed with warnings instead of hard
+  rejects. Existing saved values from the legacy **Strict Function Name
+  Enforcement** option are migrated automatically. Endpoint schemas are
+  unchanged.
+
 ## Current Releases
 
 ### v5.7.1 (Latest) — community contributions + post-release triage

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -188,7 +188,8 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     private static final int DEFAULT_PORT = 8089;
     private static final String UDS_ENABLED_OPTION = "Enable UDS Transport";
     private static final String TCP_ENABLED_OPTION = "Enable TCP Transport";
-    private static final String STRICT_FUNCTION_NAMES_OPTION = "Strict Function Name Enforcement";
+    private static final String STRICT_NAMING_ENFORCEMENT_OPTION = "Strict Naming Enforcement";
+    private static final String LEGACY_STRICT_FUNCTION_NAMES_OPTION = "Strict Function Name Enforcement";
     private static final boolean DEFAULT_UDS_ENABLED = !System.getProperty("os.name", "").toLowerCase().contains("win");
     private static final boolean DEFAULT_TCP_ENABLED = System.getProperty("os.name", "").toLowerCase().contains("win");
 
@@ -293,12 +294,14 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
             "Enable Unix Domain Socket transport for local multi-instance support.");
         options.registerOption(TCP_ENABLED_OPTION, DEFAULT_TCP_ENABLED, null,
             "Enable TCP transport for remote/network access.");
-        options.registerOption(STRICT_FUNCTION_NAMES_OPTION,
-            NamingPolicy.defaultStrictFunctionNames(), null,
-            "Reject rename_function_by_address names that fail the built-in " +
-            "function-name quality checks. Disable when your naming convention " +
+        options.registerOption(STRICT_NAMING_ENFORCEMENT_OPTION,
+            NamingPolicy.defaultStrictNamingEnforcement(), null,
+            "Reject function/global names that fail the built-in name-quality checks " +
+            "on rename_function_by_address, rename_data, rename_global_variable, " +
+            "set_global, and related write guards. Disable when your naming convention " +
             "does not match the built-in heuristic; convention warnings are still returned. " +
             "Takes effect when the MCP server starts or restarts.");
+        migrateLegacyNamingOption(options);
         refreshNamingPolicyFromOptions();
 
         boolean udsEnabled = options.getBoolean(UDS_ENABLED_OPTION, DEFAULT_UDS_ENABLED);
@@ -351,10 +354,23 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
 
     private void refreshNamingPolicyFromOptions() {
         Options options = tool.getOptions(OPTION_CATEGORY_NAME);
-        boolean strict = options.getBoolean(STRICT_FUNCTION_NAMES_OPTION,
-            NamingPolicy.defaultStrictFunctionNames());
-        NamingPolicy.getInstance().setStrictFunctionNames(strict, "tool_options");
-        Msg.info(this, "GhidraMCP strict function-name enforcement: " + strict);
+        boolean strict = options.getBoolean(STRICT_NAMING_ENFORCEMENT_OPTION,
+            NamingPolicy.defaultStrictNamingEnforcement());
+        NamingPolicy.getInstance().setStrictNamingEnforcement(strict, "tool_options");
+        Msg.info(this, "GhidraMCP strict naming enforcement: " + strict);
+    }
+
+    private void migrateLegacyNamingOption(Options options) {
+        if (!options.contains(LEGACY_STRICT_FUNCTION_NAMES_OPTION)
+                || !options.isDefaultValue(STRICT_NAMING_ENFORCEMENT_OPTION)) {
+            return;
+        }
+
+        boolean legacyStrict = options.getBoolean(LEGACY_STRICT_FUNCTION_NAMES_OPTION,
+                NamingPolicy.defaultStrictNamingEnforcement());
+        options.setBoolean(STRICT_NAMING_ENFORCEMENT_OPTION, legacyStrict);
+        options.removeOption(LEGACY_STRICT_FUNCTION_NAMES_OPTION);
+        Msg.info(this, "Migrated GhidraMCP naming enforcement option from legacy function-name setting");
     }
 
     private void stopServer() {
@@ -451,7 +467,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
                 String message = "GhidraMCP Server Status\n\n" +
                     "UDS: " + udsStatus + "\n" +
                     "TCP: " + tcpStatus + "\n" +
-                    "Strict function names: " + NamingPolicy.getInstance().isStrictFunctionNames() + "\n" +
+                    "Strict naming enforcement: " + NamingPolicy.getInstance().isStrictNamingEnforcement() + "\n" +
                     "Version: " + VersionInfo.getFullVersion() + "\n" +
                     "Endpoints: " + VersionInfo.getEndpointCount();
                 Msg.showInfo(getClass(), null, "GhidraMCP", message);

--- a/src/main/java/com/xebyte/core/DataTypeService.java
+++ b/src/main/java/com/xebyte/core/DataTypeService.java
@@ -1222,6 +1222,7 @@ public class DataTypeService {
             }
 
             Listing listing = program.getListing();
+            List<String> enforcementWarnings = new ArrayList<>();
 
             // Check if address is in a valid memory block
             if (!program.getMemory().contains(address)) {
@@ -1246,7 +1247,7 @@ public class DataTypeService {
                     NamingConventions.GlobalNameResult preCheckResult =
                             NamingConventions.checkGlobalNameQuality(existingName, typeName);
                     if (!preCheckResult.ok && "prefix_type_mismatch".equals(preCheckResult.issue)) {
-                        return Response.ok(JsonHelper.mapOf(
+                        Map<String, Object> rejection = JsonHelper.mapOf(
                                 "status", "rejected",
                                 "error", "prefix_type_mismatch",
                                 "address", addressStr,
@@ -1257,7 +1258,11 @@ public class DataTypeService {
                                         + "' first (use rename_data / rename_global_variable), "
                                         + "or apply the type+name change atomically with set_global "
                                         + "to avoid the silently-lying-name state."
-                        ));
+                        );
+                        if (NamingPolicy.getInstance().isStrictNamingEnforcement()) {
+                            return Response.ok(rejection);
+                        }
+                        enforcementWarnings.add(disabledGlobalEnforcementWarning(rejection));
                     }
                 }
             }
@@ -1294,6 +1299,9 @@ public class DataTypeService {
                 // Add value information if available
                 if (data != null && data.getValue() != null) {
                     resultText += "\nValue: " + data.getValue().toString();
+                }
+                for (String warning : enforcementWarnings) {
+                    resultText += "\nWarning: " + warning;
                 }
 
                 return Response.text(resultText);
@@ -3446,8 +3454,10 @@ public class DataTypeService {
         Address addr = ServiceUtils.parseAddress(program, addressStr);
         if (addr == null) return Response.err(ServiceUtils.getLastParseError());
 
-        // Pre-flight validation. If anything fails, return structured error
-        // and DO NOT touch the program.
+        // Pre-flight validation. Strict naming enforcement preserves the
+        // no-partial-write behavior for name-quality failures; when disabled,
+        // the write proceeds and reports the same issue as a warning.
+        List<String> enforcementWarnings = new ArrayList<>();
         if (newName != null && !newName.isEmpty()) {
             String typeForCheck = (typeName != null && !typeName.isEmpty()) ? typeName : null;
             // If type isn't being set, fall back to whatever's already at the address.
@@ -3460,7 +3470,7 @@ public class DataTypeService {
             NamingConventions.GlobalNameResult quality =
                     NamingConventions.checkGlobalNameQuality(newName, typeForCheck);
             if (!quality.ok) {
-                return Response.ok(JsonHelper.mapOf(
+                Map<String, Object> rejection = JsonHelper.mapOf(
                         "status", "rejected",
                         "error", "name_quality",
                         "issue", quality.issue,
@@ -3468,7 +3478,11 @@ public class DataTypeService {
                         "address", addressStr,
                         "message", quality.message,
                         "suggestion", quality.suggestion
-                ));
+                );
+                if (NamingPolicy.getInstance().isStrictNamingEnforcement()) {
+                    return Response.ok(rejection);
+                }
+                enforcementWarnings.add(disabledGlobalEnforcementWarning(rejection));
             }
         }
 
@@ -3667,12 +3681,23 @@ public class DataTypeService {
         }
 
         if (success.get()) {
-            return Response.ok(JsonHelper.mapOf(
+            Map<String, Object> result = JsonHelper.mapOf(
                     "status", "success",
                     "address", addr.toString(),
                     "applied", applied
-            ));
+            );
+            if (!enforcementWarnings.isEmpty()) {
+                result.put("warnings", enforcementWarnings);
+            }
+            return Response.ok(result);
         }
         return Response.err(errorMsg.get() != null ? errorMsg.get() : "Unknown failure");
+    }
+
+    private static String disabledGlobalEnforcementWarning(Map<String, Object> rejection) {
+        Object issue = rejection.containsKey("issue") ? rejection.get("issue") : rejection.get("error");
+        return "Strict naming enforcement disabled: would have rejected "
+                + rejection.get("error") + "/" + issue + " - "
+                + rejection.get("message");
     }
 }

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -804,7 +804,7 @@ public class FunctionService {
             return Response.err("No function found for " + functionAddrStr);
         }
 
-        boolean enforceStrictFunctionNames = NamingPolicy.getInstance().isStrictFunctionNames();
+        boolean enforceStrictNaming = NamingPolicy.getInstance().isStrictNamingEnforcement();
         List<String> enforcementWarnings = new ArrayList<>();
 
         // ---- Q1-Q5 validator gate (defense in depth) ----------------------
@@ -817,7 +817,7 @@ public class FunctionService {
                     NamingConventions.checkFunctionNameQuality(newName);
             if (!quality.ok) {
                 Map<String, Object> rejection = nameQualityRejection(newName, quality);
-                if (enforceStrictFunctionNames) {
+                if (enforceStrictNaming) {
                     return Response.ok(rejection);
                 }
                 enforcementWarnings.add(disabledEnforcementWarning(rejection));
@@ -835,7 +835,7 @@ public class FunctionService {
                     NamingConventions.findTokenSubsetCollision(newName, existingNames);
             if (collidesWith != null) {
                 Map<String, Object> rejection = tokenSubsetCollisionRejection(newName, collidesWith);
-                if (enforceStrictFunctionNames) {
+                if (enforceStrictNaming) {
                     return Response.ok(rejection);
                 }
                 enforcementWarnings.add(disabledEnforcementWarning(rejection));
@@ -908,7 +908,7 @@ public class FunctionService {
     }
 
     private static String disabledEnforcementWarning(Map<String, Object> rejection) {
-        return "Strict function-name enforcement disabled: would have rejected "
+        return "Strict naming enforcement disabled: would have rejected "
                 + rejection.get("error") + "/" + rejection.get("issue") + " - "
                 + rejection.get("message");
     }

--- a/src/main/java/com/xebyte/core/NamingPolicy.java
+++ b/src/main/java/com/xebyte/core/NamingPolicy.java
@@ -4,21 +4,21 @@ package com.xebyte.core;
  * Runtime policy for naming-convention enforcement.
  *
  * <p>The default is intentionally strict to preserve the v5.6.0 behavior:
- * {@code rename_function_by_address} rejects low-quality function names before
- * mutating the program. GUI users can disable the hard reject layer through
- * Tool Options when the built-in heuristic does not match their naming
- * convention. Warning-only validation still runs in that mode.
+ * rename endpoints reject low-quality function/global names before mutating
+ * the program. GUI users can disable the hard reject layer through Tool
+ * Options when the built-in heuristic does not match their naming convention.
+ * Warning-only validation still runs in that mode.
  */
 public final class NamingPolicy {
 
     private static final NamingPolicy INSTANCE = new NamingPolicy();
-    private static final boolean DEFAULT_STRICT_FUNCTION_NAMES = true;
+    private static final boolean DEFAULT_STRICT_NAMING_ENFORCEMENT = true;
 
-    private volatile boolean strictFunctionNames;
+    private volatile boolean strictNamingEnforcement;
     private volatile String source;
 
     private NamingPolicy() {
-        this.strictFunctionNames = DEFAULT_STRICT_FUNCTION_NAMES;
+        this.strictNamingEnforcement = DEFAULT_STRICT_NAMING_ENFORCEMENT;
         this.source = "default";
     }
 
@@ -26,17 +26,17 @@ public final class NamingPolicy {
         return INSTANCE;
     }
 
-    public static boolean defaultStrictFunctionNames() {
-        return DEFAULT_STRICT_FUNCTION_NAMES;
+    public static boolean defaultStrictNamingEnforcement() {
+        return DEFAULT_STRICT_NAMING_ENFORCEMENT;
     }
 
-    public synchronized void setStrictFunctionNames(boolean strictFunctionNames, String source) {
-        this.strictFunctionNames = strictFunctionNames;
+    public synchronized void setStrictNamingEnforcement(boolean strictNamingEnforcement, String source) {
+        this.strictNamingEnforcement = strictNamingEnforcement;
         this.source = source != null && !source.isBlank() ? source : "runtime";
     }
 
-    public boolean isStrictFunctionNames() {
-        return strictFunctionNames;
+    public boolean isStrictNamingEnforcement() {
+        return strictNamingEnforcement;
     }
 
     public String getSource() {

--- a/src/main/java/com/xebyte/core/SymbolLabelService.java
+++ b/src/main/java/com/xebyte/core/SymbolLabelService.java
@@ -389,7 +389,7 @@ public class SymbolLabelService {
                     @SuppressWarnings("unchecked")
                     java.util.Map<String, Object> okData = okResp.data() instanceof java.util.Map
                             ? (java.util.Map<String, Object>) okResp.data() : new java.util.LinkedHashMap<>();
-                    okData.put("warnings", conventions);
+                    appendWarnings(okData, conventions);
                     return Response.ok(okData);
                 }
                 return result;
@@ -401,7 +401,7 @@ public class SymbolLabelService {
                     @SuppressWarnings("unchecked")
                     java.util.Map<String, Object> okData = okResp.data() instanceof java.util.Map
                             ? (java.util.Map<String, Object>) okResp.data() : new java.util.LinkedHashMap<>();
-                    okData.put("warnings", conventions);
+                    appendWarnings(okData, conventions);
                     return Response.ok(okData);
                 }
                 return result;
@@ -627,6 +627,7 @@ public class SymbolLabelService {
                 ? existingData.getDataType().getName() : null;
         NamingConventions.GlobalNameResult quality =
                 NamingConventions.checkGlobalNameQuality(newName, existingTypeName);
+        List<String> enforcementWarnings = new ArrayList<>();
         if (!quality.ok) {
             // Append a structural hint nudging the worker toward set_global.
             // Workers that hit name_quality repeatedly are usually mid-chain
@@ -640,7 +641,7 @@ public class SymbolLabelService {
                     + "type_name=..., name=..., plate_comment=...) — "
                     + "single-transaction write that validates name + type "
                     + "consistency before applying anything.";
-            return Response.ok(JsonHelper.mapOf(
+            Map<String, Object> rejection = JsonHelper.mapOf(
                     "status", "rejected",
                     "error", "name_quality",
                     "issue", quality.issue,
@@ -649,7 +650,11 @@ public class SymbolLabelService {
                     "current_type", existingTypeName != null ? existingTypeName : "",
                     "message", quality.message,
                     "suggestion", enrichedSuggestion
-            ));
+            );
+            if (NamingPolicy.getInstance().isStrictNamingEnforcement()) {
+                return Response.ok(rejection);
+            }
+            enforcementWarnings.add(disabledGlobalEnforcementWarning(rejection));
         }
 
         final AtomicBoolean success = new AtomicBoolean(false);
@@ -697,7 +702,11 @@ public class SymbolLabelService {
         }
 
         if (success.get()) {
-            return Response.ok(JsonHelper.mapOf("status", "success", "message", successMsg.get()));
+            Map<String, Object> result = JsonHelper.mapOf("status", "success", "message", successMsg.get());
+            if (!enforcementWarnings.isEmpty()) {
+                result.put("warnings", enforcementWarnings);
+            }
+            return Response.ok(result);
         }
         return Response.err(errorMsg.get() != null ? errorMsg.get() : "Unknown failure");
     }
@@ -746,6 +755,7 @@ public class SymbolLabelService {
         }
         NamingConventions.GlobalNameResult quality =
                 NamingConventions.checkGlobalNameQuality(newName, existingTypeName);
+        List<String> enforcementWarnings = new ArrayList<>();
         if (!quality.ok) {
             String addrHint = !initialSymbols.isEmpty()
                     ? "0x" + initialSymbols.get(0).getAddress().toString()
@@ -756,7 +766,7 @@ public class SymbolLabelService {
                     + "type_name=..., name=..., plate_comment=...) — "
                     + "single-transaction write that validates name + type "
                     + "consistency before applying anything.";
-            return Response.ok(JsonHelper.mapOf(
+            Map<String, Object> rejection = JsonHelper.mapOf(
                     "status", "rejected",
                     "error", "name_quality",
                     "issue", quality.issue,
@@ -764,7 +774,11 @@ public class SymbolLabelService {
                     "current_type", existingTypeName != null ? existingTypeName : "",
                     "message", quality.message,
                     "suggestion", enrichedSuggestion
-            ));
+            );
+            if (NamingPolicy.getInstance().isStrictNamingEnforcement()) {
+                return Response.ok(rejection);
+            }
+            enforcementWarnings.add(disabledGlobalEnforcementWarning(rejection));
         }
 
         int txId = program.startTransaction("Rename Global Variable");
@@ -797,14 +811,22 @@ public class SymbolLabelService {
             // after a successful prior call hit this; treat as already-applied.
             if (newName.equals(symbol.getName())) {
                 success = true;
-                return Response.ok(JsonHelper.mapOf("status", "success", "message",
-                        "Global variable already named '" + newName + "' at " + symbolAddr + " (no-op)"));
+                Map<String, Object> result = JsonHelper.mapOf("status", "success", "message",
+                        "Global variable already named '" + newName + "' at " + symbolAddr + " (no-op)");
+                if (!enforcementWarnings.isEmpty()) {
+                    result.put("warnings", enforcementWarnings);
+                }
+                return Response.ok(result);
             }
             symbol.setName(newName, SourceType.USER_DEFINED);
 
             success = true;
-            return Response.ok(JsonHelper.mapOf("status", "success", "message",
-                    "Renamed global variable '" + oldName + "' to '" + newName + "' at " + symbolAddr));
+            Map<String, Object> result = JsonHelper.mapOf("status", "success", "message",
+                    "Renamed global variable '" + oldName + "' to '" + newName + "' at " + symbolAddr);
+            if (!enforcementWarnings.isEmpty()) {
+                result.put("warnings", enforcementWarnings);
+            }
+            return Response.ok(result);
 
         } catch (Exception e) {
             Msg.error(this, "Error renaming global variable: " + e.getMessage());
@@ -812,6 +834,25 @@ public class SymbolLabelService {
         } finally {
             program.endTransaction(txId, success);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void appendWarnings(Map<String, Object> responseData, List<String> warnings) {
+        if (warnings == null || warnings.isEmpty()) {
+            return;
+        }
+        Object existing = responseData.get("warnings");
+        List<String> merged = existing instanceof List
+                ? new ArrayList<>((List<String>) existing)
+                : new ArrayList<>();
+        merged.addAll(warnings);
+        responseData.put("warnings", merged);
+    }
+
+    private static String disabledGlobalEnforcementWarning(Map<String, Object> rejection) {
+        return "Strict naming enforcement disabled: would have rejected "
+                + rejection.get("error") + "/" + rejection.get("issue") + " - "
+                + rejection.get("message");
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/xebyte/offline/NamingPolicyTest.java
+++ b/src/test/java/com/xebyte/offline/NamingPolicyTest.java
@@ -4,28 +4,28 @@ import com.xebyte.core.NamingPolicy;
 import junit.framework.TestCase;
 
 /**
- * Pure-logic tests for the function-name enforcement policy.
+ * Pure-logic tests for the naming enforcement policy.
  */
 public class NamingPolicyTest extends TestCase {
 
     public void testDefaultPreservesStrictBehavior() {
-        assertTrue(NamingPolicy.defaultStrictFunctionNames());
+        assertTrue(NamingPolicy.defaultStrictNamingEnforcement());
     }
 
     public void testGlobalSettingCanBeUpdatedAndRestored() {
         NamingPolicy policy = NamingPolicy.getInstance();
-        boolean originalValue = policy.isStrictFunctionNames();
+        boolean originalValue = policy.isStrictNamingEnforcement();
         String originalSource = policy.getSource();
 
         try {
-            policy.setStrictFunctionNames(false, "test");
-            assertFalse(policy.isStrictFunctionNames());
+            policy.setStrictNamingEnforcement(false, "test");
+            assertFalse(policy.isStrictNamingEnforcement());
             assertEquals("test", policy.getSource());
 
-            policy.setStrictFunctionNames(true, "test");
-            assertTrue(policy.isStrictFunctionNames());
+            policy.setStrictNamingEnforcement(true, "test");
+            assertTrue(policy.isStrictNamingEnforcement());
         } finally {
-            policy.setStrictFunctionNames(originalValue, originalSource);
+            policy.setStrictNamingEnforcement(originalValue, originalSource);
         }
     }
 }


### PR DESCRIPTION
## Summary
- broaden the GUI naming policy from function-only to strict naming enforcement
- apply the same toggle to global name-quality gates in rename_data, rename_global_variable, set_global, and the apply_data_type prefix/type guard
- rename the Tool Options checkbox to Strict Naming Enforcement and migrate the legacy saved Strict Function Name Enforcement value

## Verification
- mvn -Dghidra.version=12.0.3 test
- env XONSH_HISTORY_BACKEND=dummy python3 -m pytest tests/unit/ -v --no-cov