### PR TITLE
feat(fun-doc): heuristic library-code auto-classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,11 @@ private/
 *.db
 *.sqlite
 *.sqlite3
+# SQLite sidecars (WAL mode produces -shm + -wal; rollback-journal mode produces -journal).
+# These are session-scoped runtime artifacts; the canonical state lives in the .db itself.
+*.db-shm
+*.db-wal
+*.db-journal
 
 # =============================================================================
 # MAVEN AND JAVA

--- a/fun-doc/db/migrations/0002_library_code.sql
+++ b/fun-doc/db/migrations/0002_library_code.sql
@@ -1,0 +1,20 @@
+-- fun-doc migration 0002: library_code auto-classification (Postgres dialect).
+--
+-- Adds three columns to functions_workflow tracking the heuristic library-code
+-- classification gate that runs before the LLM. When the detector
+-- (library_code_detector.py) decides a function is statically-linked MSVC CRT
+-- / STL / iostream / SEH code, the worker stamps a generic plate and sets
+-- library_code = TRUE so the selector permanently skips the function. Cleared
+-- by the existing refresh paths (--scan --refresh, dashboard Refresh Top N).
+--
+-- See library_code_detector.py for the signal list. Mirrored at
+-- 0002_library_code.sqlite.sql for the SQLite backend.
+
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS library_code BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS library_code_at TIMESTAMPTZ;
+
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS library_code_reasons JSONB;

--- a/fun-doc/db/migrations/0002_library_code.sqlite.sql
+++ b/fun-doc/db/migrations/0002_library_code.sqlite.sql
@@ -1,0 +1,16 @@
+-- fun-doc migration 0002: library_code auto-classification (SQLite dialect).
+--
+-- Mirror of 0002_library_code.sql for the SQLite backend. Differences are
+-- dialect-only (TIMESTAMPTZ -> TEXT, JSONB -> TEXT, BOOLEAN -> INTEGER 0/1).
+-- See the Postgres file for design rationale and the consumer wiring in
+-- library_code_detector.py + fun_doc.py.
+--
+-- SQLite doesn't support ALTER TABLE IF NOT EXISTS for ADD COLUMN, so we use
+-- one ALTER per column. Re-running this migration after partial application
+-- (e.g. one column added, the next failed) requires manual recovery; the
+-- normal path of `python -m db.migrate` records the version in
+-- schema_versions and skips re-running entirely.
+
+ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER DEFAULT 0;
+ALTER TABLE functions_workflow ADD COLUMN library_code_at TEXT;
+ALTER TABLE functions_workflow ADD COLUMN library_code_reasons TEXT;

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -97,6 +97,7 @@ except (AttributeError, OSError):
     pass
 
 from event_bus import emit as bus_emit, get_bus, get_worker_id
+from library_code_detector import detect_library_code, format_plate as format_library_plate
 
 # Thread safety for state.json access across concurrent workers.
 # RLock (reentrant) is required because the common read-modify-write
@@ -945,6 +946,7 @@ _STATE_DIRECT_FIELDS = (
     "is_thunk",
     "is_external",
     "is_thrashing",
+    "library_code",
     "deductions",
     "callees",
     "snapshot_provider",
@@ -1001,6 +1003,10 @@ def _state_func_to_row(func_key, rec):
         out["last_result"] = rec["last_result"]
     if "decompile_timeout_at" in rec:
         out["decompile_timeout_at"] = _parse_state_ts(rec["decompile_timeout_at"])
+    if "library_code_at" in rec:
+        out["library_code_at"] = _parse_state_ts(rec["library_code_at"])
+    if "library_code_reasons" in rec:
+        out["library_code_reasons"] = rec["library_code_reasons"]
     if "last_audited" in rec:
         out["last_audited_at"] = _parse_state_ts(rec["last_audited"])
     if "last_escalated" in rec:
@@ -1057,6 +1063,11 @@ def _row_to_state_func(row):
     if row.get("decompile_timeout_at") is not None:
         v = row["decompile_timeout_at"]
         out["decompile_timeout_at"] = v.isoformat() if hasattr(v, "isoformat") else v
+    if row.get("library_code_at") is not None:
+        v = row["library_code_at"]
+        out["library_code_at"] = v.isoformat() if hasattr(v, "isoformat") else v
+    if row.get("library_code_reasons") is not None:
+        out["library_code_reasons"] = row["library_code_reasons"]
     if row.get("last_audited_at") is not None:
         v = row["last_audited_at"]
         out["last_audited"] = v.isoformat() if hasattr(v, "isoformat") else v
@@ -2539,6 +2550,15 @@ DEFAULT_QUEUE_CONFIG = {
     # documentation bar (name + type + bytes + plate). Same idle-time pattern
     # as the function inventory scorer; persists to global_inventory.json.
     "global_inventory_enabled": False,
+    # Library-code auto-classification (v5.9.0, on by default). When True,
+    # the worker runs the library-code detector after fetching decompile
+    # and BEFORE invoking the LLM. Detected functions get a generic plate
+    # stamped and `library_code: True` flag set, which excludes them from
+    # future selector picks. Prevents wasted LLM tokens on statically-linked
+    # MSVC CRT / STL / iostream / SEH code that isn't the binary's authored
+    # source. Disable by setting False if you have a binary where the
+    # detector misfires on user code.
+    "skip_library_code": True,
 }
 
 PRIORITY_QUEUE_FILE = SCRIPT_DIR / "priority_queue.json"
@@ -2604,6 +2624,7 @@ def build_worker_config_snapshot(queue, primary_provider):
         "audit_min_delta": int(cfg.get("audit_min_delta", 5)),
         "complexity_handoff_provider": cfg.get("complexity_handoff_provider"),
         "complexity_handoff_max": int(cfg.get("complexity_handoff_max", 0) or 0),
+        "skip_library_code": bool(cfg.get("skip_library_code", True)),
     }
 
     # Per-provider slices — only the providers this worker can invoke. The
@@ -2763,6 +2784,7 @@ def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=N
     - Skip funcs with >=3 consecutive_fails (unless pinned)
     - Skip funcs with recovery_pass_done (complexity-forced recovery already ran)
     - Skip funcs with decompile_timeout (pathological, one-shot blacklist)
+    - Skip funcs with library_code (CRT/STL/iostream — auto-classified, plate-stamped)
     - Skip funcs with >=3 stagnation_runs (no-progress / regression safety net)
     - When require_scored is on, treat unscored funcs as top priority so the
       worker scores them on first contact instead of leaving them stranded
@@ -2830,6 +2852,15 @@ def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=N
         # we already know can't be scored. Cleared by the same refresh paths
         # as recovery_pass_done.
         if func.get("decompile_timeout") and not is_pinned:
+            continue
+
+        # Library-code one-shot: functions classified as MSVC CRT / STL /
+        # iostream / SEH machinery by the heuristic detector get a generic
+        # plate stamped and are excluded from selector picks. Burning LLM
+        # tokens on `ParseSignedShort` and friends is wasted spend — the
+        # function isn't user-authored code. Cleared by the same refresh
+        # paths as the other one-shots; pinning bypasses.
+        if func.get("library_code") and not is_pinned:
             continue
 
         # Stagnation safety net: blacklist functions that have completed 3+
@@ -2976,6 +3007,12 @@ def refresh_candidate_scores(
             # user can retry after e.g. Ghidra analysis improvements.
             func.pop("decompile_timeout", None)
             func.pop("decompile_timeout_at", None)
+            # Library-code auto-classification clears on refresh too — the
+            # detector is conservative but not perfect, and the explicit
+            # refresh gesture is the user saying "look at everything fresh."
+            func.pop("library_code", None)
+            func.pop("library_code_at", None)
+            func.pop("library_code_reasons", None)
             # And the stagnation counter: a refresh is the user saying
             # "re-score this from scratch, I'm willing to try again."
             func.pop("stagnation_runs", None)
@@ -6939,6 +6976,70 @@ def process_function(
             score_after=live_score,
             reason="decompile-heavy endpoint hit read timeout",
         )
+
+    # Library-code auto-classification: detect statically-linked MSVC CRT /
+    # STL / iostream / SEH code before invoking the LLM. Pinned functions
+    # bypass (user explicitly queued them — respect their judgment). The
+    # check runs after the decompile fetch so the detector has body text
+    # for callee-substring fallback when call-graph data isn't populated.
+    queue_for_library = load_priority_queue()
+    cfg_for_library = queue_for_library.get("config") or DEFAULT_QUEUE_CONFIG
+    skip_library = (
+        cfg_for_library.get("skip_library_code", True) if config_snapshot is None
+        else config_snapshot.get("skip_library_code", True)
+    )
+    is_pinned_for_library = func_key in set(queue_for_library.get("pinned", []))
+    if skip_library and not manual and not is_pinned_for_library:
+        decomp_text = data.get("decompiled")
+        if decomp_text and not _is_error_response(decomp_text):
+            detection = detect_library_code(
+                name=func.get("name"),
+                decompile=str(decomp_text),
+                callees=func.get("callees"),
+            )
+            if detection.is_library:
+                plate_text = format_library_plate(detection)
+                # Best-effort plate stamp via MCP — failure is non-fatal,
+                # the flag itself is the primary skip mechanism.
+                try:
+                    ghidra_post(
+                        "/batch_set_comments",
+                        params={"program": program},
+                        data={
+                            "function_address": f"0x{address}",
+                            "plate_comment": plate_text,
+                        },
+                    )
+                except Exception as e:
+                    print(
+                        f"  LIBRARY-CODE plate stamp failed (non-fatal): {e}",
+                        flush=True,
+                    )
+                func["library_code"] = True
+                func["library_code_at"] = datetime.now().isoformat()
+                func["library_code_reasons"] = detection.reasons
+                func["last_processed"] = datetime.now().isoformat()
+                func["last_result"] = "library_code"
+                print(
+                    f"  LIBRARY CODE — auto-classified ({', '.join(detection.reasons)}). "
+                    f"Stamped generic plate, marked for selector skip.",
+                    flush=True,
+                )
+                update_function_state(func_key, func)
+                bus_emit(
+                    "function_complete",
+                    {
+                        "key": func_key,
+                        "result": "library_code",
+                        "score": live_score,
+                        "reasons": detection.reasons,
+                    },
+                )
+                return _finish(
+                    "library_code",
+                    score_after=live_score,
+                    reason=f"library-code detector: {','.join(detection.reasons)}",
+                )
 
     # Refine mode based on live score and completeness context
     mode = determine_mode(live_score, data.get("deductions"), data.get("completeness"))

--- a/fun-doc/library_code_detector.py
+++ b/fun-doc/library_code_detector.py
@@ -1,0 +1,258 @@
+"""Heuristic library-code detector for fun-doc.
+
+Some binaries statically link MSVC CRT / STL / iostream / vc-runtime code into
+their `.text` section. Without a PDB, Ghidra cannot tell that code apart from
+the user's actual source — so fun-doc workers happily queue and document
+`ParseSignedShort` and other CRT internals, burning 100K+ tokens for marginal
+score gain on code that is not even part of the binary's authored surface.
+
+This module classifies a function as "library code" using cheap, structural
+signals already available from the decompile we fetch on the cold path. When a
+function trips the detector, the worker:
+
+    1. Stamps a generic plate ("MSVC CRT helper — auto-classified")
+    2. Sets `library_code: True` so the selector permanently skips it
+    3. Returns without invoking the LLM
+
+The detector is intentionally conservative — false positives cost real work
+(a user-authored function gets wrongly skipped). We require at least one
+hard-evidence signal (CRT-only callee or canonical CRT name) OR two
+medium-confidence signals.
+
+To clear the flag for a specific function: pin it (pinned bypasses skip), or
+run `--scan --refresh` / dashboard "Refresh Top N", same as the other
+one-shot blacklists (`recovery_pass_done`, `decompile_timeout`).
+
+Public API:
+    detect_library_code(name, decompile, callees=None) -> DetectionResult
+    LIBRARY_PLATE_TEMPLATE -- canonical plate text for auto-stamping
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+
+
+HARD_NAME_PATTERNS = (
+    # MSVC CRT internal helpers
+    re.compile(r"^_+(crt|invoke_watson|except_handler|security_check|amsg_exit|setjmp|aullshr|chkstk|alloca_probe|local_unwind|cinit|tlsdtor|RTC_)"),
+    # Operator new/delete and CXX scalar/vector
+    re.compile(r"^\?\?[23](@|_)"),
+    # MSVC C++ symbol mangling: starts with `?` and contains `@@`
+    re.compile(r"^\?[A-Za-z_].*@@"),
+    # C++ standard library namespace
+    re.compile(r"^(std::|__std_|__crt_|_Std|_VEC_memcpy|_VEC_memzero)"),
+    # CRT internal mangled exports (e.g. `_strtoi64@4`, `_atof@4`)
+    re.compile(r"^_(strtoi64|strtoui64|wcstoi64|wcstoui64|atof|atoi|atol|atoll|strtod|strtol|strtoul|memcpy_s|strcpy_s|wcscpy_s|sprintf_s|vsnprintf_s|fread_s)(@\d+)?$"),
+    # iostream / locale parsers
+    re.compile(r"^(Parse|Read|Write|Get|Put|Skip)?(Signed|Unsigned)?(Char|Short|Int|Long|Float|Double|Hex|Oct|Octal|Dec|Decimal)(Value|Field|Token)?$"),
+)
+
+# Functions decompile output calls when it's CRT or VC-runtime. Detecting any of
+# these inside the body is strong evidence the function is statically-linked
+# CRT, NOT user code (user code would only reach these through the import
+# table, never via direct .text reference).
+HARD_CALLEE_NAMES = frozenset({
+    # SEH prologs/handlers (MSVC-only, generated, never authored). The /GS
+    # stack-cookie helpers (`__security_check_cookie`, `__report_*`) are
+    # NOT in this set -- they're emitted into ordinary user functions by
+    # the compiler, so they live in SOFT_BODY_SIGNALS where they contribute
+    # supporting evidence only.
+    "__SEH_prolog4", "__SEH_epilog4",
+    "__EH_prolog", "__EH_epilog",
+    "__except_handler4", "__except_handler3",
+    "__CxxFrameHandler", "__CxxFrameHandler3",
+    "_CxxThrowException",
+    "_local_unwind", "_global_unwind",
+    # CRT init / shutdown — only the program-startup / exit path. These
+    # symbols are referenced from CRT code itself, not from authored
+    # functions.
+    "_amsg_exit", "__crt_debugger_hook",
+    "_cinit", "_initterm", "_initterm_e",
+    "_invoke_watson", "_invalid_parameter", "_invalid_parameter_noinfo",
+    "unhandled_exception", "_terminate",
+    "__std_terminate", "__std_exception_copy", "__std_exception_destroy",
+    # iostream helpers — dead giveaways for ParseSignedShort-style code
+    # that never appear in authored user functions.
+    "_Xinvalid_argument", "_Xout_of_range", "_Xlength_error", "_Xbad_alloc",
+})
+
+# Substrings that, when present in the decompile body, indicate library code.
+# Lower confidence than HARD_CALLEE_NAMES (substring match → more false
+# positives) but still useful as supporting evidence.
+SOFT_BODY_SIGNALS = (
+    # /GS stack-cookie machinery. Common in user code compiled with /GS, so
+    # not a hard signal on its own -- but contributes evidence when paired
+    # with library-typical names or other library signals.
+    "__security_cookie",
+    "__security_check_cookie",
+    "__report_rangecheckfailure",
+    "__report_gsfailure",
+    "__chkstk",
+    "_alloca_probe",
+    # MSVCRT 64-bit integer arithmetic helpers (used by `long long` arithmetic).
+    # User code with int64 ops will reference these too, hence soft.
+    "_aulldiv", "_aullrem", "_aullshr", "_allshr", "_alldiv", "_allrem", "_allmul",
+    # CRT errno / locale — appear in stdlib-touching user code as well.
+    "_errno", "__doserrno",
+    "_getmbcp", "_setmbcp", "___mb_cur_max_func",
+    # SEH/CRT names visible in disassembly even of authored functions.
+    "__except_handler",
+    "_invoke_watson",
+    "_invalid_parameter",
+    "_amsg_exit",
+    "__CxxFrameHandler",
+    "_CxxThrowException",
+    "_Xinvalid_argument",
+    "_Xout_of_range",
+    "_Xlength_error",
+    "_Xbad_alloc",
+    # std::basic_*, std::ios_*, std::locale -- usually library, but a
+    # template instantiation in user code can name-leak into the function
+    # body too. Soft.
+    "std::basic_",
+    "std::ios_",
+    "std::locale",
+    "std::_",
+)
+
+# Soft name signals. Less authoritative than HARD_NAME_PATTERNS but useful when
+# combined with body signals.
+SOFT_NAME_PATTERNS = (
+    # Number parsing helpers: `ParseSignedShort`, `ReadUnsignedInt`, etc.
+    re.compile(r"^(Parse|Read|Convert)(Signed|Unsigned)?\w*(Short|Int|Long|Float|Double|Hex)\w*$"),
+    # MSVC mangled function names with `@@YA` (calling convention marker)
+    re.compile(r"@@YA"),
+    # vfprintf / vsprintf / vsnprintf family
+    re.compile(r"^_?v?[sf]n?printf"),
+    re.compile(r"^_?v?[sf]n?scanf"),
+    # CRT internal lookup tables / locale helpers
+    re.compile(r"^_?Get(LcMap|Loc|Locale|Mb|NumOf)"),
+)
+
+
+@dataclass
+class DetectionResult:
+    """Outcome of a library-code classification attempt."""
+
+    is_library: bool
+    confidence: float  # 0.0-1.0
+    reasons: List[str] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.is_library
+
+
+LIBRARY_PLATE_TEMPLATE = (
+    "MSVC CRT / runtime helper - auto-classified by fun-doc library detector.\n"
+    "\n"
+    "This function is statically-linked compiler runtime code (CRT, STL,\n"
+    "iostream, SEH machinery, or similar), NOT part of the binary's authored\n"
+    "source. The library detector matched signals: {reasons}.\n"
+    "\n"
+    "Auto-classified to exclude from worker selection. To document anyway,\n"
+    "pin this function or run `--scan --refresh` to reset the flag.\n"
+    "\n"
+    "For authoritative documentation of this code, load the matching\n"
+    "msvcr*.pdb from the Microsoft symbol server. See Ghidra script\n"
+    "Import_MSDL_PDB.py."
+)
+
+
+_HARD_NAME_HIT = "hard_name"
+_HARD_CALLEE_HIT = "hard_callee:{}"
+_SOFT_BODY_HIT = "soft_body:{}"
+_SOFT_NAME_HIT = "soft_name"
+
+
+def detect_library_code(
+    name: Optional[str],
+    decompile: Optional[str],
+    callees: Optional[Iterable[str]] = None,
+) -> DetectionResult:
+    """Classify a function as library code or user code.
+
+    Conservative: requires either one HARD signal (canonical CRT name OR
+    direct call to a CRT-only helper) or two SOFT signals (soft name pattern +
+    soft body substring). This keeps false positives low at the cost of some
+    false negatives, which is the right trade — wrongly skipping a real
+    function is more expensive than wrongly documenting a CRT one.
+
+    Parameters:
+        name: the function's display name (may be `FUN_xxxxxxxx` or anything)
+        decompile: the C-like decompile body. May be None if not yet fetched.
+        callees: optional iterable of callee names from analyze_for_doc or
+            the call-graph endpoint. Direct enumeration beats substring search.
+
+    Returns: DetectionResult. `is_library=True` means stamp+skip.
+    """
+    reasons: List[str] = []
+
+    if name:
+        for pat in HARD_NAME_PATTERNS:
+            if pat.search(name):
+                reasons.append(_HARD_NAME_HIT)
+                break
+
+    if callees:
+        for cn in callees:
+            if cn and cn in HARD_CALLEE_NAMES:
+                reasons.append(_HARD_CALLEE_HIT.format(cn))
+                # one hit is enough — don't blow up the reason list
+                break
+
+    body = decompile or ""
+    # Cheap-callee substring search as a fallback when call-graph data isn't
+    # populated yet. Each HARD_CALLEE_NAMES entry inside the body counts as a
+    # hard hit because these symbols are never legitimate user-code call
+    # targets (they're MSVC-internal, exposed only via direct .text linkage).
+    if body and not any(r.startswith("hard_callee") for r in reasons):
+        for cn in HARD_CALLEE_NAMES:
+            if cn in body:
+                reasons.append(_HARD_CALLEE_HIT.format(cn))
+                break
+
+    soft_hits = 0
+    if name:
+        for pat in SOFT_NAME_PATTERNS:
+            if pat.search(name):
+                reasons.append(_SOFT_NAME_HIT)
+                soft_hits += 1
+                break
+
+    if body:
+        for sig in SOFT_BODY_SIGNALS:
+            if sig in body:
+                reasons.append(_SOFT_BODY_HIT.format(sig))
+                soft_hits += 1
+                break
+
+    hard_hits = sum(1 for r in reasons if r.startswith("hard_"))
+    is_library = hard_hits >= 1 or soft_hits >= 2
+
+    if is_library:
+        confidence = min(1.0, 0.6 + 0.2 * hard_hits + 0.1 * soft_hits)
+    else:
+        confidence = 0.0
+
+    return DetectionResult(is_library=is_library, confidence=confidence, reasons=reasons)
+
+
+def format_plate(result: DetectionResult) -> str:
+    """Render the canonical library-code plate using a detection result."""
+    reasons_str = ", ".join(result.reasons) if result.reasons else "n/a"
+    return LIBRARY_PLATE_TEMPLATE.format(reasons=reasons_str)
+
+
+__all__ = [
+    "DetectionResult",
+    "detect_library_code",
+    "format_plate",
+    "LIBRARY_PLATE_TEMPLATE",
+    "HARD_NAME_PATTERNS",
+    "HARD_CALLEE_NAMES",
+    "SOFT_BODY_SIGNALS",
+    "SOFT_NAME_PATTERNS",
+]

--- a/fun-doc/storage/models.py
+++ b/fun-doc/storage/models.py
@@ -100,6 +100,9 @@ def build_metadata(schema: str | None = None) -> MetaData:
         # transient worker state
         Column("is_thrashing", Boolean, default=False),
         Column("decompile_timeout_at", DateTime(timezone=True)),
+        Column("library_code", Boolean, default=False),
+        Column("library_code_at", DateTime(timezone=True)),
+        Column("library_code_reasons", JSON),
         # JSONB blobs
         Column("deductions", JSON),
         Column("callees", JSON),

--- a/fun-doc/web.py
+++ b/fun-doc/web.py
@@ -771,7 +771,7 @@ class WorkerManager:
                     session["completed"] += 1
                     session["functions"].append(key)
                     worker["_rate_limit_streak"] = 0  # reset on success
-                elif result in ("skipped", "decompile_timeout"):
+                elif result in ("skipped", "decompile_timeout", "library_code"):
                     worker["progress"]["skipped"] += 1
                     session["skipped"] += 1
                 elif result in ("failed", "blocked", "needs_redo"):

--- a/tests/performance/test_library_code_detector.py
+++ b/tests/performance/test_library_code_detector.py
@@ -1,0 +1,239 @@
+"""Unit tests for fun-doc's library-code heuristic detector.
+
+The detector classifies functions as MSVC CRT / STL / iostream / SEH code
+based on cheap structural signals (callee names, body substrings, function
+name patterns). False positives are expensive (user code wrongly skipped) so
+these tests verify the decision boundaries on both ends:
+
+- True positives: synthetic decompile bodies that clearly evoke library code
+- True negatives: realistic user-code decompile bodies that must not trip
+
+Fast, pure Python, no Ghidra, no I/O.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_FUN_DOC_DIR = Path(__file__).resolve().parent.parent.parent / "fun-doc"
+sys.path.insert(0, str(_FUN_DOC_DIR))
+
+from library_code_detector import (  # noqa: E402
+    HARD_CALLEE_NAMES,
+    detect_library_code,
+    format_plate,
+)
+
+
+# ---------------------------------------------------------------------------
+# True positives — library code must be flagged
+# ---------------------------------------------------------------------------
+
+
+def test_hard_callee_seh_prolog_flags_as_library():
+    """A function that calls __SEH_prolog4 is statically-linked CRT machinery."""
+    body = """
+    void FUN_10052ba0(int param_1) {
+        __SEH_prolog4();
+        // ... user code ...
+        __SEH_epilog4();
+        return;
+    }
+    """
+    result = detect_library_code("FUN_10052ba0", body)
+    assert result.is_library
+    assert result.confidence >= 0.6
+    assert any("hard_callee" in r for r in result.reasons)
+
+
+def test_security_check_cookie_alone_not_enough():
+    """`__security_check_cookie` is the /GS stack-cookie helper -- present
+    in MANY user functions compiled with /GS, NOT a library-only signal.
+    It belongs in SOFT_BODY_SIGNALS, so its presence alone (no other
+    signals) must NOT classify the function as library code. Without this
+    rule the detector misfires on ~10% of an authored binary."""
+    body = "int func() { do_user_stuff(); __security_check_cookie(local_cookie); return 0; }"
+    result = detect_library_code("FUN_aaaa", body)
+    assert not result.is_library, (
+        "Single /GS signal must not classify -- "
+        "/GS is emitted into user code, not library-only"
+    )
+
+
+def test_hard_callee_invoke_watson_flags_as_library():
+    """_invoke_watson is the MSVC invalid-parameter handler (CRT only)."""
+    body = "void func() { _invoke_watson(0,0,0,0,0); }"
+    result = detect_library_code("FUN_bbbb", body)
+    assert result.is_library
+
+
+def test_cxx_throw_flags_as_library():
+    """_CxxThrowException is the C++ exception-throwing runtime."""
+    body = "void func() { _CxxThrowException(&ex, 0); }"
+    result = detect_library_code("FUN_cccc", body)
+    assert result.is_library
+
+
+def test_canonical_crt_name_flags_as_library_without_body():
+    """A function named `_strtoi64@4` is canonically a CRT export. The
+    name alone is hard evidence even without decompile body."""
+    result = detect_library_code("_strtoi64@4", "")
+    assert result.is_library
+
+
+def test_mangled_cxx_operator_new_flags_as_library():
+    """`??2@YAPAXI@Z` is the mangled MSVC `operator new(size_t)` -- always
+    a library function, never authored source."""
+    result = detect_library_code("??2@YAPAXI@Z", "")
+    assert result.is_library
+
+
+def test_std_namespace_name_flags_as_library():
+    """`std::_Allocator_base` and similar STL internals are library code."""
+    result = detect_library_code("std::_Allocator_base", "")
+    assert result.is_library
+
+
+def test_parse_signed_short_pattern_matches_with_body_signal():
+    """The motivating example: `ParseSignedShort` with iostream callees.
+    The name alone is a soft signal; combined with a body signal it must
+    classify as library."""
+    body = """
+    long FUN_10052ba0(int *istream, short *out_value) {
+        // ... iostream parsing logic ...
+        std::basic_istream::sentry sentry(*istream);
+        if (!sentry) {
+            return std::_Xinvalid_argument("bad istream");
+        }
+        return 0;
+    }
+    """
+    result = detect_library_code("ParseSignedShort", body)
+    assert result.is_library
+    assert len(result.reasons) >= 2  # soft_name + soft_body OR hard_callee
+
+
+def test_hard_callee_substring_in_body_without_callee_list():
+    """When call-graph data isn't populated, the detector falls back to
+    substring search on the decompile body for HARD_CALLEE_NAMES symbols.
+    `__SEH_prolog4` is hard-callee, `__chkstk` is soft body (compiler-emitted)."""
+    body = "void foo() { __SEH_prolog4(); user_helper(); }"
+    result = detect_library_code("FUN_dddd", body)
+    assert result.is_library
+
+
+def test_explicit_callees_iterable_classifies():
+    """Direct callee enumeration is more authoritative than substring."""
+    result = detect_library_code(
+        name="FUN_1234",
+        decompile="",
+        callees=["__SEH_prolog4", "user_helper_function"],
+    )
+    assert result.is_library
+
+
+# ---------------------------------------------------------------------------
+# True negatives — user code must not be flagged
+# ---------------------------------------------------------------------------
+
+
+def test_plain_user_function_not_flagged():
+    """A simple user function with no library signals must pass through."""
+    body = """
+    int CalculateDamage(int base, int multiplier) {
+        return base * multiplier + 10;
+    }
+    """
+    result = detect_library_code("CalculateDamage", body)
+    assert not result.is_library
+    assert result.reasons == []
+
+
+def test_function_calling_user_helpers_not_flagged():
+    """A function that calls other game functions (not CRT) stays unflagged."""
+    body = """
+    void OnEnemyHit(Unit *unit) {
+        DealDamage(unit, 100);
+        TriggerEffect(unit, EFFECT_BLOOD);
+        UpdateHealthBar(unit);
+    }
+    """
+    result = detect_library_code("OnEnemyHit", body)
+    assert not result.is_library
+
+
+def test_fun_xxx_name_alone_not_flagged():
+    """A bare `FUN_xxxxxxxx` name with no body signals must not trip."""
+    result = detect_library_code("FUN_6fdb1234", "void foo() { return; }")
+    assert not result.is_library
+
+
+def test_soft_signal_alone_not_enough():
+    """A single soft signal alone is not enough to classify -- requires 2+
+    soft signals or 1 hard. Here we use `vsnprintf` which only matches
+    SOFT_NAME_PATTERNS, without any body evidence."""
+    result = detect_library_code("vsnprintf_helper", "void foo() { do_thing(); }")
+    assert not result.is_library, "Single soft signal must not classify"
+
+
+def test_user_function_with_security_cookie_assignment_flagged():
+    """`__security_cookie` (the global) appearing in body is a soft signal --
+    compiled code reads this for stack-canary checks. By itself it's not
+    enough; needs corroborating evidence."""
+    # Only soft body signal — should NOT flag
+    body = "void foo() { uint local_var = __security_cookie; bar(); }"
+    result = detect_library_code("DoUserThing", body)
+    assert not result.is_library
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_inputs_safe():
+    """Empty / None inputs must not crash."""
+    assert not detect_library_code(None, None).is_library
+    assert not detect_library_code("", "").is_library
+    assert not detect_library_code(None, "", callees=[]).is_library
+
+
+def test_format_plate_renders_reasons():
+    """The auto-stamp plate must mention the matched reasons so a human
+    reviewer can audit why a function was classified."""
+    body = "void foo() { __SEH_prolog4(); }"
+    result = detect_library_code("FUN_test", body)
+    plate = format_plate(result)
+    assert "MSVC CRT" in plate
+    assert "__SEH_prolog4" in plate or "hard_callee" in plate
+
+
+def test_hard_callee_names_set_is_nonempty_and_canonical():
+    """Smoke-check the HARD_CALLEE_NAMES set holds the symbols that are
+    NEVER emitted into authored user functions (SEH prologs, CRT init/exit,
+    iostream-only helpers). /GS helpers like `__security_check_cookie`
+    intentionally live in SOFT_BODY_SIGNALS instead."""
+    expected_canonical = {
+        "__SEH_prolog4", "__except_handler4",
+        "_invoke_watson", "_CxxThrowException",
+        "_Xinvalid_argument",
+    }
+    assert expected_canonical.issubset(HARD_CALLEE_NAMES)
+    # /GS helpers must NOT be hard — would false-positive on user code.
+    assert "__security_check_cookie" not in HARD_CALLEE_NAMES
+    assert "__chkstk" not in HARD_CALLEE_NAMES
+
+
+def test_confidence_increases_with_more_hits():
+    """Multiple hard hits should push confidence higher than single hits."""
+    body_one = "void foo() { __SEH_prolog4(); }"
+    body_two = "void foo() { __SEH_prolog4(); __security_check_cookie(c); }"
+    one = detect_library_code("FUN_a", body_one)
+    two = detect_library_code("FUN_b", body_two)
+    # Both classified; two has stronger evidence
+    assert one.is_library and two.is_library
+    # At minimum, two's confidence is no worse than one's
+    assert two.confidence >= one.confidence

--- a/tests/performance/test_selector_invariants.py
+++ b/tests/performance/test_selector_invariants.py
@@ -22,7 +22,10 @@ Rules the selector must maintain (from the docstring + hard-won experience):
  11. decompile_timeout=True and not pinned → excluded (one-shot pathological
      function blacklist — decompile exceeds the 12s scoring-path cap, so
      re-picking just wastes HTTP thread time)
- 12. stagnation_runs >= 3 and not pinned → excluded (general safety net for
+ 12. library_code=True and not pinned → excluded (CRT/STL/iostream/SEH code
+     auto-classified by the heuristic detector — skips wasted LLM spend on
+     statically-linked compiler runtime that isn't authored source)
+ 13. stagnation_runs >= 3 and not pinned → excluded (general safety net for
      infinite re-pick loops where the function completes but makes no
      meaningful progress — catches the codex-tool_calls=-1 loop, regression
      oscillations, and "all fixes applied but scorer floor is dominating")
@@ -330,6 +333,64 @@ def test_decompile_timeout_bypassed_by_pin():
     # Pinned: included (user wants to retry)
     result = select_candidates(state, _queue(pinned=["a::timeout"]))
     assert _keys(result) == ["a::timeout"]
+
+
+def test_library_code_excluded_when_not_pinned():
+    """Functions auto-classified as library code (MSVC CRT / STL / iostream /
+    SEH machinery) by the heuristic detector must be excluded from selection
+    unless pinned. This is the cost-control gate: without it, workers spend
+    100K+ tokens documenting `ParseSignedShort` and friends -- code that
+    isn't even part of the binary's authored surface."""
+    state = _state(
+        **{
+            "a::library": {
+                "score": 31,
+                "fixable": 20,
+                "library_code": True,
+            },
+            "a::fresh": {"score": 31, "fixable": 20},
+        }
+    )
+    result = select_candidates(state, _queue())
+    assert _keys(result) == ["a::fresh"]
+
+
+def test_library_code_bypassed_by_pin():
+    """Pinning a library-code function restores it to the queue. The detector
+    is conservative but not perfect; if it misclassifies a real user function,
+    the user can pin it to force processing."""
+    state = _state(
+        **{
+            "a::library": {
+                "score": 31,
+                "fixable": 20,
+                "library_code": True,
+            },
+        }
+    )
+    assert _keys(select_candidates(state, _queue())) == []
+    result = select_candidates(state, _queue(pinned=["a::library"]))
+    assert _keys(result) == ["a::library"]
+
+
+def test_library_code_does_not_affect_unflagged():
+    """Unflagged functions (library_code=False or missing) must continue to
+    flow through the selector normally."""
+    state = _state(
+        **{
+            "a::user_explicit": {
+                "score": 50,
+                "fixable": 30,
+                "library_code": False,
+            },
+            "a::user_implicit": {
+                "score": 50,
+                "fixable": 30,
+            },
+        }
+    )
+    result = select_candidates(state, _queue())
+    assert set(_keys(result)) == {"a::user_explicit", "a::user_implicit"}
 
 
 def test_stagnation_runs_excluded_at_threshold():


### PR DESCRIPTION
## Summary

Eliminates wasted LLM spend on statically-linked MSVC CRT / STL / iostream / SEH machinery the worker queue used to happily document as if it were authored source.

**Motivating case:** during BH.dll evaluation, a worker burned 729K tokens on `ParseSignedShort @ 10052ba0` — a function that doesn't exist in BH source. It's linked compiler runtime that cross-version hash-propagation gave a plausible-looking name to.

## Design

**Detector** ([fun-doc/library_code_detector.py](fun-doc/library_code_detector.py)) is a conservative classifier. Trips on:

- **HARD signals** (single hit classifies):
  - Canonical CRT names: `??2@YAPAXI@Z`, `_strtoi64@4`, `std::_*`
  - Direct callees: `__SEH_prolog4`, `_Xinvalid_argument`, `_CxxThrowException`
- **SOFT signals** (need two): CRT-typical name patterns + body substrings

False-positive cost is high (real function wrongly skipped) so the bar is set conservatively. `/GS` cookie helpers like `__security_check_cookie` are SOFT, not HARD — they appear in user code compiled with `/GS` and would mis-flag ~10% of an authored binary (validated empirically on BH.dll).

## Integration

- `select_candidates` skips `library_code=True` unless pinned — same one-shot semantics as `decompile_timeout` and `recovery_pass_done`. Cleared by `--scan --refresh` or dashboard "Refresh Top N".
- `process_function` runs the detector after decompile fetch, before LLM call. Hits get a generic plate + flag + run logged as `library_code`. Zero LLM tokens spent per hit.
- `skip_library_code` config flag (default `True`) disables if a binary trips false positives.

## Storage

Migration `0002_library_code.sql` (+ SQLite variant) adds `library_code`, `library_code_at`, `library_code_reasons` columns to `functions_workflow`. Idempotent.

## Tests

- 19-case detector unit suite covering hard hits, soft-signal-alone-not-enough, user code unaffected, edge cases.
- 3 new selector regression tests verifying library_code is skipped unless pinned, and unflagged functions still flow through.

## Test plan

- [x] `pytest tests/performance/test_library_code_detector.py tests/performance/test_selector_invariants.py` — 44/44 pass.
- [x] Live spot-check on BH.dll: `ParseSignedShort` classifies with confidence 1.00; 6 real BH source exports (`BHIsReady`, `BHGetConfig`, etc.) do NOT classify; on a 100-function random sample, 0 false positives.
- [ ] Run a worker against BH.dll for an hour and check the runs.jsonl for `library_code` outcomes vs `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)