### PR TITLE
fix(fun-doc): stop tight-loop on cross-version-archive matches

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -2288,6 +2288,7 @@ def fetch_function_data(program, address, mode="FIX"):
         "fixable_categories": [],
         "decompile_timeout": False,
         "ghidra_offline": False,
+        "not_a_function": False,
     }
 
     # Navigation removed — was calling /tool/goto_address on every function,
@@ -2373,6 +2374,30 @@ def fetch_function_data(program, address, mode="FIX"):
                 data["decompile_timeout"] = True
                 return data
         data["analyze_for_doc"] = afd
+
+    # Pre-flight: detect addresses that aren't functions at all (raw data,
+    # PRIMITIVE-typed regions, dead code that the priority queue lists with
+    # a stale score). Without this signal the worker falls through to the
+    # LLM, which then burns 100K-500K input tokens confirming "this is
+    # data, not code." Observed in production: 21 archive-applied loops on
+    # a single data address in one hour. The caller marks the function
+    # `not_a_function` so the selector won't re-pick.
+    #
+    # Definitive when BOTH the decompile call and the completeness call
+    # came back with no usable result and neither timed out / went
+    # offline (those are retryable). Conservative — if either returned
+    # SOMETHING, the LLM might still extract value, so we don't short-
+    # circuit.
+    if not data["decompile_timeout"] and not data["ghidra_offline"]:
+        decompiled_is_error = _is_error_response(data.get("decompiled"))
+        completeness = data.get("completeness")
+        completeness_missing_name = (
+            not completeness
+            or not (isinstance(completeness, dict)
+                    and completeness.get("function_name"))
+        )
+        if decompiled_is_error and completeness_missing_name:
+            data["not_a_function"] = True
 
     return data
 
@@ -2958,6 +2983,33 @@ def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=N
         # function isn't user-authored code. Cleared by the same refresh
         # paths as the other one-shots; pinning bypasses.
         if func.get("library_code") and not is_pinned:
+            continue
+
+        # Archive-apply terminal: when the cross-version doc archive (re-kb)
+        # matches and writes name + plate via the Q5-D gate, the function
+        # is done from this worker's perspective even though the score
+        # may stay below good_enough (the archive-applied score reflects
+        # what the archive provided, not a fresh local re-score). Without
+        # this skip the selector re-picks the same function every cycle:
+        # the score doesn't change, no consecutive_fails increment (archive
+        # apply is "success"), and the next archive lookup hits the same
+        # match. Observed in production: 21 archive_applied loops on a
+        # single data address in one hour, burning ~1.4M input tokens.
+        # Cleared by refresh / re-scan paths (same as the other one-shots).
+        # Pinned bypasses for "re-document this even though archive matched."
+        if func.get("last_result") == "archive_applied" and not is_pinned:
+            continue
+
+        # Not-a-function one-shot: addresses that the priority queue thinks
+        # are functions but Ghidra disagrees with (raw data regions, dead
+        # code that was never disassembled). Without this guard the
+        # selector keeps picking them and the worker falls through to the
+        # LLM, which then burns 100K-500K input tokens to confirm "this is
+        # data, not code." Set by process_function when fetch_function_data
+        # returns no decompiled body and no function_name in completeness.
+        # Cleared by refresh / re-scan paths so post-analysis changes
+        # (Ghidra recovering a function at that address) get re-evaluated.
+        if func.get("not_a_function") and not is_pinned:
             continue
 
         # Propagation-provenance skip (#204): when a function's name came
@@ -6962,8 +7014,21 @@ def process_function(
         if _debug_ctx.get().get("enabled", False):
             path = _debug_get_log_path()
             debug_path = str(path) if path else None
+        # Stamp the worker_id from the event-bus thread-local so per-worker
+        # filtering in the dashboard and audit attribution in logs/events.jsonl
+        # work. Before this fix the run.logged events carried worker_id=null
+        # even when heartbeats from the same thread carried a real worker_id,
+        # so the dashboard's per-worker run filter silently dropped every row.
+        # The CLI / non-dashboard path leaves worker_id unset (None), which is
+        # the right behavior — there's no worker context to attribute to.
+        try:
+            from event_bus import get_worker_id as _get_worker_id
+            _worker_id = _get_worker_id()
+        except Exception:
+            _worker_id = None
         entry = {
             "run_id": run_id,
+            "worker_id": _worker_id,
             "timestamp": datetime.now().isoformat(),
             "program": program,
             "address": address,
@@ -7162,6 +7227,40 @@ def process_function(
             "decompile_timeout",
             score_after=live_score,
             reason="decompile-heavy endpoint hit read timeout",
+        )
+
+    if data.get("not_a_function"):
+        # The priority queue thinks 0x{address} is a function, but Ghidra
+        # came back with no decompiled body AND no function_name in the
+        # completeness response — the address is data (or dead code that
+        # was never disassembled). Mark it so the selector skips it
+        # until an explicit refresh re-evaluates whether it became a
+        # function in the meantime (rare but possible after analysis
+        # re-runs on the binary).
+        func["not_a_function"] = True
+        func["not_a_function_at"] = datetime.now().isoformat()
+        func["last_processed"] = datetime.now().isoformat()
+        func["last_result"] = "not_a_function"
+        print(
+            f"  NOT A FUNCTION — 0x{address} has no decompiled body and "
+            f"no function_name. Marking and skipping. "
+            f"Will be excluded from selector until next refresh.",
+            flush=True,
+        )
+        update_function_state(func_key, func)
+        bus_emit(
+            "function_complete",
+            {
+                "key": func_key,
+                "result": "not_a_function",
+                "score": live_score,
+            },
+        )
+        return _finish(
+            "blocked",
+            logged_result="not_a_function",
+            score_after=live_score,
+            reason=f"address 0x{address} is not a function",
         )
 
     # Library-code auto-classification: detect statically-linked MSVC CRT /

--- a/tests/performance/test_ghidra_offline.py
+++ b/tests/performance/test_ghidra_offline.py
@@ -91,6 +91,111 @@ def test_fetch_function_data_returns_offline_flag():
 
 
 # ---------------------------------------------------------------------------
+# Unit: fetch_function_data detects "not a function" (data address) when
+# Ghidra is online but both /decompile_function and
+# /analyze_function_completeness come back with no usable result. Without
+# this signal the worker burns 100K-500K input tokens on the LLM
+# confirming "this address is data, not code." Observed in production:
+# 21 archive_applied loops on 0x10101014 in BH.dll in one hour.
+# ---------------------------------------------------------------------------
+
+
+def _mock_ghidra_response(json_payload):
+    """Mock helper: return a MagicMock response that .json() to the payload."""
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = json_payload
+    # ghidra_get also inspects .text for the "Error" string-shape fallback
+    m.text = json.dumps(json_payload) if isinstance(json_payload, dict) else str(json_payload)
+    return m
+
+
+def test_fetch_function_data_marks_not_a_function_when_data_address():
+    """When the address is raw data (no function body, no name), both
+    Ghidra endpoints return error-shaped responses and fetch_function_data
+    must set not_a_function=True so the caller can flag the function
+    once-and-done. The dual-signal check (decompile error + completeness
+    missing function_name) keeps false positives down — a transient
+    decompile failure on a real function would still have a function_name
+    in completeness and is therefore not marked."""
+
+    def fake_get(url, *args, **kwargs):
+        if "/decompile_function" in url:
+            return _mock_ghidra_response({"error": "No function found at 0x10101014"})
+        if "/analyze_function_completeness" in url:
+            return _mock_ghidra_response({"error": "No function at 0x10101014"})
+        # variables / analyze_for_doc — irrelevant for the gate
+        return _mock_ghidra_response({})
+
+    with patch("fun_doc.requests.get", side_effect=fake_get):
+        data = fun_doc.fetch_function_data(
+            "/Mods/PD2-S12/BH.dll", "10101014", mode="FIX"
+        )
+
+    assert data["not_a_function"] is True
+    assert data["ghidra_offline"] is False
+    assert data["decompile_timeout"] is False
+
+
+def test_fetch_function_data_does_not_mark_not_a_function_when_decompile_succeeds():
+    """Sanity: if /decompile_function returns a real body, not_a_function
+    must stay False even if completeness scoring happens to fail. A real
+    function with a temporarily broken scorer is a retryable condition,
+    not a permanent blacklist."""
+
+    def fake_get(url, *args, **kwargs):
+        if "/decompile_function" in url:
+            return _mock_ghidra_response({"decompiled": "void FUN_x() { return; }"})
+        if "/analyze_function_completeness" in url:
+            return _mock_ghidra_response({"error": "scorer hiccup"})
+        return _mock_ghidra_response({})
+
+    with patch("fun_doc.requests.get", side_effect=fake_get):
+        data = fun_doc.fetch_function_data(
+            "/Mods/PD2-S12/BH.dll", "10001000", mode="FIX"
+        )
+
+    assert data["not_a_function"] is False
+
+
+def test_fetch_function_data_does_not_mark_not_a_function_when_completeness_has_name():
+    """Sanity: completeness reporting a function_name even with no
+    decompiled body means Ghidra knows the function exists — keep it
+    retryable, don't blacklist."""
+
+    def fake_get(url, *args, **kwargs):
+        if "/decompile_function" in url:
+            return _mock_ghidra_response({"error": "decompile transient"})
+        if "/analyze_function_completeness" in url:
+            return _mock_ghidra_response({
+                "function_name": "RealFunc",
+                "effective_score": 40,
+                "deduction_breakdown": [],
+            })
+        return _mock_ghidra_response({})
+
+    with patch("fun_doc.requests.get", side_effect=fake_get):
+        data = fun_doc.fetch_function_data(
+            "/Mods/PD2-S12/BH.dll", "10001000", mode="FIX"
+        )
+
+    assert data["not_a_function"] is False
+
+
+def test_fetch_function_data_does_not_mark_not_a_function_when_offline():
+    """The offline path short-circuits BEFORE the not_a_function gate.
+    Offline is retryable; not_a_function is a one-shot blacklist —
+    confusing the two would permanently exclude functions during a
+    transient Ghidra outage."""
+    with patch("fun_doc.requests.get", side_effect=_make_offline_requests_get):
+        data = fun_doc.fetch_function_data(
+            "/Mods/PD2-S12/BH.dll", "10001000", mode="FIX"
+        )
+    assert data["ghidra_offline"] is True
+    assert data["not_a_function"] is False
+
+
+# ---------------------------------------------------------------------------
 # Unit: check_ghidra_online returns False when server is down
 # ---------------------------------------------------------------------------
 

--- a/tests/performance/test_selector_invariants.py
+++ b/tests/performance/test_selector_invariants.py
@@ -622,3 +622,133 @@ def test_recovery_pass_done_does_not_affect_unflagged_functions():
     )
     result = select_candidates(state, _queue())
     assert set(_keys(result)) == {"a::normal", "a::explicit_false"}
+
+
+# ---------------------------------------------------------------------------
+# Archive-applied terminal — closes the cross-version archive re-pick loop.
+# ---------------------------------------------------------------------------
+
+
+def test_archive_applied_excluded_when_not_pinned():
+    """Functions whose last_result is 'archive_applied' (cross-version
+    archive matched + wrote name + plate via the Q5-D gate) must be
+    excluded from selection unless pinned. Without this guard the
+    selector re-picks the same function every cycle: the score doesn't
+    change, consecutive_fails isn't incremented (archive_apply is a
+    success path), and the next archive lookup hits the same match.
+
+    Observed in production: 21 archive_applied loops on a single data
+    address in one hour, ~1.4M input tokens burned before the guard
+    landed."""
+    state = _state(
+        **{
+            "a::archived": {
+                "score": 70,
+                "fixable": 20,
+                "last_result": "archive_applied",
+            },
+            "a::fresh": {"score": 55, "fixable": 20},
+        }
+    )
+    result = select_candidates(state, _queue())
+    assert _keys(result) == ["a::fresh"]
+
+
+def test_archive_applied_bypassed_by_pin():
+    """Pinning an archive-applied function should restore it to the queue
+    — the user explicitly asked for a re-document pass, archive match
+    notwithstanding."""
+    state = _state(
+        **{
+            "a::archived": {
+                "score": 70,
+                "fixable": 20,
+                "last_result": "archive_applied",
+            },
+        }
+    )
+    assert _keys(select_candidates(state, _queue())) == []
+    result = select_candidates(state, _queue(pinned=["a::archived"]))
+    assert _keys(result) == ["a::archived"]
+
+
+def test_archive_applied_does_not_affect_other_last_results():
+    """Sanity: the guard fires only on the exact string 'archive_applied'.
+    Other last_result values (completed, blocked, failed, scanned) follow
+    their existing rules."""
+    state = _state(
+        **{
+            "a::archived": {
+                "score": 70,
+                "fixable": 20,
+                "last_result": "archive_applied",
+            },
+            # 'completed' separately maps to queue_status='done' and
+            # gets filtered by the good_enough_score gate normally —
+            # represented here at score 55 < good_enough so it stays.
+            "a::completed": {
+                "score": 55,
+                "fixable": 20,
+                "last_result": "completed",
+            },
+            "a::blocked": {
+                "score": 55,
+                "fixable": 20,
+                "last_result": "blocked",
+            },
+            "a::scanned": {
+                "score": 55,
+                "fixable": 20,
+                "last_result": "scanned",
+            },
+        }
+    )
+    result_keys = set(_keys(select_candidates(state, _queue())))
+    assert "a::archived" not in result_keys
+    # The other three follow normal selector behavior (admit/exclude
+    # by score, consecutive_fails, etc.). For this synthetic state they
+    # should all be admitted — last_result alone doesn't drop them.
+    assert result_keys == {"a::completed", "a::blocked", "a::scanned"}
+
+
+# ---------------------------------------------------------------------------
+# Not-a-function one-shot — pre-flight gate for data addresses the priority
+# queue mistakenly lists as functions.
+# ---------------------------------------------------------------------------
+
+
+def test_not_a_function_excluded_when_not_pinned():
+    """Functions flagged with not_a_function=True (process_function detected
+    no decompiled body and no function_name from Ghidra) must be excluded
+    from selection unless pinned. This catches data addresses the priority
+    queue mistakenly lists as functions — without the guard the LLM burns
+    100K-500K input tokens confirming 'this is data, not code.'"""
+    state = _state(
+        **{
+            "a::data": {
+                "score": 70,
+                "fixable": 20,
+                "not_a_function": True,
+            },
+            "a::real": {"score": 55, "fixable": 20},
+        }
+    )
+    result = select_candidates(state, _queue())
+    assert _keys(result) == ["a::real"]
+
+
+def test_not_a_function_bypassed_by_pin():
+    """Pinning a not_a_function-flagged entry restores it (user wants the
+    re-evaluation, e.g., after Ghidra re-analysis recovered the function)."""
+    state = _state(
+        **{
+            "a::data": {
+                "score": 70,
+                "fixable": 20,
+                "not_a_function": True,
+            },
+        }
+    )
+    assert _keys(select_candidates(state, _queue())) == []
+    result = select_candidates(state, _queue(pinned=["a::data"]))
+    assert _keys(result) == ["a::data"]


### PR DESCRIPTION
## Summary

Observed in production today: a single data address (`0x10101014` in `BH.dll` on `/Mods/PD2-S12`) hit **21 `archive_applied` cycles** in one hour, burning **~1.4M input tokens** before being noticed. Three compounding bugs.

### Bugs fixed

1. **Selector doesn't skip `last_result == \"archive_applied\"`.** The cross-version doc-archive (re-kb) hash-match path sets `last_result` but doesn't raise the score above `good_enough_score`, so the function stays selectable. The next archive lookup hits the same match, looping forever. Fixed by adding the skip to `select_candidates` alongside the other one-shot guards (`decompile_timeout`, `library_code`, `recovery_pass_done`, etc.). Pin bypass preserved.
2. **No pre-flight for data addresses.** When the archive lookup occasionally misses, the worker falls through to FULL:comments mode and burns 100K-500K input tokens having the LLM confirm \"this isn't a function, it's data.\" `fetch_function_data` now detects the dual-negative signal (decompile error AND completeness missing `function_name`) and sets `not_a_function=True`. `process_function` marks the func and the selector skips. Conservative: only fires when BOTH signals are negative AND nothing timed out / went offline (retryable failures stay retryable).
3. **`worker_id` is null in every `run.logged` event.** Heartbeats from the same thread carried `worker_id` correctly via `event_bus`'s thread-local, but the run-entry dict in `_log_run_once` never set the field. Dashboard's per-worker filtering and audit attribution silently broke. Now reads `event_bus.get_worker_id()` — same source the heartbeat path uses. CLI path leaves it `None` (no worker context to attribute).

### Tests

- **5 new selector tests** in `test_selector_invariants.py` covering `archive_applied` skip + pin-bypass + sanity (other `last_result` values not affected), and `not_a_function` skip + pin-bypass.
- **4 new `fetch_function_data` tests** in `test_ghidra_offline.py` covering the dual-signal detection with three negative cases (real function + scorer hiccup; real function_name in completeness despite decompile error; offline path short-circuits before the gate) and one positive (data address with both signals negative).

All 48 selector + offline tests pass locally.

### Risks

- **`not_a_function` is a one-shot blacklist** like `decompile_timeout` and `library_code` — cleared only by explicit refresh / re-scan. If Ghidra later recovers a function at that address through re-analysis, the user has to refresh or pin to re-evaluate. Documented in the comment.
- **The detection is conservative** — only fires when BOTH decompile and completeness come back unusable. If we missed a third case where the LLM could still extract value, it'll fall through to the LLM as before (no regression).

## Test plan

- [x] `pytest tests/performance/test_selector_invariants.py tests/performance/test_ghidra_offline.py` → 48 pass
- [x] Broader `tests/performance/` offline suite → 445 pass (1 unrelated state-lock test flaked once, passed in isolation)
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)