### PR TITLE
fix(tests): isolate perf suite from real fun-doc DB; collectible in one process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,12 +179,13 @@ jobs:
         pip install -q -r requirements.txt
         pip install -q -r fun-doc/requirements.txt
 
-    - name: Run offline performance/regression tests (per-file isolation)
+    - name: Run offline performance/regression tests
       run: |
         # These suites guard fun-doc (fun_doc.py, storage/, audit/, library detector,
-        # selector, etc.) and run without a live Ghidra server. They share fun-doc module
-        # globals (e.g. the reentrant _state_lock) and leak across files when collected in
-        # one process, so each file is run in its own pytest process for isolation.
+        # selector, etc.) and run without a live Ghidra server. The autouse fixture in
+        # tests/performance/conftest.py isolates every test from the real fun-doc DB
+        # (forces FUN_DOC_DB_URL to a per-test SQLite + resets the repo singleton), so the
+        # whole suite is collectible in a single process — no per-file isolation needed.
         #
         # Excluded from this CI tier:
         #   * the four live-Ghidra files (need http://127.0.0.1:8089) — integration tier
@@ -192,26 +193,15 @@ jobs:
         #   * the benchmark tests — "manual only" by design (CLAUDE.md); they depend on local
         #     benchmark assets not tracked in the repo (e.g. fun-doc/benchmark/extract_truth.py),
         #     a live Ghidra (Benchmark.dll), or an LLM judge, none of which exist in CI.
-        # Do NOT use `set -e` here: it would stop at the first failing file and mask the rest.
-        # Collect every failure and fail once at the end.
-        EXCLUDE='batch_scoring_consistency|health_endpoint|http_concurrency|listing_consistency|test_benchmark_'
-        failed=""
-        for f in tests/performance/test_*.py; do
-          if echo "$f" | grep -Eq "$EXCLUDE"; then
-            echo "skip (live-Ghidra / manual-benchmark tier): $f"
-            continue
-          fi
-          echo "::group::$f"
-          if ! python -m pytest "$f" --no-cov -q; then
-            failed="$failed $f"
-            echo "::error::offline regression failed: $f"
-          fi
-          echo "::endgroup::"
-        done
-        if [ -n "$failed" ]; then
-          echo "❌ Offline regression failures:$failed"
-          exit 1
-        fi
+        python -m pytest tests/performance/ --no-cov -q \
+          --ignore=tests/performance/test_batch_scoring_consistency.py \
+          --ignore=tests/performance/test_health_endpoint.py \
+          --ignore=tests/performance/test_http_concurrency.py \
+          --ignore=tests/performance/test_listing_consistency.py \
+          --ignore=tests/performance/test_benchmark_extract_truth.py \
+          --ignore=tests/performance/test_benchmark_ghidra_bridge.py \
+          --ignore=tests/performance/test_benchmark_haiku_judge.py \
+          --ignore=tests/performance/test_benchmark_scorer.py
         echo "✅ Offline regression suite passed"
 
   code-quality:

--- a/docs/project-management/AUDIT_STRUCTURAL_BACKLOG.md
+++ b/docs/project-management/AUDIT_STRUCTURAL_BACKLOG.md
@@ -26,13 +26,20 @@ deliberately rather than rushed — none is a release blocker.
 
 ## Correctness follow-ups (deferred from the shipped fixes)
 
-4. **`tests/performance/` cross-file isolation leak.** When the offline perf suite is
-   collected in one process, `test_state_atomicity.py` (×3) and
-   `test_state_lock_reentrant.py` fail with "the non-reentrant Lock deadlock has regressed";
-   each file passes in isolation. An earlier file leaves `fun_doc._state_lock` held by a
-   leaked daemon thread. CI now runs each file in its own process (`python-offline-regression`
-   job) to sidestep this, but the underlying leaked thread/lock should be root-caused and the
-   suite made collectible in one process.
+4. **`tests/performance/` cross-file isolation leak. — RESOLVED.** Symptom: in a single
+   process, `test_state_atomicity.py` (×3) and `test_state_lock_reentrant.py` failed with
+   "the non-reentrant Lock deadlock has regressed"; each passed in isolation. Real root cause
+   (not a leaked lock): `load_state()` goes through `_get_storage_repo()`, which fell back to
+   the developer's **real** `fun-doc/state.db` (the conftest size-guard correctly refuses to
+   delete a populated DB). Real multi-thousand-row queries + SQLite write-lock contention made
+   the 5s timeout trip under single-process load. It only reproduced on a dev machine with real
+   data (clean CI had none), which is why each file and clean CI passed. Fix: the autouse
+   `_isolate_storage_repo` fixture now forces `FUN_DOC_DB_URL` to a per-test throwaway SQLite,
+   so no test ever opens the real DB (also bulletproofs the documented data-loss incident). The
+   suite is now collectible in one process (428 passed, 0 failures even with live Ghidra + real
+   data), and CI runs it as a single invocation. A separate, purely local artifact remains: a
+   global-scorer test picks up the live Ghidra server's open programs when one is running — it
+   skips/mocks correctly in CI; left as-is.
 
 5. **`provider_pause.py` full cross-process lost-update.** The shipped fix serializes writes
    with an OS-level interprocess lock and retries `replace()` on Windows `PermissionError`,

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -71,8 +71,34 @@ def _safe_clean_state_db() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_storage_repo():
-    """Reset the fun_doc storage repo singleton + clean stray state.db."""
+def _isolate_storage_repo(tmp_path, monkeypatch):
+    """Isolate every perf test from the real fun-doc database.
+
+    Two layers:
+
+    1. Force ``FUN_DOC_DB_URL`` to a per-test throwaway SQLite. ``resolve_config``
+       checks this env var first, so any call to ``_get_storage_repo()`` (including
+       from a freshly importlib-loaded ``fun_doc`` module, e.g. the state-lock test)
+       resolves to an empty isolated DB instead of the repo's real ``state.db``.
+
+       Without this, the size-guard below correctly REFUSES to delete a populated
+       real ``state.db`` (data-safety), so on a developer machine ``load_state()``
+       would fall back to the real, multi-thousand-row database. That produced
+       slow real-data queries and SQLite write-lock contention when the suite runs
+       in one process — surfacing as the spurious "_state_lock deadlock has
+       regressed" timeout and atomicity flakiness. Each file passed in isolation
+       and in clean CI (no real data), masking the cause. Forcing the env var makes
+       the tests hermetic regardless of the developer's real DB.
+
+       Tests that specifically assert the no-env fallback (test_sqlite_default_path)
+       ``monkeypatch.delenv`` it themselves; tests that build explicit repositories
+       pass an explicit config and ignore the env. So this override is safe.
+
+    2. Reset the cached repo singleton before/after each test so the next
+       ``_get_storage_repo()`` re-initializes against the isolated DB.
+    """
+    monkeypatch.setenv("FUN_DOC_DB_URL", f"sqlite:///{tmp_path / 'isolated_state.db'}")
+
     _safe_clean_state_db()
     # Pre-test: drop the cached repo so the next call re-initializes.
     if "fun_doc" in sys.modules:


### PR DESCRIPTION
Resolves backlog item #4 from the 2026-06 audit (AUDIT_STRUCTURAL_BACKLOG.md).

## Root cause (not what it looked like)
The single-process "_state_lock deadlock has regressed" + atomicity flakiness was **not** a leaked lock. `load_state()` goes through `_get_storage_repo()`, which fell back to the developer's **real** `fun-doc/state.db` — the conftest size-guard correctly refuses to delete a populated DB (data-safety). Real multi-thousand-row queries + SQLite write-lock contention tripped the test's 5s timeout under single-process load. It only reproduced on a machine with real local data, so each file and clean CI passed — masking the cause.

## Fix
The autouse `_isolate_storage_repo` fixture now forces `FUN_DOC_DB_URL` to a per-test throwaway SQLite, so no test ever opens the real database (also hardens against the documented data-loss incident beyond the size-guard). Tests asserting the no-env fallback `delenv` it themselves; tests building explicit repositories pass explicit config — so the override is safe.

With the suite hermetic, the `python-offline-regression` CI job drops the per-file loop (added last PR as a workaround) and runs a single pytest invocation — faster and simpler.

## Verification
428 passed / 0 failures / 0 errors **single-process** in the hostile local env (live Ghidra + 30 real programs + real `state.db`); all sensitive storage/migration/state files also pass per-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)