### PR TITLE
fix(setup): Linux/Nix compatibility — pip discovery + ghidraRun selection

### DIFF
--- a/tests/unit/test_setup_requirements.py
+++ b/tests/unit/test_setup_requirements.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for tools.setup.requirements — pip command resolution.
+
+Covers the nix / Linux case where ``python -m pip`` fails but a bare
+``pip`` exists on PATH (#190). All tests stub subprocess and shutil so no
+real pip invocation happens.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.setup import requirements as req
+
+
+@pytest.fixture(autouse=True)
+def _clear_pip_cache():
+    """Reset the resolved-pip cache between tests so each scenario gets a
+    fresh probe."""
+    req._PIP_COMMAND_CACHE.clear()
+    yield
+    req._PIP_COMMAND_CACHE.clear()
+
+
+def _completed(returncode: int) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr="")
+
+
+def test_pip_command_prefers_python_dash_m_pip(monkeypatch):
+    """The happy path on Windows / Mac / most Linux: ``python -m pip`` works."""
+
+    def fake_run(cmd, **kwargs):
+        assert "-m" in cmd and "pip" in cmd, cmd
+        return _completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(req.shutil, "which", lambda _: None)  # don't fall through
+
+    py = Path("/usr/bin/python3")
+    assert req.pip_command(py) == [str(py), "-m", "pip"]
+
+
+def test_pip_command_falls_back_to_bare_pip_on_nix(monkeypatch):
+    """The nix case: ``python -m pip`` fails but bare ``pip`` works.
+
+    This is the #190 regression — without the fallback, setup commands
+    failed on nix-managed Python environments where pip is exposed as a
+    binary but not importable from the active interpreter.
+    """
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "-m" in cmd and "pip" in cmd:
+            return _completed(1)  # python -m pip fails
+        if cmd[0] == "/usr/bin/pip":
+            return _completed(0)  # bare pip works
+        raise AssertionError(f"unexpected probe: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(req.shutil, "which", lambda name: "/usr/bin/pip" if name == "pip" else None)
+
+    py = Path("/nix/store/abc/bin/python3")
+    result = req.pip_command(py)
+    assert result == ["/usr/bin/pip"]
+    # Probed both forms before settling on the fallback.
+    assert any("-m" in c and "pip" in c for c in calls)
+    assert ["/usr/bin/pip", "--version"] in calls
+
+
+def test_pip_command_raises_when_neither_form_works(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(1))
+    monkeypatch.setattr(req.shutil, "which", lambda _: None)
+
+    py = Path("/usr/bin/python3")
+    with pytest.raises(FileNotFoundError) as exc:
+        req.pip_command(py)
+    msg = str(exc.value)
+    # Path renders with native separators (/ on POSIX, \ on Windows); check
+    # the str(py) form to stay portable.
+    assert str(py) in msg
+    assert "pip is not available" in msg
+
+
+def test_pip_command_cached_per_python_executable(monkeypatch):
+    """Resolving twice for the same interpreter must not re-probe subprocess."""
+    probe_count = 0
+
+    def fake_run(cmd, **kwargs):
+        nonlocal probe_count
+        probe_count += 1
+        return _completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(req.shutil, "which", lambda _: None)
+
+    py = Path("/usr/bin/python3")
+    first = req.pip_command(py)
+    second = req.pip_command(py)
+    assert first == second
+    assert probe_count == 1, "second call should hit the cache, not re-probe"
+    # Caller mutating the returned list must not poison the cache.
+    first.append("--mutated")
+    third = req.pip_command(py)
+    assert "--mutated" not in third
+
+
+def test_pip_command_per_interpreter_isolation(monkeypatch):
+    """Different python executables get independent cache entries."""
+
+    def fake_run(cmd, **kwargs):
+        # Both interpreters succeed at python -m pip
+        return _completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(req.shutil, "which", lambda _: None)
+
+    py_a = Path("/usr/bin/python3.11")
+    py_b = Path("/usr/bin/python3.12")
+    assert req.pip_command(py_a)[0] == str(py_a)
+    assert req.pip_command(py_b)[0] == str(py_b)
+    assert req.pip_command(py_a)[0] == str(py_a)  # cache wasn't overwritten by py_b
+
+
+def test_install_requirements_file_uses_resolved_pip_command(monkeypatch, tmp_path):
+    """install_requirements_file must go through pip_command, not the old
+    hardcoded ``python -m pip`` invocation."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(req.shutil, "which", lambda _: None)
+    # Force the bare-pip fallback so we can assert the command prefix matches.
+    req._PIP_COMMAND_CACHE[str(Path("/nix/python"))] = ["/usr/bin/pip"]
+
+    reqs = tmp_path / "requirements.txt"
+    reqs.write_text("requests\n")
+    req.install_requirements_file(Path("/nix/python"), reqs)
+
+    assert captured["cmd"][:3] == ["/usr/bin/pip", "install", "-r"]

--- a/tools/setup/cli.py
+++ b/tools/setup/cli.py
@@ -20,6 +20,7 @@ from .maven import find_maven_command, run_gradle, run_maven
 from .requirements import (
     execute_install_plan,
     make_install_plan,
+    pip_command,
     resolve_requirements_files,
 )
 from .version_bump import apply_version_bump
@@ -373,17 +374,10 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     python_executable = find_repo_python(repo_root)
 
     if _get_backend() == "gradle":
-        pip_check = subprocess.run(
-            [str(python_executable), "-m", "pip", "--version"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if pip_check.returncode != 0:
-            print(
-                "pip is not available for the selected Python interpreter.",
-                file=sys.stderr,
-            )
+        try:
+            pip_command(python_executable)
+        except FileNotFoundError as exc:
+            print(str(exc), file=sys.stderr)
             return 1
         print(f"Python: {python_executable}")
         print("pip: available")
@@ -397,16 +391,10 @@ def cmd_preflight(args: argparse.Namespace) -> int:
         return 1
     print(f"Python: {python_executable}")
     print(f"Maven: {maven_command}")
-    pip_check = subprocess.run(
-        [str(python_executable), "-m", "pip", "--version"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if pip_check.returncode != 0:
-        print(
-            "pip is not available for the selected Python interpreter.", file=sys.stderr
-        )
+    try:
+        pip_command(python_executable)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
         return 1
     print("pip: available")
     if shutil.which("java") is None:

--- a/tools/setup/ghidra.py
+++ b/tools/setup/ghidra.py
@@ -353,11 +353,23 @@ def install_user_extension(
 
 
 def find_ghidra_executable(ghidra_path: Path) -> Path:
-    candidates = [
-        ghidra_path / "ghidraRun.bat",
-        ghidra_path / "ghidraRun",
-        ghidra_path / "ghidra",
-    ]
+    # Ghidra release zips ship BOTH ghidraRun (shell script) and
+    # ghidraRun.bat (Windows batch) regardless of host OS, so picking the
+    # right one requires a platform check rather than first-match-found.
+    # On Linux/macOS, returning ghidraRun.bat made subprocess.Popen try to
+    # exec cmd.exe and fail with FileNotFoundError. See #191.
+    if sys.platform == "win32":
+        candidates = [
+            ghidra_path / "ghidraRun.bat",
+            ghidra_path / "ghidraRun",
+            ghidra_path / "ghidra",
+        ]
+    else:
+        candidates = [
+            ghidra_path / "ghidraRun",
+            ghidra_path / "ghidra",
+            ghidra_path / "ghidraRun.bat",
+        ]
     for candidate in candidates:
         if candidate.is_file():
             return candidate
@@ -1804,16 +1816,14 @@ def collect_preflight_issues(
     strict: bool = False,
     user_base_dir: Path | None = None,
 ) -> list[str]:
+    from .requirements import pip_command
+
     issues: list[str] = []
 
-    pip_check = subprocess.run(
-        [str(python_executable), "-m", "pip", "--version"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if pip_check.returncode != 0:
-        issues.append("pip is not available for the selected Python interpreter.")
+    try:
+        pip_command(python_executable)
+    except FileNotFoundError as exc:
+        issues.append(str(exc))
 
     if shutil.which("java") is None:
         issues.append("Java not found on PATH (JDK 21 recommended).")

--- a/tools/setup/requirements.py
+++ b/tools/setup/requirements.py
@@ -1,8 +1,62 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+
+# Cache the resolved pip invocation per python_executable so we don't probe
+# twice. Some environments (nix, certain Linux distros) install pip as a
+# standalone executable but don't expose it as a module; others (Windows
+# venvs, most Mac setups) only have python -m pip. Probing once per process
+# lets us route to whichever works without forcing one or the other on users.
+# See #190.
+_PIP_COMMAND_CACHE: dict[str, list[str]] = {}
+
+
+def pip_command(python_executable: Path) -> list[str]:
+    """Return a command-list prefix that invokes pip for the given Python.
+
+    Prefers ``python -m pip`` (consistent with the active interpreter's
+    site-packages), falls back to a bare ``pip`` if the module path isn't
+    available — this is the nix-style environment where pip ships as an
+    executable but the python interpreter can't import it. Raises if neither
+    form works.
+    """
+    key = str(python_executable)
+    cached = _PIP_COMMAND_CACHE.get(key)
+    if cached is not None:
+        return list(cached)
+
+    # First try: python -m pip
+    module_form = [str(python_executable), "-m", "pip"]
+    probe = subprocess.run(
+        module_form + ["--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        _PIP_COMMAND_CACHE[key] = module_form
+        return list(module_form)
+
+    # Fallback: bare pip on PATH
+    bare = shutil.which("pip")
+    if bare:
+        probe = subprocess.run(
+            [bare, "--version"], capture_output=True, text=True, check=False,
+        )
+        if probe.returncode == 0:
+            bare_form = [bare]
+            _PIP_COMMAND_CACHE[key] = bare_form
+            return list(bare_form)
+
+    raise FileNotFoundError(
+        f"pip is not available for {python_executable} — neither "
+        f"`{python_executable} -m pip` nor a bare `pip` on PATH responded "
+        "to --version. Install pip into the active Python environment."
+    )
 
 
 @dataclass(frozen=True)
@@ -46,7 +100,7 @@ def make_install_plan(
 
 def install_requirements_file(python_executable: Path, requirements_file: Path) -> None:
     subprocess.run(
-        [str(python_executable), "-m", "pip", "install", "-r", str(requirements_file)],
+        pip_command(python_executable) + ["install", "-r", str(requirements_file)],
         check=True,
     )
 


### PR DESCRIPTION
## Summary

Two related Linux/Nix compatibility fixes for `tools.setup` that block bootstrap on systems where the original code's platform assumptions don't hold.

Closes #190, #191.

## Fixes

### #190 — `pip` discovery on Nix / Debian

`tools.setup` invoked pip as `[python, "-m", "pip"]` in four places. On nix-managed Python environments, the active interpreter can't import pip even though `pip` exists as a standalone executable on PATH. @Molkars reported it on Nix; @letsjustfixit confirmed the same on Debian.

**Fix:** new `pip_command(python_executable)` helper in `tools/setup/requirements.py` that probes `python -m pip --version` first (safer, venv-aware) and falls back to a bare `pip` on PATH only when the module form fails. Result is cached per `python_executable`. Raises a clear `FileNotFoundError` when neither form works.

All four call sites converted:
- `tools/setup/cli.py` — `cmd_preflight` (gradle backend + maven backend)
- `tools/setup/ghidra.py::collect_preflight_issues`
- `tools/setup/requirements.py::install_requirements_file`

### #191 — `find_ghidra_executable` returns `ghidraRun.bat` on Linux

Ghidra release zips ship both `ghidraRun` (shell script) and `ghidraRun.bat` (Windows batch) regardless of host OS. The `candidates` list had `ghidraRun.bat` first, so `is_file()` would return the Windows batch on Linux too. `subprocess.Popen` then tried to exec `cmd.exe` and failed with `FileNotFoundError: [Errno 2] No such file or directory: 'cmd.exe'`. @Molkars's traceback identified this exactly.

**Fix:** make the candidate order platform-aware — `ghidraRun` first on non-Windows, `ghidraRun.bat` first on Windows.

## Verification

- New regression tests in `tests/unit/test_setup_requirements.py` (6 tests):
  - `test_pip_command_prefers_python_dash_m_pip` — happy path (Windows/Mac/most Linux)
  - `test_pip_command_falls_back_to_bare_pip_on_nix` — the #190 regression
  - `test_pip_command_raises_when_neither_form_works` — fail-loud path
  - `test_pip_command_cached_per_python_executable` — no re-probing
  - `test_pip_command_per_interpreter_isolation` — cache isolation
  - `test_install_requirements_file_uses_resolved_pip_command` — integration
- All 304 existing unit tests still pass.
- Local smoke: `tools.setup verify-version` and `tools.setup preflight` both pass on Windows after the changes.

## Why a smarter helper instead of @Molkars's `["pip", ...]` patch

@Molkars's patch in the issue body hardcoded a bare `pip` everywhere, which would regress Windows/Mac venv users who currently rely on `python -m pip` to invoke their venv's pip rather than a system-wide one in PATH. The helper-with-fallback keeps the safer venv-aware default while gracefully handling the nix/Debian case.

## Test plan

- [x] Unit tests pass locally (Windows)
- [x] `tools.setup preflight` works on Windows post-change
- [ ] CI green
- [ ] Manual verification on Linux/Nix (deferred — needs the reporter's environment to truly confirm)

@Molkars — once this is merged, would you confirm whether `tools.setup preflight` + `deploy` work end-to-end on your Nix setup?
