### PR TITLE
feat: disassemble_bytes instruction text (#205) + Gemini SDK error hint (#201)

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -5085,9 +5085,21 @@ def _invoke_gemini(prompt, model=None, max_turns=25):
             ErrorEvent,
             ResultEvent,
         )
-    except ImportError:
+    except ImportError as e:
+        # The PyPI build of gemini-cli-sdk 0.1.0 is missing GeminiCli; the
+        # working version lives in a local source tree that hasn't been
+        # republished. Issue #201 tracks the fix. For now, surface a clear
+        # path forward instead of a bare ImportError.
         print(
-            "ERROR: gemini-cli-sdk not installed. Run: pip install gemini-cli-sdk",
+            f"ERROR: gemini-cli-sdk import failed ({e}).\n"
+            f"\n"
+            f"  The published PyPI version (0.1.0) lacks the GeminiCli class\n"
+            f"  this worker uses. Fix is tracked in ghidra-mcp issue #201.\n"
+            f"\n"
+            f"  Workaround until a working version is published: switch\n"
+            f"  fun-doc's primary provider in priority_queue.json to one of\n"
+            f"  'minimax', 'claude', or 'codex' (config.provider_models),\n"
+            f"  OR pin gemini-cli-sdk to a working build from source.\n",
             file=sys.stderr,
         )
         return None

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -2347,7 +2347,7 @@ public class FunctionService {
      * @param restrictToExecuteMemory If true, restricts disassembly to executable memory (default: true)
      * @return JSON result with disassembly status
      */
-    @McpTool(path = "/disassemble_bytes", method = "POST", description = "Disassemble a range of bytes. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution.", category = "function")
+    @McpTool(path = "/disassemble_bytes", method = "POST", description = "Disassemble a range of bytes. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution. Returns the disassembled instruction text (mnemonic + operands + bytes) when `include_instructions` is true (default), so callers working on custom processor definitions (#205) can read back what Ghidra produced without a follow-up call.", category = "function")
     public Response disassembleBytes(
             @Param(value = "start_address", paramType = "address", source = ParamSource.BODY,
                    description = "Address in the program. Accepts 0x<hex> (default space) or <space>:<hex> "
@@ -2363,6 +2363,10 @@ public class FunctionService {
                                + "address is unambiguous.") String endAddress,
             @Param(value = "length", source = ParamSource.BODY, defaultValue = "0") Integer length,
             @Param(value = "restrict_to_execute_memory", source = ParamSource.BODY, defaultValue = "true") boolean restrictToExecuteMemory,
+            @Param(value = "include_instructions", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Return the disassembled instruction list (mnemonic, operands, raw bytes, address) in the response. Disable for byte ranges where you only need the success/byte-count summary.") boolean includeInstructions,
+            @Param(value = "max_instructions", source = ParamSource.BODY, defaultValue = "1000",
+                   description = "Cap on number of instructions returned when include_instructions is true. Protects against runaway payload for large ranges; if the actual count exceeds this, the response sets truncated=true and instructions_total reports the real count.") int maxInstructions,
             @Param(value = "program", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2470,13 +2474,65 @@ public class FunctionService {
                     if (cmd.applyTo(program, ghidra.util.task.TaskMonitor.DUMMY)) {
                         // Success - build result
                         Msg.debug(this, "disassembleBytes: Successfully disassembled " + numBytes + " byte(s) from " + start + " to " + end);
-                        resultData.set(JsonHelper.mapOf(
-                            "success", true,
-                            "start_address", start.toString(),
-                            "end_address", end.toString(),
-                            "bytes_disassembled", numBytes,
-                            "message", "Successfully disassembled " + numBytes + " byte(s)"
-                        ));
+                        Map<String, Object> result = new java.util.LinkedHashMap<>();
+                        result.put("success", true);
+                        result.put("start_address", start.toString());
+                        result.put("end_address", end.toString());
+                        result.put("bytes_disassembled", numBytes);
+                        result.put("message", "Successfully disassembled " + numBytes + " byte(s)");
+
+                        // Issue #205: surface the actual instruction text so
+                        // callers working on custom processor definitions can
+                        // read back what Ghidra produced without a follow-up
+                        // /disassemble_function call.
+                        if (includeInstructions) {
+                            List<Map<String, Object>> instructions = new java.util.ArrayList<>();
+                            int truncatedLimit = Math.max(1, maxInstructions);
+                            int totalCount = 0;
+                            Listing listing = program.getListing();
+                            ghidra.program.model.listing.InstructionIterator instIter =
+                                listing.getInstructions(addressSet, true);
+                            while (instIter.hasNext()) {
+                                ghidra.program.model.listing.Instruction inst = instIter.next();
+                                totalCount++;
+                                if (instructions.size() < truncatedLimit) {
+                                    Map<String, Object> instJson = new java.util.LinkedHashMap<>();
+                                    instJson.put("address", inst.getAddress().toString());
+                                    instJson.put("mnemonic", inst.getMnemonicString());
+                                    // Operands joined with comma to match the
+                                    // visible listing format users see in the GUI.
+                                    String[] operands = new String[inst.getNumOperands()];
+                                    for (int i = 0; i < operands.length; i++) {
+                                        operands[i] = inst.getDefaultOperandRepresentation(i);
+                                    }
+                                    instJson.put("operands", String.join(", ", operands));
+                                    instJson.put("length", inst.getLength());
+                                    // Raw bytes as lowercase hex string for
+                                    // emulator / encoder verification.
+                                    try {
+                                        byte[] bytes = inst.getBytes();
+                                        StringBuilder hex = new StringBuilder(bytes.length * 2);
+                                        for (byte b : bytes) {
+                                            hex.append(String.format("%02x", b));
+                                        }
+                                        instJson.put("bytes", hex.toString());
+                                    } catch (Exception e) {
+                                        instJson.put("bytes", null);
+                                    }
+                                    instructions.add(instJson);
+                                }
+                            }
+                            result.put("instructions", instructions);
+                            result.put("instructions_total", totalCount);
+                            if (totalCount > instructions.size()) {
+                                result.put("truncated", true);
+                                result.put("truncation_note", "max_instructions=" + truncatedLimit
+                                    + " reached; raise the cap to get the rest.");
+                            } else {
+                                result.put("truncated", false);
+                            }
+                        }
+                        resultData.set(result);
                         success = true;
                     } else {
                         errorMsg.set("Disassembly failed: " + cmd.getStatusMsg());
@@ -2511,9 +2567,23 @@ public class FunctionService {
         return Response.err("Unknown failure");
     }
 
+    /**
+     * Back-compat overloads for callers that don't care about the
+     * include_instructions / max_instructions options added for issue #205.
+     * Default to the new behavior (instructions included, 1000-instruction cap)
+     * so the headless and registry paths surface the same data as the MCP
+     * endpoint.
+     */
     public Response disassembleBytes(String startAddress, String endAddress, Integer length,
                                    boolean restrictToExecuteMemory) {
-        return disassembleBytes(startAddress, endAddress, length, restrictToExecuteMemory, null);
+        return disassembleBytes(startAddress, endAddress, length, restrictToExecuteMemory,
+                                true, 1000, null);
+    }
+
+    public Response disassembleBytes(String startAddress, String endAddress, Integer length,
+                                   boolean restrictToExecuteMemory, String programName) {
+        return disassembleBytes(startAddress, endAddress, length, restrictToExecuteMemory,
+                                true, 1000, programName);
     }
 
     // ========================================================================

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -954,6 +954,8 @@
         "end_address",
         "length",
         "restrict_to_execute_memory",
+        "include_instructions",
+        "max_instructions",
         "program"
       ],
       "description": "Disassemble byte range"


### PR DESCRIPTION
## Summary

Two community-issue fixes for the v5.9.1 patch bundle.

### #205 — instruction text in \`/disassemble_bytes\` (@larrynz)

User working on custom firmware processor definitions asked to read back the actual mnemonic/operands/bytes after disassembly. Currently the endpoint returns only a success summary.

Adds two new POST params (both optional):

| Param | Default | Effect |
|---|---|---|
| \`include_instructions\` | \`true\` | Append disassembled instruction list to the response |
| \`max_instructions\` | \`1000\` | Cap to prevent runaway payload; response sets \`truncated\` + \`instructions_total\` when exceeded |

Each instruction entry: \`address\`, \`mnemonic\`, \`operands\` (joined like the GUI listing), \`length\`, \`bytes\` (lowercase hex).

Implementation: \`InstructionIterator\` over the address set immediately after the disassembly transaction succeeds. Two back-compat overloads added so \`HeadlessEndpointHandler\` and \`EndpointRegistry\` callers keep compiling.

### #201 — friendlier error when \`gemini-cli-sdk\` import fails (@dalen)

The published \`gemini-cli-sdk 0.1.0\` on PyPI lacks the \`GeminiCli\` class \`fun_doc.py\` imports. The bare \`ImportError\` is unactionable. New error message:

- Quotes the actual \`ImportError\` text
- Explains the published-version-is-incomplete situation
- Links to issue #201 for tracking
- Lists working alternative providers (\`minimax\` / \`claude\` / \`codex\`)
- Mentions the pin-to-source workaround for advanced users

This doesn't republish the SDK — the root cause is out-of-repo — but stops the next user from filing the same issue.

## Test plan

- [x] \`mvn clean compile\` — BUILD SUCCESS
- [x] \`mvn test -Dtest='com.xebyte.offline.*Test'\` — 89/89 pass (was 87 in v5.9.0; +2 from #202)
- [x] \`pytest tests/unit/\` — 318 pass
- [x] \`tests/endpoints.json\` regenerated; reflects new \`include_instructions\` / \`max_instructions\` params on \`/disassemble_bytes\`
- [ ] Live readonly test after deploy: \`POST /disassemble_bytes\` against a known byte range, confirm \`instructions[]\` array contains expected mnemonics

Targets v5.9.1 alongside PR #203 (block-reason capture + detector tuning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)