### PR TITLE
fix(build): support Ghidra 12.1 (#211)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -48,6 +48,8 @@ MCP_PORT=8081
 # Connect the bridge and headless server to a Ghidra Server repository.
 # The GUI plugin uses GhidraMCPAuthInitializer to suppress the password dialog;
 # the headless server uses GhidraServerManager to connect programmatically.
+# Ghidra 12.1 clients require Ghidra Server 12.1, 12.0.5, or a newer
+# compatible server. Do not point a 12.1 client at an older shared server.
 #
 # Credential resolution order (first non-empty value wins):
 #   1. GHIDRA_SERVER_PASSWORD environment variable (or this .env file)

--- a/.env.template
+++ b/.env.template
@@ -9,9 +9,9 @@
 # Path to your Ghidra installation directory
 # Used by `python -m tools.setup` deploy and prerequisite commands
 # Examples:
-#   Windows: GHIDRA_PATH=F:\ghidra_12.0.4_PUBLIC
-#   Linux:   GHIDRA_PATH=/opt/ghidra_12.0.4_PUBLIC
-#   macOS:   GHIDRA_PATH=/Applications/ghidra_12.0.4_PUBLIC
+#   Windows: GHIDRA_PATH=F:\ghidra_12.1_PUBLIC
+#   Linux:   GHIDRA_PATH=/opt/ghidra_12.1_PUBLIC
+#   macOS:   GHIDRA_PATH=/Applications/ghidra_12.1_PUBLIC
 GHIDRA_PATH=
 
 # Automatically install optional standalone debugger dependencies during
@@ -90,7 +90,7 @@ TOOLS_SETUP_BACKEND=maven
 
 # Path to Ghidra installation — used by fun-doc to auto-launch Ghidra
 # Defaults to GHIDRA_PATH above when not set separately
-# GHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+# GHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
 
 # =============================================================================
 # Knowledge Database (Optional — RE-Universe PostgreSQL + pgvector)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GHIDRA_VERSION: 12.0.4
-      GHIDRA_DATE: 20260303
+      GHIDRA_VERSION: 12.1
+      GHIDRA_DATE: 20260513
       GHIDRA_LIBS: >-
         Features/Base/lib/Base.jar
         Features/Decompiler/lib/Decompiler.jar

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,11 +17,11 @@ on:
       ghidra_path:
         description: 'Ghidra path for live regression self-hosted runner'
         required: false
-        default: 'F:\ghidra_12.0.4_PUBLIC'
+        default: 'F:\ghidra_12.1_PUBLIC'
 
 env:
-  GHIDRA_VERSION: 12.0.4
-  GHIDRA_DATE: 20260303
+  GHIDRA_VERSION: 12.1
+  GHIDRA_DATE: 20260513
 
 jobs:
   release-regression:

--- a/.github/workflows/release-regression.yml
+++ b/.github/workflows/release-regression.yml
@@ -8,7 +8,7 @@ on:
       ghidra_path:
         description: "Path to the Ghidra install on the self-hosted runner"
         required: true
-        default: "F:\\ghidra_12.0.4_PUBLIC"
+        default: "F:\\ghidra_12.1_PUBLIC"
       test_tier:
         description: "Deploy regression tier to run"
         required: true
@@ -41,7 +41,7 @@ jobs:
     runs-on: [self-hosted, Windows]
     timeout-minutes: 30
     env:
-      GHIDRA_REGRESSION_PATH: ${{ inputs.ghidra_path || vars.GHIDRA_PATH || 'F:\ghidra_12.0.4_PUBLIC' }}
+      GHIDRA_REGRESSION_PATH: ${{ inputs.ghidra_path || vars.GHIDRA_PATH || 'F:\ghidra_12.1_PUBLIC' }}
       GHIDRA_REGRESSION_TIER: ${{ inputs.test_tier || 'release' }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ on:
       ghidra_path:
         description: 'Ghidra path for live regression self-hosted runner'
         required: false
-        default: 'F:\ghidra_12.0.4_PUBLIC'
+        default: 'F:\ghidra_12.1_PUBLIC'
 
 env:
-  GHIDRA_VERSION: 12.0.4
-  GHIDRA_DATE: 20260303
+  GHIDRA_VERSION: 12.1
+  GHIDRA_DATE: 20260513
 
 jobs:
   release-regression:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /tmp/ghidra
-        key: ghidra-12.0.4-PUBLIC-20260303
+        key: ghidra-12.1-PUBLIC-20260513
 
     - name: Download Ghidra
       if: steps.cache-ghidra.outputs.cache-hit != 'true'
       run: |
-        echo "Downloading Ghidra 12.0.4..."
+        echo "Downloading Ghidra 12.1..."
         curl -sL -o /tmp/ghidra.zip \
-          "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.4_build/ghidra_12.0.4_PUBLIC_20260303.zip"
+          "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1_build/ghidra_12.1_PUBLIC_20260513.zip"
         mkdir -p /tmp/ghidra
         unzip -q /tmp/ghidra.zip -d /tmp/ghidra
         rm /tmp/ghidra.zip
@@ -44,7 +44,7 @@ jobs:
     - name: Install Ghidra JARs to Maven local repository
       run: |
         GHIDRA_DIR=$(find /tmp/ghidra -maxdepth 1 -type d -name 'ghidra_*' | head -1)
-        GHIDRA_VERSION="12.0.4"
+        GHIDRA_VERSION="12.1"
         echo "Using Ghidra directory: $GHIDRA_DIR"
 
         # Install Framework JARs

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
 		{
 			"id": "ghidraPath",
 			"description": "Path to Ghidra installation directory",
-			"default": "F:\\ghidra_12.0.4_PUBLIC",
+			"default": "F:\\ghidra_12.1_PUBLIC",
 			"type": "promptString"
 		},
 		{

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,6 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 - Build: `mvn clean package assembly:single -DskipTests`
 - Quick compile: `mvn clean compile -q`
 - Test (Python): `pytest tests/unit/ -v --no-cov`
-- Preflight: `python -m tools.setup preflight --ghidra-path F:\ghidra_12.0.4_PUBLIC`
-- Deploy: `python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.0.4_PUBLIC` then `python -m tools.setup build` then `python -m tools.setup deploy --ghidra-path F:\ghidra_12.0.4_PUBLIC`
+- Preflight: `python -m tools.setup preflight --ghidra-path F:\ghidra_12.1_PUBLIC`
+- Deploy: `python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.1_PUBLIC` then `python -m tools.setup build` then `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC`
 - Version bump: `python -m tools.setup bump-version --new X.Y.Z`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ headless diagnostics need a plugin redeploy to take effect.
 
 ### Fixed
 
+- **#211 - Ghidra 12.1 compatibility** (@firefart). Updated the
+  project Ghidra dependency version, CI/release/Docker download
+  metadata, setup defaults, examples, and compatibility tests from
+  Ghidra 12.0.4 to the latest official Ghidra 12.1 release.
+
 - **#207 — fun-doc called Ghidra endpoints with wrong parameter
   names** (@dalen). Audited every `ghidra_get`/`ghidra_post` call in
   `fun_doc.py` against the endpoint catalog. Three real bugs + one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ headless diagnostics need a plugin redeploy to take effect.
 - **#211 - Ghidra 12.1 compatibility** (@firefart). Updated the
   project Ghidra dependency version, CI/release/Docker download
   metadata, setup defaults, examples, and compatibility tests from
-  Ghidra 12.0.4 to the latest official Ghidra 12.1 release.
+  Ghidra 12.0.4 to the latest official Ghidra 12.1 release. Added
+  12.1-specific shared-server guidance, Jython-extension documentation,
+  preflight messaging for configured shared servers, and a clearer
+  `.py` script-provider error when Jython is not installed.
 
 - **#207 — fun-doc called Ghidra endpoints with wrong parameter
   names** (@dalen). Audited every `ghidra_get`/`ghidra_post` call in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 244 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.10.0 | **Java**: 21 LTS | **Ghidra**: 12.0.4
+- **Package**: `com.xebyte` | **Version**: 5.10.0 | **Java**: 21 LTS | **Ghidra**: 12.1
 
 ## Boil the ocean
 
@@ -46,29 +46,29 @@ Two backends are supported. Maven is the default; Gradle is the new primary path
 
 ```text
 # Direct Gradle invocation — no tools.setup required
-./gradlew buildExtension -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
-./gradlew preflight      -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
-./gradlew deploy         -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
-./gradlew startGhidra    -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+./gradlew buildExtension -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
+./gradlew preflight      -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
+./gradlew deploy         -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
+./gradlew startGhidra    -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
 
 # Via tools.setup facade (same commands, Gradle backend)
 $env:TOOLS_SETUP_BACKEND = "gradle"
 python -m tools.setup build
-python -m tools.setup preflight --ghidra-path F:\ghidra_12.0.4_PUBLIC
-python -m tools.setup deploy    --ghidra-path F:\ghidra_12.0.4_PUBLIC
+python -m tools.setup preflight --ghidra-path F:\ghidra_12.1_PUBLIC
+python -m tools.setup deploy    --ghidra-path F:\ghidra_12.1_PUBLIC
 ```
 
 **Maven (default — existing tooling unchanged):**
 
 ```text
 python -m tools.setup build
-python -m tools.setup preflight      --ghidra-path F:\ghidra_12.0.4_PUBLIC
-python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.0.4_PUBLIC
-python -m tools.setup deploy         --ghidra-path F:\ghidra_12.0.4_PUBLIC
+python -m tools.setup preflight      --ghidra-path F:\ghidra_12.1_PUBLIC
+python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.1_PUBLIC
+python -m tools.setup deploy         --ghidra-path F:\ghidra_12.1_PUBLIC
 ```
 
 - Maven: `C:\Users\benam\tools\apache-maven-3.9.6\bin\mvn.cmd`
-- Ghidra install: `F:\ghidra_12.0.4_PUBLIC`
+- Ghidra install: `F:\ghidra_12.1_PUBLIC`
 - `tools.setup` delegates to Maven by default; set `TOOLS_SETUP_BACKEND=gradle` to route the same commands to Gradle
 - Deploy handles: build, extension install, FrontEndTool.xml patching, Ghidra restart
 - Migration plan: `docs/project-management/GRADLE_MIGRATION_CHECKLIST.md`
@@ -85,7 +85,7 @@ Release floor before tagging or publishing:
 python -m tools.setup verify-version
 python -m tools.setup build
 pytest tests/unit/ -v --no-cov
-python -m tools.setup deploy --ghidra-path F:\ghidra_12.0.4_PUBLIC --test release
+python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC --test release
 ```
 
 Run UI-touching deploy/regression only after confirming the current Ghidra UI
@@ -183,7 +183,7 @@ pytest tests/unit/ --no-cov
 
 ```text
 # Gradle
-./gradlew test --tests 'com.xebyte.offline.*' -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+./gradlew test --tests 'com.xebyte.offline.*' -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
 # Maven
 mvn test -Dtest='com.xebyte.offline.*Test'
 ```
@@ -205,7 +205,7 @@ pytest tests/performance/ \
 
 ```text
 # Java
-./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC   # or: mvn test
+./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC   # or: mvn test
 # Python — subset by marker
 pytest tests/ -m readonly          # safe, no writes
 pytest tests/ -m safe_write        # identity writes only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Title: Decompile timeout on binary > 10MB
 
 Environment:
 - OS: Windows 11
-- Ghidra: 12.0.4
+- Ghidra: 12.1
 - Binary: 12MB x86-64
 
 Steps:
@@ -394,7 +394,7 @@ pytest tests/ -v
 - Java 21 LTS
 - Apache Maven 3.9+
 - Python 3.10+
-- Ghidra 12.0.4
+- Ghidra 12.1
 
 ### Local Development
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![Java](https://img.shields.io/badge/Java-21-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/21/)
-[![Ghidra](https://img.shields.io/badge/Ghidra-12.0.4-brightgreen?style=for-the-badge&logoColor=white)](https://ghidra-sre.org/)
+[![Ghidra](https://img.shields.io/badge/Ghidra-12.1-brightgreen?style=for-the-badge&logoColor=white)](https://ghidra-sre.org/)
 [![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-6C5CE7?style=for-the-badge&logoColor=white)](https://modelcontextprotocol.io/)
 
 [![Stars](https://img.shields.io/github/stars/bethington/ghidra-mcp?style=for-the-badge&logo=github&logoColor=white&color=yellow)](https://github.com/bethington/ghidra-mcp/stargazers)
@@ -99,7 +99,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 - **Java 21 LTS** (OpenJDK recommended)
 - **Apache Maven 3.9+**
-- **Ghidra 12.0.4** (or compatible version)
+- **Ghidra 12.1** (or compatible version)
 - **Python 3.10+** with pip
 
 ### Installation
@@ -117,14 +117,14 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 2. **Recommended: run environment preflight first:**
    ```text
-   python -m tools.setup preflight --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+   python -m tools.setup preflight --ghidra-path "F:\ghidra_12.1_PUBLIC"
    ```
 
 3. **Build and deploy to Ghidra:**
    ```text
-   python -m tools.setup ensure-prereqs --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+   python -m tools.setup ensure-prereqs --ghidra-path "F:\ghidra_12.1_PUBLIC"
    python -m tools.setup build
-   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC"
    ```
 
    `deploy` saves/closes an already-running matching Ghidra instance when
@@ -135,7 +135,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
    ```text
    # Skip automatic prerequisite setup
    python -m tools.setup build
-   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC"
    ```
 
 5. **Show command help**:
@@ -175,14 +175,14 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 3. **Run environment preflight:**
    ```bash
-   python -m tools.setup preflight --ghidra-path ~/ghidra_12.0.4_PUBLIC
+   python -m tools.setup preflight --ghidra-path ~/ghidra_12.1_PUBLIC
    ```
 
 4. **Build and deploy to Ghidra (single command):**
    ```bash
-   python -m tools.setup ensure-prereqs --ghidra-path ~/ghidra_12.0.4_PUBLIC
+   python -m tools.setup ensure-prereqs --ghidra-path ~/ghidra_12.1_PUBLIC
    python -m tools.setup build
-   python -m tools.setup deploy --ghidra-path ~/ghidra_12.0.4_PUBLIC
+   python -m tools.setup deploy --ghidra-path ~/ghidra_12.1_PUBLIC
    ```
 
    This will:
@@ -194,7 +194,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 5. **Optional: setup only Maven dependencies:**
    ```bash
-   python -m tools.setup install-ghidra-deps --ghidra-path ~/ghidra_12.0.4_PUBLIC
+   python -m tools.setup install-ghidra-deps --ghidra-path ~/ghidra_12.1_PUBLIC
    ```
 
 6. **Show command help:**
@@ -232,7 +232,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
     python -m tools.setup deploy \
        --ghidra-path /opt/homebrew/opt/ghidra/libexec
    ```
-   The extension is installed to `~/Library/ghidra/ghidra_12.0.4_PUBLIC/Extensions/GhidraMCP/`.
+   The extension is installed to `~/Library/ghidra/ghidra_12.1_PUBLIC/Extensions/GhidraMCP/`.
 
    > **Note:** `--ghidra-version` is required when using the Homebrew path because the path contains no version string.
 
@@ -467,7 +467,7 @@ into and run from the same interpreter.
 **Cause:** JAR file in wrong location.
 
 **Solution:**
-1. Manual install location: `~/.ghidra/ghidra_12.0.4_PUBLIC/Extensions/GhidraMCP/lib/GhidraMCP.jar`
+1. Manual install location: `~/.ghidra/ghidra_12.1_PUBLIC/Extensions/GhidraMCP/lib/GhidraMCP.jar`
 2. Or use: **File > Install Extensions > Add** and select the ZIP file
 3. Ensure JAR/ZIP was built for your Ghidra version
 
@@ -478,7 +478,7 @@ into and run from the same interpreter.
 **Solution:**
 ```text
 # Windows (recommended)
-python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1_PUBLIC"
 ```
 
 ## 📊 Production Performance
@@ -734,9 +734,9 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 ### Building from Source
 ```bash
 # Recommended: direct Python-first workflow
-python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.1_PUBLIC"
 python -m tools.setup build
-python -m tools.setup deploy --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup deploy --ghidra-path "C:\ghidra_12.1_PUBLIC"
 
 # Version bump (updates all maintained version references atomically)
 python -m tools.setup bump-version --new X.Y.Z
@@ -782,12 +782,12 @@ on your machine to run the live benchmark regression. See
 
 ```text
 # Standard first-time setup and deploy
-python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.1_PUBLIC"
 python -m tools.setup build
-python -m tools.setup deploy --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup deploy --ghidra-path "C:\ghidra_12.1_PUBLIC"
 
 # Preflight check before deploying
-python -m tools.setup preflight --strict --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup preflight --strict --ghidra-path "C:\ghidra_12.1_PUBLIC"
 
 # Version bump and tag
 python -m tools.setup bump-version --new X.Y.Z --tag
@@ -832,7 +832,7 @@ This is a one-time setup per machine, and again when your Ghidra version changes
 
 The tool enforces version consistency between:
 - `pom.xml` (`ghidra.version`)
-- `--ghidra-path` version segment (e.g., `ghidra_12.0.4_PUBLIC`)
+- `--ghidra-path` version segment (e.g., `ghidra_12.1_PUBLIC`)
 
 If these do not match, deployment fails fast with a clear error.
 
@@ -845,12 +845,12 @@ If you see a version mismatch error, align both values:
 Then rerun:
 
 ```text
-python -m tools.setup preflight --ghidra-path "C:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup preflight --ghidra-path "C:\ghidra_12.1_PUBLIC"
 ```
 
 ```text
 # Windows
-python -m tools.setup install-ghidra-deps --ghidra-path "C:\path\to\ghidra_12.0.4_PUBLIC"
+python -m tools.setup install-ghidra-deps --ghidra-path "C:\path\to\ghidra_12.1_PUBLIC"
 ```
 
 **Required Libraries (14 JARs, ~37MB):**

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 - **Ghidra 12.1** (or compatible version)
 - **Python 3.10+** with pip
 
+> Shared Ghidra Server users: Ghidra 12.1 clients require a Ghidra
+> Server at 12.1, 12.0.5, or a newer compatible version. Upgrade the
+> server before using this plugin from a 12.1 client.
+>
+> Ghidra 12.1 ships Jython as an optional extension. Java scripts work
+> by default, but `.py` scripts in `ghidra_scripts/` require installing
+> the Jython extension from **File > Install Extensions** and restarting
+> Ghidra.
+
 ### Installation
 
 > Recommended for all platforms: use `python -m tools.setup` directly.
@@ -389,6 +398,10 @@ java -jar GhidraMCPHeadless.jar --bind 0.0.0.0 --port 8089
 
 When connecting to a shared Ghidra Server, GhidraMCP can suppress the password dialog automatically. It resolves credentials in this order (first non-empty value wins):
 
+Compatibility note: Ghidra 12.1 clients require Ghidra Server 12.1,
+12.0.5, or a newer compatible server. Older shared servers are not safe
+targets for a 12.1 client upgrade.
+
 1. `GHIDRA_SERVER_PASSWORD` environment variable (or `.env` file in the Ghidra install directory or `~`)
 2. `~/.ghidra-cred` — single-line password file in your home directory
 3. `<ghidra-install-dir>/.ghidra-cred`
@@ -461,6 +474,17 @@ into and run from the same interpreter.
 1. Verify endpoint exists: `curl http://127.0.0.1:8089/get_version`
 2. Check for typos in endpoint name
 3. Ensure you're using correct HTTP method (GET vs POST)
+
+### Python Ghidra scripts fail with "No script provider found"
+
+**Cause:** In Ghidra 12.1, Jython support is no longer enabled by
+default. `.py` scripts need the bundled Jython extension; Python 3
+scripts should use PyGhidra instead of the Ghidra Script Manager.
+
+**Solution:**
+1. In the Ghidra Front End, open **File > Install Extensions**.
+2. Check **Jython**, restart Ghidra, then refresh Script Manager.
+3. For new automation, prefer Java Ghidra scripts or PyGhidra.
 
 ### Extension not appearing in Install Extensions
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@ FROM eclipse-temurin:21-jdk AS builder
 # the Ghidra release zip. A mismatch means Maven can't resolve dependencies
 # (see #183). GHIDRA_DATE must match the asset filename of the chosen
 # version on the upstream NSA/ghidra GitHub release.
-ARG GHIDRA_VERSION=12.0.4
-ARG GHIDRA_DATE=20260303
+ARG GHIDRA_VERSION=12.1
+ARG GHIDRA_DATE=20260513
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,13 +22,13 @@ pytest tests/unit/ -v --no-cov
 Deploy without importing the benchmark binary:
 
 ```text
-python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC"
 ```
 
 Deploy and run the release-grade live regression:
 
 ```text
-python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC" --test release
+python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC" --test release
 ```
 
 Opt in locally so every deploy runs the release regression:
@@ -171,7 +171,7 @@ The normal CI suite runs on GitHub-hosted runners.
 
 The live release regression requires a self-hosted Windows runner with:
 
-- Ghidra 12.0.4 installed.
+- Ghidra 12.1 installed.
 - Java 21.
 - Python 3.13.
 - Maven.
@@ -218,10 +218,10 @@ and post-release steps, see
 Minimum local verification:
 
 ```text
-python -m tools.setup preflight --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup preflight --ghidra-path "F:\ghidra_12.1_PUBLIC"
 python -m tools.setup build
 pytest tests/unit/ -v --no-cov
-python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC" --test release
+python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC" --test release
 ```
 
 For GitHub releases, enable `run_live_regression` in the release workflow when a

--- a/docs/project-management/GHIDRA_RECOVERY_RFC.md
+++ b/docs/project-management/GHIDRA_RECOVERY_RFC.md
@@ -127,7 +127,7 @@ Example recovery state:
   "transport": "uds",
   "pid": 12345,
   "launched_by_bridge": true,
-  "ghidra_path": "F:/ghidra_12.0.4_PUBLIC",
+  "ghidra_path": "F:/ghidra_12.1_PUBLIC",
   "project": "MyProject",
   "project_path": "C:/Users/benam/ghidra/projects/MyProject.gpr",
   "program": "/Mods/PD2-S12/D2Common.dll",

--- a/docs/project-management/GRADLE_PHASE1_BACKLOG.md
+++ b/docs/project-management/GRADLE_PHASE1_BACKLOG.md
@@ -89,7 +89,7 @@ Reads `ghidra.version` from `pom.xml` and compares it against the version report
 
 ```
 ./gradlew verifyVersion
-./gradlew verifyVersion -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+./gradlew verifyVersion -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
 ```
 
 ---
@@ -101,7 +101,7 @@ Reads `ghidra.version` from `pom.xml` and compares it against the version report
 Validates Java on PATH, all 18 required Ghidra jars present, write access to both the Ghidra install extensions dir and the user-profile extensions dir. Depends on `verifyVersion`.
 
 ```
-./gradlew preflight -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+./gradlew preflight -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
 ```
 
 ---
@@ -113,7 +113,7 @@ Validates Java on PATH, all 18 required Ghidra jars present, write access to bot
 Checks that all 18 required Ghidra jars exist under `GHIDRA_INSTALL_DIR`. No `mvn install:install-file` step required — Gradle uses fileTree directly for compilation.
 
 ```
-./gradlew prepareGhidraClasspath -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC
+./gradlew prepareGhidraClasspath -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
 ```
 
 ---
@@ -171,7 +171,7 @@ def find_plugin_archive(repo_root: Path) -> Path:
     raise FileNotFoundError("No GhidraMCP plugin archive found in build/distributions/ or target/")
 ```
 
-**Acceptance test**: run `./gradlew buildExtension`, then `python -m tools.setup deploy --ghidra-path F:\ghidra_12.0.4_PUBLIC`. Should find the zip and complete without error.
+**Acceptance test**: run `./gradlew buildExtension`, then `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC`. Should find the zip and complete without error.
 
 ---
 
@@ -179,14 +179,14 @@ def find_plugin_archive(repo_root: Path) -> Path:
 
 Run these after applying item 10:
 
-- [ ] `./gradlew buildExtension -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC` exits 0
+- [ ] `./gradlew buildExtension -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC` exits 0
 - [ ] `build/distributions/GhidraMCP-5.4.1.zip` exists
 - [ ] ZIP contains exactly: `GhidraMCP/extension.properties`, `GhidraMCP/Module.manifest`, `GhidraMCP/lib/GhidraMCP-5.4.1.jar` (no extra jars)
 - [ ] `extension.properties` inside the ZIP has the substituted version (not `${project.version}`)
-- [ ] `./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC` passes (offline unit tests)
-- [ ] `./gradlew verifyVersion -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC` exits 0
-- [ ] `./gradlew preflight -PGHIDRA_INSTALL_DIR=F:\ghidra_12.0.4_PUBLIC` exits 0
-- [ ] `python -m tools.setup deploy --ghidra-path F:\ghidra_12.0.4_PUBLIC` finds the Gradle-produced ZIP
+- [ ] `./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC` passes (offline unit tests)
+- [ ] `./gradlew verifyVersion -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC` exits 0
+- [ ] `./gradlew preflight -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC` exits 0
+- [ ] `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC` finds the Gradle-produced ZIP
 
 ---
 

--- a/docs/releases/RELEASE_CHECKLIST.md
+++ b/docs/releases/RELEASE_CHECKLIST.md
@@ -63,7 +63,7 @@ rg -n "OLD_VERSION|NEW_VERSION|MCP Tools|GUI Endpoints|Headless Endpoints|total_
 Run the cheap gates before any live Ghidra work:
 
 ```text
-python -m tools.setup preflight --ghidra-path "F:\ghidra_12.0.4_PUBLIC"
+python -m tools.setup preflight --ghidra-path "F:\ghidra_12.1_PUBLIC"
 python -m tools.setup build
 pytest tests/unit/ -v --no-cov
 git diff --check
@@ -91,7 +91,7 @@ benchmark, or endpoint behavior changes.
 - [ ] Run the release-grade deploy regression:
 
 ```text
-python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC" --test release
+python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC" --test release
 ```
 
 - [ ] Record whether the release regression passed.

--- a/docs/releases/v5.7.0-VERIFY.md
+++ b/docs/releases/v5.7.0-VERIFY.md
@@ -6,11 +6,11 @@ Most steps are scripted by `tests/integration/test_global_endpoints.py`. The lis
 
 ## Prerequisites
 
-- Ghidra 12.0.4 running with a binary loaded (D2Game.dll in the dev environment).
+- Ghidra 12.1 running with a binary loaded (D2Game.dll in the dev environment).
 - `python -m tools.setup verify-version` reports **5.7.0**.
 - The v5.7.0 plugin has been deployed to Ghidra. If you haven't deployed yet:
   ```text
-  python -m tools.setup deploy --ghidra-path "F:\ghidra_12.0.4_PUBLIC" --test release
+  python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC" --test release
   ```
   Per-CLAUDE.md, the graceful sequence is: `save_program` → `exit_ghidra` → wait → run deploy.
 

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -834,8 +834,8 @@ def try_launch_ghidra():
         candidates.append(Path(env_dir))
     # Common install locations
     candidates += [
-        Path("F:/ghidra_12.0.4_PUBLIC"),
-        Path("C:/ghidra_12.0.4_PUBLIC"),
+        Path("F:/ghidra_12.1_PUBLIC"),
+        Path("C:/ghidra_12.1_PUBLIC"),
         Path("C:/Program Files/ghidra"),
         Path(os.path.expanduser("~/ghidra")),
     ]

--- a/ghidra-mcp-setup.ps1
+++ b/ghidra-mcp-setup.ps1
@@ -1,6 +1,6 @@
 # GhidraMCP Deployment Script
 # Automatically builds, installs, and configures the GhidraMCP plugin
-# Target: Ghidra 12.0.4
+# Target: Ghidra 12.1
 
 <#
 .SYNOPSIS
@@ -18,10 +18,10 @@ Version safety checks enforce consistency between:
 - version inferred from -GhidraPath (if present)
 
 .EXAMPLE
-.\ghidra-mcp-setup.ps1 -Deploy -GhidraPath "F:\ghidra_12.0.4_PUBLIC"
+.\ghidra-mcp-setup.ps1 -Deploy -GhidraPath "F:\ghidra_12.1_PUBLIC"
 
 .EXAMPLE
-.\ghidra-mcp-setup.ps1 -SetupDeps -GhidraPath "F:\ghidra_12.0.4_PUBLIC"
+.\ghidra-mcp-setup.ps1 -SetupDeps -GhidraPath "F:\ghidra_12.1_PUBLIC"
 
 .EXAMPLE
 .\ghidra-mcp-setup.ps1 -BuildOnly
@@ -58,7 +58,7 @@ function Write-LogWarning { param($msg) Write-Host "[WARNING] $msg" -ForegroundC
 function Write-LogError { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor Red }
 
 # Configuration
-$DefaultGhidraVersion = "12.0.4"
+$DefaultGhidraVersion = "12.1"
 $PluginVersion = "5.2.0"
 
 function Show-Usage {
@@ -73,7 +73,7 @@ function Show-Usage {
     Write-Host "  -Preflight       Validate environment and prerequisites without making changes"
     Write-Host ""
     Write-Host "Common options:"
-    Write-Host "  -GhidraPath      Path to Ghidra install (e.g., F:\ghidra_12.0.4_PUBLIC)"
+    Write-Host "  -GhidraPath      Path to Ghidra install (e.g., F:\ghidra_12.1_PUBLIC)"
     Write-Host "  -GhidraVersion   Explicit Ghidra version (must match pom.xml/path version)"
     Write-Host "  -StrictPreflight Fail preflight on network checks (Maven Central/PyPI reachability)"
     Write-Host "  -NoAutoPrereqs   Disable automatic prerequisite setup during deploy"
@@ -89,9 +89,9 @@ function Show-Usage {
     Write-Host "  -Help            Show this help text"
     Write-Host ""
     Write-Host "Examples:"
-    Write-Host "  .\ghidra-mcp-setup.ps1 -Deploy -GhidraPath 'F:\ghidra_12.0.4_PUBLIC'"
-    Write-Host "  .\ghidra-mcp-setup.ps1 -SetupDeps -GhidraPath 'F:\ghidra_12.0.4_PUBLIC'"
-    Write-Host "  .\ghidra-mcp-setup.ps1 -Preflight -GhidraPath 'F:\ghidra_12.0.4_PUBLIC'"
+    Write-Host "  .\ghidra-mcp-setup.ps1 -Deploy -GhidraPath 'F:\ghidra_12.1_PUBLIC'"
+    Write-Host "  .\ghidra-mcp-setup.ps1 -SetupDeps -GhidraPath 'F:\ghidra_12.1_PUBLIC'"
+    Write-Host "  .\ghidra-mcp-setup.ps1 -Preflight -GhidraPath 'F:\ghidra_12.1_PUBLIC'"
     Write-Host "  .\ghidra-mcp-setup.ps1 -BuildOnly"
     Write-Host "  .\ghidra-mcp-setup.ps1 -Clean"
     Write-Host ""
@@ -931,7 +931,7 @@ $ghidraVersionDir = $null
 $ghidraUserBase = "$env:USERPROFILE\AppData\Roaming\ghidra"
 
 if (Test-Path $ghidraUserBase) {
-    # Extract version from GhidraPath (e.g., "F:\ghidra_12.0.4_PUBLIC" -> "12.0.4")
+    # Extract version from GhidraPath (e.g., "F:\ghidra_12.1_PUBLIC" -> "12.1")
     $targetVersion = $null
     if ($GhidraPath -match "ghidra_([0-9.]+)") {
         $targetVersion = $Matches[1]
@@ -971,7 +971,7 @@ if (-not $ghidraVersionDir) {
     if ($GhidraPath -match "ghidra_([0-9.]+)") {
         $ghidraVersionDir = "ghidra_$($Matches[1])_PUBLIC"
     } else {
-        $ghidraVersionDir = "ghidra_12.0.4_PUBLIC"
+        $ghidraVersionDir = "ghidra_12.1_PUBLIC"
     }
     Write-LogInfo "Using Ghidra version dir: $ghidraVersionDir"
 }
@@ -1199,7 +1199,7 @@ Write-Host ""
 if ($version -match "^2\.") {
     Write-LogInfo "New in v2.0.0 - Major Release:"
     Write-Host "   + 133 total endpoints (was 132)"
-    Write-Host "   + Ghidra 12.0.4 support"
+    Write-Host "   + Ghidra 12.1 support"
     Write-Host "   + Malware analysis: IOC extraction, behavior detection, anti-analysis detection"
     Write-Host "   + Function similarity analysis with CFG comparison"
     Write-Host "   + Control flow complexity analysis (cyclomatic complexity)"

--- a/ghidra_scripts/README.md
+++ b/ghidra_scripts/README.md
@@ -42,7 +42,10 @@ import ghidra.program.model.listing.*;
 ```
 
 ### Python Scripts (Jython)
-Ghidra uses Jython 2.7, not Python 3. Scripts must use:
+Ghidra uses Jython 2.7, not Python 3. In Ghidra 12.1, Jython is shipped
+as an optional extension and is not enabled by default. Install it from
+**File > Install Extensions**, restart Ghidra, then refresh Script Manager
+before running `.py` scripts. Scripts must use:
 ```python
 from ghidra.app.script import GhidraScript
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ghidra.version>12.0.4</ghidra.version>
+        <ghidra.version>12.1</ghidra.version>
         <!-- Build timestamp generated at compile time (format: yyyyMMdd-HHmmss) -->
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>

--- a/scripts/launch-ghidra-scoped.ps1
+++ b/scripts/launch-ghidra-scoped.ps1
@@ -16,7 +16,7 @@
 # Plain `ghidraRun.bat` (no env var) keeps the default unscoped behavior.
 
 param(
-    [string]$GhidraPath = "F:\ghidra_12.0.4_PUBLIC",
+    [string]$GhidraPath = "F:\ghidra_12.1_PUBLIC",
     [string]$Scope      = "/Mods/PD2-S12"
 )
 

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -1223,6 +1223,11 @@ public class ProgramScriptService {
                     ghidra.app.script.GhidraScriptProvider provider = ghidra.app.script.GhidraScriptUtil.getProvider(scriptFile);
                     if (provider == null) {
                         resultMsg.append("ERROR: No script provider found for: ").append(scriptFile.getName()).append("\n");
+                        if (scriptFile.getName().toLowerCase(java.util.Locale.ROOT).endsWith(".py")) {
+                            resultMsg.append("Ghidra 12.1 ships Jython as an optional extension. ")
+                                    .append("Install the Jython extension from File > Install Extensions, ")
+                                    .append("restart Ghidra, then refresh Script Manager before running .py scripts.\n");
+                        }
                         return;
                     }
 

--- a/tests/integration/test_global_endpoints.py
+++ b/tests/integration/test_global_endpoints.py
@@ -56,7 +56,7 @@ def require_v5_7_endpoints(server_url, http_session):
         pytest.skip(
             "audit_global endpoint not registered on running server "
             "(v5.7.0 not deployed yet — run "
-            "`python -m tools.setup deploy --ghidra-path F:\\ghidra_12.0.4_PUBLIC --test release` "
+            "`python -m tools.setup deploy --ghidra-path F:\\ghidra_12.1_PUBLIC --test release` "
             "to deploy then re-run these tests)"
         )
 

--- a/tests/unit/test_setup_cli.py
+++ b/tests/unit/test_setup_cli.py
@@ -222,7 +222,7 @@ def test_cmd_deploy_routes_to_gradle(tmp_path, monkeypatch):
         lambda root, tasks, **kw: recorded.update({"tasks": tasks, **kw}) or 0,
     )
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     result = cli.cmd_deploy(_args(ghidra_path=ghidra_path))
 
@@ -248,7 +248,7 @@ def test_cmd_deploy_routes_to_maven(tmp_path, monkeypatch):
         or 0,
     )
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     result = cli.cmd_deploy(_args(ghidra_path=ghidra_path))
 
@@ -295,7 +295,7 @@ def test_cmd_start_ghidra_routes_to_gradle(tmp_path, monkeypatch):
         lambda root, tasks, **kw: recorded.update({"tasks": tasks}) or 0,
     )
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     result = cli.cmd_start_ghidra(_args(ghidra_path=ghidra_path))
 
@@ -315,7 +315,7 @@ def test_cmd_start_ghidra_routes_to_maven(tmp_path, monkeypatch):
         cli, "start_ghidra", lambda path, dry_run=False: called.append(path) or 0
     )
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     result = cli.cmd_start_ghidra(_args(ghidra_path=ghidra_path))
 
@@ -389,7 +389,7 @@ def test_cmd_install_ghidra_deps_routes_to_maven(tmp_path, monkeypatch):
         lambda root, path, force=False, dry_run=False: called.append(path) or 0,
     )
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     cli.cmd_install_ghidra_deps(_args(ghidra_path=ghidra_path))
     assert called
@@ -409,7 +409,7 @@ def test_cmd_install_ghidra_deps_routes_to_gradle(tmp_path, monkeypatch):
         lambda root, tasks, **kw: recorded.update({"tasks": tasks}) or 0,
     )
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     cli.cmd_install_ghidra_deps(_args(ghidra_path=ghidra_path))
     assert recorded["tasks"] == ["prepareGhidraClasspath"]
@@ -428,7 +428,7 @@ def test_cmd_verify_version_maven_no_ghidra_path(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(cli, "_get_backend", lambda: "maven")
     monkeypatch.setattr(cli, "_load_repo_env", lambda root: {})
     monkeypatch.setattr(
-        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.0.4")
+        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.1")
     )
 
     result = cli.cmd_verify_version(_args(ghidra_path=None))
@@ -436,7 +436,7 @@ def test_cmd_verify_version_maven_no_ghidra_path(tmp_path, monkeypatch, capsys):
     assert result == 0
     out = capsys.readouterr().out
     assert "5.4.1" in out
-    assert "12.0.4" in out
+    assert "12.1" in out
 
 
 def test_cmd_verify_version_maven_versions_match(tmp_path, monkeypatch):
@@ -447,11 +447,11 @@ def test_cmd_verify_version_maven_versions_match(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "_get_backend", lambda: "maven")
     monkeypatch.setattr(cli, "_load_repo_env", lambda root: {})
     monkeypatch.setattr(
-        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.0.4")
+        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.1")
     )
-    monkeypatch.setattr(cli, "infer_ghidra_version_from_path", lambda path: "12.0.4")
+    monkeypatch.setattr(cli, "infer_ghidra_version_from_path", lambda path: "12.1")
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     result = cli.cmd_verify_version(_args(ghidra_path=ghidra_path))
 
@@ -466,7 +466,7 @@ def test_cmd_verify_version_maven_version_mismatch(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "_get_backend", lambda: "maven")
     monkeypatch.setattr(cli, "_load_repo_env", lambda root: {})
     monkeypatch.setattr(
-        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.0.4")
+        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.1")
     )
     monkeypatch.setattr(cli, "infer_ghidra_version_from_path", lambda path: "11.0.0")
 
@@ -485,7 +485,7 @@ def test_cmd_verify_version_maven_uninferrable_path(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "_get_backend", lambda: "maven")
     monkeypatch.setattr(cli, "_load_repo_env", lambda root: {})
     monkeypatch.setattr(
-        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.0.4")
+        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.1")
     )
     monkeypatch.setattr(cli, "infer_ghidra_version_from_path", lambda path: None)
 
@@ -593,7 +593,7 @@ def test_cmd_bump_version_passes_dry_run_and_tag(tmp_path, monkeypatch):
 def test_resolve_ghidra_path_prefers_arg(tmp_path, monkeypatch):
     from tools.setup import cli
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     other_path = tmp_path / "other"
     monkeypatch.setattr(
@@ -607,7 +607,7 @@ def test_resolve_ghidra_path_prefers_arg(tmp_path, monkeypatch):
 def test_resolve_ghidra_path_from_env(tmp_path, monkeypatch):
     from tools.setup import cli
 
-    env_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    env_path = tmp_path / "ghidra_12.1_PUBLIC"
     env_path.mkdir()
     monkeypatch.setattr(
         cli, "_load_repo_env", lambda root: {"GHIDRA_PATH": str(env_path)}
@@ -637,7 +637,7 @@ def test_require_ghidra_path_raises_when_missing(tmp_path, monkeypatch):
 def test_require_ghidra_path_returns_path_when_set(tmp_path, monkeypatch):
     from tools.setup import cli
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     monkeypatch.setattr(cli, "_load_repo_env", lambda root: {})
 
@@ -747,7 +747,7 @@ def test_cmd_preflight_maven_passes_without_ghidra_path(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "find_repo_python", lambda root: Path("python"))
     monkeypatch.setattr(cli, "find_maven_command", lambda: Path("/usr/bin/mvn"))
     monkeypatch.setattr(
-        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.0.4")
+        cli, "read_pom_versions", lambda root: VersionInfo("5.4.1", "12.1")
     )
     monkeypatch.setattr(
         subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})()
@@ -811,7 +811,7 @@ def test_cmd_ensure_prereqs_dry_run_prints_plan(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(cli, "execute_install_plan", lambda plan: None)
     monkeypatch.setattr(cli, "run_gradle", lambda root, tasks, **kw: 0)
 
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     ghidra_path.mkdir()
     result = cli.cmd_ensure_prereqs(_args(ghidra_path=ghidra_path, dry_run=True))
 

--- a/tests/unit/test_setup_ghidra.py
+++ b/tests/unit/test_setup_ghidra.py
@@ -74,12 +74,12 @@ def test_patch_codebrowser_tcd_removes_ghidra_mcp_package_block():
 
 def test_resolve_ghidra_user_dir_prefers_matching_public_dir(tmp_path: Path):
     user_base = tmp_path / "ghidra"
-    matching_dir = user_base / "ghidra_12.0.4_PUBLIC"
+    matching_dir = user_base / "ghidra_12.1_PUBLIC"
     other_dir = user_base / "ghidra_12.0.3_PUBLIC"
     matching_dir.mkdir(parents=True)
     other_dir.mkdir(parents=True)
 
-    resolved = resolve_ghidra_user_dir(Path("F:/ghidra_12.0.4_PUBLIC"), user_base)
+    resolved = resolve_ghidra_user_dir(Path("F:/ghidra_12.1_PUBLIC"), user_base)
 
     assert resolved == matching_dir
 
@@ -99,11 +99,11 @@ def test_resolve_ghidra_user_dir_falls_back_to_latest_existing_dir(tmp_path: Pat
 def test_collect_preflight_issues_reports_missing_jar_and_debugger_requirements(
     tmp_path: Path,
 ):
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     (ghidra_path / "Extensions" / "Ghidra").mkdir(parents=True)
     (ghidra_path / "ghidraRun.bat").write_text("echo off\n", encoding="utf-8")
     user_base = tmp_path / "user-ghidra"
-    (user_base / "ghidra_12.0.4_PUBLIC").mkdir(parents=True)
+    (user_base / "ghidra_12.1_PUBLIC").mkdir(parents=True)
 
     issues = collect_preflight_issues(
         tmp_path,
@@ -123,7 +123,7 @@ def _stub_version(
 ) -> None:
     monkeypatch.setattr(
         "tools.setup.ghidra.read_pom_versions",
-        lambda _root: VersionInfo(project_version=version, ghidra_version="12.0.4"),
+        lambda _root: VersionInfo(project_version=version, ghidra_version="12.1"),
     )
 
 
@@ -174,7 +174,7 @@ class TestFindPluginArchive:
 def test_collect_preflight_issues_passes_with_required_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    ghidra_path = tmp_path / "ghidra_12.0.4_PUBLIC"
+    ghidra_path = tmp_path / "ghidra_12.1_PUBLIC"
     (ghidra_path / "Extensions" / "Ghidra").mkdir(parents=True)
     (ghidra_path / "ghidraRun.bat").write_text("echo off\n", encoding="utf-8")
     for _artifact_id, relative_path in REQUIRED_GHIDRA_JARS:
@@ -186,7 +186,7 @@ def test_collect_preflight_issues_passes_with_required_files(
         "pybag==1.0\n", encoding="utf-8"
     )
     user_base = tmp_path / "user-ghidra"
-    (user_base / "ghidra_12.0.4_PUBLIC").mkdir(parents=True)
+    (user_base / "ghidra_12.1_PUBLIC").mkdir(parents=True)
     monkeypatch.setattr(
         "tools.setup.ghidra.shutil.which",
         lambda name: "java" if name == "java" else None,

--- a/tests/unit/test_version_bump.py
+++ b/tests/unit/test_version_bump.py
@@ -402,7 +402,7 @@ def test_get_current_version_reads_pom(tmp_path: Path):
         '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
         f"  <version>{OLD}</version>\n"
         "  <properties>\n"
-        "    <ghidra.version>12.0.4</ghidra.version>\n"
+        "    <ghidra.version>12.1</ghidra.version>\n"
         "  </properties>\n"
         "</project>\n",
         encoding="utf-8",

--- a/tools/README.md
+++ b/tools/README.md
@@ -42,8 +42,8 @@ python -m tools.setup --help
 
 # common ones
 python -m tools.setup build
-python -m tools.setup preflight      --ghidra-path F:\ghidra_12.0.4_PUBLIC
-python -m tools.setup deploy         --ghidra-path F:\ghidra_12.0.4_PUBLIC
+python -m tools.setup preflight      --ghidra-path F:\ghidra_12.1_PUBLIC
+python -m tools.setup deploy         --ghidra-path F:\ghidra_12.1_PUBLIC
 python -m tools.setup bump-version   --new 5.10.0
 python -m tools.setup verify-version
 ```


### PR DESCRIPTION
## Description
Updates Ghidra MCP to target Ghidra 12.1 and fixes the setup/CI metadata mismatch reported in #211.

Fixes #211

## Changes
- Bump `pom.xml` `ghidra.version` to 12.1.
- Update CI, release, and Docker download metadata to the Ghidra 12.1 20260513 upstream asset.
- Refresh setup docs, examples, active defaults, and compatibility tests for `ghidra_12.1_PUBLIC`.
- Document the Ghidra 12.1 shared-server requirement: 12.1 clients need Ghidra Server 12.1, 12.0.5, or newer compatible server.
- Document that Jython is optional in Ghidra 12.1 and improve the `.py` script-provider error when Jython is not installed.

## Testing
- `python -m tools.setup verify-version`
- `python -m pytest -o addopts= tests/unit/test_setup_cli.py tests/unit/test_setup_ghidra.py tests/unit/test_version_bump.py -v`
- `python -m pytest -o addopts= tests/unit/ -m "not slow" -q`
- `.\gradlew.bat verifyVersion`
- `pytest -o addopts="" tests/unit/test_setup_cli.py tests/unit/test_setup_ghidra.py tests/unit/test_version_bump.py tests/unit/test_project_consistency.py -q`
- `git diff --check`
- checked for stale active `ghidra_12.0.4` references

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] No breaking changes
