### PR TITLE
feat(headless): /load_program accepts optional language + compiler_spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Complete version history for the Ghidra MCP Server project.
 
 ## Unreleased
 
+### Added
+
+- **`/load_program` accepts optional `language` and `compiler_spec`.**
+  Raw firmware blobs with no recognizable header (e.g. ARM Cortex-M
+  `.mem` dumps) can now be imported as raw binary with an explicit
+  processor by passing `language` (e.g. `ARM:LE:32:Cortex`) and
+  optionally `compiler_spec`; when `language` is omitted the loader
+  auto-detects the format as before. Both values are trimmed before
+  the `LanguageID` / `CompilerSpecID` lookup so doc-copied inputs like
+  `" ARM:LE:32:Cortex "` resolve instead of failing the lookup. The
+  success response now also echoes the resolved `language`.
+
 ### Fixed
 
 - **Headless: `/run_ghidra_script` and `/run_script_inline` crashed
@@ -34,6 +46,19 @@ Complete version history for the Ghidra MCP Server project.
   `JavaScriptProvider.activateAll()` output is appended to the error
   response under `--- BUILD/ACTIVATE OUTPUT ---`, so Felix compile
   errors are visible to the caller instead of being silently dropped.
+  The capturing `PrintWriter` is flushed before the buffer is read so
+  the surfaced text is complete, and the output is bounded to its last
+  16 KB (with a truncation notice) so a verbose compiler failure can't
+  blow up the response payload.
+
+- **Headless script init no longer registers a placeholder bundle when
+  the user script directory can't be created.** If `mkdirs()` fails on
+  the primary location the server now falls back to a writable temp
+  directory, and if that also fails it short-circuits BundleHost
+  acquisition entirely (script execution stays disabled) instead of
+  acquiring on a missing path and crashing later with
+  `ClassCastException: GhidraPlaceholderBundle cannot be cast to
+  GhidraSourceBundle`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ Complete version history for the Ghidra MCP Server project.
   `GHIDRA_MCP_FILE_ROOT` is configured the path is canonicalized through
   `SecurityConfig.resolveWithinFileRoot(...)` (resolving symlinks and
   `..`) and rejected with `Access denied` when it escapes the root,
-  before any disk access. Previously the allow-list helper existed but
-  was never wired to this endpoint, so an operator who set the root
-  expecting path-traversal protection could still have the agent read
-  any file on disk. With no root configured the behavior is unchanged.
+  before any disk access. The rejection message is generic (the
+  configured root is logged server-side, not echoed to the caller, to
+  avoid disclosing the filesystem layout). Previously the allow-list
+  helper existed but was never wired to this endpoint, so an operator
+  who set the root expecting path-traversal protection could still
+  have the agent read any file on disk. With no root configured the
+  behavior is unchanged.
 
 ### Added
 
@@ -64,11 +67,14 @@ Complete version history for the Ghidra MCP Server project.
   blow up the response payload.
 
 - **Headless script init no longer registers a placeholder bundle when
-  the user script directory can't be created.** If `mkdirs()` fails on
-  the primary location the server now falls back to a writable temp
-  directory, and if that also fails it short-circuits BundleHost
-  acquisition entirely (script execution stays disabled) instead of
-  acquiring on a missing path and crashing later with
+  the user script directory can't be created.** `acquireBundleHostReference()`
+  registers `GhidraScriptUtil.USER_SCRIPTS_DIR` itself, so a local temp-dir
+  fallback wouldn't change the path it registers and the missing canonical
+  directory would still become a `GhidraPlaceholderBundle`. The server now
+  ensures the canonical user script directory is a real, writable directory
+  (creating it if needed) and short-circuits BundleHost acquisition entirely
+  when it isn't (script execution stays disabled, the server keeps running)
+  instead of acquiring on a missing path and crashing later with
   `ClassCastException: GhidraPlaceholderBundle cannot be cast to
   GhidraSourceBundle`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **Headless: `/run_ghidra_script` and `/run_script_inline` crashed
+  with `NullPointerException`** at
+  `JavaScriptProvider.getScriptInstance()` because
+  `GhidraScriptUtil.bundleHost` is never initialized outside the GUI
+  (in GUI mode `GhidraScriptMgrPlugin` does it). The headless server
+  now calls `GhidraScriptUtil.acquireBundleHostReference()` at startup
+  and `releaseBundleHostReference()` at shutdown when
+  `GHIDRA_MCP_ALLOW_SCRIPTS` is enabled (via
+  `SecurityConfig.areScriptsAllowed()`), then ensures the user script
+  directory is registered as an enabled `GhidraSourceBundle` so
+  `JavaScriptProvider.loadClass()` can resolve compiled scripts.
+  Gated on the existing opt-in flag to keep the ~hundreds-of-ms Felix
+  OSGi startup cost off the default path.
+
+- **Docker runtime image switched from `eclipse-temurin:21-jre` to
+  `eclipse-temurin:21-jdk`.** Ghidra's `GhidraScript` OSGi loader
+  invokes `javax.tools.ToolProvider.getSystemJavaCompiler()` to
+  compile `.java` scripts on the fly; that returns `null` on a JRE,
+  surfacing as `AssertException: Can't find java compiler` for any
+  Java script run inside the container.
+
+- **`ProgramScriptService` now surfaces OSGi build/activate output**
+  when script execution fails. The `StringWriter` capturing
+  `JavaScriptProvider.activateAll()` output is appended to the error
+  response under `--- BUILD/ACTIVATE OUTPUT ---`, so Felix compile
+  errors are visible to the caller instead of being silently dropped.
+
+---
+
 ## v5.12.0 - 2026-05-23 (community-driven tools: /get_current_selection + GUI /open_project)
 
 Minor release. Two new endpoints filed/scoped by community feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Complete version history for the Ghidra MCP Server project.
 
 ## Unreleased
 
+### Security
+
+- **`/load_program` now enforces the `GHIDRA_MCP_FILE_ROOT` allow-list.**
+  The endpoint accepts an absolute filesystem path; when
+  `GHIDRA_MCP_FILE_ROOT` is configured the path is canonicalized through
+  `SecurityConfig.resolveWithinFileRoot(...)` (resolving symlinks and
+  `..`) and rejected with `Access denied` when it escapes the root,
+  before any disk access. Previously the allow-list helper existed but
+  was never wired to this endpoint, so an operator who set the root
+  expecting path-traversal protection could still have the agent read
+  any file on disk. With no root configured the behavior is unchanged.
+
 ### Added
 
 - **`/load_program` accepts optional `language` and `compiler_spec`.**

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ GhidraMCP is designed for **localhost-only development**. The default configurat
 |---|---|
 | `GHIDRA_MCP_AUTH_TOKEN` | When set, every HTTP request must carry `Authorization: Bearer <token>`. Timing-safe comparison. `/mcp/health`, `/health`, `/check_connection` are exempt. |
 | `GHIDRA_MCP_ALLOW_SCRIPTS` | Set to `1`, `true`, or `yes` to enable `/run_script_inline` and `/run_ghidra_script`. **Off by default as of v5.4.1** — these endpoints execute arbitrary Java against the Ghidra process. In headless mode this also triggers OSGi `BundleHost` initialization at server startup (Felix framework, ~hundreds of ms); leave it off if you don't need script execution. |
-| `GHIDRA_MCP_FILE_ROOT` | When set to a directory path, filesystem-path endpoints (`/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. Prevents path-traversal. |
+| `GHIDRA_MCP_FILE_ROOT` | When set to a directory path, filesystem-path endpoints (`/load_program`, `/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. Prevents path-traversal. |
 
 Name-quality enforcement is separate from security. By default,
 `rename_function_by_address` and global write endpoints reject names that fail

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ GhidraMCP is designed for **localhost-only development**. The default configurat
 | Env var | Effect |
 |---|---|
 | `GHIDRA_MCP_AUTH_TOKEN` | When set, every HTTP request must carry `Authorization: Bearer <token>`. Timing-safe comparison. `/mcp/health`, `/health`, `/check_connection` are exempt. |
-| `GHIDRA_MCP_ALLOW_SCRIPTS` | Set to `1`, `true`, or `yes` to enable `/run_script_inline` and `/run_ghidra_script`. **Off by default as of v5.4.1** — these endpoints execute arbitrary Java against the Ghidra process. |
+| `GHIDRA_MCP_ALLOW_SCRIPTS` | Set to `1`, `true`, or `yes` to enable `/run_script_inline` and `/run_ghidra_script`. **Off by default as of v5.4.1** — these endpoints execute arbitrary Java against the Ghidra process. In headless mode this also triggers OSGi `BundleHost` initialization at server startup (Felix framework, ~hundreds of ms); leave it off if you don't need script execution. |
 | `GHIDRA_MCP_FILE_ROOT` | When set to a directory path, filesystem-path endpoints (`/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. Prevents path-traversal. |
 
 Name-quality enforcement is separate from security. By default,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,11 @@ RUN mvn clean package -P headless -DskipTests -q
 # =============================================================================
 # Stage 2: Runtime - Minimal image with Ghidra and plugin
 # =============================================================================
-FROM eclipse-temurin:21-jre
+# NOTE: must be a JDK (not JRE) — Ghidra's GhidraScript OSGi loader uses
+# javax.tools.ToolProvider.getSystemJavaCompiler() to compile .java scripts on
+# the fly. That returns null on a JRE, causing
+# "AssertException: Can't find java compiler" when running any Java script.
+FROM eclipse-temurin:21-jdk
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/docs/prompts/TOOL_USAGE_GUIDE.md
+++ b/docs/prompts/TOOL_USAGE_GUIDE.md
@@ -369,7 +369,7 @@ GhidraMCP defaults to localhost-unauthenticated — safe on a single-user dev bo
 |---|---|
 | `GHIDRA_MCP_AUTH_TOKEN` | When set, every HTTP request must carry `Authorization: Bearer <token>`. Timing-safe comparison. `/mcp/health`, `/health`, `/check_connection` are always exempt. |
 | `GHIDRA_MCP_ALLOW_SCRIPTS` | Set to `1`, `true`, or `yes` to enable `/run_script_inline` and `/run_ghidra_script`. **Off by default as of v5.4.1** (breaking change — these endpoints execute arbitrary Java against the Ghidra process). |
-| `GHIDRA_MCP_FILE_ROOT` | When set, filesystem-path endpoints (`/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. |
+| `GHIDRA_MCP_FILE_ROOT` | When set, filesystem-path endpoints (`/load_program`, `/import_file`, `/open_project`, `/delete_file`, etc.) canonicalize the input and require it to fall under this root. |
 
 The headless server refuses to start on a non-loopback bind address (`0.0.0.0`, explicit external IP) unless `GHIDRA_MCP_AUTH_TOKEN` is set.
 

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -32,6 +32,28 @@ public class ProgramScriptService {
     private final ThreadingStrategy threadingStrategy;
     private static final String AUTO_ANALYSIS_COMPLETION_MESSAGE = "Auto-analysis completed";
 
+    /**
+     * Upper bound on the OSGi build/activate output echoed back in an error
+     * response. Verbose compiler failures can run to many KB of repeated
+     * diagnostics; beyond this we keep only the tail (where the actual error
+     * usually is) and prepend a truncation notice.
+     */
+    private static final int MAX_BUILD_OUTPUT_CHARS = 16 * 1024;
+
+    /**
+     * Return {@code text} unchanged when it fits within {@code maxChars};
+     * otherwise return its last {@code maxChars} characters prefixed with a
+     * notice naming how many characters were dropped.
+     */
+    private static String boundTail(String text, int maxChars) {
+        if (text.length() <= maxChars) {
+            return text;
+        }
+        int dropped = text.length() - maxChars;
+        return "[... truncated " + dropped + " characters; showing last "
+                + maxChars + " ...]\n" + text.substring(dropped);
+    }
+
     public ProgramScriptService(ProgramProvider programProvider, ThreadingStrategy threadingStrategy) {
         this.programProvider = programProvider;
         this.threadingStrategy = threadingStrategy;
@@ -1147,9 +1169,12 @@ public class ProgramScriptService {
         // Track whether we copied the script (for cleanup)
         final File[] copiedScript = {null};
 
-        // Holder so the catch block can surface OSGi build/activate output
-        // captured into scriptWriter before a failure.
+        // Holders so the catch block can surface OSGi build/activate output
+        // captured into scriptWriter before a failure. The PrintWriter holder
+        // lets the failure path flush buffered output into the StringWriter
+        // before reading it, otherwise the captured text can be truncated.
         final StringWriter[] scriptWriterHolder = {null};
+        final PrintWriter[] scriptPrintWriterHolder = {null};
 
         // Get the PluginTool for script state (GUI mode only)
         final PluginTool pluginTool = getToolFromProvider();
@@ -1241,6 +1266,7 @@ public class ProgramScriptService {
                     StringWriter scriptWriter = new StringWriter();
                     PrintWriter scriptPrintWriter = new PrintWriter(scriptWriter);
                     scriptWriterHolder[0] = scriptWriter;
+                    scriptPrintWriterHolder[0] = scriptPrintWriter;
 
                     ghidra.app.script.GhidraScript script = provider.getScriptInstance(scriptFile, scriptPrintWriter);
                     if (script == null) {
@@ -1295,14 +1321,22 @@ public class ProgramScriptService {
 
                     // Surface any build/activate output that was captured into the
                     // script writer before the failure (e.g. OSGi/Felix compile
-                    // errors from JavaScriptProvider.activateAll()).
+                    // errors from JavaScriptProvider.activateAll()). Flush the
+                    // PrintWriter first so buffered text reaches the StringWriter,
+                    // and bound the result so a verbose compiler failure can't
+                    // blow up the response payload.
                     try {
+                        PrintWriter pw2 = scriptPrintWriterHolder[0];
+                        if (pw2 != null) {
+                            pw2.flush();
+                        }
                         StringWriter sw2 = scriptWriterHolder[0];
                         if (sw2 != null) {
                             String capturedBuild = sw2.toString();
                             if (!capturedBuild.isEmpty()) {
                                 resultMsg.append("--- BUILD/ACTIVATE OUTPUT ---\n")
-                                        .append(capturedBuild).append("\n");
+                                        .append(boundTail(capturedBuild, MAX_BUILD_OUTPUT_CHARS))
+                                        .append("\n");
                             }
                         }
                     } catch (Throwable ignore) { /* scriptWriter may be unavailable */ }

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -1147,6 +1147,10 @@ public class ProgramScriptService {
         // Track whether we copied the script (for cleanup)
         final File[] copiedScript = {null};
 
+        // Holder so the catch block can surface OSGi build/activate output
+        // captured into scriptWriter before a failure.
+        final StringWriter[] scriptWriterHolder = {null};
+
         // Get the PluginTool for script state (GUI mode only)
         final PluginTool pluginTool = getToolFromProvider();
 
@@ -1236,6 +1240,7 @@ public class ProgramScriptService {
                     // Create script instance
                     StringWriter scriptWriter = new StringWriter();
                     PrintWriter scriptPrintWriter = new PrintWriter(scriptWriter);
+                    scriptWriterHolder[0] = scriptWriter;
 
                     ghidra.app.script.GhidraScript script = provider.getScriptInstance(scriptFile, scriptPrintWriter);
                     if (script == null) {
@@ -1287,6 +1292,20 @@ public class ProgramScriptService {
                     PrintWriter pw = new PrintWriter(sw);
                     e.printStackTrace(pw);
                     resultMsg.append("Stack trace:\n").append(sw.toString()).append("\n");
+
+                    // Surface any build/activate output that was captured into the
+                    // script writer before the failure (e.g. OSGi/Felix compile
+                    // errors from JavaScriptProvider.activateAll()).
+                    try {
+                        StringWriter sw2 = scriptWriterHolder[0];
+                        if (sw2 != null) {
+                            String capturedBuild = sw2.toString();
+                            if (!capturedBuild.isEmpty()) {
+                                resultMsg.append("--- BUILD/ACTIVATE OUTPUT ---\n")
+                                        .append(capturedBuild).append("\n");
+                            }
+                        }
+                    } catch (Throwable ignore) { /* scriptWriter may be unavailable */ }
 
                     Msg.error(this, "Script execution failed: " + scriptPath, e);
                 } finally {

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -21,9 +21,11 @@ import com.xebyte.core.AnnotationScanner;
 import com.xebyte.core.EndpointDef;
 import com.xebyte.core.JsonHelper;
 import com.xebyte.core.ProgramProvider;
+import com.xebyte.core.SecurityConfig;
 import com.xebyte.core.ThreadingStrategy;
 import ghidra.GhidraApplicationLayout;
 import ghidra.GhidraLaunchable;
+import ghidra.app.script.GhidraScriptUtil;
 import ghidra.framework.Application;
 import ghidra.framework.ApplicationConfiguration;
 import ghidra.framework.HeadlessGhidraApplicationConfiguration;
@@ -62,6 +64,7 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
     private int port = DEFAULT_PORT;
     private String bindAddress = DEFAULT_BIND_ADDRESS;
     private boolean running = false;
+    private boolean scriptingBundleHostAcquired = false;
 
     // Endpoint handler registry
     private HeadlessEndpointHandler endpointHandler;
@@ -201,6 +204,80 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
             ApplicationConfiguration config = new HeadlessGhidraApplicationConfiguration();
             Application.initializeApplication(layout, config);
             System.out.println("Ghidra initialized in headless mode");
+        }
+
+        // Initialize the OSGi/BundleHost subsystem used by GhidraScriptProvider.
+        // In GUI mode this is done by GhidraScriptMgrPlugin; in headless we must do it
+        // explicitly or every /run_ghidra_script and /run_script_inline call throws
+        // NullPointerException at JavaScriptProvider.getScriptInstance() because
+        // GhidraScriptUtil.bundleHost is null.
+        //
+        // Gated on GHIDRA_MCP_ALLOW_SCRIPTS (via SecurityConfig) to avoid the Felix
+        // OSGi framework startup cost (~hundreds of ms) when script execution is
+        // disabled (default since v5.4.1). Held for the lifetime of the server;
+        // released by stop().
+        if (SecurityConfig.getInstance().areScriptsAllowed()) {
+            try {
+                // BundleHost.add() inspects each path: an existing directory yields a
+                // GhidraSourceBundle, anything else (missing path, plain file) yields a
+                // GhidraPlaceholderBundle. A placeholder makes JavaScriptProvider crash
+                // later with `ClassCastException: GhidraPlaceholderBundle cannot be cast
+                // to GhidraSourceBundle`. Ensure the user script dir exists before
+                // acquire so it gets registered as a real source bundle.
+                java.io.File userScriptDir = GhidraScriptUtil.USER_SCRIPTS_DIR != null
+                        ? new java.io.File(GhidraScriptUtil.USER_SCRIPTS_DIR)
+                        : new java.io.File(System.getProperty("user.home"), "ghidra_scripts");
+                if (!userScriptDir.exists()) {
+                    if (userScriptDir.mkdirs()) {
+                        System.out.println(
+                                "Created user script directory: " + userScriptDir.getAbsolutePath());
+                    } else {
+                        System.err.println(
+                                "Warning: failed to create user script directory: "
+                                        + userScriptDir.getAbsolutePath());
+                    }
+                }
+
+                GhidraScriptUtil.acquireBundleHostReference();
+                scriptingBundleHostAcquired = true;
+                System.out.println(
+                        "GhidraScriptUtil BundleHost acquired (script execution enabled)");
+
+                // acquireBundleHostReference() registers script directories but leaves
+                // them DISABLED. JavaScriptProvider.loadClass() then fails with
+                // "Failed to get OSGi bundle containing script" because the Felix
+                // framework refuses to resolve classes from disabled bundles.
+                // HeadlessAnalyzer explicitly calls bundleHost.add(paths, true, true)
+                // — we do the equivalent by enabling the user script dir bundle here.
+                try {
+                    ghidra.app.plugin.core.osgi.BundleHost bh =
+                            GhidraScriptUtil.getBundleHost();
+                    generic.jar.ResourceFile userScriptResource =
+                            new generic.jar.ResourceFile(userScriptDir);
+                    ghidra.app.plugin.core.osgi.GhidraBundle bundle =
+                            bh.getGhidraBundle(userScriptResource);
+                    if (bundle == null) {
+                        bh.add(userScriptResource, true, false);
+                        System.out.println(
+                                "Added user script directory bundle (enabled): "
+                                        + userScriptDir.getAbsolutePath());
+                    } else if (!bundle.isEnabled()) {
+                        bh.enable(bundle);
+                        System.out.println(
+                                "Enabled existing user script directory bundle: "
+                                        + userScriptDir.getAbsolutePath());
+                    }
+                } catch (Throwable t2) {
+                    System.err.println(
+                            "Failed to enable user script bundle: " + t2.getMessage());
+                    t2.printStackTrace();
+                }
+            } catch (Throwable t) {
+                System.err.println(
+                        "Failed to initialize GhidraScriptUtil BundleHost; script execution will fail: "
+                                + t.getMessage());
+                t.printStackTrace();
+            }
         }
     }
 
@@ -548,6 +625,17 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
         if (programProvider != null) {
             System.out.println("Closing programs...");
             programProvider.closeAllPrograms();
+        }
+
+        if (scriptingBundleHostAcquired) {
+            try {
+                GhidraScriptUtil.releaseBundleHostReference();
+                scriptingBundleHostAcquired = false;
+                System.out.println("GhidraScriptUtil BundleHost released");
+            } catch (Throwable t) {
+                System.err.println(
+                        "Error releasing GhidraScriptUtil BundleHost: " + t.getMessage());
+            }
         }
 
         System.out.println("Server stopped");

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -227,15 +227,37 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
                 java.io.File userScriptDir = GhidraScriptUtil.USER_SCRIPTS_DIR != null
                         ? new java.io.File(GhidraScriptUtil.USER_SCRIPTS_DIR)
                         : new java.io.File(System.getProperty("user.home"), "ghidra_scripts");
-                if (!userScriptDir.exists()) {
-                    if (userScriptDir.mkdirs()) {
-                        System.out.println(
-                                "Created user script directory: " + userScriptDir.getAbsolutePath());
-                    } else {
+                boolean scriptDirExisted = userScriptDir.exists();
+                if (!scriptDirExisted && !userScriptDir.mkdirs()) {
+                    // The primary location is not writable. Acquiring BundleHost
+                    // now would register a GhidraPlaceholderBundle for the missing
+                    // directory and crash JavaScriptProvider later with a
+                    // ClassCastException. Try a writable temp fallback instead.
+                    java.io.File fallback = new java.io.File(
+                            System.getProperty("java.io.tmpdir"), "ghidra_mcp_scripts");
+                    if (fallback.exists() || fallback.mkdirs()) {
                         System.err.println(
-                                "Warning: failed to create user script directory: "
-                                        + userScriptDir.getAbsolutePath());
+                                "Warning: could not create user script directory "
+                                        + userScriptDir.getAbsolutePath()
+                                        + "; falling back to " + fallback.getAbsolutePath());
+                        userScriptDir = fallback;
+                    } else {
+                        // No writable script directory at all: short-circuit so we
+                        // never acquire BundleHost on a placeholder path. Script
+                        // execution stays disabled, but the server keeps running.
+                        System.err.println(
+                                "Failed to create a writable user script directory ("
+                                        + userScriptDir.getAbsolutePath() + " and fallback "
+                                        + fallback.getAbsolutePath()
+                                        + "); skipping BundleHost init, script execution disabled.");
+                        return;
                     }
+                } else if (scriptDirExisted) {
+                    System.out.println(
+                            "Using user script directory: " + userScriptDir.getAbsolutePath());
+                } else {
+                    System.out.println(
+                            "Created user script directory: " + userScriptDir.getAbsolutePath());
                 }
 
                 GhidraScriptUtil.acquireBundleHostReference();

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -228,37 +228,26 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
                         ? new java.io.File(GhidraScriptUtil.USER_SCRIPTS_DIR)
                         : new java.io.File(System.getProperty("user.home"), "ghidra_scripts");
                 boolean scriptDirExisted = userScriptDir.exists();
-                if (!scriptDirExisted && !userScriptDir.mkdirs()) {
-                    // The primary location is not writable. Acquiring BundleHost
-                    // now would register a GhidraPlaceholderBundle for the missing
-                    // directory and crash JavaScriptProvider later with a
-                    // ClassCastException. Try a writable temp fallback instead.
-                    java.io.File fallback = new java.io.File(
-                            System.getProperty("java.io.tmpdir"), "ghidra_mcp_scripts");
-                    if (fallback.exists() || fallback.mkdirs()) {
-                        System.err.println(
-                                "Warning: could not create user script directory "
-                                        + userScriptDir.getAbsolutePath()
-                                        + "; falling back to " + fallback.getAbsolutePath());
-                        userScriptDir = fallback;
-                    } else {
-                        // No writable script directory at all: short-circuit so we
-                        // never acquire BundleHost on a placeholder path. Script
-                        // execution stays disabled, but the server keeps running.
-                        System.err.println(
-                                "Failed to create a writable user script directory ("
-                                        + userScriptDir.getAbsolutePath() + " and fallback "
-                                        + fallback.getAbsolutePath()
-                                        + "); skipping BundleHost init, script execution disabled.");
-                        return;
-                    }
-                } else if (scriptDirExisted) {
-                    System.out.println(
-                            "Using user script directory: " + userScriptDir.getAbsolutePath());
-                } else {
-                    System.out.println(
-                            "Created user script directory: " + userScriptDir.getAbsolutePath());
+                if (!scriptDirExisted) {
+                    userScriptDir.mkdirs();
                 }
+                // acquireBundleHostReference() registers GhidraScriptUtil.USER_SCRIPTS_DIR
+                // itself — not a local override — so a temp-dir fallback would still
+                // leave the canonical (missing) path registered as a
+                // GhidraPlaceholderBundle, which crashes JavaScriptProvider later with a
+                // ClassCastException. If the canonical directory isn't a real, writable
+                // directory after the mkdir attempt we therefore short-circuit: scripts
+                // stay disabled but the server keeps running, instead of acquiring on a
+                // placeholder path.
+                if (!userScriptDir.isDirectory() || !userScriptDir.canWrite()) {
+                    System.err.println(
+                            "User script directory is missing or not writable ("
+                                    + userScriptDir.getAbsolutePath()
+                                    + "); skipping BundleHost init, script execution disabled.");
+                    return;
+                }
+                System.out.println((scriptDirExisted ? "Using" : "Created")
+                        + " user script directory: " + userScriptDir.getAbsolutePath());
 
                 GhidraScriptUtil.acquireBundleHostReference();
                 scriptingBundleHostAcquired = true;

--- a/src/main/java/com/xebyte/headless/HeadlessManagementService.java
+++ b/src/main/java/com/xebyte/headless/HeadlessManagementService.java
@@ -48,9 +48,14 @@ public class HeadlessManagementService {
         if (!file.exists()) {
             return Response.err("File not found: " + filePath);
         }
-        boolean hasLanguage = languageId != null && !languageId.trim().isEmpty();
+        // Normalize once so the provider call and the error messages all use the
+        // same trimmed values (a doc-copied " ARM:LE:32:Cortex " otherwise passes
+        // the non-empty check but fails lookup with a confusing message).
+        String normalizedLanguageId = (languageId == null) ? "" : languageId.trim();
+        String normalizedCompilerSpecId = (compilerSpecId == null) ? "" : compilerSpecId.trim();
+        boolean hasLanguage = !normalizedLanguageId.isEmpty();
         Program program = hasLanguage
-            ? programProvider.loadProgramFromFileWithLanguage(file, languageId, compilerSpecId)
+            ? programProvider.loadProgramFromFileWithLanguage(file, normalizedLanguageId, normalizedCompilerSpecId)
             : programProvider.loadProgramFromFile(file);
         if (program != null) {
             String langOut = program.getLanguageID() != null
@@ -60,7 +65,7 @@ public class HeadlessManagementService {
                 + ServiceUtils.escapeJson(langOut) + "\"}");
         }
         if (hasLanguage) {
-            return Response.err("Failed to load program with language '" + languageId
+            return Response.err("Failed to load program with language '" + normalizedLanguageId
                 + "' from: " + filePath);
         }
         return Response.err("Failed to load program from: " + filePath

--- a/src/main/java/com/xebyte/headless/HeadlessManagementService.java
+++ b/src/main/java/com/xebyte/headless/HeadlessManagementService.java
@@ -29,9 +29,18 @@ public class HeadlessManagementService {
     // Program management
     // ========================================================================
 
-    @McpTool(path = "/load_program", method = "POST", description = "Load a binary file into the headless server for analysis", category = "headless")
+    @McpTool(path = "/load_program", method = "POST",
+            description = "Load a binary file into the headless server for analysis. "
+                + "For raw firmware (no recognizable header), pass `language` (e.g. 'ARM:LE:32:Cortex') "
+                + "and optionally `compiler_spec` (e.g. 'default'); the file is then imported as raw binary "
+                + "with the requested processor. When `language` is omitted, the loader auto-detects the format.",
+            category = "headless")
     public Response loadProgram(
-            @Param(value = "file", source = ParamSource.BODY, description = "Absolute path to the binary file") String filePath) {
+            @Param(value = "file", source = ParamSource.BODY, description = "Absolute path to the binary file") String filePath,
+            @Param(value = "language", source = ParamSource.BODY, defaultValue = "",
+                description = "Optional Ghidra language ID for raw binaries (e.g. 'ARM:LE:32:Cortex', 'x86:LE:64:default'). Leave empty to auto-detect.") String languageId,
+            @Param(value = "compiler_spec", source = ParamSource.BODY, defaultValue = "",
+                description = "Optional compiler-spec ID (e.g. 'default', 'gcc', 'windows'). Only consulted when `language` is set; falls back to the language default when empty.") String compilerSpecId) {
         if (filePath == null || filePath.isEmpty()) {
             return Response.err("file path required");
         }
@@ -39,11 +48,23 @@ public class HeadlessManagementService {
         if (!file.exists()) {
             return Response.err("File not found: " + filePath);
         }
-        Program program = programProvider.loadProgramFromFile(file);
+        boolean hasLanguage = languageId != null && !languageId.trim().isEmpty();
+        Program program = hasLanguage
+            ? programProvider.loadProgramFromFileWithLanguage(file, languageId, compilerSpecId)
+            : programProvider.loadProgramFromFile(file);
         if (program != null) {
-            return Response.text("{\"success\": true, \"program\": \"" + ServiceUtils.escapeJson(program.getName()) + "\"}");
+            String langOut = program.getLanguageID() != null
+                ? program.getLanguageID().getIdAsString() : "";
+            return Response.text("{\"success\": true, \"program\": \""
+                + ServiceUtils.escapeJson(program.getName()) + "\", \"language\": \""
+                + ServiceUtils.escapeJson(langOut) + "\"}");
         }
-        return Response.err("Failed to load program from: " + filePath);
+        if (hasLanguage) {
+            return Response.err("Failed to load program with language '" + languageId
+                + "' from: " + filePath);
+        }
+        return Response.err("Failed to load program from: " + filePath
+            + " (auto-detect failed; for raw firmware pass `language`, e.g. 'ARM:LE:32:Cortex')");
     }
 
     // ========================================================================

--- a/src/main/java/com/xebyte/headless/HeadlessManagementService.java
+++ b/src/main/java/com/xebyte/headless/HeadlessManagementService.java
@@ -4,6 +4,7 @@ import com.xebyte.core.*;
 import ghidra.program.model.listing.Program;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,19 @@ public class HeadlessManagementService {
         if (filePath == null || filePath.isEmpty()) {
             return Response.err("file path required");
         }
-        File file = new File(filePath);
+        // Enforce the GHIDRA_MCP_FILE_ROOT allow-list before touching the disk.
+        // resolveWithinFileRoot canonicalizes the path (resolving symlinks and
+        // `..`) and returns null when a root is configured and the path escapes
+        // it; with no root configured it returns the canonical path unchanged.
+        // filePath is non-null here, so a null result means "outside the root".
+        SecurityConfig security = SecurityConfig.getInstance();
+        Path resolved = security.resolveWithinFileRoot(filePath);
+        if (resolved == null) {
+            return Response.err("Access denied: '" + filePath
+                + "' is outside the configured GHIDRA_MCP_FILE_ROOT ("
+                + security.getFileRoot() + ")");
+        }
+        File file = resolved.toFile();
         if (!file.exists()) {
             return Response.err("File not found: " + filePath);
         }

--- a/src/main/java/com/xebyte/headless/HeadlessManagementService.java
+++ b/src/main/java/com/xebyte/headless/HeadlessManagementService.java
@@ -2,6 +2,7 @@ package com.xebyte.headless;
 
 import com.xebyte.core.*;
 import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -53,9 +54,13 @@ public class HeadlessManagementService {
         SecurityConfig security = SecurityConfig.getInstance();
         Path resolved = security.resolveWithinFileRoot(filePath);
         if (resolved == null) {
-            return Response.err("Access denied: '" + filePath
-                + "' is outside the configured GHIDRA_MCP_FILE_ROOT ("
+            // Log the configured root server-side for the operator, but keep it
+            // out of the client response so we don't disclose the filesystem
+            // layout to the (untrusted) caller.
+            Msg.warn(this, "Rejected /load_program for '" + filePath
+                + "': outside configured GHIDRA_MCP_FILE_ROOT ("
                 + security.getFileRoot() + ")");
+            return Response.err("Access denied: path is outside the configured file root");
         }
         File file = resolved.toFile();
         if (!file.exists()) {
@@ -73,9 +78,10 @@ public class HeadlessManagementService {
         if (program != null) {
             String langOut = program.getLanguageID() != null
                 ? program.getLanguageID().getIdAsString() : "";
-            return Response.text("{\"success\": true, \"program\": \""
-                + ServiceUtils.escapeJson(program.getName()) + "\", \"language\": \""
-                + ServiceUtils.escapeJson(langOut) + "\"}");
+            return Response.text(JsonHelper.toJson(JsonHelper.mapOf(
+                "success", true,
+                "program", program.getName(),
+                "language", langOut)));
         }
         if (hasLanguage) {
             return Response.err("Failed to load program with language '" + normalizedLanguageId

--- a/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
+++ b/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
@@ -197,14 +197,19 @@ public class HeadlessProgramProvider implements ProgramProvider {
             Msg.error(this, "loadProgramFromFileWithLanguage requires a non-empty languageId");
             return null;
         }
+        // Normalize before constructing IDs: a doc-copied " ARM:LE:32:Cortex "
+        // passes the non-empty check above but fails the LanguageID lookup.
+        languageId = languageId.trim();
+        String normalizedCompilerSpecId =
+            (compilerSpecId == null) ? "" : compilerSpecId.trim();
 
         try {
             LanguageService langService = DefaultLanguageService.getLanguageService();
             Language language = langService.getLanguage(new LanguageID(languageId));
 
             CompilerSpec compilerSpec;
-            if (compilerSpecId != null && !compilerSpecId.trim().isEmpty()) {
-                compilerSpec = language.getCompilerSpecByID(new CompilerSpecID(compilerSpecId));
+            if (!normalizedCompilerSpecId.isEmpty()) {
+                compilerSpec = language.getCompilerSpecByID(new CompilerSpecID(normalizedCompilerSpecId));
             } else {
                 compilerSpec = language.getDefaultCompilerSpec();
             }

--- a/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
+++ b/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
@@ -19,6 +19,7 @@ import com.xebyte.core.ProgramProvider;
 import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
 import ghidra.app.util.importer.AutoImporter;
 import ghidra.app.util.importer.MessageLog;
+import ghidra.app.util.opinion.Loaded;
 import ghidra.app.util.opinion.LoadResults;
 import ghidra.base.project.GhidraProject;
 import ghidra.framework.model.DomainFile;
@@ -26,7 +27,13 @@ import ghidra.framework.model.DomainFolder;
 import ghidra.framework.model.Project;
 import ghidra.framework.model.ProjectData;
 import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.lang.CompilerSpec;
+import ghidra.program.model.lang.CompilerSpecID;
+import ghidra.program.model.lang.Language;
+import ghidra.program.model.lang.LanguageID;
+import ghidra.program.model.lang.LanguageService;
 import ghidra.program.model.listing.Program;
+import ghidra.program.util.DefaultLanguageService;
 import ghidra.util.Msg;
 import ghidra.util.task.ConsoleTaskMonitor;
 import ghidra.util.task.TaskMonitor;
@@ -163,6 +170,80 @@ public class HeadlessProgramProvider implements ProgramProvider {
             return program;
         } catch (Exception e) {
             Msg.error(this, "Error loading program from file: " + file.getAbsolutePath(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Load a raw binary with an explicit language / compiler spec.
+     *
+     * Used for firmware blobs and other raw images where AutoImporter's best-guess
+     * format detection has no header to latch onto (e.g. ARM Cortex-M .mem dumps).
+     * Mirrors {@link #loadProgramFromFile(File)} for openPrograms / currentProgram
+     * bookkeeping so subsequent /list_functions, /decompile_function, etc. resolve
+     * the result transparently.
+     *
+     * @param file         The raw binary file
+     * @param languageId   Ghidra language ID, e.g. "ARM:LE:32:Cortex"
+     * @param compilerSpecId Optional compiler-spec ID; empty/null falls back to the language default
+     * @return The loaded Program, or null on failure
+     */
+    public Program loadProgramFromFileWithLanguage(File file, String languageId, String compilerSpecId) {
+        if (!file.exists()) {
+            Msg.error(this, "File not found: " + file.getAbsolutePath());
+            return null;
+        }
+        if (languageId == null || languageId.trim().isEmpty()) {
+            Msg.error(this, "loadProgramFromFileWithLanguage requires a non-empty languageId");
+            return null;
+        }
+
+        try {
+            LanguageService langService = DefaultLanguageService.getLanguageService();
+            Language language = langService.getLanguage(new LanguageID(languageId));
+
+            CompilerSpec compilerSpec;
+            if (compilerSpecId != null && !compilerSpecId.trim().isEmpty()) {
+                compilerSpec = language.getCompilerSpecByID(new CompilerSpecID(compilerSpecId));
+            } else {
+                compilerSpec = language.getDefaultCompilerSpec();
+            }
+
+            MessageLog log = new MessageLog();
+            Loaded<Program> loaded = AutoImporter.importAsBinary(
+                file,
+                null,   // project (null = in-memory, same model as loadProgramFromFile)
+                "/",    // folder path (ignored when project is null)
+                language,
+                compilerSpec,
+                this,   // consumer
+                log,
+                monitor
+            );
+
+            Program program = null;
+            if (loaded != null) {
+                program = loaded.getDomainObject(this);
+            }
+
+            if (program != null) {
+                openPrograms.put(program.getName(), program);
+                if (currentProgram == null) {
+                    currentProgram = program;
+                }
+                Msg.info(this, "Loaded raw binary: " + program.getName()
+                    + " (" + file.getAbsolutePath() + ") as " + languageId);
+            } else {
+                Msg.error(this, "Failed to load raw binary from: " + file.getAbsolutePath());
+                if (!log.toString().isEmpty()) {
+                    Msg.error(this, "Import log: " + log.toString());
+                }
+            }
+
+            return program;
+        } catch (Exception e) {
+            Msg.error(this, "Error loading raw binary from file: " + file.getAbsolutePath()
+                + " (language=" + languageId + ")", e);
             return null;
         }
     }

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1818,9 +1818,11 @@
       "method": "POST",
       "category": "headless",
       "params": [
-        "file"
+        "file",
+        "language",
+        "compiler_spec"
       ],
-      "description": "Load a binary file into the headless server for analysis"
+      "description": "Load a binary file into the headless server for analysis. For raw firmware (no recognizable header), pass `language` (e.g. 'ARM:LE:32:Cortex') and optionally `compiler_spec` (e.g. 'default'); the file is then imported as raw binary with the requested processor. When `language` is omitted, the loader auto-detects the format."
     },
     {
       "path": "/load_program_from_project",


### PR DESCRIPTION
Extends HeadlessManagementService.loadProgram with optional 'language' and 'compiler_spec' body params. When 'language' is set, the request is routed to a new HeadlessProgramProvider.loadProgramFromFileWithLanguage that uses AutoImporter.importAsBinary(...) — the same backend API the GUI /import_file endpoint already uses — instead of importByUsingBestGuess.

This unblocks raw firmware (e.g. STM32 .mem dumps loaded as ARM:LE:32:Cortex) in fully headless mode, without requiring a PluginTool or any GUI context. The auto-detect path (language='') is unchanged, so existing callers keep working.

Tested against a real STM32 Cortex-M firmware image: load_program + run_analysis yields 1535 functions where the previous auto-detect path yielded 0.