### PR TITLE
release: v5.12.0 — /get_current_selection + GUI /open_project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.11.4
+- **Version**: 5.12.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
 - **Key feature**: 245 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## v5.12.0 - 2026-05-23 (community-driven tools: /get_current_selection + GUI /open_project)
+
+Minor release. Two new endpoints filed/scoped by community feedback
+(@I-Knight-I on #153, plus an internal "open project without launching
+a CodeBrowser" workflow request), plus a quiet headless parity fix
+that surfaced while writing the parity test. 245 tools.
+
+### Added
+
+- **`/get_current_selection`** (GUI-only). Closes the "where am I?"
+  tool family alongside `/get_current_address` and
+  `/get_current_function`. Returns the CodeBrowser listing's current
+  selection as `{program, is_empty, ranges, min_address, max_address,
+  num_addresses}`. Reads from `CodeViewerService.getCurrentSelection()`
+  — the canonical Ghidra API for the listing's highlight state. Like
+  its siblings, returns "Code viewer service not available" when no
+  CodeBrowser is up, so AI clients see one consistent error shape for
+  the whole family. Filed by @I-Knight-I on issue #153.
+- **GUI plugin `/open_project`** with optional `headless=true` (default
+  true) and optional `program` body params. The headless server has
+  had `/open_project` since v4.x; the GUI plugin previously had no
+  programmatic way to point Ghidra at a different project. The new
+  route closes (saves) the active project, opens the requested one
+  via `ProjectManager.openProject(locator, ...)`, calls
+  `AppInfo.setActiveProject`, and — only when `headless=false` and
+  `program` is set — auto-launches a CodeBrowser for that DomainFile.
+  Same project already active is a no-op success (`already_open: true`)
+  so accidental re-opens don't blow away CodeBrowser state. All
+  FrontEnd mutations run on the EDT via `SwingUtilities.invokeAndWait`.
+
+### Fixed
+
+- **Headless server now registers `/server/admin/terminate_all_checkouts`**
+  for GUI parity. The GUI plugin has registered this route since v5.6
+  but the headless server didn't, causing
+  `test_manual_gui_headless_shared_endpoints_do_not_drift` to fail on
+  CI when /get_current_selection was added (the parity test enumerates
+  all `server.createContext` and `safeContext` registrations). Also
+  accepts `checkout_id` as an alias for `checkoutId` on
+  `/server/admin/terminate_checkout` to match the cataloged param name.
+
+### Tests
+
+- **OpenProjectGuiEndpointTest** (4 source-level invariants) — route
+  registration, helper signature, EDT marshaling, `AppInfo.setActiveProject`
+  call, and the catalog `params` drift guard.
+- **GetCurrentSelectionEndpointTest** (3 source-level invariants) —
+  route registration, helper uses `CodeViewerService.getCurrentSelection()`,
+  catalog entry exists with empty `params: []`.
+
+### Notes
+
+`/open_project` is shared between the GUI and headless servers. The
+catalog entry now lists `path`, `headless`, and `program`; the
+headless server's `@McpTool` annotation still consumes only `path`
+(headless mode has no CodeBrowser to launch), and
+`EndpointsJsonParityTest` tolerates extra catalog params over what's
+scanned. The shared path appears in neither `gui_only_expected` nor
+`headless_only_expected` because the annotation also lives in the
+`headless/` package and the parity check subtracts the annotated set.
+
+---
+
 ## v5.11.4 - 2026-05-22 (automatic ghidratrace install for debugger launcher)
 
 Targeted patch release. One real change: the deploy flow now keeps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 245 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.11.4 | **Java**: 21 LTS | **Ghidra**: 12.1
+- **Package**: `com.xebyte` | **Version**: 5.12.0 | **Java**: 21 LTS | **Ghidra**: 12.1
 
 ## Boil the ocean
 

--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.11.4
+# Connection OK - GhidraMCP Headless Server v5.12.0
 ```
 
 ### Headless API Workflow
@@ -1010,7 +1010,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.11.4 |
+| **Version** | 5.12.0 |
 | **MCP Tools** | 245 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,7 +9,49 @@ For the release preparation runbook, see
 
 ## Current Releases
 
-### v5.11.4 (Latest) — automatic ghidratrace install for the debugger launcher
+### v5.12.0 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
+
+Minor release. Two new endpoints filed/scoped by community feedback,
+plus a quiet headless parity fix that surfaced while writing the
+parity test. 245 tools.
+
+- **`/get_current_selection` (GUI-only)** — closes the "where am I?"
+  family alongside `/get_current_address` and `/get_current_function`.
+  Returns the CodeBrowser listing's current selection as
+  `{program, is_empty, ranges, min_address, max_address, num_addresses}`.
+  Reads from `CodeViewerService.getCurrentSelection()` — the canonical
+  Ghidra API for the listing's highlight state. Returns "Code viewer
+  service not available" when no CodeBrowser is up, matching the
+  sibling tools' error shape so AI clients see one consistent fall-
+  through path for the whole family. Filed by @I-Knight-I on issue #153.
+- **GUI plugin `/open_project`** with optional `headless=true` (default
+  true) and optional `program` body params. The headless server has
+  had `/open_project` since v4.x; the GUI plugin previously had no
+  programmatic way to point Ghidra at a different project. The new
+  route saves and closes the active project, opens the requested one
+  via `ProjectManager.openProject(locator, ...)`, calls
+  `AppInfo.setActiveProject`, and only when `headless=false` and
+  `program` is set — auto-launches a CodeBrowser for that DomainFile.
+  Same project already active is a no-op success (`already_open: true`)
+  so accidental re-opens don't blow away CodeBrowser state. All
+  FrontEnd mutations run on the EDT via `SwingUtilities.invokeAndWait`.
+- **Headless `/server/admin/terminate_all_checkouts` parity fix** — the
+  GUI plugin has registered this route since v5.6 but the headless
+  server didn't. Added the `safeContext` registration plus the
+  `terminateAllCheckouts()` implementation on `GhidraServerManager`.
+  Also accepts `checkout_id` alias on
+  `/server/admin/terminate_checkout` to match the cataloged param.
+- **7 new offline tests** pin the new endpoints at the source level:
+  route registrations, helper signatures, EDT marshaling, the
+  `AppInfo.setActiveProject` call, and the catalog `params` drift
+  guards.
+
+Backward compatibility: every change is additive. Existing endpoint
+behavior unchanged.
+
+- See [CHANGELOG.md](../../CHANGELOG.md) for full details.
+
+### v5.11.4 — automatic ghidratrace install for the debugger launcher
 
 Patch release with one targeted fix: the deploy flow now auto-installs
 the matching `ghidratrace` wheel into the launcher Python during

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.11.4</version>
+    <version>5.12.0</version>
     <name>Ghidra MCP Server</name>
     <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. Provides MCP-based tooling and automation for reverse engineering workflows: convention-enforcing rename/type/comment endpoints, batch operations, P-code emulation, live debugger integration, headless server, and Ghidra Server multi-version support.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -106,7 +106,7 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.11.4"; // Default fallback
+    private static String VERSION = "5.12.0"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -52,7 +52,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.11.4-headless";
+    private static final String VERSION = "5.12.0-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -42,7 +42,7 @@ import ghidra.app.cmd.disassemble.DisassembleCommand;
  */
 public class HeadlessEndpointHandler {
 
-    private static final String VERSION = "5.11.4-headless";
+    private static final String VERSION = "5.12.0-headless";
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
     private final TaskMonitor monitor;

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.11.4
+Plugin-Version: 5.12.0
 Plugin-Author: Ben Ethington
 Plugin-Description: GhidraMCP - HTTP server plugin with 245 MCP tools for reverse engineering automation

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.11.4",
+  "version": "5.12.0",
   "description": "GhidraMCP REST API Endpoint Specification",
   "total_endpoints": 245,
   "categories": {


### PR DESCRIPTION
## Summary

Two new endpoints filed/scoped by community feedback, plus a quiet headless parity fix that surfaced while writing the parity test. **245 tools.**

### Added

- **`/get_current_selection` (GUI-only)** — closes the "where am I?" tool family alongside `/get_current_address` and `/get_current_function`. Reads from `CodeViewerService.getCurrentSelection()`. Filed by @I-Knight-I on #153 (#245).
- **GUI plugin `/open_project`** with optional `headless=true` (default true) and optional `program` body params (#246). Mirrors the headless server's `/open_project` but adds a "GUI but no CodeBrowser" mode for automation that wants to access programs via the `program` query parameter without flooding the screen with windows. Same project already active → no-op success preserving CodeBrowsers.

### Fixed

- **Headless server `/server/admin/terminate_all_checkouts` parity** — registered the route + added `terminateAllCheckouts()` implementation to match the GUI plugin. Also accepts `checkout_id` alias on `/server/admin/terminate_checkout`.

### Tests + regression

- **Java offline:** `mvn test -Dtest='com.xebyte.offline.*Test'` → 135 pass.
- **Python unit:** `pytest tests/unit/` → 356 pass.
- **Live release deploy regression:** all checks green — schema 196 tools (GUI mode count, total 245 across GUI + headless), benchmark fixture reset, 29 endpoint contract tests passed, both YAML regressions passed (50 assertion-blocks, 18 skips), multi-program targeting passed, negative/error-shape contract passed, debugger live test passed.

### Risks

- New endpoints — covered by 7 new offline source-level invariant tests (4 for `/open_project`, 3 for `/get_current_selection`).
- `/open_project` SAVES + CLOSES the active project when switching — destructive to unsaved CodeBrowser state. Same-project no-op case avoids accidental data loss. Documented in `CHANGELOG.md`.

## Test plan

- [x] Local Maven build → `GhidraMCP-5.12.0.zip`
- [x] `python -m tools.setup verify-version` → 5.12.0 everywhere
- [x] `python -m tools.setup preflight` → passed
- [x] `pytest tests/unit/` → 356 pass
- [x] `mvn test -Dtest='com.xebyte.offline.*Test'` → 135 pass
- [x] `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC --test release` → all checks green
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)