### PR TITLE
fix(fun-doc): address Copilot review batch (7 items)

### DIFF
--- a/fun-doc/db/migrate.py
+++ b/fun-doc/db/migrate.py
@@ -129,6 +129,58 @@ def _connect(backend: str, url: Optional[str]):
     raise SystemExit(f"Unknown backend: {backend!r}")
 
 
+_ALTER_ADD_COLUMN_RE = re.compile(
+    r"""ALTER\s+TABLE\s+                        # ALTER TABLE
+        (?P<table>[A-Za-z_][\w.]*)\s+           # qualified table name
+        ADD\s+COLUMN\s+                          # ADD COLUMN
+        (?P<column>[A-Za-z_]\w*)                # column identifier (must be word-bounded)
+        \b                                       # …no embedded suffix
+        [^;]*;                                   # type + defaults + closing semicolon
+    """,
+    re.IGNORECASE | re.VERBOSE | re.DOTALL,
+)
+
+
+def _existing_columns_sqlite(conn, table: str) -> set[str]:
+    """Lower-cased column names already on ``table`` (empty if missing)."""
+    try:
+        cur = conn.execute(f"PRAGMA table_info({table})")
+        return {row[1].lower() for row in cur.fetchall()}
+    except Exception:
+        # Table doesn't exist yet (the migration creating it hasn't run);
+        # let the script run and surface the real error naturally.
+        return set()
+
+
+def _strip_existing_alter_add_column_sqlite(conn, sql: str) -> str:
+    """SQLite ALTER TABLE ADD COLUMN has no IF NOT EXISTS form. Without
+    pre-flight skipping, re-running a migration whose schema_versions
+    entry didn't commit (process crashed between executescript and
+    commit) raises "duplicate column name" and forces manual recovery.
+
+    This helper inspects each ALTER TABLE ADD COLUMN statement against
+    PRAGMA table_info(<table>); if the column is already present it
+    rewrites the statement to a SQL comment so the rest of the script
+    still runs. Postgres migrations are unaffected — they use ADD
+    COLUMN IF NOT EXISTS natively.
+
+    Bare-string scanning is sufficient because the migration files are
+    hand-authored, one-statement-per-line, no embedded `;` inside types.
+    A more elaborate parser would be overkill for this controlled input.
+    """
+    def _maybe_strip(match: re.Match) -> str:
+        table = match.group("table").lower()
+        column = match.group("column").lower()
+        if column in _existing_columns_sqlite(conn, table):
+            return (
+                f"-- [migrate] skipped: column {column!r} already present on "
+                f"{table!r} (idempotent ADD COLUMN)"
+            )
+        return match.group(0)
+
+    return _ALTER_ADD_COLUMN_RE.sub(_maybe_strip, sql)
+
+
 class _SqliteConnAdapter:
     """Thin wrapper so SQLite and psycopg connections share a tiny interface."""
 
@@ -144,7 +196,11 @@ class _SqliteConnAdapter:
         return cur
 
     def executescript(self, sql):
-        self._conn.executescript(sql)
+        # Make ALTER TABLE ADD COLUMN idempotent so a crashed-mid-migration
+        # retry doesn't fail with "duplicate column name". The check
+        # consults PRAGMA table_info before each statement runs.
+        filtered = _strip_existing_alter_add_column_sqlite(self, sql)
+        self._conn.executescript(filtered)
 
     def commit(self):
         self._conn.commit()

--- a/fun-doc/db/migrations/0002_library_code.sqlite.sql
+++ b/fun-doc/db/migrations/0002_library_code.sqlite.sql
@@ -5,11 +5,12 @@
 -- See the Postgres file for design rationale and the consumer wiring in
 -- library_code_detector.py + fun_doc.py.
 --
--- SQLite doesn't support ALTER TABLE IF NOT EXISTS for ADD COLUMN, so we use
--- one ALTER per column. Re-running this migration after partial application
--- (e.g. one column added, the next failed) requires manual recovery; the
--- normal path of `python -m db.migrate` records the version in
--- schema_versions and skips re-running entirely.
+-- SQLite doesn't support ALTER TABLE ADD COLUMN IF NOT EXISTS. fun-doc's
+-- migration runner (db/migrate.py) makes this idempotent automatically by
+-- inspecting PRAGMA table_info(functions_workflow) before each ADD COLUMN
+-- and skipping ones whose column is already present. A crashed-mid-script
+-- retry (where the column landed but the schema_versions row didn't) now
+-- succeeds on the next run instead of requiring manual recovery.
 
 ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER DEFAULT 0;
 ALTER TABLE functions_workflow ADD COLUMN library_code_at TEXT;

--- a/fun-doc/db/migrations/0003_name_source.sqlite.sql
+++ b/fun-doc/db/migrations/0003_name_source.sqlite.sql
@@ -5,11 +5,10 @@
 -- schema prefix). See the Postgres file for design rationale and the
 -- consumer wiring in repository.py + fun_doc.py.
 --
--- SQLite doesn't support ALTER TABLE IF NOT EXISTS for ADD COLUMN, so we
--- use one ALTER per column. Re-running this migration after partial
--- application requires manual recovery; the normal path of
--- `python -m db.migrate` records the version in schema_versions and
--- skips re-running entirely.
+-- SQLite doesn't support ALTER TABLE ADD COLUMN IF NOT EXISTS. fun-doc's
+-- migration runner (db/migrate.py) makes this idempotent automatically by
+-- inspecting PRAGMA table_info(functions_workflow) before each ADD COLUMN
+-- and skipping ones whose column is already present.
 
 ALTER TABLE functions_workflow ADD COLUMN name_source TEXT DEFAULT 'scan';
 ALTER TABLE functions_workflow ADD COLUMN name_source_binary TEXT;

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -1218,16 +1218,19 @@ def _ts_to_iso(value):
 
 
 def load_state():
-    """Load state from the SQL backend, with a state.json fallback.
+    """Load state from the SQL backend.
 
-    SQL backend is the runtime path (see Q4-A in the storage migration plan).
-    Returns the same dict shape callers have always expected:
+    SQL backend is the only runtime path. Returns the same dict shape
+    callers have always expected:
         {project_folder, last_scan, active_binary, current_session,
          sessions: list, functions: {key: record}}
 
-    Falls back to reading state.json directly only if the storage layer
-    can't be loaded (missing sqlalchemy, misconfigured URL). This keeps a
-    half-installed environment functional during the cutover window.
+    The state.json fallback below is now test-only scaffolding (reached
+    only when the test fixture flips ``_storage_repo_failed = True``).
+    At runtime the import guard (line ~109) and the storage-init
+    loud-fail (line ~987) sys.exit(1) before this point is ever reached
+    with a missing backend. See test_state_atomicity.py for the
+    fixture's exercise of the fallback.
     """
     repo = _get_storage_repo()
     if repo is not None:
@@ -1310,7 +1313,10 @@ def _atomic_write_state(state):
 
 
 def save_state(state):
-    """Persist state to the SQL backend (or state.json fallback).
+    """Persist state to the SQL backend.
+
+    (state.json fallback path below is test-only scaffolding; runtime
+    loud-fail above prevents reaching it without an explicit test flag.)
 
     The legacy contract was 'rewrite the entire state.json from this dict.'
     Under the SQL backend that maps to:
@@ -1411,8 +1417,10 @@ def update_function_state(func_key, updated_func):
     "I just finished a run" signal. Other shapes fall back to the workflow
     UPDATE alone.
 
-    Falls back to the legacy state.json RMW when the storage layer isn't
-    available.
+    State.json RMW path below is test-only scaffolding (test fixtures
+    set ``_storage_repo_failed = True`` to exercise it). At runtime the
+    sqlalchemy import guard + storage-init loud-fail ensure the repo
+    is always available before this point.
     """
     repo = _get_storage_repo()
     if repo is not None:
@@ -7161,14 +7169,23 @@ def process_function(
     # bypass (user explicitly queued them — respect their judgment). The
     # check runs after the decompile fetch so the detector has body text
     # for callee-substring fallback when call-graph data isn't populated.
-    queue_for_library = load_priority_queue()
-    cfg_for_library = queue_for_library.get("config") or DEFAULT_QUEUE_CONFIG
+    #
+    # v5.11.5 hot-path optimization: previously this branch loaded
+    # priority_queue.json from disk on EVERY processed function (Copilot
+    # review #3) — across N workers × M functions/min that was a real
+    # I/O bottleneck and contention point. Now:
+    #   * skip_library_code reads from config_snapshot (already frozen
+    #     at worker start; lifetime-stable per worker)
+    #   * pinned-check is deferred until AFTER detect_library_code says
+    #     "library" — for the vast majority of (non-library) functions
+    #     the disk read never happens at all.
     skip_library = (
-        cfg_for_library.get("skip_library_code", True) if config_snapshot is None
-        else config_snapshot.get("skip_library_code", True)
+        config_snapshot.get("skip_library_code", True)
+        if config_snapshot is not None
+        else (load_priority_queue().get("config") or DEFAULT_QUEUE_CONFIG)
+            .get("skip_library_code", True)
     )
-    is_pinned_for_library = func_key in set(queue_for_library.get("pinned", []))
-    if skip_library and not manual and not is_pinned_for_library:
+    if skip_library and not manual:
         decomp_text = data.get("decompiled")
         if decomp_text and not _is_error_response(decomp_text):
             detection = detect_library_code(
@@ -7177,53 +7194,63 @@ def process_function(
                 callees=func.get("callees"),
             )
             if detection.is_library:
-                plate_text = format_library_plate(detection)
-                # Best-effort plate stamp via MCP — failure is non-fatal,
-                # the flag itself is the primary skip mechanism.
-                try:
-                    # /batch_set_comments' address param is named `address`,
-                    # not `function_address` (#207 — fun-doc had it wrong, so
-                    # the generic library-code plate silently never landed;
-                    # the library_code flag is the real skip mechanism so the
-                    # gate still worked, but the plate was missing).
-                    ghidra_post(
-                        "/batch_set_comments",
-                        params={"program": program},
-                        data={
-                            "address": f"0x{address}",
-                            "plate_comment": plate_text,
-                        },
-                    )
-                except Exception as e:
+                # Deferred pinned check: only consult the queue if the
+                # detector wants to skip. Saves one priority_queue.json
+                # disk read per non-library function (the common case).
+                if func_key in set(load_priority_queue().get("pinned", [])):
+                    # User explicitly pinned this function — respect the
+                    # override, fall through to the normal LLM workflow
+                    # below. Drop into the same code path we would have
+                    # without the library_code branch.
+                    pass
+                else:
+                    plate_text = format_library_plate(detection)
+                    # Best-effort plate stamp via MCP — failure is non-fatal,
+                    # the flag itself is the primary skip mechanism.
+                    try:
+                        # /batch_set_comments' address param is named `address`,
+                        # not `function_address` (#207 — fun-doc had it wrong, so
+                        # the generic library-code plate silently never landed;
+                        # the library_code flag is the real skip mechanism so the
+                        # gate still worked, but the plate was missing).
+                        ghidra_post(
+                            "/batch_set_comments",
+                            params={"program": program},
+                            data={
+                                "address": f"0x{address}",
+                                "plate_comment": plate_text,
+                            },
+                        )
+                    except Exception as e:
+                        print(
+                            f"  LIBRARY-CODE plate stamp failed (non-fatal): {e}",
+                            flush=True,
+                        )
+                    func["library_code"] = True
+                    func["library_code_at"] = datetime.now().isoformat()
+                    func["library_code_reasons"] = detection.reasons
+                    func["last_processed"] = datetime.now().isoformat()
+                    func["last_result"] = "library_code"
                     print(
-                        f"  LIBRARY-CODE plate stamp failed (non-fatal): {e}",
+                        f"  LIBRARY CODE — auto-classified ({', '.join(detection.reasons)}). "
+                        f"Stamped generic plate, marked for selector skip.",
                         flush=True,
                     )
-                func["library_code"] = True
-                func["library_code_at"] = datetime.now().isoformat()
-                func["library_code_reasons"] = detection.reasons
-                func["last_processed"] = datetime.now().isoformat()
-                func["last_result"] = "library_code"
-                print(
-                    f"  LIBRARY CODE — auto-classified ({', '.join(detection.reasons)}). "
-                    f"Stamped generic plate, marked for selector skip.",
-                    flush=True,
-                )
-                update_function_state(func_key, func)
-                bus_emit(
-                    "function_complete",
-                    {
-                        "key": func_key,
-                        "result": "library_code",
-                        "score": live_score,
-                        "reasons": detection.reasons,
-                    },
-                )
-                return _finish(
-                    "library_code",
-                    score_after=live_score,
-                    reason=f"library-code detector: {','.join(detection.reasons)}",
-                )
+                    update_function_state(func_key, func)
+                    bus_emit(
+                        "function_complete",
+                        {
+                            "key": func_key,
+                            "result": "library_code",
+                            "score": live_score,
+                            "reasons": detection.reasons,
+                        },
+                    )
+                    return _finish(
+                        "library_code",
+                        score_after=live_score,
+                        reason=f"library-code detector: {','.join(detection.reasons)}",
+                    )
 
     # Refine mode based on live score and completeness context
     mode = determine_mode(live_score, data.get("deductions"), data.get("completeness"))

--- a/fun-doc/library_code_detector.py
+++ b/fun-doc/library_code_detector.py
@@ -40,14 +40,27 @@ HARD_NAME_PATTERNS = (
     re.compile(r"^_+(crt|invoke_watson|except_handler|security_check|amsg_exit|setjmp|aullshr|chkstk|alloca_probe|local_unwind|cinit|tlsdtor|RTC_)"),
     # Operator new/delete and CXX scalar/vector
     re.compile(r"^\?\?[23](@|_)"),
-    # MSVC C++ symbol mangling: starts with `?` and contains `@@`
-    re.compile(r"^\?[A-Za-z_].*@@"),
+    # MSVC C++ mangled names with a recognized STL/MSVCP namespace.
+    # The earlier `^\?[A-Za-z_].*@@` (any mangled name) was too broad:
+    # it matched user-authored exported C++ APIs whose mangled names
+    # happen to follow the same outer shape (e.g., `?MyApiFunc@MyApp@@YA…`).
+    # Restricting to the std / experimental / chrono / filesystem /
+    # ranges / regex / thread / locale / iostream namespace markers
+    # keeps the CRT/STL cases (the actual library targets) without
+    # catching every user-namespaced export.
+    re.compile(r"^\?[A-Za-z_].*@(std|experimental|chrono|filesystem|ranges|regex|locale|ios_base|_System_error_category)@@"),
     # C++ standard library namespace
     re.compile(r"^(std::|__std_|__crt_|_Std|_VEC_memcpy|_VEC_memzero)"),
     # CRT internal mangled exports (e.g. `_strtoi64@4`, `_atof@4`)
     re.compile(r"^_(strtoi64|strtoui64|wcstoi64|wcstoui64|atof|atoi|atol|atoll|strtod|strtol|strtoul|memcpy_s|strcpy_s|wcscpy_s|sprintf_s|vsnprintf_s|fread_s)(@\d+)?$"),
-    # iostream / locale parsers
-    re.compile(r"^(Parse|Read|Write|Get|Put|Skip)?(Signed|Unsigned)?(Char|Short|Int|Long|Float|Double|Hex|Oct|Octal|Dec|Decimal)(Value|Field|Token)?$"),
+    # (REMOVED v5.11.5) The iostream/locale parser HARD regex
+    # `^(Parse|Read|Write|Get|Put|Skip)?(Signed|Unsigned)?(Char|Short|...)
+    #  (Value|Field|Token)?$` was too broad — it matched user-authored
+    # functions like `GetInt`, `ReadLong`, `WriteFloat`, even literally
+    # `Char`. The narrower SOFT_NAME_PATTERNS entry (Parse|Read|Convert
+    # + Signed/Unsigned + numeric type) catches the actual library
+    # cases when corroborated by body/callee evidence; removing the
+    # broad HARD form prevents false-positive classification.
 )
 
 # Functions decompile output calls when it's CRT or VC-runtime. Detecting any of

--- a/fun-doc/scripts/migrate_state_to_sql.py
+++ b/fun-doc/scripts/migrate_state_to_sql.py
@@ -179,19 +179,31 @@ def function_record_to_row(rec: dict) -> dict:
     for key in _DIRECT_FIELDS:
         if key in rec:
             out[key] = rec[key]
+    # Rename + timestamp-parse in one pass. Any destination column whose
+    # name ends in ``_at`` is treated as a timestamp and parsed via
+    # parse_ts; ``last_processed`` is also a timestamp despite its name
+    # not ending in _at (legacy state.json schema predates the suffix
+    # convention). Everything else is copied as-is.
+    #
+    # Pre-v5.11.5 this loop ran a fuzzy substring check ("audited" in dest
+    # or "escalated" in dest or "timeout" in dest) and then three explicit
+    # post-loop blocks re-assigned last_processed, decompile_timeout_at,
+    # and library_code_at via parse_ts. That produced double-assignments
+    # — last_processed and decompile_timeout_at got the same value
+    # written twice (wasted CPU), while library_code_at first got the
+    # raw string from _maybe_ts and then was overwritten by the datetime
+    # from parse_ts (correct end-state, confusing flow). The unified
+    # check below removes all three duplicate assignments.
+    _ts_destinations = {"last_processed"}  # explicit non-_at exceptions
     for src, dest in _RENAMED_FIELDS.items():
-        if src in rec:
-            out[dest] = parse_ts(rec[src]) if "audited" in dest or "escalated" in dest or "timeout" in dest else _maybe_ts(rec[src], dest)
-    # last_result / last_processed are special: state.json stores them as the
-    # last_result string and last_processed ISO timestamp respectively.
+        if src not in rec:
+            continue
+        if dest.endswith("_at") or dest in _ts_destinations:
+            out[dest] = parse_ts(rec[src])
+        else:
+            out[dest] = _maybe_ts(rec[src], dest)
     if "last_result" in rec:
         out["last_result"] = rec["last_result"]
-    if "last_processed" in rec:
-        out["last_processed"] = parse_ts(rec["last_processed"])
-    if "decompile_timeout_at" in rec:
-        out["decompile_timeout_at"] = parse_ts(rec["decompile_timeout_at"])
-    if "library_code_at" in rec:
-        out["library_code_at"] = parse_ts(rec["library_code_at"])
     # ``attempts`` int column = len(inline attempts list). Migrating the
     # list contents into the runs table happens after the bulk upsert.
     inline = rec.get("attempts")

--- a/tests/performance/test_library_code_detector.py
+++ b/tests/performance/test_library_code_detector.py
@@ -268,3 +268,102 @@ def test_confidence_increases_with_more_hits():
     assert one.is_library and two.is_library
     # At minimum, two's confidence is no worse than one's
     assert two.confidence >= one.confidence
+
+
+# ---------------------------------------------------------------------------
+# Copilot review false-positive guards (v5.11.5)
+#
+# The original HARD_NAME_PATTERNS list had two regexes that were too broad
+# and would misclassify legitimate user code:
+#
+#   1. `^\?[A-Za-z_].*@@` matched ANY MSVC-mangled name, including
+#      user-authored exported C++ APIs whose mangled form happens to
+#      share the same outer shape (e.g., `?MyApiFunc@MyApp@@YA...`).
+#      Restricted to known STL/MSVCP namespace markers.
+#
+#   2. `^(Parse|Read|Write|Get|Put|Skip)?(Signed|Unsigned)?(Char|Short|
+#      Int|Long|Float|Double|Hex|...)(Value|Field|Token)?$` matched
+#      legitimate user functions like `GetInt`, `ReadLong`, `WriteFloat`,
+#      and even just `Char` alone. Removed; the narrower
+#      SOFT_NAME_PATTERNS entry already catches the real library cases
+#      when corroborated by body evidence.
+#
+# These tests pin the false-positive prevention.
+# ---------------------------------------------------------------------------
+
+
+def test_user_mangled_cxx_export_not_misclassified():
+    """A user-authored C++ class method with a non-std namespace and a
+    clean body (no library callees) should NOT be classified as library
+    code. The pre-v5.11.5 regex would catch this purely on the mangled
+    name shape — losing real user code to the auto-skip."""
+    # Mangled form: ?DoWork@MyApp@@QAEHXZ
+    # = MyApp::DoWork (instance method, returns int, no params)
+    result = detect_library_code("?DoWork@MyApp@@QAEHXZ", "iVar1 = this->field_4; return iVar1;")
+    assert not result.is_library, (
+        f"User-authored export was misclassified: reasons={result.reasons}"
+    )
+
+
+def test_std_mangled_name_still_classifies():
+    """The restriction must not regress the actual library cases —
+    `?_Xinvalid_argument@std@@YAXPBD@Z` (std::_Xinvalid_argument) is
+    canonical STL and must still flag."""
+    result = detect_library_code("?_Xinvalid_argument@std@@YAXPBD@Z", "")
+    assert result.is_library
+
+
+def test_chrono_namespace_mangled_classifies():
+    """`?...@chrono@@` is std::chrono internals — must still classify."""
+    result = detect_library_code("?duration_cast@chrono@@YA?AV12@H@Z", "")
+    assert result.is_library
+
+
+def test_GetInt_alone_not_misclassified():
+    """`GetInt` is a common user-function name (config readers, deserializers,
+    etc.). The pre-v5.11.5 broad HARD regex matched it directly. After the
+    fix, with no body evidence, it must NOT classify as library."""
+    result = detect_library_code("GetInt", "iVar1 = this->m_value; return iVar1;")
+    assert not result.is_library, (
+        f"GetInt was misclassified: reasons={result.reasons}"
+    )
+
+
+def test_ReadLong_with_user_body_not_misclassified():
+    """`ReadLong` from a user binary deserializer. No library callees
+    in the body. Must NOT classify."""
+    body = """
+    lVar1 = *(longlong *)(this->buffer + this->offset);
+    this->offset = this->offset + 8;
+    return lVar1;
+    """
+    result = detect_library_code("ReadLong", body)
+    assert not result.is_library
+
+
+def test_WriteFloat_isolated_not_misclassified():
+    """Same as above but for `WriteFloat`. User-authored buffer writer."""
+    body = "*(float *)(this->buf + this->pos) = fVar1; this->pos = this->pos + 4;"
+    result = detect_library_code("WriteFloat", body)
+    assert not result.is_library
+
+
+def test_Char_function_alone_not_misclassified():
+    """The original broad regex even matched a function literally named
+    `Char`. Pin that this is no longer a HARD signal."""
+    result = detect_library_code("Char", "return this->m_char;")
+    assert not result.is_library
+
+
+def test_ParseSignedShort_with_iostream_body_still_classifies():
+    """The motivating original case (test_parse_signed_short_pattern_matches_with_body_signal
+    above already covers this with iostream callees). Re-pinning here as
+    part of the false-positive guard suite: when the name pattern IS
+    corroborated by body evidence, classification still works through
+    the SOFT pattern + body callee path."""
+    body = """
+    _Xinvalid_argument(s);
+    iVar1 = std::ios_base::flags(this);
+    """
+    result = detect_library_code("ParseSignedShort", body)
+    assert result.is_library

--- a/tests/performance/test_migrate_sqlite_idempotent.py
+++ b/tests/performance/test_migrate_sqlite_idempotent.py
@@ -1,0 +1,164 @@
+"""Regression: SQLite migration runner makes ALTER TABLE ADD COLUMN idempotent.
+
+Copilot review #4 on the v5.9.0 PR: the SQLite-dialect migration files
+issue plain ``ALTER TABLE ... ADD COLUMN`` (SQLite doesn't accept the
+``IF NOT EXISTS`` form). If the runner crashed between
+``executescript`` and the ``schema_versions`` row commit — process kill,
+power loss, SIGINT during deploy — the column landed but the version
+didn't, so the next migrate run tried to add it again and failed with
+``duplicate column name``, requiring manual recovery.
+
+``db/migrate.py``'s ``_SqliteConnAdapter.executescript`` now inspects
+``PRAGMA table_info(<table>)`` before each ADD COLUMN and rewrites the
+statement to a comment when the column is already present. These tests
+pin that behavior:
+
+* A second run of the exact same script is a no-op (the original bug).
+* Only the duplicate ADD COLUMN is suppressed; non-duplicate statements
+  in the same script still execute.
+* A statement targeting an unrelated table is untouched.
+* Non-ALTER statements (CREATE INDEX, etc.) pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MIGRATE_PY = _REPO_ROOT / "fun-doc" / "db" / "migrate.py"
+
+
+@pytest.fixture
+def migrate_module(monkeypatch):
+    """Load fun-doc/db/migrate.py without importing it as a package
+    (it imports relative siblings; isolating via importlib avoids
+    polluting sys.modules between tests)."""
+    monkeypatch.syspath_prepend(str(_MIGRATE_PY.parent))
+    spec = importlib.util.spec_from_file_location("fun_doc_migrate_under_test", _MIGRATE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["fun_doc_migrate_under_test"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pytest.skip("migrate.py raised SystemExit during import (missing optional dep)")
+    yield mod
+    sys.modules.pop("fun_doc_migrate_under_test", None)
+
+
+def _make_adapter(migrate_module, tmp_path: Path):
+    """Build the SQLite adapter against a fresh on-disk DB with the
+    functions_workflow table the migrations target."""
+    conn = sqlite3.connect(str(tmp_path / "state.db"))
+    conn.isolation_level = None
+    conn.execute(
+        "CREATE TABLE functions_workflow ("
+        "id INTEGER PRIMARY KEY, "
+        "address TEXT NOT NULL"
+        ")"
+    )
+    return migrate_module._SqliteConnAdapter(conn), conn
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def test_add_column_then_replay_does_not_raise(migrate_module, tmp_path):
+    """The whole reason this fix exists: re-applying the same migration
+    SQL must not fail with 'duplicate column name'."""
+    adapter, conn = _make_adapter(migrate_module, tmp_path)
+    try:
+        sql = "ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER DEFAULT 0;"
+        adapter.executescript(sql)
+        adapter.executescript(sql)   # second run is the regression case
+        assert "library_code" in _columns(conn, "functions_workflow")
+    finally:
+        conn.close()
+
+
+def test_multi_column_partial_replay_completes_missing_columns(
+    migrate_module, tmp_path
+):
+    """Realistic partial-apply: column 1 landed on the first run before a
+    crash; column 2 didn't. The replay must skip column 1 (already there)
+    but still add column 2."""
+    adapter, conn = _make_adapter(migrate_module, tmp_path)
+    try:
+        # Simulate partial application — column 1 is already in the schema.
+        conn.execute("ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER DEFAULT 0")
+        before = _columns(conn, "functions_workflow")
+        assert "library_code" in before
+        assert "library_code_at" not in before
+
+        adapter.executescript(
+            "ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER DEFAULT 0;\n"
+            "ALTER TABLE functions_workflow ADD COLUMN library_code_at TEXT;\n"
+        )
+        after = _columns(conn, "functions_workflow")
+        assert "library_code" in after
+        assert "library_code_at" in after, (
+            "second column must be added even though the first was a no-op skip"
+        )
+    finally:
+        conn.close()
+
+
+def test_unrelated_table_alter_passes_through(migrate_module, tmp_path):
+    """The pre-flight skip is scoped per-(table, column). A statement
+    against a different table whose schema we don't know yet should NOT
+    be suppressed — let SQLite raise the real error if it's malformed,
+    but if the table happens to exist with a missing column, run it."""
+    adapter, conn = _make_adapter(migrate_module, tmp_path)
+    try:
+        # Build a second table with its own column already present.
+        conn.execute("CREATE TABLE schema_versions (version INTEGER, applied_at TEXT)")
+        adapter.executescript(
+            "ALTER TABLE schema_versions ADD COLUMN extra_field TEXT;"
+        )
+        assert "extra_field" in _columns(conn, "schema_versions")
+    finally:
+        conn.close()
+
+
+def test_non_alter_statements_unaffected(migrate_module, tmp_path):
+    """CREATE INDEX (and other non-ALTER statements) must pass through
+    the filter unchanged. The filter is intentionally narrow — it only
+    knows how to suppress duplicate ADD COLUMN, nothing else."""
+    adapter, conn = _make_adapter(migrate_module, tmp_path)
+    try:
+        adapter.executescript(
+            "ALTER TABLE functions_workflow ADD COLUMN name_source TEXT;\n"
+            "CREATE INDEX IF NOT EXISTS ix_name_source "
+            "ON functions_workflow (name_source);\n"
+        )
+        idx_rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='ix_name_source'"
+        ).fetchall()
+        assert idx_rows, "CREATE INDEX statement was not executed"
+    finally:
+        conn.close()
+
+
+def test_strip_helper_in_isolation(migrate_module, tmp_path):
+    """The regex helper rewrites a duplicate ADD COLUMN to a comment;
+    pin that behavior so a future regex tweak can't silently regress."""
+    adapter, conn = _make_adapter(migrate_module, tmp_path)
+    try:
+        # Pre-populate column 'library_code'.
+        conn.execute("ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER")
+        sql = (
+            "ALTER TABLE functions_workflow ADD COLUMN library_code INTEGER DEFAULT 0;\n"
+            "ALTER TABLE functions_workflow ADD COLUMN library_code_at TEXT;\n"
+        )
+        rewritten = migrate_module._strip_existing_alter_add_column_sqlite(adapter, sql)
+        # First (duplicate) statement → comment; second (new) → unchanged
+        assert "-- [migrate] skipped:" in rewritten
+        assert "library_code_at TEXT" in rewritten
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Seven Copilot review items from the v5.9.0 and v5.9.1 PRs, resolved together. Two were real bugs silently affecting documentation quality, the rest are robustness/perf/doc-accuracy cleanups.

| # | Severity | What |
|---|---|---|
| 1 | bug | \`/batch_set_comments\` contract mismatch — **already fixed** in v5.11.0 via #207; AST parity test pins it |
| 2+5 | bug | HARD_NAME_PATTERNS over-matched — restricted MSVC mangled to STL namespaces; removed broad iostream parser regex; **7 new false-positive guard tests** |
| 3 | perf | \`load_priority_queue()\` hot-path I/O — use \`config_snapshot\` + defer pinned-check until after detection |
| 4 | robustness | SQLite migration ADD COLUMN now auto-idempotent at the runner level (covers 0002, 0003, and future migrations); **5 new idempotency tests** |
| 6 | doc | Stale \"fall back to state.json\" wording removed — that path is test-only scaffolding now (sqlalchemy import guard + storage-init loud-fail make it runtime-unreachable) |
| 7 | quality | \`migrate_state_to_sql.py\` library_code_at double-assignment fixed by unifying rename-loop timestamp parsing (incidentally fixes \`last_processed\` and \`decompile_timeout_at\` too) |

## Test plan

- [x] 356 Python unit tests pass
- [x] 125 Java offline tests pass
- [x] 29 library_code_detector tests pass (was 22, +7 new false-positive guards)
- [x] 5 new \`test_migrate_sqlite_idempotent.py\` tests pass
- [x] fun_doc.py parses clean (ast.parse with utf-8)
- [x] No functional API changes — all existing parity tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)