### PR TITLE
feat(analysis): P-code dump + language metadata endpoints (#192)

### DIFF
--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -4778,6 +4778,210 @@ public class AnalysisService {
         if (r == null) return false;
         return r.equals(target) || target.contains(r) || r.contains(target);
     }
+
+    // ----------------------------------------------------------------------
+    // Issue #192: P-code dump + language metadata
+    // ----------------------------------------------------------------------
+
+    private static Map<String, Object> varnodeToJson(Varnode v) {
+        if (v == null) return null;
+        Map<String, Object> m = new LinkedHashMap<>();
+        Address a = v.getAddress();
+        m.put("space", a != null && a.getAddressSpace() != null ? a.getAddressSpace().getName() : null);
+        m.put("offset", a != null ? Long.toHexString(a.getOffset()) : null);
+        m.put("size", v.getSize());
+        m.put("is_register", v.isRegister());
+        m.put("is_constant", v.isConstant());
+        m.put("is_unique", v.isUnique());
+        return m;
+    }
+
+    private static Map<String, Object> pcodeOpToJson(PcodeOp op) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("mnemonic", op.getMnemonic());
+        m.put("opcode", op.getOpcode());
+        Address seq = op.getSeqnum() != null ? op.getSeqnum().getTarget() : null;
+        if (seq != null) {
+            m.put("seq_offset", Long.toHexString(seq.getOffset()));
+            m.put("seq_space", seq.getAddressSpace().getName());
+        }
+        List<Map<String, Object>> inputs = new ArrayList<>();
+        Varnode[] vis = op.getInputs();
+        if (vis != null) {
+            for (Varnode v : vis) inputs.add(varnodeToJson(v));
+        }
+        m.put("inputs", inputs);
+        m.put("output", varnodeToJson(op.getOutput()));
+        return m;
+    }
+
+    @McpTool(path = "/get_function_pcode",
+             description = "Dump raw P-code for a function (issue #192). Returns low (basic-iter) and high (HighFunction) P-code with basic blocks and varnodes. Granularity controls output: 'basic' = basic-block iter only (less memory), 'high' = HighFunction graph (default; includes both BB iter and op-iter). For P-code emulators / ML pipelines / alternative decompilers.",
+             category = "analysis")
+    public Response getFunctionPcode(
+            @Param(value = "function_address", paramType = "address",
+                   description = "Function entry address (0x<hex> or <space>:<hex>).") String functionAddress,
+            @Param(value = "granularity", defaultValue = "high",
+                   description = "'basic' = raw PcodeOps from basic-block iter only; 'high' = HighFunction P-code graph (default; richer, includes varnode SSA info).") String granularity,
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit for active program).") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        Address addr = ServiceUtils.parseAddress(program, functionAddress);
+        if (addr == null) return Response.err(ServiceUtils.getLastParseError());
+
+        Function func = program.getFunctionManager().getFunctionAt(addr);
+        if (func == null) func = program.getFunctionManager().getFunctionContaining(addr);
+        if (func == null) return Response.err("No function at address: " + functionAddress);
+
+        DecompileResults decompResults = functionService.decompileFunctionNoRetry(func, program);
+        if (decompResults == null || !decompResults.decompileCompleted()) {
+            return Response.err("Decompilation failed for " + func.getName());
+        }
+        HighFunction hf = decompResults.getHighFunction();
+        if (hf == null) {
+            return Response.err("No HighFunction available for " + func.getName());
+        }
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("name", func.getName());
+        out.putAll(ServiceUtils.addressToJson(func.getEntryPoint(), program));
+
+        // Basic-block-level P-code (raw iteration order, matches the issue's
+        // requested "getBasicIter" output shape).
+        boolean wantHigh = !"basic".equalsIgnoreCase(granularity);
+        List<Map<String, Object>> basicBlocks = new ArrayList<>();
+        try {
+            for (var bb : hf.getBasicBlocks()) {
+                Map<String, Object> bbMap = new LinkedHashMap<>();
+                Address start = bb.getStart();
+                Address stop = bb.getStop();
+                bbMap.put("start_space", start.getAddressSpace().getName());
+                bbMap.put("start_offset", Long.toHexString(start.getOffset()));
+                bbMap.put("stop_space", stop.getAddressSpace().getName());
+                bbMap.put("stop_offset", Long.toHexString(stop.getOffset()));
+                List<Map<String, Object>> bbOps = new ArrayList<>();
+                var iter = bb.getIterator();
+                while (iter.hasNext()) {
+                    bbOps.add(pcodeOpToJson(iter.next()));
+                }
+                bbMap.put("pcodes", bbOps);
+                basicBlocks.add(bbMap);
+            }
+        } catch (Exception e) {
+            out.put("basic_blocks_error", e.getMessage());
+        }
+        out.put("basic_blocks", basicBlocks);
+
+        if (wantHigh) {
+            // HighFunction global PcodeOp iterator
+            List<Map<String, Object>> highOps = new ArrayList<>();
+            try {
+                var allOps = hf.getPcodeOps();
+                while (allOps.hasNext()) {
+                    PcodeOpAST op = allOps.next();
+                    highOps.add(pcodeOpToJson(op));
+                }
+            } catch (Exception e) {
+                out.put("high_pcodes_error", e.getMessage());
+            }
+            out.put("high_pcodes", highOps);
+        }
+
+        return Response.ok(out);
+    }
+
+    @McpTool(path = "/get_language_metadata",
+             description = "Dump the program's language description: address spaces, registers, default symbols, endianness, pointer size (issue #192). Use for P-code emulators / ML pipelines that need the SLEIGH-level facts. include_registers/include_default_symbols toggle expensive sections.",
+             category = "program")
+    public Response getLanguageMetadata(
+            @Param(value = "include_registers", defaultValue = "true",
+                   description = "Include the full register list (can be hundreds of entries on x86).") String includeRegistersStr,
+            @Param(value = "include_default_symbols", defaultValue = "true",
+                   description = "Include the language's default symbol set (entry points, interrupt vectors).") String includeDefaultSymbolsStr,
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit for active program).") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        boolean includeRegisters = !"false".equalsIgnoreCase(includeRegistersStr);
+        boolean includeDefaultSymbols = !"false".equalsIgnoreCase(includeDefaultSymbolsStr);
+
+        ghidra.program.model.lang.Language lang = program.getLanguage();
+        ghidra.program.model.lang.LanguageDescription ld = lang.getLanguageDescription();
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("language_id", lang.getLanguageID().getIdAsString());
+        out.put("processor", lang.getProcessor().toString());
+        out.put("endian", ld.getEndian().toString());
+        out.put("size", ld.getSize());
+        out.put("variant", ld.getVariant());
+        out.put("default_space", lang.getDefaultSpace() != null ? lang.getDefaultSpace().getName() : null);
+        out.put("default_data_space", lang.getDefaultDataSpace() != null ? lang.getDefaultDataSpace().getName() : null);
+        Register pc = lang.getProgramCounter();
+        out.put("program_counter", pc != null ? pc.getName() : null);
+
+        // Address spaces
+        List<Map<String, Object>> spaces = new ArrayList<>();
+        for (var space : program.getAddressFactory().getAllAddressSpaces()) {
+            Map<String, Object> s = new LinkedHashMap<>();
+            s.put("name", space.getName());
+            s.put("id", space.getSpaceID());
+            s.put("size", space.getSize());
+            s.put("pointer_size", space.getPointerSize());
+            s.put("type", space.getType());
+            Address min = space.getMinAddress();
+            Address max = space.getMaxAddress();
+            if (min != null) s.put("min_offset", Long.toHexString(min.getOffset()));
+            if (max != null) s.put("max_offset", Long.toHexString(max.getOffset()));
+            spaces.add(s);
+        }
+        out.put("address_spaces", spaces);
+
+        if (includeRegisters) {
+            List<Map<String, Object>> regs = new ArrayList<>();
+            for (Register r : lang.getRegisters()) {
+                Map<String, Object> rj = new LinkedHashMap<>();
+                rj.put("name", r.getName());
+                rj.put("bit_length", r.getBitLength());
+                rj.put("is_big_endian", r.isBigEndian());
+                Address ra = r.getAddress();
+                if (ra != null) {
+                    rj.put("space", ra.getAddressSpace().getName());
+                    rj.put("offset", Long.toHexString(ra.getOffset()));
+                }
+                List<String> children = new ArrayList<>();
+                for (Register c : r.getChildRegisters()) children.add(c.getName());
+                rj.put("children", children);
+                regs.add(rj);
+            }
+            out.put("registers", regs);
+        }
+
+        if (includeDefaultSymbols) {
+            List<Map<String, Object>> syms = new ArrayList<>();
+            try {
+                for (var info : lang.getDefaultSymbols()) {
+                    Map<String, Object> sj = new LinkedHashMap<>();
+                    sj.put("label", info.getLabel());
+                    Address a = info.getAddress();
+                    if (a != null) {
+                        sj.put("space", a.getAddressSpace().getName());
+                        sj.put("offset", Long.toHexString(a.getOffset()));
+                    }
+                    syms.add(sj);
+                }
+            } catch (Exception e) {
+                out.put("default_symbols_error", e.getMessage());
+            }
+            out.put("default_symbols", syms);
+        }
+
+        return Response.ok(out);
+    }
 }
 
 

--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -4786,24 +4786,44 @@ public class AnalysisService {
     private static Map<String, Object> varnodeToJson(Varnode v) {
         if (v == null) return null;
         Map<String, Object> m = new LinkedHashMap<>();
+        // Varnodes live in SLEIGH spaces ("const", "unique", "register", "ram",
+        // etc.) -- not all of these are real program addresses, so we keep the
+        // explicit space/offset/size shape rather than reusing the program-
+        // address helper. Real program addresses for seq numbers and basic-
+        // block bounds go through ServiceUtils.addressToJson() instead, so
+        // consumers get a consistent representation for the address-bearing
+        // fields.
         Address a = v.getAddress();
         m.put("space", a != null && a.getAddressSpace() != null ? a.getAddressSpace().getName() : null);
         m.put("offset", a != null ? Long.toHexString(a.getOffset()) : null);
         m.put("size", v.getSize());
+        // Space-classification flags (which Varnode slot this is).
         m.put("is_register", v.isRegister());
         m.put("is_constant", v.isConstant());
         m.put("is_unique", v.isUnique());
+        // SSA / data-flow flags from HighFunction analysis. `addr_tied` means
+        // the varnode is bound to a stack/global address (escapes SSA);
+        // `hash` is set on HighFunction-internal hash varnodes; `persistent`
+        // means the varnode holds a value across function calls. `merge_group`
+        // partitions varnodes that share an SSA-resolved storage slot.
+        m.put("is_addrtied", v.isAddrTied());
+        m.put("is_hash", v.isHash());
+        m.put("is_persistent", v.isPersistent());
+        m.put("merge_group", v.getMergeGroup());
         return m;
     }
 
-    private static Map<String, Object> pcodeOpToJson(PcodeOp op) {
+    private static Map<String, Object> pcodeOpToJson(PcodeOp op, Program program) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("mnemonic", op.getMnemonic());
         m.put("opcode", op.getOpcode());
+        // Seq number's target is a real program address — emit via the
+        // shared helper so multi-space binaries (mem:0x1000 etc.) format
+        // consistently with the rest of the API.
         Address seq = op.getSeqnum() != null ? op.getSeqnum().getTarget() : null;
-        if (seq != null) {
-            m.put("seq_offset", Long.toHexString(seq.getOffset()));
-            m.put("seq_space", seq.getAddressSpace().getName());
+        if (seq != null && program != null) {
+            Map<String, Object> seqJson = ServiceUtils.addressToJson(seq, program);
+            m.put("seq", seqJson);
         }
         List<Map<String, Object>> inputs = new ArrayList<>();
         Varnode[] vis = op.getInputs();
@@ -4838,7 +4858,12 @@ public class AnalysisService {
 
         DecompileResults decompResults = functionService.decompileFunctionNoRetry(func, program);
         if (decompResults == null || !decompResults.decompileCompleted()) {
-            return Response.err("Decompilation failed for " + func.getName());
+            // Surface the underlying decompiler error so callers can diagnose
+            // (matches the convention used elsewhere in this file).
+            String detail = decompResults != null ? decompResults.getErrorMessage() : null;
+            String msg = "Decompilation failed for " + func.getName();
+            if (detail != null && !detail.isEmpty()) msg += ": " + detail;
+            return Response.err(msg);
         }
         HighFunction hf = decompResults.getHighFunction();
         if (hf == null) {
@@ -4850,22 +4875,20 @@ public class AnalysisService {
         out.putAll(ServiceUtils.addressToJson(func.getEntryPoint(), program));
 
         // Basic-block-level P-code (raw iteration order, matches the issue's
-        // requested "getBasicIter" output shape).
+        // requested "getBasicIter" output shape). Basic-block bounds are real
+        // program addresses -- serialize via the shared helper for consistent
+        // multi-space formatting.
         boolean wantHigh = !"basic".equalsIgnoreCase(granularity);
         List<Map<String, Object>> basicBlocks = new ArrayList<>();
         try {
             for (var bb : hf.getBasicBlocks()) {
                 Map<String, Object> bbMap = new LinkedHashMap<>();
-                Address start = bb.getStart();
-                Address stop = bb.getStop();
-                bbMap.put("start_space", start.getAddressSpace().getName());
-                bbMap.put("start_offset", Long.toHexString(start.getOffset()));
-                bbMap.put("stop_space", stop.getAddressSpace().getName());
-                bbMap.put("stop_offset", Long.toHexString(stop.getOffset()));
+                bbMap.put("start", ServiceUtils.addressToJson(bb.getStart(), program));
+                bbMap.put("stop", ServiceUtils.addressToJson(bb.getStop(), program));
                 List<Map<String, Object>> bbOps = new ArrayList<>();
                 var iter = bb.getIterator();
                 while (iter.hasNext()) {
-                    bbOps.add(pcodeOpToJson(iter.next()));
+                    bbOps.add(pcodeOpToJson(iter.next(), program));
                 }
                 bbMap.put("pcodes", bbOps);
                 basicBlocks.add(bbMap);
@@ -4882,7 +4905,7 @@ public class AnalysisService {
                 var allOps = hf.getPcodeOps();
                 while (allOps.hasNext()) {
                     PcodeOpAST op = allOps.next();
-                    highOps.add(pcodeOpToJson(op));
+                    highOps.add(pcodeOpToJson(op, program));
                 }
             } catch (Exception e) {
                 out.put("high_pcodes_error", e.getMessage());
@@ -4894,21 +4917,18 @@ public class AnalysisService {
     }
 
     @McpTool(path = "/get_language_metadata",
-             description = "Dump the program's language description: address spaces, registers, default symbols, endianness, pointer size (issue #192). Use for P-code emulators / ML pipelines that need the SLEIGH-level facts. include_registers/include_default_symbols toggle expensive sections.",
+             description = "Dump the program's language description: address spaces, registers (with parent/child/aliases/description), default symbols (with end address and isEntry/isPrimary/isVolatile flags), endianness, pointer size. For P-code emulators / ML pipelines that need the SLEIGH-level facts.",
              category = "program")
     public Response getLanguageMetadata(
             @Param(value = "include_registers", defaultValue = "true",
-                   description = "Include the full register list (can be hundreds of entries on x86).") String includeRegistersStr,
+                   description = "Include the full register list (can be hundreds of entries on x86).") boolean includeRegisters,
             @Param(value = "include_default_symbols", defaultValue = "true",
-                   description = "Include the language's default symbol set (entry points, interrupt vectors).") String includeDefaultSymbolsStr,
+                   description = "Include the language's default symbol set (entry points, interrupt vectors).") boolean includeDefaultSymbols,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit for active program).") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
-
-        boolean includeRegisters = !"false".equalsIgnoreCase(includeRegistersStr);
-        boolean includeDefaultSymbols = !"false".equalsIgnoreCase(includeDefaultSymbolsStr);
 
         ghidra.program.model.lang.Language lang = program.getLanguage();
         ghidra.program.model.lang.LanguageDescription ld = lang.getLanguageDescription();
@@ -4924,7 +4944,9 @@ public class AnalysisService {
         Register pc = lang.getProgramCounter();
         out.put("program_counter", pc != null ? pc.getName() : null);
 
-        // Address spaces
+        // Address spaces. min/max addresses are SLEIGH-internal -- they
+        // describe the space, not program data -- so the flat space/offset
+        // shape is appropriate here.
         List<Map<String, Object>> spaces = new ArrayList<>();
         for (var space : program.getAddressFactory().getAllAddressSpaces()) {
             Map<String, Object> s = new LinkedHashMap<>();
@@ -4948,14 +4970,33 @@ public class AnalysisService {
                 rj.put("name", r.getName());
                 rj.put("bit_length", r.getBitLength());
                 rj.put("is_big_endian", r.isBigEndian());
+                // Register description (often null for raw SLEIGH registers,
+                // populated for processor-specific helpers like x87 / SIMD).
+                String desc = r.getDescription();
+                rj.put("description", desc);
                 Address ra = r.getAddress();
                 if (ra != null) {
                     rj.put("space", ra.getAddressSpace().getName());
                     rj.put("offset", Long.toHexString(ra.getOffset()));
                 }
+                // Parent / child hierarchy: needed by SSA-aware tools for
+                // aliasing analysis (e.g. EAX is a child of RAX on x86_64).
+                Register parent = r.getParentRegister();
+                rj.put("parent", parent != null ? parent.getName() : null);
                 List<String> children = new ArrayList<>();
                 for (Register c : r.getChildRegisters()) children.add(c.getName());
                 rj.put("children", children);
+                // Aliases (alternate SLEIGH names that resolve to the same
+                // storage). Empty list when there are none -- consumers can
+                // treat absence and empty list identically.
+                List<String> aliases = new ArrayList<>();
+                try {
+                    Iterable<String> ai = r.getAliases();
+                    if (ai != null) for (String s : ai) aliases.add(s);
+                } catch (Exception ignored) {
+                    // Some custom languages don't implement getAliases().
+                }
+                rj.put("aliases", aliases);
                 regs.add(rj);
             }
             out.put("registers", regs);
@@ -4972,6 +5013,20 @@ public class AnalysisService {
                         sj.put("space", a.getAddressSpace().getName());
                         sj.put("offset", Long.toHexString(a.getOffset()));
                     }
+                    // Range + flag metadata called out in the issue spec:
+                    // end_address, byte_size, is_entry (interrupt/reset vector
+                    // marker), is_primary, is_volatile.
+                    try {
+                        Address end = info.getEndAddress();
+                        if (end != null) {
+                            sj.put("end_space", end.getAddressSpace().getName());
+                            sj.put("end_offset", Long.toHexString(end.getOffset()));
+                        }
+                    } catch (Exception ignored) {}
+                    try { sj.put("byte_size", info.getByteSize()); } catch (Exception ignored) {}
+                    try { sj.put("is_entry", info.isEntry()); } catch (Exception ignored) {}
+                    try { sj.put("is_primary", info.isPrimary()); } catch (Exception ignored) {}
+                    try { sj.put("is_volatile", info.isVolatile()); } catch (Exception ignored) {}
                     syms.add(sj);
                 }
             } catch (Exception e) {

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.7.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 241,
+  "total_endpoints": 243,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -1358,6 +1358,17 @@
       "description": "Get labels in function"
     },
     {
+      "path": "/get_function_pcode",
+      "method": "GET",
+      "category": "analysis",
+      "params": [
+        "function_address",
+        "granularity",
+        "program"
+      ],
+      "description": "Dump raw P-code for a function (issue #192). Returns low (basic-iter) and high (HighFunction) P-code with basic blocks and varnodes. Granularity controls output: 'basic' = basic-block iter only (less memory), 'high' = HighFunction graph (default; includes both BB iter and op-iter). For P-code emulators / ML pipelines / alternative decompilers."
+    },
+    {
       "path": "/get_function_signature",
       "method": "GET",
       "category": "utility",
@@ -1402,6 +1413,17 @@
         "program"
       ],
       "description": "Get function cross-references"
+    },
+    {
+      "path": "/get_language_metadata",
+      "method": "GET",
+      "category": "program",
+      "params": [
+        "include_registers",
+        "include_default_symbols",
+        "program"
+      ],
+      "description": "Dump the program's language description: address spaces, registers, default symbols, endianness, pointer size (issue #192). Use for P-code emulators / ML pipelines that need the SLEIGH-level facts. include_registers/include_default_symbols toggle expensive sections."
     },
     {
       "path": "/get_metadata",
@@ -2407,6 +2429,17 @@
       "description": "Set function prototype (return type, param types, calling convention). NOTE: the function name in the prototype string does NOT rename the function — call rename_function_by_address separately if needed."
     },
     {
+      "path": "/set_function_tag_comment",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "name",
+        "comment",
+        "program"
+      ],
+      "description": "Update the comment/description on an existing program-wide function tag."
+    },
+    {
       "path": "/set_global",
       "method": "POST",
       "category": "datatype",
@@ -2419,17 +2452,6 @@
         "program"
       ],
       "description": "Atomically apply name + type + plate-comment + array length to a global variable. Single-transaction; rejects on validation failure with no partial write. Replaces the 4-tool chain (apply_data_type → rename_data → batch_set_comments → create_label)."
-    },
-    {
-      "path": "/set_function_tag_comment",
-      "method": "POST",
-      "category": "function",
-      "params": [
-        "name",
-        "comment",
-        "program"
-      ],
-      "description": "Update the comment/description on an existing program-wide function tag."
     },
     {
       "path": "/set_image_base",

--- a/tests/integration/test_readonly_endpoints.py
+++ b/tests/integration/test_readonly_endpoints.py
@@ -111,7 +111,8 @@ class TestProgramInfo:
             params={"include_registers": "false", "include_default_symbols": "false"},
         )
         assert response.status_code == 200
-        data = response.json().get("data", {})
+        # Endpoint returns flat JSON (no `data` wrapper).
+        data = response.json()
         # Core SLEIGH facts must always be present
         for key in (
             "language_id", "processor", "endian", "size", "default_space",
@@ -133,7 +134,7 @@ class TestProgramInfo:
             params={"include_registers": "true", "include_default_symbols": "false"},
         )
         assert response.status_code == 200
-        data = response.json().get("data", {})
+        data = response.json()
         assert "registers" in data
         regs = data["registers"]
         assert isinstance(regs, list)
@@ -478,7 +479,8 @@ class TestFunctionAnalysis:
             },
         )
         assert response.status_code == 200
-        data = response.json().get("data", {})
+        # Endpoint returns flat JSON (no `data` wrapper).
+        data = response.json()
         assert "basic_blocks" in data
         assert isinstance(data["basic_blocks"], list)
         # `basic` granularity omits the high-PcodeOp graph
@@ -508,7 +510,7 @@ class TestFunctionAnalysis:
             },
         )
         assert response.status_code == 200
-        data = response.json().get("data", {})
+        data = response.json()
         assert "basic_blocks" in data
         assert "high_pcodes" in data
         assert isinstance(data["high_pcodes"], list)

--- a/tests/integration/test_readonly_endpoints.py
+++ b/tests/integration/test_readonly_endpoints.py
@@ -128,7 +128,11 @@ class TestProgramInfo:
     def test_get_language_metadata_with_registers(self, http_client):
         """Issue #192: register list is included when requested. x86 typically
         has 100+ registers; ARM has fewer; either way the list must be
-        non-empty."""
+        non-empty. After Copilot review: every register entry has a stable
+        shape (name/bit_length/is_big_endian/children/aliases always present)
+        and richer fields (description/parent) appear when non-null. Gson
+        strips null values so absence of a key means the underlying value
+        was null, not that the endpoint forgot to emit it."""
         response = http_client.get(
             "/get_language_metadata",
             params={"include_registers": "true", "include_default_symbols": "false"},
@@ -139,10 +143,21 @@ class TestProgramInfo:
         regs = data["registers"]
         assert isinstance(regs, list)
         assert len(regs) > 0
-        # Every register entry has a name and bit_length
-        for r in regs[:5]:  # spot-check the first few
-            assert "name" in r
-            assert "bit_length" in r
+        # Stable fields present on every entry.
+        for r in regs[:5]:
+            for key in ("name", "bit_length", "is_big_endian", "children", "aliases"):
+                assert key in r, f"missing key '{key}' on register: {list(r.keys())}"
+            assert isinstance(r["children"], list)
+            assert isinstance(r["aliases"], list)
+        # At least one register reports a parent (e.g. AX → EAX on x86).
+        # If none do, the parent linkage isn't being emitted at all -- bug.
+        parent_count = sum(1 for r in regs if "parent" in r)
+        assert parent_count > 0, "no register reported a parent linkage"
+        # At least one register reports a description (e.g. EFLAGS bits on x86
+        # carry descriptions). If none do, the description is being silently
+        # dropped server-side.
+        desc_count = sum(1 for r in regs if "description" in r)
+        assert desc_count > 0, "no register reported a description"
 
 
 class TestFunctionListing:
@@ -485,19 +500,29 @@ class TestFunctionAnalysis:
         assert isinstance(data["basic_blocks"], list)
         # `basic` granularity omits the high-PcodeOp graph
         assert "high_pcodes" not in data
-        # Validate shape of the first basic block (if any)
+        # Validate shape of the first basic block (if any). Start/stop are
+        # nested ServiceUtils.addressToJson objects with a guaranteed
+        # 'address' key (and optional address_full/address_space on multi-
+        # space binaries).
         if data["basic_blocks"]:
             bb = data["basic_blocks"][0]
-            assert "start_offset" in bb
-            assert "stop_offset" in bb
+            assert "start" in bb and isinstance(bb["start"], dict)
+            assert "stop" in bb and isinstance(bb["stop"], dict)
+            assert "address" in bb["start"]
+            assert "address" in bb["stop"]
             assert "pcodes" in bb
             assert isinstance(bb["pcodes"], list)
-            # PcodeOps carry mnemonic + opcode if non-empty
+            # PcodeOps carry mnemonic + opcode + SSA varnode flags
             if bb["pcodes"]:
                 op = bb["pcodes"][0]
                 assert "mnemonic" in op
                 assert "opcode" in op
                 assert "inputs" in op
+                # SSA flags now present on every varnode
+                if op["inputs"]:
+                    vn = op["inputs"][0]
+                    for key in ("is_addrtied", "is_hash", "is_persistent", "merge_group"):
+                        assert key in vn, f"missing SSA flag '{key}' on varnode: {vn}"
 
     def test_get_function_pcode_high_granularity(self, http_client, first_function_address):
         """Issue #192: `high` granularity (default) adds the full HighFunction

--- a/tests/integration/test_readonly_endpoints.py
+++ b/tests/integration/test_readonly_endpoints.py
@@ -101,6 +101,48 @@ class TestProgramInfo:
         response = http_client.get("/get_entry_points")
         assert response.status_code == 200
 
+    def test_get_language_metadata(self, http_client):
+        """Issue #192: language metadata dump (address spaces, registers,
+        default symbols, endianness). Skip the heavy sections to keep the
+        readonly suite fast — they're exercised separately in
+        TestGetLanguageMetadataFull."""
+        response = http_client.get(
+            "/get_language_metadata",
+            params={"include_registers": "false", "include_default_symbols": "false"},
+        )
+        assert response.status_code == 200
+        data = response.json().get("data", {})
+        # Core SLEIGH facts must always be present
+        for key in (
+            "language_id", "processor", "endian", "size", "default_space",
+            "address_spaces",
+        ):
+            assert key in data, f"missing '{key}' in language metadata: {data}"
+        assert isinstance(data["address_spaces"], list)
+        assert len(data["address_spaces"]) > 0
+        # When the heavy sections are off they should not be in the payload.
+        assert "registers" not in data
+        assert "default_symbols" not in data
+
+    def test_get_language_metadata_with_registers(self, http_client):
+        """Issue #192: register list is included when requested. x86 typically
+        has 100+ registers; ARM has fewer; either way the list must be
+        non-empty."""
+        response = http_client.get(
+            "/get_language_metadata",
+            params={"include_registers": "true", "include_default_symbols": "false"},
+        )
+        assert response.status_code == 200
+        data = response.json().get("data", {})
+        assert "registers" in data
+        regs = data["registers"]
+        assert isinstance(regs, list)
+        assert len(regs) > 0
+        # Every register entry has a name and bit_length
+        for r in regs[:5]:  # spot-check the first few
+            assert "name" in r
+            assert "bit_length" in r
+
 
 class TestFunctionListing:
     """Test function listing and query endpoints (read-only)."""
@@ -423,6 +465,53 @@ class TestFunctionAnalysis:
             "/analyze_function_completeness", params={"address": first_function_address}
         )
         assert response.status_code == 200
+
+    def test_get_function_pcode_basic(self, http_client, first_function_address):
+        """Issue #192: dump P-code for a function (basic-block iter only).
+        Validates that basic_blocks is a list and each entry has start/stop
+        addresses + a pcodes list."""
+        response = http_client.get(
+            "/get_function_pcode",
+            params={
+                "function_address": first_function_address,
+                "granularity": "basic",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json().get("data", {})
+        assert "basic_blocks" in data
+        assert isinstance(data["basic_blocks"], list)
+        # `basic` granularity omits the high-PcodeOp graph
+        assert "high_pcodes" not in data
+        # Validate shape of the first basic block (if any)
+        if data["basic_blocks"]:
+            bb = data["basic_blocks"][0]
+            assert "start_offset" in bb
+            assert "stop_offset" in bb
+            assert "pcodes" in bb
+            assert isinstance(bb["pcodes"], list)
+            # PcodeOps carry mnemonic + opcode if non-empty
+            if bb["pcodes"]:
+                op = bb["pcodes"][0]
+                assert "mnemonic" in op
+                assert "opcode" in op
+                assert "inputs" in op
+
+    def test_get_function_pcode_high_granularity(self, http_client, first_function_address):
+        """Issue #192: `high` granularity (default) adds the full HighFunction
+        PcodeOp graph. Verify both basic_blocks and high_pcodes appear."""
+        response = http_client.get(
+            "/get_function_pcode",
+            params={
+                "function_address": first_function_address,
+                "granularity": "high",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json().get("data", {})
+        assert "basic_blocks" in data
+        assert "high_pcodes" in data
+        assert isinstance(data["high_pcodes"], list)
 
 
 class TestXRefEndpoints:


### PR DESCRIPTION
## Summary

Closes #192. Two new endpoints for downstream tooling that needs the raw decompiler graph rather than the C surface (P-code emulators, alternative decompilers, ML pipelines).

- **`/get_function_pcode?function_address=...&granularity={basic|high}`** — dumps HighFunction P-code. `basic` returns only the basic-block iter (PcodeOps in program order, lighter payload). `high` (default) additionally returns the full HighFunction PcodeOp graph from `hf.getPcodeOps()`. Each op carries mnemonic, opcode, varnode inputs/output with space/offset/size and SSA flags. Basic blocks carry start/stop addresses.
- **`/get_language_metadata?include_registers=true&include_default_symbols=true`** — SLEIGH-level program facts: language ID, processor, endian, size, variant, default space, default data space, program counter, full address-space list, registers (with parent/child relations), default symbol set.

`getDecompiledFunction` from the original issue spec maps to existing `/decompile_function` + `/get_function_signature` (or `/analyze_for_documentation` for both in one call), so not duplicated here.

Endpoint count: 241 → 243.

## Test plan

- [x] `mvn clean compile` — BUILD SUCCESS.
- [x] `mvn test -Dtest='com.xebyte.offline.*Test'` — 84 tests pass, including `EndpointsJsonParityTest` (catalog matches scanner output).
- [ ] Live verification on a known binary: call `/get_function_pcode` against a small function and confirm op count matches Ghidra GUI's Pcode view.
- [ ] Live verification: `/get_language_metadata` returns the expected processor / endian / register list for x86 and ARM binaries.

## Future extensions

The varnode shape includes SSA position flags but not the symbol/HighSymbol link — open to adding that if @Molkars's emulator needs it for variable identity tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)