### PR TITLE
fix(setup): resolve user-config dir from install layout, not APPDATA scan (#217)

### DIFF
--- a/tests/unit/test_setup_ghidra.py
+++ b/tests/unit/test_setup_ghidra.py
@@ -163,6 +163,75 @@ def test_resolve_ghidra_user_dir_picks_public_when_dev_and_public_coexist(
     assert resolved != dev_loc
 
 
+def test_resolve_ghidra_user_dir_returns_public_when_only_dev_exists(tmp_path: Path):
+    """#217 regression: a freshly-installed Ghidra has no user-config
+    dir yet (Ghidra creates it lazily on first launch). If the deploy
+    target is ``ghidra_12.1_PUBLIC`` and only a leftover
+    ``ghidra_12.1_DEV`` sibling exists in ``%APPDATA%\\ghidra\\``, the
+    resolver must NOT silently fall back to the DEV dir — that
+    installs the extension where the running PUBLIC Ghidra never
+    looks. Return the (nonexistent) PUBLIC path; Ghidra will create
+    it."""
+    user_base = tmp_path / "ghidra"
+    dev_dir = user_base / "ghidra_12.1_DEV"
+    dev_dir.mkdir(parents=True)
+    # Note: no _PUBLIC dir created — the bug scenario.
+
+    resolved = resolve_ghidra_user_dir(Path("F:/ghidra_12.1_PUBLIC"), user_base)
+
+    assert resolved == user_base / "ghidra_12.1_PUBLIC"
+    assert resolved != dev_dir
+
+
+def test_resolve_ghidra_user_dir_returns_dev_when_install_is_dev(tmp_path: Path):
+    """Symmetric to the PUBLIC case: a DEV install resolves to the
+    DEV user dir, even when a PUBLIC sibling exists from a prior
+    install."""
+    user_base = tmp_path / "ghidra"
+    public_dir = user_base / "ghidra_12.1_PUBLIC"
+    public_dir.mkdir(parents=True)
+
+    resolved = resolve_ghidra_user_dir(Path("F:/ghidra_12.1_DEV"), user_base)
+
+    assert resolved == user_base / "ghidra_12.1_DEV"
+    assert resolved != public_dir
+
+
+def test_resolve_ghidra_user_dir_ignores_unrelated_appdata_dirs(tmp_path: Path):
+    """The resolver must not be influenced by sibling Ghidra-version
+    dirs from older installs when constructing the target dir name.
+    Previously the resolver globbed for ``ghidra_<version>*`` and
+    could match e.g. ``ghidra_12.1_DEV_location_ghidra`` (a Ghidra
+    locator file) instead of the proper user dir."""
+    user_base = tmp_path / "ghidra"
+    (user_base / "ghidra_12.0.4_PUBLIC").mkdir(parents=True)
+    (user_base / "ghidra_12.1_DEV_location_ghidra").mkdir(parents=True)
+
+    resolved = resolve_ghidra_user_dir(Path("F:/ghidra_12.1_PUBLIC"), user_base)
+
+    assert resolved == user_base / "ghidra_12.1_PUBLIC"
+
+
+def test_resolve_ghidra_user_dir_reads_application_properties_when_path_unnamed(
+    tmp_path: Path,
+):
+    """A custom install path that doesn't follow the standard
+    ``ghidra_<version>_<layout>`` naming falls back to reading
+    ``application.properties`` for the version. Layout is unknown in
+    that case; resolver defaults to PUBLIC since released Ghidras are
+    PUBLIC."""
+    install = tmp_path / "custom-ghidra-install"
+    (install / "Ghidra").mkdir(parents=True)
+    (install / "Ghidra" / "application.properties").write_text(
+        "application.version=12.1\n", encoding="utf-8"
+    )
+    user_base = tmp_path / "ghidra"
+
+    resolved = resolve_ghidra_user_dir(install, user_base)
+
+    assert resolved == user_base / "ghidra_12.1_PUBLIC"
+
+
 def test_resolve_ghidra_user_dir_falls_back_to_latest_existing_dir(tmp_path: Path):
     user_base = tmp_path / "ghidra"
     latest_dir = user_base / "ghidra_12.1.0_PUBLIC"

--- a/tools/setup/ghidra.py
+++ b/tools/setup/ghidra.py
@@ -17,7 +17,11 @@ from pathlib import Path
 
 from .envfile import load_env_file
 from .maven import find_maven_command
-from .versioning import infer_ghidra_version_from_path, read_pom_versions
+from .versioning import (
+    infer_ghidra_install_meta,
+    infer_ghidra_version_from_path,
+    read_pom_versions,
+)
 
 
 REQUIRED_GHIDRA_JARS: tuple[tuple[str, str], ...] = (
@@ -127,17 +131,48 @@ def _version_sort_key(name: str) -> tuple[int, int, int]:
 def resolve_ghidra_user_dir(
     ghidra_path: Path, user_base_dir: Path | None = None
 ) -> Path:
+    """Resolve the user-config dir matching a Ghidra install.
+
+    Ghidra writes its per-user state under
+    ``%APPDATA%\\ghidra\\ghidra_<version>_<layout>\\``. The dir is
+    created lazily on first launch, so for a freshly-installed Ghidra
+    it may not exist yet. We therefore prefer to *construct* the
+    expected dir name from the install path rather than enumerating
+    existing siblings — see #217, where a v5.10→v5.11 deploy targeting
+    a freshly-installed ``F:\\ghidra_12.1_PUBLIC`` quietly resolved to
+    a leftover ``ghidra_12.1_DEV`` user dir and installed the
+    extension where the running Ghidra never looked for it.
+    """
     user_base_dir = user_base_dir or ghidra_user_base_dir()
-    target_version = infer_ghidra_version_from_path(ghidra_path)
+    target_version, target_layout = infer_ghidra_install_meta(ghidra_path)
 
-    if user_base_dir.is_dir() and target_version:
-        matching_dirs = sorted(user_base_dir.glob(f"ghidra_{target_version}*"))
-        if matching_dirs:
-            public_dir = next(
-                (path for path in matching_dirs if "PUBLIC" in path.name), None
+    # When both version and layout are recoverable from the install
+    # path, return the explicit dir unconditionally. The dir does not
+    # need to already exist — Ghidra will create it on first launch.
+    if target_version and target_layout:
+        return user_base_dir / f"ghidra_{target_version}_{target_layout}"
+
+    # Version known but layout couldn't be inferred (e.g. a custom
+    # install path with application.properties present). Prefer an
+    # existing matching dir, then PUBLIC, then a constructed PUBLIC
+    # default.
+    if target_version:
+        if user_base_dir.is_dir():
+            matching_dirs = sorted(
+                path
+                for path in user_base_dir.glob(f"ghidra_{target_version}*")
+                if path.is_dir() and "_location_" not in path.name
             )
-            return public_dir or matching_dirs[0]
+            if matching_dirs:
+                public_dir = next(
+                    (path for path in matching_dirs if "PUBLIC" in path.name), None
+                )
+                return public_dir or matching_dirs[0]
+        return user_base_dir / f"ghidra_{target_version}_PUBLIC"
 
+    # No version metadata at all — last-resort fallback to the
+    # newest-looking existing dir so a totally custom install still
+    # gets *some* answer instead of an exception.
     if user_base_dir.is_dir():
         version_dirs = sorted(
             (path for path in user_base_dir.glob("ghidra_*") if path.is_dir()),
@@ -147,8 +182,6 @@ def resolve_ghidra_user_dir(
         if version_dirs:
             return version_dirs[0]
 
-    if target_version:
-        return user_base_dir / f"ghidra_{target_version}_PUBLIC"
     return user_base_dir / "ghidra_unknown_PUBLIC"
 
 

--- a/tools/setup/ghidra.py
+++ b/tools/setup/ghidra.py
@@ -121,11 +121,29 @@ def ghidra_user_base_dir() -> Path:
     return Path.home() / ".config" / "ghidra"
 
 
-def _version_sort_key(name: str) -> tuple[int, int, int]:
+def _version_sort_key(name: str) -> tuple[int, int, int, int]:
+    """Sort key for Ghidra user-config dir names.
+
+    Returns ``(major, minor, patch, explicit_patch)``. The trailing
+    flag is 1 when the dir name carried an explicit patch component
+    (e.g. ``ghidra_12.1.0_PUBLIC``) and 0 when it didn't
+    (``ghidra_12.1_PUBLIC``), so a dir with an explicit patch beats
+    an otherwise-equal shorter dir name. Without this tiebreaker the
+    sort was non-deterministic across filesystems: Windows' alpha
+    glob order put ``ghidra_12.1.0_PUBLIC`` before ``ghidra_12.1_PUBLIC``
+    and the test passed; Linux's creation-order glob produced the
+    opposite outcome and CI failed.
+    """
     match = re.search(r"ghidra_(\d+)\.(\d+)(?:\.(\d+))?", name)
     if not match:
-        return (0, 0, 0)
-    return (int(match.group(1)), int(match.group(2)), int(match.group(3) or 0))
+        return (0, 0, 0, 0)
+    explicit_patch = 1 if match.group(3) is not None else 0
+    return (
+        int(match.group(1)),
+        int(match.group(2)),
+        int(match.group(3) or 0),
+        explicit_patch,
+    )
 
 
 def resolve_ghidra_user_dir(

--- a/tools/setup/versioning.py
+++ b/tools/setup/versioning.py
@@ -39,18 +39,38 @@ def read_pom_versions(repo_root: Path) -> VersionInfo:
     )
 
 
-def infer_ghidra_version_from_path(ghidra_path: Path) -> str | None:
-    match = re.search(r"ghidra_([0-9]+(?:\.[0-9]+){1,3})_PUBLIC", str(ghidra_path))
+_GHIDRA_PATH_RE = re.compile(r"ghidra_([0-9]+(?:\.[0-9]+){1,3})_(PUBLIC|DEV)")
+
+
+def infer_ghidra_install_meta(ghidra_path: Path) -> tuple[str | None, str | None]:
+    """Return ``(version, layout)`` for a Ghidra install path.
+
+    ``layout`` is ``"PUBLIC"`` or ``"DEV"`` when the path follows the
+    standard ``ghidra_<version>_<layout>`` naming used by official
+    release zips, otherwise ``None``. ``version`` is recovered from the
+    path name first and falls back to ``Ghidra/application.properties``.
+
+    Both are needed to construct the user-config dir name explicitly —
+    see #217: enumerating ``%APPDATA%\\ghidra\\*`` silently picks a stale
+    ``_DEV`` sibling when the target ``_PUBLIC`` dir hasn't been
+    created yet (Ghidra creates it lazily on first launch).
+    """
+    match = _GHIDRA_PATH_RE.search(str(ghidra_path))
     if match:
-        return match.group(1)
+        return match.group(1), match.group(2)
 
     props_path = ghidra_path / "Ghidra" / "application.properties"
     if not props_path.is_file():
-        return None
+        return None, None
 
+    version: str | None = None
     for line in props_path.read_text(encoding="utf-8", errors="ignore").splitlines():
         stripped = line.strip()
         if stripped.startswith("application.version="):
-            return stripped.split("=", 1)[1].strip()
+            version = stripped.split("=", 1)[1].strip()
+            break
+    return version, None
 
-    return None
+
+def infer_ghidra_version_from_path(ghidra_path: Path) -> str | None:
+    return infer_ghidra_install_meta(ghidra_path)[0]


### PR DESCRIPTION
## Summary

- `resolve_ghidra_user_dir()` now constructs the expected
  `%APPDATA%\ghidra\ghidra_<version>_<layout>\` name explicitly from
  the install path's `_PUBLIC` / `_DEV` suffix rather than globbing
  APPDATA for a sibling that happens to match the version. This
  fixes the v5.10 → v5.11 (Ghidra 12.0.4 → 12.1) deploy gap from #217
  where a leftover `ghidra_12.1_DEV` sibling silently won over the
  not-yet-created `ghidra_12.1_PUBLIC` target.
- New `infer_ghidra_install_meta()` returns `(version, layout)`;
  `infer_ghidra_version_from_path()` delegates to it for backwards
  compat with three existing call sites.
- Bug B from the issue (`patch_ghidra_user_configs` leaking patches
  across sibling Ghidra versions) was already addressed structurally
  in `deploy_to_ghidra`, which passes `target_user_dir` to scope the
  glob. This PR only fixes the remaining Bug A — the resolver feeding
  `install_user_extension` and the deploy's `patch_ghidra_user_configs`
  call.

## Test plan

- [x] All 360 unit tests pass (`pytest tests/unit/ --no-cov`).
- [x] 4 new resolver tests pin the #217 scenarios:
  - target `_PUBLIC`, only `_DEV` exists → returns constructed `_PUBLIC` path
  - target `_DEV` with `_PUBLIC` sibling → returns `_DEV`
  - `ghidra_<version>_DEV_location_ghidra` locator dirs ignored
  - custom install path → `application.properties` fallback, defaults to PUBLIC
- [ ] **Manual repro pending** (requires Windows + side-by-side 12.0.4/12.1 installs): run
  `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC`
  on a machine where `%APPDATA%\ghidra\ghidra_12.1_DEV\` exists but
  `ghidra_12.1_PUBLIC\` does not. Confirm:
  - extension lands in `ghidra_12.1_PUBLIC\Extensions\GhidraMCP\` (not `_DEV`)
  - `FrontEndTool.xml` patched in `ghidra_12.1_PUBLIC\` only
  - Ghidra starts up with the FrontEnd plugin loaded, `check_connection`
    responds without manually opening a CodeBrowser

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)