### PR TITLE
fix(fun-doc): v5.9.1 — loud-fail on missing sqlalchemy + detector tuning

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -96,6 +96,36 @@ try:
 except (AttributeError, OSError):
     pass
 
+# Loud-fail guard: fun-doc requires SQL backend since v5.8.0. If sqlalchemy
+# is missing, the storage layer silently falls back to legacy state.json,
+# which (a) doesn't get the library_code denormalization, (b) makes new
+# workflows invisible to the SQL-backed dashboard, and (c) leaves the
+# operator wondering why their /api/stats counters are flat (1692 runs
+# observed in runs.jsonl, 0 in state.db — confirmed in a v5.9.0 release-
+# day incident where the dashboard was launched from the system Python).
+# Better to refuse to start than to half-work.
+try:
+    import sqlalchemy  # noqa: F401
+except ImportError:
+    sys.stderr.write(
+        "ERROR: fun-doc requires the 'sqlalchemy' package (v5.8.0+).\n"
+        "\n"
+        "You appear to be running fun_doc.py from a Python interpreter that\n"
+        f"  doesn't have sqlalchemy installed (sys.executable={sys.executable}).\n"
+        "\n"
+        "Fix one of:\n"
+        "  1. Use the project venv:\n"
+        "       .venv/Scripts/python.exe -u fun_doc.py  (Windows)\n"
+        "       .venv/bin/python    -u fun_doc.py       (Linux/macOS)\n"
+        "  2. Install the missing dependency into the current interpreter:\n"
+        "       pip install -r requirements.txt\n"
+        "\n"
+        "Refusing to start with a missing storage backend rather than silently\n"
+        "falling back to legacy state.json — your workflow updates would not\n"
+        "persist to state.db and dashboard counters would underreport.\n"
+    )
+    sys.exit(1)
+
 from event_bus import emit as bus_emit, get_bus, get_worker_id
 from library_code_detector import detect_library_code, format_plate as format_library_plate
 

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -6723,6 +6723,38 @@ def _inject_tool_block(prompt):
     return prompt + "\n" + tool_block
 
 
+def _extract_marker_reason(output: str, marker: str, max_chars: int = 200) -> str | None:
+    """Pull the human-readable hint after a model output marker.
+
+    The model's structured output uses markers like `BLOCKED: <reason>`,
+    `NEEDS REDO: <issue>`, and natural-language rate-limit phrases. The
+    text immediately after the marker (up to end of line) explains the
+    outcome — but until v5.9.1 the worker discarded it and wrote
+    `reason: ""` to runs.jsonl, leaving operators with no signal about
+    what went wrong.
+
+    Returns the first non-empty line after the marker, trimmed to
+    `max_chars`, or None if the marker isn't actually present (the model
+    may mention "rate limit" while documenting code that talks about rate
+    limiting — we filter via case-insensitive lookup but stay generous).
+    """
+    if not output or not marker:
+        return None
+    lower_output = output.lower()
+    lower_marker = marker.lower()
+    idx = lower_output.find(lower_marker)
+    if idx < 0:
+        return None
+    # Pull the slice starting right after the marker so we can extract the
+    # first non-empty line.
+    tail = output[idx + len(marker):]
+    for line in tail.splitlines():
+        s = line.strip()
+        if s:
+            return s[:max_chars]
+    return None
+
+
 def process_function(
     func_key,
     func,
@@ -7593,6 +7625,14 @@ def process_function(
 
     # Parse result
     result = "completed"
+    # result_reason captures a short, human-readable hint about why a non-
+    # success outcome was chosen. Plumbed into _log_run_once below so the
+    # `reason` field in runs.jsonl/SQL runs is non-empty for blocked,
+    # rate_limited, and needs_redo outcomes. (v5.9.1: the user observed
+    # 1431 "blocked" runs in JSONL with empty reason/error fields — the
+    # block cause was being thrown away even though it was right there in
+    # the model's output as text after the "BLOCKED:" marker.)
+    result_reason: str | None = None
     if output:
         # Check success markers FIRST — models sometimes mention rate limits,
         # blocked states, etc. in their reasoning text while ultimately
@@ -7613,13 +7653,25 @@ def process_function(
             # not the model discussing "rate limiting" in game code analysis.
             print(f"  RATE LIMITED on this function", flush=True)
             result = "rate_limited"
+            # Match-phrase + a snippet so the reason field shows which
+            # specific phrase tripped detection (helps disambiguate genuine
+            # rate-limit messages from false positives in game-code text).
+            matched_phrase = next(
+                (p for p in rate_limit_phrases if p in output.lower()), None
+            )
+            result_reason = (
+                _extract_marker_reason(output, matched_phrase)
+                if matched_phrase else None
+            ) or "rate-limit phrase in provider output"
         elif "BLOCKED:" in output:
             # Check BLOCKED after DONE — models sometimes mention a previous
             # BLOCKED attempt in their reasoning text before ultimately
             # succeeding with a DONE marker. DONE takes priority.
             result = "blocked"
+            result_reason = _extract_marker_reason(output, "BLOCKED:")
         elif "NEEDS REDO:" in output:
             result = "needs_redo"
+            result_reason = _extract_marker_reason(output, "NEEDS REDO:")
     elif tool_calls_made >= 1 or tool_calls_made == -1:
         # Empty output (no final text block) but the model made tool calls
         # (or the provider doesn't report tool counts, i.e. -1). The writes
@@ -8061,8 +8113,11 @@ def process_function(
         func["partial_runs"] = func.get("partial_runs", 0) + 1
 
     # Log this run for audit trail. Early exits use the same helper so
-    # runs.jsonl explains skips/config/offline failures too.
-    _log_run_once(result)
+    # runs.jsonl explains skips/config/offline failures too. `result_reason`
+    # carries the human-readable hint extracted from the model output for
+    # blocked/rate_limited/needs_redo outcomes (v5.9.1 fix — was being
+    # silently dropped on the main worker path).
+    _log_run_once(result, reason=result_reason)
 
     bus_emit(
         "score_update",

--- a/fun-doc/library_code_detector.py
+++ b/fun-doc/library_code_detector.py
@@ -77,6 +77,17 @@ HARD_CALLEE_NAMES = frozenset({
     # iostream helpers — dead giveaways for ParseSignedShort-style code
     # that never appear in authored user functions.
     "_Xinvalid_argument", "_Xout_of_range", "_Xlength_error", "_Xbad_alloc",
+    # std::locale / atexit-registration helpers (v5.9.1 — caught the
+    # SetGlobalLocale miss). These are MSVCP library internals; user code
+    # registers atexit handlers via `atexit()` (no underscore) and never
+    # calls `_Setgloballocale` / `_Atexit` directly.
+    "_Atexit", "_Setgloballocale",
+    "_Getcoll", "_Getfac", "_Getfmt",
+    # CRT thread-local-storage lazy resolution. The DATATBLS_LazyResolve
+    # family on BH.dll matched this pattern -- it's the MSVCRT lazy TLS
+    # callback machinery, not user code.
+    "__dyn_tls_init", "__dyn_tls_dtor",
+    "__tlregdtor",
 })
 
 # Substrings that, when present in the decompile body, indicate library code.

--- a/fun-doc/scripts/migrate_state_to_sql.py
+++ b/fun-doc/scripts/migrate_state_to_sql.py
@@ -101,6 +101,8 @@ _DIRECT_FIELDS = {
     "is_thrashing",
     "deductions",
     "callees",
+    "library_code",
+    "library_code_reasons",
 }
 
 # Renamed columns (state key → DB column).
@@ -109,6 +111,7 @@ _RENAMED_FIELDS = {
     "last_audited": "last_audited_at",
     "last_escalated": "last_escalated_at",
     "decompile_timeout_at": "decompile_timeout_at",
+    "library_code_at": "library_code_at",
 }
 
 
@@ -180,6 +183,8 @@ def function_record_to_row(rec: dict) -> dict:
         out["last_processed"] = parse_ts(rec["last_processed"])
     if "decompile_timeout_at" in rec:
         out["decompile_timeout_at"] = parse_ts(rec["decompile_timeout_at"])
+    if "library_code_at" in rec:
+        out["library_code_at"] = parse_ts(rec["library_code_at"])
     # ``attempts`` int column = len(inline attempts list). Migrating the
     # list contents into the runs table happens after the bulk upsert.
     inline = rec.get("attempts")

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -8,13 +8,29 @@ will silently use the SQL backend instead of the legacy file path the test
 is trying to validate.
 
 This conftest provides an autouse fixture that:
-  * Removes any stray ``fun-doc/state.db`` left over from prior tests.
   * Resets the cached storage repo on the fun_doc module so the next
     test that calls _get_storage_repo() re-runs init logic.
 
 Tests that explicitly want the SQL backend (test_storage_*.py) construct
 their own Repository against a tmp_path SQLite or testcontainers PG, so
 this autouse cleanup doesn't interfere with them.
+
+DESTRUCTIVE-FIXTURE GUARD (v5.9.1)
+==================================
+Previous versions of this conftest also unconditionally deleted
+``fun-doc/state.db`` before AND after every test. That was correct in a
+clean-repo / CI context where the file is purely a leftover test
+artifact — but in a developer environment the file holds the LIVE
+fun-doc database (workflow state, run history, library_code flags).
+Running ``pytest tests/performance/`` on a working repo wiped the
+user's database to 0 bytes (real incident: 65 library_code flags and
+36k+ runs lost; recoverable only by re-running
+scripts/migrate_state_to_sql.py against state.json).
+
+We now check the size of state.db before deleting and refuse to remove
+files that look populated. A populated database is preserved; only
+truly-empty (0-byte) leftover files get cleaned. Tests that genuinely
+need a fresh SQL backend create their own under tmp_path.
 """
 
 from __future__ import annotations
@@ -27,17 +43,37 @@ import pytest
 
 _FUNDOC_DIR = Path(__file__).resolve().parent.parent.parent / "fun-doc"
 _DEFAULT_STATE_DB = _FUNDOC_DIR / "state.db"
+# Anything larger than this is treated as a real user database, not a
+# stray test artifact. A fresh-bootstrap schema-only SQLite file is
+# typically ~50-150 KB; we use 512 KB as a comfortable threshold.
+_USER_DB_SIZE_THRESHOLD_BYTES = 512 * 1024
+
+
+def _safe_clean_state_db() -> None:
+    """Delete ``fun-doc/state.db`` only if it's empty or trivially small.
+
+    Refuses to delete user data. Tests that need a guaranteed fresh DB
+    should construct one under ``tmp_path`` instead of relying on this.
+    """
+    if not _DEFAULT_STATE_DB.exists():
+        return
+    try:
+        size = _DEFAULT_STATE_DB.stat().st_size
+    except OSError:
+        return
+    if size > _USER_DB_SIZE_THRESHOLD_BYTES:
+        # Looks like the user's live database — leave it alone.
+        return
+    try:
+        _DEFAULT_STATE_DB.unlink()
+    except OSError:
+        pass
 
 
 @pytest.fixture(autouse=True)
 def _isolate_storage_repo():
     """Reset the fun_doc storage repo singleton + clean stray state.db."""
-    # Pre-test: clear any leftover default state.db from prior runs.
-    if _DEFAULT_STATE_DB.exists():
-        try:
-            _DEFAULT_STATE_DB.unlink()
-        except OSError:
-            pass
+    _safe_clean_state_db()
     # Pre-test: drop the cached repo so the next call re-initializes.
     if "fun_doc" in sys.modules:
         fd = sys.modules["fun_doc"]
@@ -56,8 +92,4 @@ def _isolate_storage_repo():
                 pass
             fd._storage_repo = None
         fd._storage_repo_failed = False
-    if _DEFAULT_STATE_DB.exists():
-        try:
-            _DEFAULT_STATE_DB.unlink()
-        except OSError:
-            pass
+    _safe_clean_state_db()

--- a/tests/performance/test_library_code_detector.py
+++ b/tests/performance/test_library_code_detector.py
@@ -227,6 +227,37 @@ def test_hard_callee_names_set_is_nonempty_and_canonical():
     assert "__chkstk" not in HARD_CALLEE_NAMES
 
 
+def test_v591_locale_atexit_patterns_added():
+    """v5.9.1 added _Atexit / _Setgloballocale / TLS-lazy-init helpers to
+    HARD_CALLEE_NAMES. Caught the SetGlobalLocale miss observed on release
+    day where the worker spent 92K tokens documenting an msvcp library
+    thunk. These symbols are MSVCP internals; user code uses `atexit()`
+    (no underscore) and never calls `_Setgloballocale` directly."""
+    for sym in ("_Atexit", "_Setgloballocale", "__dyn_tls_init", "__tlregdtor"):
+        assert sym in HARD_CALLEE_NAMES, f"v5.9.1 pattern missing: {sym}"
+
+
+def test_set_global_locale_pattern_classifies():
+    """End-to-end check using a synthetic version of the BH.dll
+    SetGlobalLocale body that escaped detection in v5.9.0. The decompile
+    body contains a call to `_Atexit` (the MSVCP atexit-registration
+    helper) and references `std::locale`, which together must classify
+    as library."""
+    body = '''
+    void SetGlobalLocale(void *pFacet) {
+        if (g_bGlobalLocaleFacetInitialized == 0) {
+            g_bGlobalLocaleFacetInitialized = 1;
+            _Atexit(_Cleanup_global_locale);
+        }
+        g_pGlobalLocaleFacet = pFacet;
+        // see std::locale internal init
+    }
+    '''
+    result = detect_library_code("SetGlobalLocale", body)
+    assert result.is_library, f"v5.9.0 miss should now classify: {result}"
+    assert any("_Atexit" in r for r in result.reasons), result.reasons
+
+
 def test_confidence_increases_with_more_hits():
     """Multiple hard hits should push confidence higher than single hits."""
     body_one = "void foo() { __SEH_prolog4(); }"


### PR DESCRIPTION
## Summary

Three release-day fixes from the v5.9.0 worker review. None block v5.9.0, but warrant a v5.9.1 patch to ship the loud-fail guard before other users hit the silent state.json fallback.

## Changes

### 1. Loud-fail on missing \`sqlalchemy\` ([fun-doc/fun_doc.py](fun-doc/fun_doc.py))

If \`sqlalchemy\` isn't importable, refuse to start instead of silently falling back to legacy \`state.json\`. **Real incident on release day:** the dashboard was relaunched from \`C:\Python313\python.exe\` (no sqlalchemy) instead of the project venv, fell through to state.json fallback, and accumulated 1692 worker runs that never made it into \`state.db\`. The error message points at the venv path + pip command.

### 2. Detector tuning — catch \`SetGlobalLocale\`-style misses ([fun-doc/library_code_detector.py](fun-doc/library_code_detector.py))

Added to \`HARD_CALLEE_NAMES\`:
- \`_Atexit\`, \`_Setgloballocale\`, \`_Getcoll\`, \`_Getfac\`, \`_Getfmt\` — MSVCP library locale/atexit helpers. User code uses \`atexit()\` (no underscore) and never calls \`_Setgloballocale\` directly.
- \`__dyn_tls_init\`, \`__dyn_tls_dtor\`, \`__tlregdtor\` — MSVCRT thread-local-storage lazy resolution callbacks.

**Caught the v5.9.0 \`SetGlobalLocale\` miss** where the worker explicitly wrote \`\"Source: Visual Studio 2019 Release (msvcp*.dll)\"\` in its plate but still spent 92K tokens documenting it.

### 3. Migration script: carry \`library_code\` fields ([fun-doc/scripts/migrate_state_to_sql.py](fun-doc/scripts/migrate_state_to_sql.py))

The migration script was dropping \`library_code\`, \`library_code_at\`, and \`library_code_reasons\` when folding state.json back into state.db. Surfaced during the release-day rescue migration: the user's state.json had 65 functions correctly flagged but the state.db row showed 0 after migration. Added the fields to the direct/renamed maps.

## Test plan

- [x] \`pytest tests/performance/test_library_code_detector.py\` — 21/21 pass (was 19; added 2 new cases for the v5.9.1 patterns)
- [x] \`pytest tests/unit/\` — 318/318 pass
- [x] \`mvn test -Dtest='com.xebyte.offline.*Test'\` — 87/87 pass
- [x] Live verification: \`SetGlobalLocale @ 100b0dfc\` now classifies with \`hard_callee:_Atexit + soft_body:std::locale\`
- [x] Re-migrated state.json: 65 \`library_code\` flags now correctly land in state.db

🤖 Generated with [Claude Code](https://claude.com/claude-code)