### PR TITLE
feat(gui): add /open_project with headless=true default

### DIFF
--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -75,8 +75,11 @@ import ghidra.framework.model.DomainFile;
 import ghidra.framework.model.DomainFolder;
 import ghidra.framework.model.Project;
 import ghidra.framework.model.ProjectData;
+import ghidra.framework.model.ProjectLocator;
+import ghidra.framework.model.ProjectManager;
 import ghidra.framework.store.ItemCheckoutStatus;
 import ghidra.framework.client.RepositoryAdapter;
+import ghidra.framework.main.AppInfo;
 
 import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
 import ghidra.util.task.TaskMonitor;
@@ -760,6 +763,26 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         // — selection is a UI concept that has no meaning there).
         server.createContext("/get_current_selection", safeHandler(exchange -> {
             sendResponse(exchange, getCurrentSelection());
+        }));
+
+        // /open_project — open (or switch to) a Ghidra project from the
+        // FrontEnd plugin programmatically. Mirrors the headless server's
+        // /open_project route but additionally supports an optional
+        // `headless` boolean (default true) that controls whether a
+        // CodeBrowser window is auto-launched for `program` after the
+        // project opens. Without the flag, the project is loaded into the
+        // FrontEnd tool only — useful for automation that wants to access
+        // programs via the `program` query parameter without spawning UI.
+        //
+        // Body: { "path": <.gpr or project dir>, "headless": true|false,
+        //         "program": "<DomainFile path to launch in CodeBrowser>" }
+        server.createContext("/open_project", safeHandler(exchange -> {
+            Map<String, Object> params = parseJsonParams(exchange);
+            String projectPath = params.get("path") != null ? params.get("path").toString() : null;
+            boolean headless = params.get("headless") == null
+                || Boolean.parseBoolean(String.valueOf(params.get("headless")));
+            String programToLaunch = params.get("program") != null ? params.get("program").toString() : null;
+            sendResponse(exchange, openProject(projectPath, headless, programToLaunch));
         }));
 
         // GET_DATA_TYPE_SIZE - Get the size in bytes of a data type (not yet in service layer)
@@ -3980,6 +4003,127 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         } catch (Exception e) {
             return "{\"error\": \"Failed to list tools: " + escapeJson(e.getMessage()) + "\"}";
         }
+    }
+
+    /**
+     * Open (or switch to) a Ghidra project from the FrontEnd plugin.
+     *
+     * <p>When the requested project is already active this is a no-op
+     * success. When a different project is active it is saved and closed
+     * before opening the new one — destructive to any unsaved CodeBrowser
+     * state, but matches the manual File &gt; Open Project flow.
+     *
+     * @param projectPath {@code .gpr} file, {@code <name>.rep} project
+     *                    directory, or a directory whose name is the
+     *                    project name (sibling .gpr/.rep expected).
+     * @param headless    {@code true} (default) opens the project without
+     *                    launching a CodeBrowser; {@code false} ALSO
+     *                    launches CodeBrowser for {@code programToLaunch}.
+     * @param programToLaunch project-internal DomainFile path to open in
+     *                        CodeBrowser when {@code headless == false};
+     *                        ignored otherwise.
+     */
+    private String openProject(String projectPath, boolean headless, String programToLaunch) {
+        if (projectPath == null || projectPath.trim().isEmpty()) {
+            return "{\"error\": \"path parameter is required\"}";
+        }
+
+        // Parse the path into a (location, name) pair for ProjectLocator.
+        // Accept three shapes the user is likely to type:
+        //   F:/proj/MyProj.gpr   — marker file
+        //   F:/proj/MyProj.rep   — project data directory
+        //   F:/proj/MyProj       — bare name, sibling .gpr/.rep expected
+        File pathFile = new File(projectPath);
+        String location;
+        String name;
+        String projExt = ProjectLocator.getProjectExtension();   // ".gpr"
+        String dirExt = ProjectLocator.getProjectDirExtension(); // ".rep"
+        String fname = pathFile.getName();
+        if (fname.endsWith(projExt)) {
+            location = pathFile.getParent();
+            name = fname.substring(0, fname.length() - projExt.length());
+        } else if (fname.endsWith(dirExt)) {
+            location = pathFile.getParent();
+            name = fname.substring(0, fname.length() - dirExt.length());
+        } else {
+            location = pathFile.getParent();
+            name = fname;
+        }
+        if (location == null || location.isEmpty()) {
+            return "{\"error\": \"path must include a parent directory: " + escapeJson(projectPath) + "\"}";
+        }
+
+        ProjectLocator locator;
+        try {
+            locator = new ProjectLocator(location, name);
+        } catch (IllegalArgumentException e) {
+            return "{\"error\": \"Invalid project path: " + escapeJson(e.getMessage()) + "\"}";
+        }
+        if (!locator.exists()) {
+            return "{\"error\": \"Project does not exist: " + escapeJson(projectPath) + "\"}";
+        }
+
+        Project currentProject = tool.getProject();
+        if (currentProject != null && locator.equals(currentProject.getProjectLocator())) {
+            // Already open — honor headless flag for CodeBrowser side-effect anyway.
+            String maybeLaunch = null;
+            if (!headless && programToLaunch != null && !programToLaunch.isEmpty()) {
+                maybeLaunch = launchCodeBrowser(programToLaunch);
+            }
+            return "{\"success\": true, \"project\": \"" + escapeJson(name) + "\", "
+                + "\"already_open\": true, \"headless\": " + headless
+                + (maybeLaunch != null ? ", \"program_launch_result\": " + maybeLaunch : "")
+                + "}";
+        }
+
+        ProjectManager pm = tool.getProjectManager();
+        if (pm == null) {
+            return "{\"error\": \"ProjectManager not available on this tool\"}";
+        }
+
+        // Must run on the EDT — FrontEndTool state updates expect Swing.
+        final String[] errMsg = {null};
+        final Project[] opened = {null};
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    if (currentProject != null) {
+                        try { currentProject.save(); } catch (Exception ignored) { /* best-effort */ }
+                        currentProject.close();
+                    }
+                    Project p = pm.openProject(locator, true, false);
+                    if (p == null) {
+                        errMsg[0] = "ProjectManager.openProject returned null";
+                        return;
+                    }
+                    AppInfo.setActiveProject(p);
+                    opened[0] = p;
+                } catch (Exception e) {
+                    errMsg[0] = e.getClass().getSimpleName() + ": " + e.getMessage();
+                }
+            });
+        } catch (Exception e) {
+            return "{\"error\": \"EDT invocation failed: " + escapeJson(e.getMessage()) + "\"}";
+        }
+        if (errMsg[0] != null) {
+            return "{\"error\": \"Failed to open project: " + escapeJson(errMsg[0]) + "\"}";
+        }
+        if (opened[0] == null) {
+            return "{\"error\": \"openProject returned null without an error\"}";
+        }
+
+        String launchResult = null;
+        if (!headless && programToLaunch != null && !programToLaunch.isEmpty()) {
+            launchResult = launchCodeBrowser(programToLaunch);
+        }
+        StringBuilder json = new StringBuilder(256);
+        json.append("{\"success\": true, \"project\": \"").append(escapeJson(opened[0].getName()))
+            .append("\", \"headless\": ").append(headless);
+        if (launchResult != null) {
+            json.append(", \"program_launch_result\": ").append(launchResult);
+        }
+        json.append("}");
+        return json.toString();
     }
 
     private String launchCodeBrowser(String filePath) {

--- a/src/test/java/com/xebyte/offline/OpenProjectGuiEndpointTest.java
+++ b/src/test/java/com/xebyte/offline/OpenProjectGuiEndpointTest.java
@@ -1,0 +1,137 @@
+package com.xebyte.offline;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Source-level invariants for the GUI-side {@code /open_project} route.
+ *
+ * <p>The headless server has had {@code /open_project} since v4.x. The
+ * GUI plugin gained its own implementation as part of Option C — a
+ * "GUI but no CodeBrowser" mode where automation can point Ghidra at a
+ * project programmatically and decide separately whether to spawn a
+ * CodeBrowser. The GUI handler accepts an optional {@code headless}
+ * boolean (default true) and an optional {@code program} path used only
+ * when {@code headless == false}.
+ *
+ * <p>These are static-analysis checks rather than integration tests
+ * because opening + switching projects requires a live FrontEnd tool
+ * with a real {@code .gpr} on disk — state CI can't stand up.
+ */
+public class OpenProjectGuiEndpointTest extends TestCase {
+
+    private String readUtf8(String relativePath) throws IOException {
+        return new String(
+                Files.readAllBytes(Paths.get(relativePath)),
+                StandardCharsets.UTF_8);
+    }
+
+    public void testPluginRegistersOpenProjectRoute() throws IOException {
+        String src = readUtf8("src/main/java/com/xebyte/GhidraMCPPlugin.java");
+        Pattern p = Pattern.compile(
+                "server\\.createContext\\s*\\(\\s*\"/open_project\"",
+                Pattern.MULTILINE);
+        assertTrue(
+                "GhidraMCPPlugin.java must register a route handler for "
+                        + "/open_project so the GUI server exposes the same tool "
+                        + "name the headless server does.",
+                p.matcher(src).find());
+    }
+
+    public void testOpenProjectHandlerReadsHeadlessAndProgramParams() throws IOException {
+        String src = readUtf8("src/main/java/com/xebyte/GhidraMCPPlugin.java");
+        // The route registration block should parse the body, default
+        // `headless` to true (option C semantics), and forward the
+        // optional `program` to launchCodeBrowser when the user asked
+        // for a non-headless open.
+        Pattern routeBlock = Pattern.compile(
+                "server\\.createContext\\(\\s*\"/open_project\"[\\s\\S]*?openProject\\s*\\(",
+                Pattern.MULTILINE);
+        Matcher m = routeBlock.matcher(src);
+        assertTrue("Expected /open_project route block to call openProject(...)",
+                m.find());
+        String block = src.substring(m.start(), Math.min(src.length(), m.end() + 200));
+
+        assertTrue(
+                "Route must read the `headless` body param (with true as the default).",
+                block.contains("\"headless\""));
+        assertTrue(
+                "Default for headless must be true so existing automation "
+                        + "doesn't spontaneously start launching CodeBrowsers.",
+                block.contains("== null")
+                        || block.contains("getOrDefault"));
+        assertTrue(
+                "Route must read the optional `program` param so non-headless "
+                        + "opens can auto-launch CodeBrowser for a specific file.",
+                block.contains("\"program\""));
+    }
+
+    public void testOpenProjectHelperRunsOnEDT() throws IOException {
+        String src = readUtf8("src/main/java/com/xebyte/GhidraMCPPlugin.java");
+        // Find the private helper.
+        Pattern decl = Pattern.compile(
+                "private\\s+String\\s+openProject\\s*\\(\\s*String[^)]*\\)\\s*\\{",
+                Pattern.MULTILINE);
+        Matcher m = decl.matcher(src);
+        assertTrue(
+                "GhidraMCPPlugin must declare a private openProject(String, boolean, String) helper.",
+                m.find());
+
+        int braceStart = m.end() - 1;
+        int depth = 1;
+        int j = braceStart + 1;
+        while (j < src.length() && depth > 0) {
+            char c = src.charAt(j++);
+            if (c == '{') depth++;
+            else if (c == '}') depth--;
+        }
+        String body = src.substring(braceStart, j);
+
+        assertTrue(
+                "openProject must invoke ProjectManager.openProject(locator, ...) "
+                        + "— that's the canonical API for opening into the FrontEnd.",
+                body.contains("pm.openProject(locator"));
+        assertTrue(
+                "openProject must run the open/close on the EDT — FrontEnd "
+                        + "state updates expect Swing.",
+                body.contains("SwingUtilities.invokeAndWait"));
+        assertTrue(
+                "openProject must call AppInfo.setActiveProject so the FrontEnd "
+                        + "UI reflects the new project.",
+                body.contains("AppInfo.setActiveProject"));
+        assertTrue(
+                "openProject must short-circuit when the requested project is "
+                        + "already the active one — silent re-open would needlessly "
+                        + "close and reopen the same project, dropping CodeBrowser state.",
+                body.contains("already_open"));
+    }
+
+    public void testCatalogIncludesOpenProjectParams() throws IOException {
+        String catalog = readUtf8("tests/endpoints.json");
+        // The catalog has a single /open_project entry shared with the
+        // headless server. The GUI side added two optional params
+        // (`headless`, `program`) — the entry must list both so the
+        // bridge schema and parity test see them.
+        Pattern entry = Pattern.compile(
+                "\\{\\s*\"path\"\\s*:\\s*\"/open_project\"[^}]*?\"params\"\\s*:\\s*\\[(?<params>[^\\]]*)\\]",
+                Pattern.DOTALL);
+        Matcher m = entry.matcher(catalog);
+        assertTrue("tests/endpoints.json must list /open_project.", m.find());
+        String params = m.group("params");
+        assertTrue(
+                "/open_project params must include 'path' (required, both modes).",
+                params.contains("\"path\""));
+        assertTrue(
+                "/open_project params must include 'headless' (GUI mode adds it).",
+                params.contains("\"headless\""));
+        assertTrue(
+                "/open_project params must include 'program' (GUI mode optional auto-launch).",
+                params.contains("\"program\""));
+    }
+}

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1915,9 +1915,11 @@
       "method": "POST",
       "category": "headless",
       "params": [
-        "path"
+        "path",
+        "headless",
+        "program"
       ],
-      "description": "Open an existing Ghidra project (.gpr file or directory)"
+      "description": "Open an existing Ghidra project (.gpr file or directory). GUI mode adds optional `headless` (default true) to suppress auto-launching CodeBrowser, and optional `program` to auto-launch CodeBrowser for a specific file when headless=false. Headless server ignores the extra params."
     },
     {
       "path": "/project/info",


### PR DESCRIPTION
## Summary

- Adds `/open_project` to the GUI plugin's HTTP server with the same path the headless server uses.
- New optional `headless` body param (default **true**) suppresses auto-launching a CodeBrowser — useful for automation that drives Ghidra via the `program` query parameter and doesn't want UI windows.
- New optional `program` body param: when `headless=false`, the DomainFile path to launch in a CodeBrowser after the project opens.

## Behavior

| Current project state | What `/open_project` does |
| --- | --- |
| Same project already active | No-op success (preserves CodeBrowsers; reports `already_open: true`) |
| Different project active | Saves + closes current, opens new, calls `AppInfo.setActiveProject` |
| No project active | Just opens |

All FrontEnd state mutations run on the EDT via `SwingUtilities.invokeAndWait`. `ProjectManager` comes from `tool.getProjectManager()` — public `PluginTool` API, no reflection needed.

The shared `/open_project` catalog entry now documents `headless` and `program`. The headless server's `@McpTool` annotation stays unchanged (it only consumes `path`); `EndpointsJsonParityTest` allows extra catalog params over what's scanned.

## Test plan

- [x] Offline `OpenProjectGuiEndpointTest` (4 tests) covering route registration, helper signature, EDT marshaling, `AppInfo.setActiveProject` call, and catalog-params drift guard.
- [x] `mvn test -Dtest='com.xebyte.offline.*Test'` → 135 tests, 0 failures.
- [x] `pytest tests/unit/test_project_consistency.py` → 22 tests, 0 failures (parity test still green because `/open_project` is in the `annotated` set via `HeadlessManagementService`).
- [ ] Live GUI verification: deploy the JAR, POST to `/open_project` with `{path, headless: true}` from a different project than the currently-open one, confirm FrontEnd switches without spawning CodeBrowser.
- [ ] Live GUI verification: same POST with `{headless: false, program: "/path/to/DomainFile"}` confirms CodeBrowser launches for the given file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)