### PR TITLE
test(services): offline coverage for remaining 5 services (#3 complete, +21 tests)

### DIFF
--- a/docs/project-management/AUDIT_STRUCTURAL_BACKLOG.md
+++ b/docs/project-management/AUDIT_STRUCTURAL_BACKLOG.md
@@ -17,14 +17,18 @@ deliberately rather than rushed — none is a release blocker.
    Flask blueprints and move the worker-loop body (`_run_worker_functions`,
    `_yield_for_quota_pause`) out of the closure so routes are testable per-blueprint.
 
-3. **Untested Java service layer** (~15K LOC) — *IN PROGRESS*. The
+3. **Untested Java service layer** (~15K LOC) — *MOSTLY DONE*. The
    `DatatypeMcpToolsHandlerValidationTest` stub-provider pattern (drive real service methods
-   to hit validation/early-error + no-program branches, no live Ghidra) is being extended.
-   **Done:** `AnalysisService`, `DocumentationHashService`, `XrefCallGraphService`,
-   `SymbolLabelService`, `CommentService` (offline validation + graceful-degradation suites).
-   **Remaining:** `MalwareSecurityService`, `BinaryComparisonService`, `EmulationService`,
-   `ListingService`, `ProgramScriptService`, plus deeper coverage of the large `AnalysisService`
-   surface beyond its validate-first branches.
+   to hit validation/early-error + no-program branches, no live Ghidra) was extended to every
+   previously-untested service: `AnalysisService`, `DocumentationHashService`,
+   `XrefCallGraphService`, `SymbolLabelService`, `CommentService`, `MalwareSecurityService`,
+   `EmulationService`, `ListingService` (incl. functional `convert_number`),
+   `ProgramScriptService` (required-param + GUI-mode + script-execution security gate), and
+   `BinaryComparisonService` (functional `computeSimilarity`). The offline Java suite grew
+   149 → 221 tests. **Remaining (optional, deeper):** these are validation/early-error +
+   graceful-degradation contracts, not full behavioral coverage of the happy paths (which
+   need a live program — see the integration tier). Deeper happy-path coverage of the large
+   `AnalysisService` surface could still be added against a live fixture.
 
 ## Correctness follow-ups (deferred from the shipped fixes)
 

--- a/src/test/java/com/xebyte/offline/BinaryComparisonServiceTest.java
+++ b/src/test/java/com/xebyte/offline/BinaryComparisonServiceTest.java
@@ -1,0 +1,50 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.BinaryComparisonService;
+import com.xebyte.core.BinaryComparisonService.FunctionSignature;
+import junit.framework.TestCase;
+
+/**
+ * Functional coverage for BinaryComparisonService.computeSimilarity — the pure scoring core
+ * behind find_similar_functions / bulk_fuzzy_match / diff_functions (previously no behavioral
+ * tests). Uses constructed FunctionSignatures so it runs offline with no Ghidra.
+ */
+public class BinaryComparisonServiceTest extends TestCase {
+
+    private static FunctionSignature sig(int insn, int bb, int edges, int calls,
+                                         String... callees) {
+        FunctionSignature s = new FunctionSignature();
+        s.instructionCount = insn;
+        s.basicBlockCount = bb;
+        s.edgeCount = edges;
+        s.callCount = calls;
+        s.cyclomaticComplexity = edges - bb + 2;
+        for (String c : callees) s.calleeNames.add(c);
+        return s;
+    }
+
+    public void testIdenticalSignaturesScoreAtLeastAsHighAsDifferent() {
+        FunctionSignature a = sig(100, 12, 16, 5, "malloc", "free", "memcpy");
+        FunctionSignature aCopy = sig(100, 12, 16, 5, "malloc", "free", "memcpy");
+        FunctionSignature different = sig(3, 1, 0, 0, "exit");
+
+        double same = BinaryComparisonService.computeSimilarity(a, aCopy);
+        double diff = BinaryComparisonService.computeSimilarity(a, different);
+
+        // Sanity: scores are well-defined probabilities (also catches NaN).
+        assertTrue("same score out of range: " + same, same >= 0.0 && same <= 1.0);
+        assertTrue("diff score out of range: " + diff, diff >= 0.0 && diff <= 1.0);
+        // Identical signatures must be at least as similar as clearly different ones.
+        assertTrue("identical (" + same + ") should be >= different (" + diff + ")", same >= diff);
+        // And identical signatures should be strongly similar.
+        assertTrue("identical signatures should score high, got " + same, same >= 0.9);
+    }
+
+    public void testSymmetry() {
+        FunctionSignature a = sig(50, 8, 10, 3, "foo", "bar");
+        FunctionSignature b = sig(40, 6, 8, 2, "foo", "baz");
+        double ab = BinaryComparisonService.computeSimilarity(a, b);
+        double ba = BinaryComparisonService.computeSimilarity(b, a);
+        assertEquals("similarity should be symmetric", ab, ba, 1e-9);
+    }
+}

--- a/src/test/java/com/xebyte/offline/EmulationServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/EmulationServiceValidationTest.java
@@ -1,0 +1,29 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.EmulationService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Graceful-degradation coverage for EmulationService (previously no behavioral tests).
+ * emulate_function must return a clean "No program loaded" error rather than throw when no
+ * binary is loaded.
+ */
+public class EmulationServiceValidationTest extends TestCase {
+
+    private EmulationService emulation;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        emulation = new EmulationService(ServiceFactory.stubProvider(), ts);
+    }
+
+    public void testEmulateFunctionDegradesGracefully() {
+        Response r = emulation.emulateFunction("0x401000", "", "", 10000, "", "");
+        assertNotNull(r);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+}

--- a/src/test/java/com/xebyte/offline/ListingServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/ListingServiceValidationTest.java
@@ -1,0 +1,66 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.ListingService;
+import com.xebyte.core.Response;
+import junit.framework.TestCase;
+
+/**
+ * Coverage for ListingService (previously no behavioral tests). convert_number is a pure
+ * utility (no program needed) and is exercised functionally; the program-scoped listers are
+ * checked for graceful "No program loaded" degradation.
+ */
+public class ListingServiceValidationTest extends TestCase {
+
+    private ListingService listing;
+
+    @Override
+    protected void setUp() {
+        listing = new ListingService(ServiceFactory.stubProvider());
+    }
+
+    // --- convert_number: pure utility, works with no program ---
+
+    public void testConvertNumberDecimalProducesHex() {
+        Response r = listing.convertNumber("255", 4);
+        assertTrue(r instanceof Response.Text);
+        String out = ((Response.Text) r).content().toLowerCase();
+        assertTrue("expected hex ff in conversion of 255, got: " + out, out.contains("ff"));
+    }
+
+    public void testConvertNumberHexInputAccepted() {
+        Response r = listing.convertNumber("0x10", 4);
+        assertTrue(r instanceof Response.Text);
+        String out = ((Response.Text) r).content();
+        assertTrue("expected decimal 16 in conversion of 0x10, got: " + out, out.contains("16"));
+    }
+
+    public void testConvertNumberEmptyReports() {
+        Response r = listing.convertNumber("", 4);
+        assertTrue(r instanceof Response.Text);
+        assertTrue(((Response.Text) r).content().contains("No number provided"));
+    }
+
+    // --- program-scoped listers degrade gracefully with no program ---
+
+    private static void assertNoProgram(Response r) {
+        assertNotNull(r);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+
+    public void testGetFunctionCountDegradesGracefully() {
+        assertNoProgram(listing.getFunctionCount(""));
+    }
+
+    public void testSearchStringsDegradesGracefully() {
+        assertNoProgram(listing.searchStrings("pattern", 4, "", 0, 100, ""));
+    }
+
+    public void testSearchFunctionsByNameDegradesGracefully() {
+        assertNoProgram(listing.searchFunctionsByName("Foo", 0, 100, ""));
+    }
+
+    public void testListImportsDegradesGracefully() {
+        assertNoProgram(listing.listImports(0, 100, ""));
+    }
+}

--- a/src/test/java/com/xebyte/offline/MalwareSecurityServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/MalwareSecurityServiceValidationTest.java
@@ -1,0 +1,48 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.MalwareSecurityService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Graceful-degradation coverage for MalwareSecurityService (previously no behavioral tests).
+ * Each analysis tool must return a clean "No program loaded" error rather than throw when no
+ * binary is loaded.
+ */
+public class MalwareSecurityServiceValidationTest extends TestCase {
+
+    private MalwareSecurityService malware;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        malware = new MalwareSecurityService(ServiceFactory.stubProvider(), ts);
+    }
+
+    private static void assertNoProgram(Response r) {
+        assertNotNull("method returned null instead of an error Response", r);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+
+    public void testFindAntiAnalysisTechniquesDegradesGracefully() {
+        assertNoProgram(malware.findAntiAnalysisTechniques());
+    }
+
+    public void testAutoDecryptStringsDegradesGracefully() {
+        assertNoProgram(malware.autoDecryptStrings());
+    }
+
+    public void testAnalyzeApiCallChainsDegradesGracefully() {
+        assertNoProgram(malware.analyzeAPICallChains());
+    }
+
+    public void testExtractIocsWithContextDegradesGracefully() {
+        assertNoProgram(malware.extractIOCsWithContext());
+    }
+
+    public void testDetectMalwareBehaviorsDegradesGracefully() {
+        assertNoProgram(malware.detectMalwareBehaviors());
+    }
+}

--- a/src/test/java/com/xebyte/offline/ProgramScriptServiceValidationTest.java
+++ b/src/test/java/com/xebyte/offline/ProgramScriptServiceValidationTest.java
@@ -1,0 +1,65 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.ProgramScriptService;
+import com.xebyte.core.Response;
+import com.xebyte.core.SecurityConfig;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Validation + guard coverage for ProgramScriptService (~2.3K LOC, previously only the
+ * run-script propagation offline test). Exercises required-param guards, GUI-mode guards
+ * (no PluginTool under the stub provider), and the script-execution security gate — all
+ * before any program access, so they run offline.
+ */
+public class ProgramScriptServiceValidationTest extends TestCase {
+
+    private ProgramScriptService scripts;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        scripts = new ProgramScriptService(ServiceFactory.stubProvider(), ts);
+    }
+
+    public void testCloseProgramRequiresName() {
+        Response r = scripts.closeProgram("");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("Program name or path is required"));
+    }
+
+    public void testSwitchProgramRequiresName() {
+        Response r = scripts.switchProgram("");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("Program name is required"));
+    }
+
+    public void testOpenProgramFromProjectRequiresPath() {
+        Response r = scripts.openProgramFromProject("");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("Program path is required"));
+    }
+
+    public void testImportFileRequiresFilePath() {
+        Response r = scripts.importFile("", "/", "", "", true);
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("file_path is required"));
+    }
+
+    public void testListProjectFilesRequiresGuiMode() {
+        // Stub provider exposes no PluginTool, so the GUI-only guard must fire.
+        Response r = scripts.listProjectFiles("/");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("requires GUI mode"));
+    }
+
+    public void testRunScriptInlineGatedByDefault() {
+        // Security gate: arbitrary-code execution is off unless GHIDRA_MCP_ALLOW_SCRIPTS is set.
+        // Assert the gate only in the (default) disabled state so the test is env-independent.
+        if (!SecurityConfig.getInstance().areScriptsAllowed()) {
+            Response r = scripts.runScriptInline("System.out.println(1);", "", "");
+            assertTrue(r instanceof Response.Err);
+            assertTrue(((Response.Err) r).message().contains("Script execution disabled"));
+        }
+    }
+}


### PR DESCRIPTION
Second installment of backlog #3 (service-layer coverage) — extends the stub-provider pattern to the last untested services. With #281, **every previously-untested service now has offline coverage**.

## Added (21 offline tests)
| Service | Tests |
|---|---|
| `ProgramScriptService` (~2.3K LOC) | required-param guards (close/switch/open/import), GUI-mode guard, and the **script-execution security gate** (run_script_inline off by default) |
| `ListingService` | functional `convert_number` (decimal/hex/empty — pure utility) + graceful degradation for program-scoped listers |
| `BinaryComparisonService` | functional `computeSimilarity` (range/NaN sanity, identical ≥ different, symmetry) via constructed `FunctionSignature`s |
| `MalwareSecurityService` | graceful "No program loaded" across all 5 analysis tools |
| `EmulationService` | graceful degradation for `emulate_function` |

## Verification
Full offline Java suite: **221 tests green** (149 before this whole effort began). All in the CI offline tier. Backlog #3 marked mostly-done (remaining = optional deeper happy-path coverage needing a live fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)