### PR TITLE
ci+docs: add OSSF Scorecard badge + workflow_dispatch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,11 @@ on:
     - cron: '17 8 * * 1'   # Mondays 08:17 UTC
   push:
     branches: [main]
+  # Manual trigger so the score can be refreshed without forcing a
+  # dummy commit (useful after enabling repo Settings toggles like
+  # Dependabot security alerts or branch protection rulesets, which
+  # don't themselves push anything).
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Last commit](https://img.shields.io/github/last-commit/bethington/ghidra-mcp?style=for-the-badge&logo=git&logoColor=white)](https://github.com/bethington/ghidra-mcp/commits/main)
 [![Discussions](https://img.shields.io/badge/discussions-join-7B68EE?style=for-the-badge&logo=github&logoColor=white)](https://github.com/bethington/ghidra-mcp/discussions)
 [![Issues](https://img.shields.io/github/issues/bethington/ghidra-mcp?style=for-the-badge&logo=github&logoColor=white&color=orange)](https://github.com/bethington/ghidra-mcp/issues)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bethington/ghidra-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/bethington/ghidra-mcp)
 
 > If you find this useful, please ⭐ star the repo — it helps others discover it!
 >


### PR DESCRIPTION
## Summary

- Adds the OpenSSF Scorecard badge to the README badge bar, linking to the per-check breakdown at scorecard.dev
- Adds `workflow_dispatch:` to the Scorecard workflow so the score can be re-scanned manually without forcing a dummy commit (useful after repo Settings changes that don't push anything — e.g. enabling Dependabot security alerts or branch protection rulesets)

## Context

Today's lift work:
- 3.5 → 5.3 from Token-Permissions + Dependabot config + CodeQL workflow
- 5.3 → 5.7 from pinning all Action references to commit SHAs
- Next scan should pick up the active main-branch ruleset and the Dependabot security alerts toggle, both enabled in repo Settings, lifting the score further

## Test plan
- [x] Badge URL resolves (verified locally — \`api.securityscorecards.dev/projects/github.com/bethington/ghidra-mcp/badge\` returns 200 with the SVG)
- [x] Scorecard workflow YAML still parses (no syntax issues; only added one trigger key)
- [ ] After merge: confirm badge renders on the rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)