### PR TITLE
fix(address): clear errors for multi-address input; stop the misleading retry loop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,9 +106,8 @@ jobs:
         # Annotation-scanner and endpoints.json parity tests.
         # No Ghidra server needed — pure reflection + static catalog checks.
         # Integration tests (GhidraMCPPluginTest, EndpointRegistrationTest,
-        # AppTest) require a running Ghidra instance and are deliberately excluded
-        # from this run. ServiceUtilsAddressTest is mock-based (Mockito, no live
-        # Ghidra) and now lives in com.xebyte.offline so it runs here.
+        # AppTest, ServiceUtilsAddressTest) require a running Ghidra instance
+        # and are deliberately excluded from this run.
         mvn -q test -Dtest='com.xebyte.offline.*Test'
 
     - name: Verify build artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,8 +106,9 @@ jobs:
         # Annotation-scanner and endpoints.json parity tests.
         # No Ghidra server needed — pure reflection + static catalog checks.
         # Integration tests (GhidraMCPPluginTest, EndpointRegistrationTest,
-        # AppTest, ServiceUtilsAddressTest) require a running Ghidra instance
-        # and are deliberately excluded from this run.
+        # AppTest) require a running Ghidra instance and are deliberately excluded
+        # from this run. ServiceUtilsAddressTest is mock-based (Mockito, no live
+        # Ghidra) and now lives in com.xebyte.offline so it runs here.
         mvn -q test -Dtest='com.xebyte.offline.*Test'
 
     - name: Verify build artifacts

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -608,6 +608,26 @@ public final class ServiceUtils {
             return null;
         }
 
+        // Detect a delimited multi-address string, e.g. "10020295;100202af;..." — another
+        // shape workers send when they meant to use the batch-comments inner lists. The plain
+        // "could not be resolved... try <space>:<hex>" message used to suggest prepending the
+        // space name to the WHOLE string, and the retry ("ram:..;ram:..") then produced a
+        // second, self-contradictory "Unknown address space 'ram'. Available: ram" error.
+        // Fail fast with the same structured hint as the array case instead. (addressStr is
+        // already stripped, so any remaining whitespace is internal — i.e. list-shaped.)
+        boolean looksLikeList = addressStr.indexOf(';') >= 0
+                || addressStr.indexOf(',') >= 0
+                || addressStr.chars().anyMatch(Character::isWhitespace);
+        if (looksLikeList) {
+            lastParseError.set("Address must be a single location, not a list. "
+                    + "Got: " + (addressStr.length() > 80 ? addressStr.substring(0, 80) + "..." : addressStr) + ". "
+                    + "If you're calling batch_set_comments, the top-level `address` is the "
+                    + "function entry only; per-line addresses go inside the `decompiler_comments` "
+                    + "and `disassembly_comments` arrays as objects like {\"address\": \"0x...\", \"comment\": \"...\"}. "
+                    + "If you're addressing a single location, pass one hex string like \"0x6ff6a4a0\".");
+            return null;
+        }
+
         // Detect if this is a segment:offset form for better error messages
         boolean hasColon = addressStr.contains(":");
 
@@ -634,8 +654,17 @@ public final class ServiceUtils {
         String available = buildAvailableSpacesHint(program);
         if (hasColon) {
             String spaceName = addressStr.substring(0, addressStr.indexOf(':'));
-            lastParseError.set("Unknown address space '" + spaceName + "' in '" + addressStr
-                + "'. Available spaces: " + available + ".");
+            String offsetPart = addressStr.substring(addressStr.indexOf(':') + 1);
+            if (isKnownSpace(program, spaceName)) {
+                // The space is valid; the failure is the offset. Don't blame the space
+                // (which produced the contradictory "Unknown space 'ram'. Available: ram").
+                lastParseError.set("Could not resolve offset '" + offsetPart
+                    + "' in address space '" + spaceName + "'. Check that it is valid hex "
+                    + "within that space's range. Available spaces: " + available + ".");
+            } else {
+                lastParseError.set("Unknown address space '" + spaceName + "' in '" + addressStr
+                    + "'. Available spaces: " + available + ".");
+            }
         } else {
             lastParseError.set("Address '" + addressStr
                 + "' could not be resolved in the default address space. "
@@ -680,6 +709,24 @@ public final class ServiceUtils {
             }
         }
         return count;
+    }
+
+    /**
+     * True if {@code spaceName} (case-insensitive) names a real physical address space
+     * (TYPE_RAM/TYPE_CODE, non-overlay) in the program. Used to distinguish a genuinely
+     * unknown space from a known space with a bad offset when building parse errors.
+     */
+    private static boolean isKnownSpace(Program program, String spaceName) {
+        if (spaceName == null || spaceName.isEmpty()) return false;
+        for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
+            if (space.isOverlaySpace()) continue;
+            int type = space.getType();
+            if ((type == AddressSpace.TYPE_RAM || type == AddressSpace.TYPE_CODE)
+                    && space.getName().equalsIgnoreCase(spaceName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String buildAvailableSpacesHint(Program program) {

--- a/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
+++ b/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
@@ -1,4 +1,4 @@
-package com.xebyte;
+package com.xebyte.offline;
 
 import com.xebyte.core.ServiceUtils;
 import ghidra.program.model.address.Address;
@@ -80,6 +80,55 @@ public class ServiceUtilsAddressTest {
         assertNotNull(err);
         assertTrue("Error should mention unknown space name", err.contains("foo"));
         assertTrue("Error should list available spaces", err.contains("ram") && err.contains("code"));
+    }
+
+    @Test
+    public void parseAddress_semicolonDelimitedList_failsFastWithHint() {
+        // Workers sometimes cram several addresses into the singular `address` field,
+        // semicolon-joined, when they meant to use the batch-comments inner lists.
+        Address result = ServiceUtils.parseAddress(program,
+                "10020295;100202af;100202c4;100202ca");
+        assertNull(result);
+        String err = ServiceUtils.getLastParseError();
+        assertNotNull(err);
+        assertTrue("Should explain it's not a single location: " + err,
+                err.contains("single location") || err.contains("not a list"));
+        assertTrue("Should point at the batch-comments inner lists: " + err,
+                err.contains("decompiler_comments") && err.contains("disassembly_comments"));
+        // Must NOT have tried (and failed) to resolve it as one address.
+        assertFalse("Should not emit the misleading space-suggestion error: " + err,
+                err.contains("Try <space>:<hex>"));
+    }
+
+    @Test
+    public void parseAddress_spacePrefixedList_failsFastNotUnknownSpace() {
+        // Regression for the reported two-error loop: after the first error suggested
+        // prepending the space, the retry "ram:..;ram:.." produced the contradictory
+        // "Unknown address space 'ram'. Available: ram". It must now fail fast as a list.
+        Address result = ServiceUtils.parseAddress(program,
+                "ram:10020295;ram:100202af;ram:100202c4");
+        assertNull(result);
+        String err = ServiceUtils.getLastParseError();
+        assertNotNull(err);
+        assertTrue("Should be the list hint: " + err,
+                err.contains("single location") || err.contains("not a list"));
+        assertFalse("Must not contradict itself with Unknown address space: " + err,
+                err.contains("Unknown address space"));
+    }
+
+    @Test
+    public void parseAddress_knownSpaceBadOffset_blamesOffsetNotSpace() {
+        // "ram:zzzz": ram IS a valid space, so the failure is the offset. The error must
+        // not claim the space is unknown (the old contradictory message).
+        when(factory.getAddress("ram:zzzz")).thenReturn(null);
+        Address result = ServiceUtils.parseAddress(program, "ram:zzzz");
+        assertNull(result);
+        String err = ServiceUtils.getLastParseError();
+        assertNotNull(err);
+        assertTrue("Should blame the offset: " + err, err.contains("Could not resolve offset"));
+        assertTrue("Should name the valid space: " + err, err.contains("ram"));
+        assertFalse("Must not call a valid space unknown: " + err,
+                err.contains("Unknown address space"));
     }
 
     @Test


### PR DESCRIPTION
Fixes the confusing two-error loop seen with `batch_set_comments` (and any address-param tool) when a caller packs several addresses into the singular `address` field, e.g. `"10020295;100202af;..."`.

## Symptom
```
batch_set_comments → error - Address '10020295;100202af;...' could not be resolved in the
  default address space. Available spaces: ram. Try ram:10020295;100202af;...
batch_set_comments → error - Unknown address space 'ram' in 'ram:10020295;ram:100202af;...'.
  Available spaces: ram.
```
The first error suggested prepending the space to the **whole** string; following that suggestion produced the self-contradictory *"Unknown address space 'ram'. Available spaces: ram"* — the parser blamed a valid space when the real problem was the malformed offset.

## Fix (`ServiceUtils.parseAddress`)
1. **Multi-address guard** — detect delimited input (`;`, `,`, or internal whitespace) and fail fast with the same structured hint as the existing JSON-array guard, pointing callers at the `decompiler_comments` / `disassembly_comments` inner lists (where per-line addresses belong; the top-level `address` is the function entry only). No more misleading space suggestion.
2. **Known-space check** — in the `space:offset` error branch, verify the space name actually exists (new `isKnownSpace` helper). If it does, report `Could not resolve offset '...' in address space '...'` instead of falsely calling a valid space unknown.

## Tests / CI
`ServiceUtilsAddressTest` is mock-based (Mockito, no live Ghidra) but the `build.yml` comment wrongly excluded it as a live-Ghidra test. Moved it into `com.xebyte.offline` so it **now runs in the CI offline tier**, and added 3 regression tests: semicolon list, the `ram:..;ram:..` retry (the exact reported bug), and known-space-bad-offset.

Verified: offline Java suite green — 167 tests, `ServiceUtilsAddressTest` now 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)