### PR TITLE
test(catalog): reverse parity check; remove 4 stale endpoints.json entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 - **Repo**: https://github.com/bethington/ghidra-mcp
 - **Version**: 5.12.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
-- **Key feature**: 252 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
+- **Key feature**: 248 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 
 ## Directory Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MCP server bridging Ghidra reverse engineering with AI tools. 252 MCP tools for binary analysis.
+MCP server bridging Ghidra reverse engineering with AI tools. 248 MCP tools for binary analysis.
 
 - **Package**: `com.xebyte` | **Version**: 5.12.0 | **Java**: 21 LTS | **Ghidra**: 12.1
 
@@ -32,7 +32,7 @@ Services use constructor injection: `ProgramProvider` + `ThreadingStrategy`.
 
 Do not try to keep the full tool list in this file.
 
-- **Authoritative repo snapshot**: `tests/endpoints.json` (252 endpoints, categories, descriptions)
+- **Authoritative repo snapshot**: `tests/endpoints.json` (248 endpoints, categories, descriptions)
 - **Authoritative runtime schema**: `/mcp/schema` from the running server
 - **Usage patterns / operator guide**: `docs/prompts/TOOL_USAGE_GUIDE.md`
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 >
 > If Ghidra MCP saves you time, consider [sponsoring the project](https://github.com/sponsors/bethington). One-time and recurring support both help fund compatibility updates, production hardening, docs, and new tooling.
 
-A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **252 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
+A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **248 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
 
 ## Why Ghidra MCP?
 
 Most Ghidra MCP implementations give you a handful of read-only tools and call it a day. This project is different — it was built by a reverse engineer who uses it daily on real binaries, not as a demo.
 
-- **252 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
+- **248 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
 - **Battle-tested AI workflows** — Proven documentation workflows (V5) refined across hundreds of functions. Includes step-by-step prompts, Hungarian notation reference, batch processing guides, and orphaned code discovery.
 - **Production-grade reliability** — Atomic transactions, batch operations (93% API call reduction), configurable timeouts, and graceful error handling. No silent failures.
 - **Cross-binary documentation transfer** — SHA-256 function hash matching propagates documentation across binary versions automatically. Document once, apply everywhere.
@@ -56,7 +56,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 ### Core MCP Integration
 - **Full MCP Compatibility** — Complete implementation of Model Context Protocol
-- **252 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
+- **248 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
 - **Production-Ready Reliability** — Atomic transactions, batch operations, configurable timeouts
 - **Real-time Analysis** — Live integration with Ghidra's analysis engine
 
@@ -508,7 +508,7 @@ python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1_PUBLIC"
 
 ## 📊 Production Performance
 
-- **MCP Tools**: 252 tools fully implemented
+- **MCP Tools**: 248 tools fully implemented
 - **Speed**: Sub-second response for most operations
 - **Efficiency**: 93% reduction in API calls via batch operations
 - **Reliability**: Atomic transactions with all-or-nothing semantics
@@ -1011,7 +1011,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 | Metric | Value |
 |--------|-------|
 | **Version** | 5.12.0 |
-| **MCP Tools** | 252 fully implemented |
+| **MCP Tools** | 248 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |
 | **Compilation** | ✅ 100% success |

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
 Plugin-Version: 5.12.0
 Plugin-Author: Ben Ethington
-Plugin-Description: GhidraMCP - HTTP server plugin with 252 MCP tools for reverse engineering automation
+Plugin-Description: GhidraMCP - HTTP server plugin with 248 MCP tools for reverse engineering automation

--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -1,5 +1,5 @@
 name=GhidraMCP
-description=A plugin that runs an embedded HTTP server to expose program data. Provides 252 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
+description=A plugin that runs an embedded HTTP server to expose program data. Provides 248 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
 author=Ben Ethington
 createdOn=2025-03-22
 version=${ghidra.version}

--- a/src/test/java/com/xebyte/offline/EndpointsJsonParityTest.java
+++ b/src/test/java/com/xebyte/offline/EndpointsJsonParityTest.java
@@ -138,6 +138,49 @@ public class EndpointsJsonParityTest extends TestCase {
             declared, actual);
     }
 
+    /**
+     * Reverse parity: every entry in {@code tests/endpoints.json} must correspond to a
+     * route that still exists in the source. Otherwise a removed/renamed tool leaves a
+     * stale catalog entry that the forward test (scanned ⊆ catalog) can never catch, and
+     * the advertised tool count drifts upward.
+     *
+     * <p>A path is considered live if its quoted literal ({@code "/foo"}) appears anywhere
+     * in the plugin sources — covering every registration mechanism (@McpTool, direct
+     * {@code createContext}, the EndpointRegistry, server/tool/mcp routes). A catalog path
+     * present in no source file is a genuine orphan.
+     */
+    public void testNoOrphanCatalogEntries() throws IOException {
+        String allSrc = readAllJavaSources(Paths.get("src", "main", "java", "com", "xebyte"));
+        List<String> orphans = new ArrayList<>();
+        for (String path : catalog.keySet()) {
+            if (!allSrc.contains("\"" + path + "\"")) {
+                orphans.add(path);
+            }
+        }
+        if (!orphans.isEmpty()) {
+            java.util.Collections.sort(orphans);
+            StringBuilder msg = new StringBuilder();
+            msg.append(orphans.size()).append(" orphaned catalog entr(y/ies) in ")
+               .append(CATALOG_PATH)
+               .append(" — no matching route literal in source (removed/renamed tool). ")
+               .append("Delete the stale entry (and update total_endpoints) or fix its path:\n");
+            for (String o : orphans) {
+                msg.append("  - ").append(o).append("\n");
+            }
+            fail(msg.toString());
+        }
+    }
+
+    private static String readAllJavaSources(Path root) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (java.util.stream.Stream<Path> paths = Files.walk(root)) {
+            for (Path p : (Iterable<Path>) paths.filter(f -> f.toString().endsWith(".java"))::iterator) {
+                sb.append(Files.readString(p)).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
     // ------------------------------------------------------------------
     // Catalog loader
     // ------------------------------------------------------------------

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.12.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 252,
+  "total_endpoints": 248,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -147,22 +147,6 @@
         "program"
       ],
       "description": "Analyze documentation completeness"
-    },
-    {
-      "path": "/analyze_function_full",
-      "method": "GET",
-      "category": "analysis",
-      "params": [
-        "name",
-        "include_xrefs",
-        "include_callees",
-        "include_callers",
-        "include_disasm",
-        "include_variables",
-        "include_completeness",
-        "program"
-      ],
-      "description": "Complete function analysis"
     },
     {
       "path": "/analyze_struct_field_usage",
@@ -399,20 +383,6 @@
         "filter"
       ],
       "description": "Bulk cross-binary function matching"
-    },
-    {
-      "path": "/bulk_fuzzy_match_functions",
-      "method": "GET",
-      "category": "utility",
-      "params": [
-        "source_program",
-        "target_program",
-        "threshold",
-        "offset",
-        "limit",
-        "filter"
-      ],
-      "description": "Bulk fuzzy match functions across programs"
     },
     {
       "path": "/can_rename_at_address",
@@ -1087,19 +1057,6 @@
       "description": "Find similar functions"
     },
     {
-      "path": "/find_similar_functions_across_programs",
-      "method": "GET",
-      "category": "documentation",
-      "params": [
-        "address",
-        "source_program",
-        "target_program",
-        "threshold",
-        "limit"
-      ],
-      "description": "Find similar functions via fuzzy matching"
-    },
-    {
       "path": "/find_similar_functions_fuzzy",
       "method": "GET",
       "category": "documentation",
@@ -1121,16 +1078,6 @@
         "program"
       ],
       "description": "Find undocumented functions referencing string"
-    },
-    {
-      "path": "/find_undocumented_functions_by_strings",
-      "method": "GET",
-      "category": "documentation",
-      "params": [
-        "pattern",
-        "program"
-      ],
-      "description": "Report strings and their undocumented functions"
     },
     {
       "path": "/force_decompile",


### PR DESCRIPTION
Implements backlog item #8 (AUDIT_STRUCTURAL_BACKLOG.md): `EndpointsJsonParityTest` was one-directional.

## What
- **New `testNoOrphanCatalogEntries`** — reverse parity. Every catalog path's quoted literal (`"/foo"`) must appear somewhere in the plugin sources, covering all registration mechanisms (`@McpTool`, `createContext`, `EndpointRegistry`, `/server`·`/tool`·`/mcp` routes). A path present in no source file is a stale entry the forward check (scanned ⊆ catalog) can never catch.
- The new check immediately found **4 orphans** — old names of since-renamed tools whose current-name entries already exist in the catalog:
  | stale entry | current tool |
  |---|---|
  | `/analyze_function_full` | `/analyze_function_complete` |
  | `/bulk_fuzzy_match_functions` | `/bulk_fuzzy_match` |
  | `/find_similar_functions_across_programs` | `/find_similar_functions(_fuzzy)` |
  | `/find_undocumented_functions_by_strings` | `/find_undocumented_by_string` |
- Removed them and corrected the advertised count **252 → 248** in `total_endpoints` and the human-facing references (`CLAUDE.md`, `README.md`, `AGENTS.md`, `MANIFEST.MF`, `extension.properties`) so the number matches the real catalog.

## Verification
Offline Java suite green — 174 tests; `endpoints.json` diff is minimal (4 entries + count); the new test fails if any future tool is removed/renamed without catalog cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)