### PR TITLE
test(services): offline coverage for 5 previously-untested services (+26 tests)

### DIFF
--- a/docs/project-management/AUDIT_STRUCTURAL_BACKLOG.md
+++ b/docs/project-management/AUDIT_STRUCTURAL_BACKLOG.md
@@ -17,12 +17,14 @@ deliberately rather than rushed — none is a release blocker.
    Flask blueprints and move the worker-loop body (`_run_worker_functions`,
    `_yield_for_quota_pause`) out of the closure so routes are testable per-blueprint.
 
-3. **Untested Java service layer** (~15K LOC with no behavioral tests): `AnalysisService`
-   (5,198 LOC — the largest file in the repo), `DocumentationHashService`,
-   `XrefCallGraphService`, and the Symbol/Comment/Malware/BinaryComparison/Emulation
-   services. The `DatatypeMcpToolsHandlerValidationTest` pattern (drive real service methods
-   with a stub provider to hit validation/early-error branches, no live Ghidra) is a proven
-   template that extends here cheaply.
+3. **Untested Java service layer** (~15K LOC) — *IN PROGRESS*. The
+   `DatatypeMcpToolsHandlerValidationTest` stub-provider pattern (drive real service methods
+   to hit validation/early-error + no-program branches, no live Ghidra) is being extended.
+   **Done:** `AnalysisService`, `DocumentationHashService`, `XrefCallGraphService`,
+   `SymbolLabelService`, `CommentService` (offline validation + graceful-degradation suites).
+   **Remaining:** `MalwareSecurityService`, `BinaryComparisonService`, `EmulationService`,
+   `ListingService`, `ProgramScriptService`, plus deeper coverage of the large `AnalysisService`
+   surface beyond its validate-first branches.
 
 ## Correctness follow-ups (deferred from the shipped fixes)
 

--- a/src/test/java/com/xebyte/offline/AnalysisServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/AnalysisServiceValidationTest.java
@@ -1,0 +1,47 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.AnalysisService;
+import com.xebyte.core.FunctionService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Validation + graceful-degradation coverage for AnalysisService (the largest service in the
+ * repo, ~5.2K LOC, previously no behavioral tests). Exercises the input-validation branches
+ * that run before any program access, plus the no-program degradation path.
+ */
+public class AnalysisServiceValidationTest extends TestCase {
+
+    private AnalysisService analysis;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        com.xebyte.core.ProgramProvider provider = ServiceFactory.stubProvider();
+        analysis = new AnalysisService(provider, ts, new FunctionService(provider, ts));
+    }
+
+    // --- validate-first branches (run before the program lookup) ---
+
+    public void testGetFieldAccessContextRejectsNegativeOffset() {
+        Response r = analysis.getFieldAccessContext("0x401000", -1, 5);
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("Field offset must be between 0 and"));
+    }
+
+    public void testBatchAnalyzeCompletenessRejectsMissingAddresses() {
+        Response r = analysis.batchAnalyzeCompleteness(null, "");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("Missing required parameter: addresses"));
+    }
+
+    // --- graceful degradation past validation, with no program loaded ---
+
+    public void testGetFieldAccessContextDegradesGracefullyWithValidArgs() {
+        Response r = analysis.getFieldAccessContext("0x401000", 0, 5);
+        assertNotNull(r);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+}

--- a/src/test/java/com/xebyte/offline/CommentServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/CommentServiceValidationTest.java
@@ -1,0 +1,58 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.CommentService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Graceful-degradation coverage for CommentService (previously no behavioral tests).
+ * With no program loaded the comment tools must return a clean "No program loaded" error
+ * instead of throwing.
+ */
+public class CommentServiceValidationTest extends TestCase {
+
+    private CommentService comments;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        comments = new CommentService(ServiceFactory.stubProvider(), ts);
+    }
+
+    private static void assertNoProgram(Response r) {
+        assertNotNull("method returned null instead of an error Response", r);
+        assertTrue("expected a graceful 'No program loaded' error, got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+
+    public void testSetDecompilerCommentDegradesGracefully() {
+        assertNoProgram(comments.setDecompilerComment("0x401000", "note"));
+    }
+
+    public void testSetDisassemblyCommentDegradesGracefully() {
+        assertNoProgram(comments.setDisassemblyComment("0x401000", "note"));
+    }
+
+    public void testSetPlateCommentDegradesGracefully() {
+        assertNoProgram(comments.setPlateComment("0x401000", "Summary of this function's behavior"));
+    }
+
+    public void testClearFunctionCommentsDegradesGracefully() {
+        assertNoProgram(comments.clearFunctionComments("0x401000", true, true, true));
+    }
+
+    public void testBatchSetCommentsDegradesGracefully() {
+        List<Map<String, String>> decompiler = new ArrayList<>();
+        List<Map<String, String>> disassembly = new ArrayList<>();
+        assertNoProgram(comments.batchSetComments("0x401000", decompiler, disassembly, null, ""));
+    }
+
+    public void testGetPlateCommentDegradesGracefully() {
+        assertNoProgram(comments.getPlateComment("0x401000", ""));
+    }
+}

--- a/src/test/java/com/xebyte/offline/DocumentationHashServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/DocumentationHashServiceValidationTest.java
@@ -1,0 +1,58 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.BinaryComparisonService;
+import com.xebyte.core.DocumentationHashService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Validation + graceful-degradation coverage for DocumentationHashService (~2K LOC, previously
+ * no behavioral tests). Exercises the required-parameter branches that run before any program
+ * access, plus the no-program degradation path.
+ */
+public class DocumentationHashServiceValidationTest extends TestCase {
+
+    private DocumentationHashService docs;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        docs = new DocumentationHashService(ServiceFactory.stubProvider(), ts, new BinaryComparisonService());
+    }
+
+    // --- validate-first branches (run before the program lookup) ---
+
+    public void testFindUndocumentedByStringRequiresAddress() {
+        Response r = docs.findUndocumentedByString("", "");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("String address is required"));
+    }
+
+    public void testBulkFuzzyMatchRequiresSourceProgram() {
+        Response r = docs.handleBulkFuzzyMatch("", "Target.dll", 0.7, 0, 50, null);
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("source_program parameter is required"));
+    }
+
+    public void testMergeProgramDocumentationRequiresSource() {
+        Response r = docs.mergeProgramDocumentation("", "Target.dll", false);
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("source is required"));
+    }
+
+    public void testMergeProgramDocumentationRequiresTarget() {
+        Response r = docs.mergeProgramDocumentation("Source.dll", "", false);
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("target is required"));
+    }
+
+    // --- graceful degradation past validation, with no program loaded ---
+
+    public void testFindUndocumentedByStringDegradesGracefullyWithValidAddress() {
+        Response r = docs.findUndocumentedByString("0x401000", "");
+        assertNotNull(r);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+}

--- a/src/test/java/com/xebyte/offline/SymbolLabelServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/SymbolLabelServiceValidationTest.java
@@ -1,0 +1,60 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.Response;
+import com.xebyte.core.SymbolLabelService;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Graceful-degradation coverage for SymbolLabelService (previously no behavioral tests).
+ * With no program loaded, the label/rename tools must return a clean "No program loaded"
+ * error instead of throwing.
+ */
+public class SymbolLabelServiceValidationTest extends TestCase {
+
+    private SymbolLabelService symbols;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        symbols = new SymbolLabelService(ServiceFactory.stubProvider(), ts);
+    }
+
+    private static void assertNoProgram(Response r) {
+        assertNotNull("method returned null instead of an error Response", r);
+        assertTrue("expected a graceful 'No program loaded' error, got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+
+    public void testCreateLabelDegradesGracefully() {
+        assertNoProgram(symbols.createLabel("0x401000", "my_label"));
+    }
+
+    public void testRenameLabelDegradesGracefully() {
+        assertNoProgram(symbols.renameLabel("0x401000", "old", "new_name"));
+    }
+
+    public void testRenameOrLabelDegradesGracefully() {
+        assertNoProgram(symbols.renameOrLabel("0x401000", "g_someGlobal"));
+    }
+
+    public void testDeleteLabelDegradesGracefully() {
+        assertNoProgram(symbols.deleteLabel("0x401000", "my_label"));
+    }
+
+    public void testRenameDataAtAddressDegradesGracefully() {
+        assertNoProgram(symbols.renameDataAtAddress("0x401000", "g_data"));
+    }
+
+    public void testRenameGlobalVariableDegradesGracefully() {
+        assertNoProgram(symbols.renameGlobalVariable("oldGlobal", "g_newGlobal"));
+    }
+
+    public void testGetFunctionLabelsDegradesGracefully() {
+        assertNoProgram(symbols.getFunctionLabels("FUN_00401000", 0, 100));
+    }
+
+    public void testCanRenameAtAddressDegradesGracefully() {
+        assertNoProgram(symbols.canRenameAtAddress("0x401000"));
+    }
+}

--- a/src/test/java/com/xebyte/offline/XrefCallGraphServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/XrefCallGraphServiceValidationTest.java
@@ -1,0 +1,47 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import com.xebyte.core.XrefCallGraphService;
+import junit.framework.TestCase;
+
+/**
+ * Graceful-degradation coverage for XrefCallGraphService (~1.3K LOC, previously no behavioral
+ * tests). With a stub provider and no program loaded, every program-scoped tool must return a
+ * clean error rather than throw — these assert the "No program loaded" contract and that the
+ * methods don't NPE when invoked without a binary.
+ */
+public class XrefCallGraphServiceValidationTest extends TestCase {
+
+    private XrefCallGraphService xref;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        xref = new XrefCallGraphService(ServiceFactory.stubProvider(), ts);
+    }
+
+    private static void assertNoProgram(Response r) {
+        assertNotNull("method returned null instead of an error Response", r);
+        assertTrue("expected a graceful 'No program loaded' error, got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+
+    public void testGetXrefsToDegradesGracefully() {
+        assertNoProgram(xref.getXrefsTo("0x401000", 0, 100, ""));
+    }
+
+    public void testGetXrefsFromDegradesGracefully() {
+        assertNoProgram(xref.getXrefsFrom("0x401000", 0, 100, ""));
+    }
+
+    public void testGetFunctionJumpTargetsDegradesGracefully() {
+        assertNoProgram(xref.getFunctionJumpTargets("FUN_00401000", 0, 100));
+    }
+
+    public void testProgramNotFoundWhenNamedProgramMissing() {
+        Response r = xref.getXrefsTo("0x401000", 0, 100, "Nonexistent.dll");
+        assertTrue("expected program-not-found error, got: " + r.toJson(),
+                r.toJson().contains("Program not found: Nonexistent.dll"));
+    }
+}


### PR DESCRIPTION
Backlog item #3 (AUDIT_STRUCTURAL_BACKLOG.md), first installment — extends the proven `DatatypeMcpToolsHandlerValidationTest` stub-provider pattern to five services that had **no behavioral tests**.

## Coverage added (26 offline tests, no live Ghidra)
| Service | Tests |
|---|---|
| `AnalysisService` (largest file, 5.2K LOC) | validate-first branches (negative field offset, missing `addresses`) + no-program degradation |
| `DocumentationHashService` (~2K LOC) | required-param branches (`find_undocumented_by_string`, `bulk_fuzzy_match`, `merge_program_documentation`) + degradation |
| `XrefCallGraphService` (~1.3K LOC) | graceful "No program loaded" across `get_xrefs_to/from`, jump targets, program-not-found |
| `CommentService` | graceful degradation across decompiler/disassembly/plate/clear/batch comment tools |
| `SymbolLabelService` | graceful degradation across create/rename/delete label, rename data/global |

The graceful-degradation tests prove the tools return a clean error (no NPE/crash) when invoked with no binary loaded — the CLAUDE.md graceful-degradation contract.

## Verification
Full offline Java suite: **200 tests green** (was 174). All run in the CI offline tier.

Remaining services (`Malware`/`BinaryComparison`/`Emulation`/`Listing`/`ProgramScript`) and deeper `AnalysisService` coverage tracked in backlog #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)