### PR TITLE
cleanup: log FastMCP-internals failures; clarify FILE_ROOT scope doc (#10, #13)

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1120,8 +1120,12 @@ def register_tools_from_schema(
     for name in _dynamic_tool_names:
         try:
             mcp._tool_manager._tools.pop(name, None)
-        except Exception:
-            pass
+        except Exception as e:
+            # Reaches into FastMCP internals; if its private structure changes this
+            # would silently leak tools across reloads. Log so the breakage is visible.
+            logger.warning(
+                "Failed to unregister dynamic tool %r via mcp._tool_manager._tools "
+                "(FastMCP internals may have changed): %s", name, e)
     _dynamic_tool_names.clear()
     _loaded_groups.clear()
 
@@ -1184,8 +1188,11 @@ def _unload_group(group_name: str) -> int:
         try:
             mcp._tool_manager._tools.pop(name, None)
             _dynamic_tool_names.remove(name)
-        except Exception:
-            pass
+        except Exception as e:
+            # See unregister note above: FastMCP-internals access, log on failure.
+            logger.warning(
+                "Failed to unload tool %r via mcp._tool_manager._tools "
+                "(FastMCP internals may have changed): %s", name, e)
 
     if to_remove:
         _loaded_groups.discard(group_name)

--- a/src/main/java/com/xebyte/core/SecurityConfig.java
+++ b/src/main/java/com/xebyte/core/SecurityConfig.java
@@ -26,12 +26,18 @@ import java.nio.file.Paths;
  *       Without an explicit opt-in they return 403. Scripts endpoints were
  *       always-on before v5.4.1; the flip to default-off is a deliberate
  *       breaking change in the security release.
- *   <li>{@code GHIDRA_MCP_FILE_ROOT} — if set to a directory path, every
- *       endpoint that takes a filesystem path ({@code /import_file},
- *       {@code /delete_file}, {@code /open_project}, etc.) canonicalizes the
- *       input and requires that the resolved path fall under this root.
- *       Prevents path traversal. When unset, paths are accepted as-is
- *       (pre-v5.4.1 behavior).
+ *   <li>{@code GHIDRA_MCP_FILE_ROOT} — if set to a directory path, endpoints that take a
+ *       real <em>filesystem</em> path canonicalize the input (via
+ *       {@link #resolveWithinFileRoot(String)}) and require that the resolved path fall
+ *       under this root, preventing path traversal. This applies to {@code /import_file}
+ *       (and the headless import path). When unset, paths are accepted as-is (pre-v5.4.1
+ *       behavior).
+ *       <p>Note: {@code /delete_file} and {@code /open_project} operate on Ghidra
+ *       <em>project domain</em> paths (e.g. {@code /Vanilla/1.00/D2Common.dll}), not
+ *       filesystem paths, so file-root canonicalization does not apply to them; their
+ *       analogous containment guard is project-folder scope
+ *       ({@link #isPathInProjectScope(String)}), which is enforced only when a project
+ *       scope is configured.</li>
  * </ul>
  *
  * Also enforces a bind-hardening rule at headless startup:


### PR DESCRIPTION
Two small, low-risk backlog cleanups.

**#10 — FastMCP private-internals access.** `bridge_mcp_ghidra.py` unregisters/unloads dynamic tools via `mcp._tool_manager._tools.pop(...)` wrapped in `except Exception: pass`. A FastMCP internal change would silently leak tools across group reloads. Both sites now `logger.warning(...)` on failure.

**#13 — SecurityConfig FILE_ROOT doc.** The class doc claimed `GHIDRA_MCP_FILE_ROOT` applies to `/import_file`, `/delete_file`, `/open_project`. Only `/import_file` takes a real filesystem path (guarded via `resolveWithinFileRoot`); `/delete_file`·`/open_project` take Ghidra *project domain* paths whose guard is project-folder scope (`isPathInProjectScope`). Reworded to be accurate.

Verified: bridge py-compiles (2206 lines, under the 2250 cap) + unit tests pass; Java compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)