### PR TITLE
feat(bridge): resilient dynamic tool registration (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ headless diagnostics need a plugin redeploy to take effect.
 
 ### Fixed
 
+- **#212 -- bridge tool registration aborted on one malformed schema
+  entry** (@killerra). Dynamic registration now skips only the failing
+  tool, keeps loading later valid tools during both connect-time
+  registration and lazy group loading, and writes a compact stderr
+  diagnostic with the bad tool name and exception.
+
 - **#207 — fun-doc called Ghidra endpoints with wrong parameter
   names** (@dalen). Audited every `ghidra_get`/`ghidra_post` call in
   `fun_doc.py` against the endpoint catalog. Three real bugs + one

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import socket
+import sys
 import time
 import threading
 import http.client
@@ -1090,6 +1091,20 @@ def _register_tool_def(tool_def: dict) -> bool:
     return True
 
 
+def _report_tool_registration_failures(failures: list[str]) -> None:
+    """Emit a compact stderr diagnostic for schema tools that could not load."""
+    if not failures:
+        return
+
+    shown = "; ".join(failures[:8])
+    suffix = "..." if len(failures) > 8 else ""
+    sys.stderr.write(
+        f"[bridge_mcp_ghidra] {len(failures)} tool(s) failed to register: "
+        f"{shown}{suffix}\n"
+    )
+    sys.stderr.flush()
+
+
 def register_tools_from_schema(
     schema: list[dict], groups: set[str] | None = None
 ) -> int:
@@ -1116,13 +1131,20 @@ def register_tools_from_schema(
     _full_schema = _normalize_tool_def_names(schema)
 
     count = 0
+    failures: list[str] = []
     for tool_def in _full_schema:
         category = tool_def.get("category", "unknown")
         if groups is not None and category not in groups:
             continue
-        if _register_tool_def(tool_def):
-            _loaded_groups.add(category)
-            count += 1
+        try:
+            if _register_tool_def(tool_def):
+                _loaded_groups.add(category)
+                count += 1
+        except Exception as e:
+            name = tool_def.get("name", "<unnamed>")
+            failures.append(f"{name}: {e}")
+
+    _report_tool_registration_failures(failures)
 
     return count
 
@@ -1130,16 +1152,21 @@ def register_tools_from_schema(
 def _load_group(group_name: str) -> list[str]:
     """Load tools for a specific group from cached schema. Returns list of newly loaded tool names."""
     loaded_names: list[str] = []
+    failures: list[str] = []
     for tool_def in _full_schema:
         if tool_def.get("category") != group_name:
             continue
         name = tool_def["name"]
         if name in _dynamic_tool_names:
             continue  # Already loaded
-        _register_tool_def(tool_def)
-        loaded_names.append(name)
+        try:
+            if _register_tool_def(tool_def):
+                loaded_names.append(name)
+        except Exception as e:
+            failures.append(f"{name}: {e}")
     if loaded_names:
         _loaded_groups.add(group_name)
+    _report_tool_registration_failures(failures)
     return loaded_names
 
 

--- a/tests/unit/test_bridge_utils.py
+++ b/tests/unit/test_bridge_utils.py
@@ -733,6 +733,54 @@ class TestRegisterToolsFromSchema(unittest.TestCase):
         self.assertIn("test_tool_reg_1", _dynamic_tool_names)
         self.assertIn("test_tool_reg_2", _dynamic_tool_names)
 
+    def test_register_skips_bad_tool_and_continues(self):
+        import bridge_mcp_ghidra as bridge
+
+        schema = [
+            {
+                "name": "issue_212_valid_before",
+                "description": "",
+                "endpoint": "/issue_212_valid_before",
+                "http_method": "GET",
+                "category": "listing",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+            {
+                "name": "issue_212_bad_signature",
+                "description": "",
+                "endpoint": "/issue_212_bad_signature",
+                "http_method": "GET",
+                "category": "listing",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"bad-param": {"type": "string"}},
+                },
+            },
+            {
+                "name": "issue_212_valid_after",
+                "description": "",
+                "endpoint": "/issue_212_valid_after",
+                "http_method": "GET",
+                "category": "listing",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+        ]
+
+        try:
+            with patch("sys.stderr") as mock_stderr:
+                count = bridge.register_tools_from_schema(schema)
+
+            self.assertEqual(count, 2)
+            self.assertIn("issue_212_valid_before", bridge._dynamic_tool_names)
+            self.assertIn("issue_212_valid_after", bridge._dynamic_tool_names)
+            self.assertNotIn("issue_212_bad_signature", bridge._dynamic_tool_names)
+            message = mock_stderr.write.call_args.args[0]
+            self.assertIn("1 tool(s) failed to register", message)
+            self.assertIn("issue_212_bad_signature", message)
+            self.assertIn("bad-param", message)
+        finally:
+            bridge.register_tools_from_schema([])
+
     def test_clears_previous_tools(self):
         from bridge_mcp_ghidra import register_tools_from_schema, _dynamic_tool_names
 

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -149,6 +149,58 @@ class TestToolGroupManagement(unittest.TestCase):
         self.assertEqual(loaded, ["grp_test_b"])
         self.assertIn("grp_beta", _loaded_groups)
 
+    def test_load_group_skips_bad_tool_and_continues(self):
+        """Lazy group loading should not abort on one malformed tool."""
+        import bridge_mcp_ghidra as bridge
+
+        schema = [
+            {
+                "name": "issue_212_already_loaded",
+                "description": "",
+                "endpoint": "/issue_212_already_loaded",
+                "http_method": "GET",
+                "category": "grp_alpha",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+            {
+                "name": "issue_212_lazy_bad_signature",
+                "description": "",
+                "endpoint": "/issue_212_lazy_bad_signature",
+                "http_method": "GET",
+                "category": "grp_beta",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"bad-param": {"type": "string"}},
+                },
+            },
+            {
+                "name": "issue_212_lazy_valid_after",
+                "description": "",
+                "endpoint": "/issue_212_lazy_valid_after",
+                "http_method": "GET",
+                "category": "grp_beta",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+        ]
+
+        try:
+            bridge.register_tools_from_schema(schema, groups={"grp_alpha"})
+            with mock.patch("sys.stderr") as mock_stderr:
+                loaded = bridge._load_group("grp_beta")
+
+            self.assertEqual(loaded, ["issue_212_lazy_valid_after"])
+            self.assertIn("grp_beta", bridge._loaded_groups)
+            self.assertIn("issue_212_lazy_valid_after", bridge._dynamic_tool_names)
+            self.assertNotIn(
+                "issue_212_lazy_bad_signature", bridge._dynamic_tool_names
+            )
+            message = mock_stderr.write.call_args.args[0]
+            self.assertIn("1 tool(s) failed to register", message)
+            self.assertIn("issue_212_lazy_bad_signature", message)
+            self.assertIn("bad-param", message)
+        finally:
+            bridge.register_tools_from_schema([])
+
 
 class TestConnectInstance(unittest.TestCase):
     """Test connect_instance eager-loading behavior."""


### PR DESCRIPTION
## Description
Make dynamic bridge tool registration resilient when one schema entry is malformed.

Fixes #212

## Changes
- Catch per-tool registration failures during connect-time schema loading.
- Apply the same skip-and-continue behavior to lazy group loading.
- Emit compact stderr diagnostics with failing tool names and errors.
- Add regression tests for eager and lazy registration paths.
- Update CHANGELOG.md for the user-facing behavior change.

## Testing
- `python -m pytest -o addopts= tests/unit/test_bridge_utils.py::TestRegisterToolsFromSchema tests/unit/test_mcp_tools.py::TestToolGroupManagement -v`
- `python -m pytest -o addopts= tests/unit --ignore=tests/unit/test_gradle_tasks.py -v`

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] No breaking changes