### PR TITLE
Fix struct field renaming when strict naming enforcement is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **#200**: Disabling **Strict Naming Enforcement** now also preserves
+  agent-provided struct field names. `create_struct`, `add_struct_field`, and
+  `modify_struct_field` no longer auto-add Hungarian prefixes when the built-in
+  naming convention is disabled.
+
+---
+
 ## v5.9.0 - 2026-05-12 (community fixes + P-code endpoints + library-code detector)
 
 Bundles three community-reported bug fixes (#170, #175, #192) plus an

--- a/README.md
+++ b/README.md
@@ -352,12 +352,15 @@ GhidraMCP is designed for **localhost-only development**. The default configurat
 
 Name-quality enforcement is separate from security. By default,
 `rename_function_by_address` and global write endpoints reject names that fail
-the built-in quality gates. Disable the hard-reject layer with **Edit > Tool
-Options > GhidraMCP HTTP Server > Strict Naming Enforcement**. The same
-Tool Options checkbox covers `rename_data`, `rename_global_variable`,
-`set_global`, and the `apply_data_type` prefix/type guard. The setting is read
-when the MCP server starts or restarts. Convention warnings are still returned
-when enforcement is disabled.
+the built-in quality gates, and struct field writes apply the built-in field
+prefix convention. Disable the built-in convention layer with **Edit > Tool
+Options > GhidraMCP HTTP Server > Strict Naming Enforcement**. The same Tool
+Options checkbox covers `rename_data`, `rename_global_variable`,
+`set_global`, the `apply_data_type` prefix/type guard, and struct-field
+Hungarian prefix auto-fixes in `create_struct`, `add_struct_field`, and
+`modify_struct_field`. The setting is read when the MCP server starts or
+restarts. Function/global convention warnings are still returned when
+enforcement is disabled.
 
 ### Example: exposing to a private LAN with auth
 

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -313,8 +313,9 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
             NamingPolicy.defaultStrictNamingEnforcement(), null,
             "Reject function/global names that fail the built-in name-quality checks " +
             "on rename_function_by_address, rename_data, rename_global_variable, " +
-            "set_global, and related write guards. Disable when your naming convention " +
-            "does not match the built-in heuristic; convention warnings are still returned. " +
+            "set_global, and related write guards. Also controls struct-field " +
+            "Hungarian prefix auto-fixes. Disable when your naming convention " +
+            "does not match the built-in heuristic; function/global convention warnings are still returned. " +
             "Takes effect when the MCP server starts or restarts.");
         migrateLegacyNamingOption(options);
         refreshNamingPolicyFromOptions();

--- a/src/main/java/com/xebyte/core/DataTypeService.java
+++ b/src/main/java/com/xebyte/core/DataTypeService.java
@@ -1463,11 +1463,11 @@ public class DataTypeService {
                         struct.replace(targetComponent.getOrdinal(), newDataType, newDataType.getLength());
                     }
 
-                    // If new name is specified, auto-fix Hungarian prefix and change the field name
+                    // If new name is specified, apply the configured field naming policy.
                     if (newName != null && !newName.isEmpty()) {
                         targetComponent = struct.getComponent(targetComponent.getOrdinal()); // Refresh component
                         String fieldTypeName = targetComponent.getDataType().getName();
-                        String fixedName = NamingConventions.autoFixFieldPrefix(newName, fieldTypeName);
+                        String fixedName = NamingConventions.applyStructFieldNamingPolicy(newName, fieldTypeName);
                         targetComponent.setFieldName(fixedName);
                     }
 
@@ -1509,8 +1509,8 @@ public class DataTypeService {
         if (fieldName == null || fieldName.isEmpty()) return Response.text("Field name is required");
         if (fieldType == null || fieldType.isEmpty()) return Response.text("Field type is required");
 
-        // Auto-fix Hungarian prefix
-        fieldName = NamingConventions.autoFixFieldPrefix(fieldName, fieldType);
+        // Apply configured struct-field naming policy.
+        fieldName = NamingConventions.applyStructFieldNamingPolicy(fieldName, fieldType);
 
         AtomicBoolean success = new AtomicBoolean(false);
         StringBuilder result = new StringBuilder();
@@ -2795,9 +2795,9 @@ public class DataTypeService {
             Msg.error(this, "Error parsing JSON object: " + e.getMessage());
         }
 
-        // Auto-fix Hungarian prefix on field name
+        // Apply configured struct-field naming policy.
         if (name != null && type != null) {
-            name = NamingConventions.autoFixFieldPrefix(name, type);
+            name = NamingConventions.applyStructFieldNamingPolicy(name, type);
         }
 
         return new FieldDefinition(name, type, offset);

--- a/src/main/java/com/xebyte/core/NamingConventions.java
+++ b/src/main/java/com/xebyte/core/NamingConventions.java
@@ -602,6 +602,21 @@ public final class NamingConventions {
         }
     }
 
+    /**
+     * Apply struct-field naming policy for write endpoints.
+     *
+     * <p>When strict naming enforcement is enabled, preserve the historical
+     * Hungarian auto-prefix behavior. When it is disabled, return the field
+     * name exactly as supplied so non-Hungarian projects can keep their local
+     * convention.
+     */
+    public static String applyStructFieldNamingPolicy(String fieldName, String typeName) {
+        if (!NamingPolicy.getInstance().shouldAutoFixStructFieldPrefixes()) {
+            return fieldName;
+        }
+        return autoFixFieldPrefix(fieldName, typeName);
+    }
+
     // -----------------------------------------------------------------------
     // Type validation
     // -----------------------------------------------------------------------

--- a/src/main/java/com/xebyte/core/NamingPolicy.java
+++ b/src/main/java/com/xebyte/core/NamingPolicy.java
@@ -39,6 +39,18 @@ public final class NamingPolicy {
         return strictNamingEnforcement;
     }
 
+    /**
+     * Whether write endpoints should rewrite struct field names to match the
+     * built-in Hungarian-prefix convention.
+     *
+     * <p>This intentionally follows the strict naming option: users who disable
+     * the built-in convention should be able to preserve names chosen by their
+     * agent, including snake_case fields.
+     */
+    public boolean shouldAutoFixStructFieldPrefixes() {
+        return strictNamingEnforcement;
+    }
+
     public String getSource() {
         return source;
     }

--- a/src/test/java/com/xebyte/offline/NamingConventionsTest.java
+++ b/src/test/java/com/xebyte/offline/NamingConventionsTest.java
@@ -2,6 +2,7 @@ package com.xebyte.offline;
 
 import com.xebyte.core.NamingConventions;
 import com.xebyte.core.NamingConventions.NameQualityResult;
+import com.xebyte.core.NamingPolicy;
 import junit.framework.TestCase;
 
 import java.util.Arrays;
@@ -621,5 +622,41 @@ public class NamingConventionsTest extends TestCase {
         // Pin the threshold — changing it requires updating the prompt
         // wrap-target guidance in step-globals.md.
         assertEquals(80, NamingConventions.PLATE_LINE_CLIP_THRESHOLD);
+    }
+
+    // ---------- struct-field naming policy ----------
+
+    public void testStructFieldPolicyAutoFixesWhenStrictNamingEnabled() {
+        NamingPolicy policy = NamingPolicy.getInstance();
+        boolean originalValue = policy.isStrictNamingEnforcement();
+        String originalSource = policy.getSource();
+
+        try {
+            policy.setStrictNamingEnforcement(true, "test");
+            assertEquals("dwItem_count",
+                    NamingConventions.applyStructFieldNamingPolicy("item_count", "uint"));
+            assertEquals("pNext_item",
+                    NamingConventions.applyStructFieldNamingPolicy("next_item", "void *"));
+        } finally {
+            policy.setStrictNamingEnforcement(originalValue, originalSource);
+        }
+    }
+
+    public void testStructFieldPolicyPreservesNamesWhenStrictNamingDisabled() {
+        NamingPolicy policy = NamingPolicy.getInstance();
+        boolean originalValue = policy.isStrictNamingEnforcement();
+        String originalSource = policy.getSource();
+
+        try {
+            policy.setStrictNamingEnforcement(false, "test");
+            assertEquals("item_count",
+                    NamingConventions.applyStructFieldNamingPolicy("item_count", "uint"));
+            assertEquals("next_item",
+                    NamingConventions.applyStructFieldNamingPolicy("next_item", "void *"));
+            assertEquals("is_enabled",
+                    NamingConventions.applyStructFieldNamingPolicy("is_enabled", "bool"));
+        } finally {
+            policy.setStrictNamingEnforcement(originalValue, originalSource);
+        }
     }
 }

--- a/src/test/java/com/xebyte/offline/NamingPolicyTest.java
+++ b/src/test/java/com/xebyte/offline/NamingPolicyTest.java
@@ -20,10 +20,12 @@ public class NamingPolicyTest extends TestCase {
         try {
             policy.setStrictNamingEnforcement(false, "test");
             assertFalse(policy.isStrictNamingEnforcement());
+            assertFalse(policy.shouldAutoFixStructFieldPrefixes());
             assertEquals("test", policy.getSource());
 
             policy.setStrictNamingEnforcement(true, "test");
             assertTrue(policy.isStrictNamingEnforcement());
+            assertTrue(policy.shouldAutoFixStructFieldPrefixes());
         } finally {
             policy.setStrictNamingEnforcement(originalValue, originalSource);
         }


### PR DESCRIPTION
## Description
Preserve agent-provided struct field names when strict naming enforcement is disabled.

Fixes #200

## Changes
- Gate struct-field Hungarian prefix auto-fixes behind the existing Strict Naming Enforcement option.
- Apply the policy to create_struct, add_struct_field, and modify_struct_field.
- Update option/help documentation and changelog entry.
- Add offline tests covering enabled and disabled strict naming behavior.

## Testing
- git diff --check
- GHIDRA_INSTALL_DIR=C:\Users\user\Documents\ghidra .\gradlew.bat test
- GHIDRA_INSTALL_DIR=C:\Users\user\Documents\ghidra .\gradlew.bat buildExtension
- Manual MCP repro: with Strict Naming Enforcement disabled, create_struct preserves item_count, next_item, and is_enabled.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] No breaking changes