### PR TITLE
fix(function): guide recovery when set_local_variable_type misses a default name

### DIFF
--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -1237,6 +1237,56 @@ public class FunctionService {
     // ========================================================================
 
     /**
+     * Build the decompiler-default-name guidance appended to a "variable not found"
+     * error from set_local_variable_type. Pure function of the requested name and the
+     * current high-symbol names, so it is unit-testable without a live decompile.
+     *
+     * <p>Ghidra default names follow {@code <prefix>Var<digits>} (uVar1, puVar3, iVar5,
+     * psVar7, ...). When such a name misses, there are two recoverable causes:
+     * <ul>
+     *   <li><b>SSA-renumber drift</b> — same-prefix default names still exist but with
+     *       different digits, because a previous set_local_variable_type call re-decompiled
+     *       and renumbered the temporaries. Fix: batch with set_variables.</li>
+     *   <li><b>Renamed-away / register-resident</b> — no default-named variables remain at
+     *       all (they were renamed, or the function is register/SIMD-heavy so Ghidra names
+     *       them local_&lt;REG&gt;_*). The caller is working from a stale decompilation. Fix:
+     *       re-decompile for current names, or batch with set_variables.</li>
+     * </ul>
+     *
+     * @return the hint sentence (with trailing space), or "" when no hint applies.
+     */
+    public static String buildVariableNameHint(String variableName, List<String> availableNames) {
+        if (variableName == null || !variableName.matches("^[a-z]+Var\\d+$")) {
+            return "";
+        }
+        if (availableNames == null) {
+            availableNames = java.util.Collections.emptyList();
+        }
+        String prefix = variableName.replaceAll("\\d+$", "");
+        boolean hasSamePrefix = availableNames.stream()
+                .anyMatch(n -> n != null && n.startsWith(prefix) && n.matches("^[a-z]+Var\\d+$"));
+        if (hasSamePrefix) {
+            return "Hint: this looks like SSA-renumber drift from a previous "
+                    + "set_local_variable_type call in the same function. "
+                    + "Use set_variables for ALL variable type+rename changes in one "
+                    + "atomic call to avoid this — individual set_local_variable_type "
+                    + "calls trigger re-decompilation that renumbers SSA temporaries. ";
+        }
+        boolean hasAnyDefaultName = availableNames.stream()
+                .anyMatch(n -> n != null && n.matches("^[a-z]+Var\\d+$"));
+        if (!hasAnyDefaultName) {
+            return "Hint: '" + variableName + "' is a Ghidra decompiler default name, but no "
+                    + "default-named (uVarN/iVarN/puVarN) variables remain in this function — "
+                    + "they have been renamed already, or the variables are register-resident "
+                    + "(e.g. local_ESI_*, local_MM*) in a register/SIMD-heavy function. You are "
+                    + "likely working from a stale decompilation: re-decompile to read the current "
+                    + "names from the Available list above, then retype — or use set_variables to "
+                    + "rename+retype in one atomic call. ";
+        }
+        return "";
+    }
+
+    /**
      * Set a local variable's type using HighFunctionDBUtil.updateDBVariable.
      */
     @McpTool(path = "/set_local_variable_type", method = "POST", description = "Set the data type of a local variable. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution.", category = "function")
@@ -1322,27 +1372,10 @@ public class FunctionService {
                                     .append(". ");
                         }
 
-                        // SSA churn hint: when the failed name follows the
-                        // <prefix><digit>+ pattern of a Ghidra SSA temporary
-                        // (iVar5, psVar7, puVar2, ...) and there is a similar
-                        // name in the available list with a *different* digit,
-                        // the most likely cause is that a previous
-                        // set_local_variable_type call retyped a variable in
-                        // the same function and re-decompilation renumbered
-                        // SSA temporaries. Recommend the atomic batch tool
-                        // explicitly rather than leaving the worker to guess.
-                        if (variableName.matches("^[a-z]+Var\\d+$")) {
-                            String prefix = variableName.replaceAll("\\d+$", "");
-                            boolean hasSamePrefix = availableNames.stream()
-                                    .anyMatch(n -> n.startsWith(prefix) && n.matches("^[a-z]+Var\\d+$"));
-                            if (hasSamePrefix) {
-                                resultMsg.append("Hint: this looks like SSA-renumber drift from a previous ")
-                                        .append("set_local_variable_type call in the same function. ")
-                                        .append("Use set_variables for ALL variable type+rename changes in one ")
-                                        .append("atomic call to avoid this — individual set_local_variable_type ")
-                                        .append("calls trigger re-decompilation that renumbers SSA temporaries. ");
-                            }
-                        }
+                        // Decompiler-default-name guidance (SSA churn / renamed-away /
+                        // register-resident). Pure function of the requested name + the
+                        // available high-symbol names — see buildVariableNameHint.
+                        resultMsg.append(buildVariableNameHint(variableName, availableNames));
 
                         // Check if variable exists in low-level API but not high-level (phantom variable)
                         Variable[] lowLevelVars = func.getLocalVariables();

--- a/src/test/java/com/xebyte/offline/FunctionServiceVariableHintTest.java
+++ b/src/test/java/com/xebyte/offline/FunctionServiceVariableHintTest.java
@@ -1,0 +1,68 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.FunctionService;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for FunctionService.buildVariableNameHint — the guidance appended to a
+ * "variable not found" error from set_local_variable_type. Pure string logic, no Ghidra
+ * runtime, so it runs in the offline tier.
+ */
+public class FunctionServiceVariableHintTest {
+
+    @Test
+    public void nonDefaultName_returnsNoHint() {
+        // A real/renamed name (not <prefix>Var<digits>) gets no decompiler-default hint.
+        assertEquals("", FunctionService.buildVariableNameHint(
+                "nTileCount", Arrays.asList("nTileCount", "local_ESI_256")));
+    }
+
+    @Test
+    public void nullName_returnsNoHint() {
+        assertEquals("", FunctionService.buildVariableNameHint(null, Arrays.asList("uVar1")));
+    }
+
+    @Test
+    public void ssaRenumberDrift_whenSamePrefixDefaultRemains_recommendsSetVariables() {
+        // uVar2 missing but uVar5/uVar7 still present → previous retype renumbered SSA temps.
+        String hint = FunctionService.buildVariableNameHint(
+                "uVar2", Arrays.asList("uVar5", "uVar7", "iVar3"));
+        assertTrue("should flag SSA-renumber drift: " + hint, hint.contains("SSA-renumber drift"));
+        assertTrue("should recommend set_variables: " + hint, hint.contains("set_variables"));
+    }
+
+    @Test
+    public void renamedAwayOrRegisterResident_whenNoDefaultNamesRemain_tellsToReDecompile() {
+        // The reported case: puVar3/uVar1 etc. missing, only register-named/renamed vars left.
+        List<String> available = Arrays.asList(
+                "local_ESI_256", "local_EAX_19", "nTileCount",
+                "local_MM2_Wb_112", "local_MM6_265");
+        String hint = FunctionService.buildVariableNameHint("puVar3", available);
+        assertTrue("should name the requested var: " + hint, hint.contains("puVar3"));
+        assertTrue("should explain renamed/register-resident: " + hint,
+                hint.contains("renamed") || hint.contains("register-resident"));
+        assertTrue("should tell caller to re-decompile: " + hint, hint.contains("re-decompile"));
+        assertTrue("should offer set_variables: " + hint, hint.contains("set_variables"));
+        // Must NOT misfire the SSA-drift branch when no default names remain.
+        assertFalse("should not claim SSA-renumber drift: " + hint, hint.contains("SSA-renumber drift"));
+    }
+
+    @Test
+    public void uVar1WithEmptyAvailable_givesRenamedAwayHint() {
+        String hint = FunctionService.buildVariableNameHint("uVar1", Collections.emptyList());
+        assertTrue(hint.contains("re-decompile"));
+    }
+
+    @Test
+    public void uVar1WithNullAvailable_doesNotThrow() {
+        String hint = FunctionService.buildVariableNameHint("uVar1", null);
+        assertNotNull(hint);
+        assertTrue(hint.contains("re-decompile"));
+    }
+}


### PR DESCRIPTION
Improves the `set_local_variable_type` "variable not found" error so a worker can recover on the **first** miss instead of looping.

## Symptom
A register/SIMD-heavy function (variables like `local_ESI_256`, `local_MM2_Wb_112`, `nTileCount`) was hit with 8 consecutive `set_local_variable_type` calls using Ghidra **default** names (`puVar3`, `uVar1`, `uVar10`, …) that no longer exist. Each returned the generic "not found / Available: …" with no recovery guidance.

## Why the existing hint didn't fire
The tool already flags **SSA-renumber drift** for `uVarN`-style misses — but only when a *same-prefix default name still exists*. Here every default name had been renamed away / is register-resident, so the available list is all `local_<REG>_*` names and the hint never fired.

## Fix
Extract the guidance into a pure, unit-testable `FunctionService.buildVariableNameHint(name, availableNames)` and add the missing branch: when the requested name is a decompiler default but **no** default-named variables remain, explain it's renamed-away / register-resident and tell the caller to **re-decompile for current names** or use **`set_variables`** to rename+retype atomically.

This is polish on an already-correct error (not a bug fix) — but it turns the 8× loop into one actionable message.

## Tests
New `FunctionServiceVariableHintTest` (6 cases) in the offline tier: non-default names, SSA-renumber drift, the renamed-away/register-resident case, and null/empty inputs.

Verified: offline Java suite green (155 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)