### PR TITLE
fix(fun-doc): back off + don't park functions on ghidra_offline

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -7110,29 +7110,26 @@ def process_function(
                     "  Ghidra did not come online within 120s. Skipping function.",
                     flush=True,
                 )
-                func["last_result"] = "ghidra_offline"
-                func["last_processed"] = datetime.now().isoformat()
-                update_function_state(func_key, func)
+                # Environmental failure, not the function's fault — do NOT park it
+                # (no sticky last_result/last_processed) so the selector re-picks it
+                # once Ghidra recovers. Return the distinct "ghidra_offline" result so
+                # the worker loop backs off and waits instead of churning the queue.
                 bus_emit(
                     "function_complete",
                     {"key": func_key, "result": "ghidra_offline", "score": None},
                 )
                 return _finish(
-                    "failed",
-                    logged_result="ghidra_offline",
+                    "ghidra_offline",
                     reason="Ghidra did not come online within 120s",
                 )
         else:
-            func["last_result"] = "ghidra_offline"
-            func["last_processed"] = datetime.now().isoformat()
-            update_function_state(func_key, func)
+            # Environmental failure — do NOT park (see note above); leave re-pickable.
             bus_emit(
                 "function_complete",
                 {"key": func_key, "result": "ghidra_offline", "score": None},
             )
             return _finish(
-                "failed",
-                logged_result="ghidra_offline",
+                "ghidra_offline",
                 reason=f"server not reachable at {GHIDRA_URL}",
             )
 
@@ -7182,12 +7179,11 @@ def process_function(
     # recovery_pass_done.
     if data.get("ghidra_offline"):
         print(
-            f"  GHIDRA OFFLINE — cannot fetch function data. Skipping until Ghidra is reachable.",
+            f"  GHIDRA OFFLINE — cannot fetch function data. Will retry when Ghidra is reachable.",
             flush=True,
         )
-        func["last_result"] = "ghidra_offline"
-        func["last_processed"] = datetime.now().isoformat()
-        update_function_state(func_key, func)
+        # Environmental failure — do NOT park (see note above); leave re-pickable so
+        # the function is retried automatically once Ghidra recovers.
         bus_emit(
             "function_complete",
             {
@@ -7197,8 +7193,7 @@ def process_function(
             },
         )
         return _finish(
-            "failed",
-            logged_result="ghidra_offline",
+            "ghidra_offline",
             score_after=live_score,
             reason="cannot fetch function data",
         )
@@ -8925,7 +8920,7 @@ def main():
                         session["functions"].append(key)
                     elif result == "skipped":
                         session["skipped"] += 1
-                    elif result == "failed" or result == "blocked":
+                    elif result in ("failed", "blocked", "ghidra_offline"):
                         session["failed"] += 1
                     elif result == "partial":
                         session["partial"] += 1
@@ -8948,7 +8943,7 @@ def main():
                         session["functions"].append(key)
                     elif result == "skipped":
                         session["skipped"] += 1
-                    elif result == "failed" or result == "blocked":
+                    elif result in ("failed", "blocked", "ghidra_offline"):
                         session["failed"] += 1
                     elif result == "partial":
                         session["partial"] += 1
@@ -9007,7 +9002,7 @@ def main():
                 session["functions"].append(key)
             elif result == "skipped":
                 session["skipped"] += 1
-            elif result == "failed" or result == "blocked":
+            elif result in ("failed", "blocked", "ghidra_offline"):
                 session["failed"] += 1
             elif result == "partial":
                 session["partial"] += 1

--- a/fun-doc/web.py
+++ b/fun-doc/web.py
@@ -431,6 +431,7 @@ class WorkerManager:
                 _bump_handoff_counter,
                 get_auto_escalation_provider,
                 update_function_state,
+                check_ghidra_online,
             )
 
             worker["status"] = "running"
@@ -780,11 +781,40 @@ class WorkerManager:
                     if worker["stop_flag"].is_set():
                         break
                     continue  # retry with next function
+                elif result == "ghidra_offline":
+                    # Ghidra is unreachable. Don't churn the queue (pre-fix this spun ~100
+                    # runs/hour for hours and parked functions). Back off with capped
+                    # exponential delay while polling /check_connection, then resume — the
+                    # function was left re-pickable, so it is retried once Ghidra is back.
+                    streak = worker.get("_ghidra_offline_streak", 0) + 1
+                    worker["_ghidra_offline_streak"] = streak
+                    backoff = min(15 * (2 ** (streak - 1)), 300)  # 15,30,60,120,240,cap 300
+                    print(
+                        f"  Ghidra offline — waiting up to {backoff}s for recovery "
+                        f"(streak {streak})...",
+                        flush=True,
+                    )
+                    waited = 0
+                    while waited < backoff and not worker["stop_flag"].is_set():
+                        chunk = min(10, backoff - waited)
+                        worker["stop_flag"].wait(chunk)
+                        waited += chunk
+                        try:
+                            if check_ghidra_online():
+                                print("  Ghidra is back online — resuming.", flush=True)
+                                worker["_ghidra_offline_streak"] = 0
+                                break
+                        except Exception:
+                            pass
+                    if worker["stop_flag"].is_set():
+                        break
+                    continue  # leave function re-pickable; pick next once healthy
                 elif result in ("completed", "partial"):
                     worker["progress"]["completed"] += 1
                     session["completed"] += 1
                     session["functions"].append(key)
                     worker["_rate_limit_streak"] = 0  # reset on success
+                    worker["_ghidra_offline_streak"] = 0  # reset on success
                 elif result in ("skipped", "decompile_timeout", "library_code"):
                     worker["progress"]["skipped"] += 1
                     session["skipped"] += 1

--- a/tests/performance/test_ghidra_offline.py
+++ b/tests/performance/test_ghidra_offline.py
@@ -213,13 +213,15 @@ def test_check_ghidra_online_returns_true_when_reachable():
 
 
 # ---------------------------------------------------------------------------
-# Integration: process_function returns "failed" without calling the model
+# Integration: process_function returns "ghidra_offline" without calling the model
 # ---------------------------------------------------------------------------
 
 
 def test_process_function_skips_model_when_ghidra_offline(monkeypatch, tmp_path):
-    """process_function must return 'failed' and never reach the model when
-    Ghidra is not reachable, preserving last_result='ghidra_offline'."""
+    """process_function must return the distinct 'ghidra_offline' result and never
+    reach the model when Ghidra is unreachable. It must NOT park the function
+    (no sticky last_result) so the selector re-picks it once Ghidra recovers; the
+    distinct result lets the worker loop back off instead of churning the queue."""
     state = {"functions": {}}
     func = dict(_OFFLINE_FUNC)
     func_key = f"{func['program']}::{func['address']}"
@@ -244,9 +246,13 @@ def test_process_function_skips_model_when_ghidra_offline(monkeypatch, tmp_path)
     ):
         result = fun_doc.process_function(func_key, func, state)
 
-    assert result == "failed", f"Expected 'failed', got {result!r}"
+    assert result == "ghidra_offline", f"Expected 'ghidra_offline', got {result!r}"
     assert not model_invoked, "Model was invoked despite Ghidra being offline"
-    assert func.get("last_result") == "ghidra_offline"
+    # Must NOT park the function: leaving last_result unset keeps it re-pickable so
+    # it is retried automatically once Ghidra recovers (no manual refresh needed).
+    assert func.get("last_result") != "ghidra_offline", (
+        "function was parked as ghidra_offline; it should be left re-pickable"
+    )
     entry = json.loads(log_file.read_text(encoding="utf-8").splitlines()[0])
     assert entry["result"] == "ghidra_offline"
     assert entry["reason"] == f"server not reachable at {fun_doc.GHIDRA_URL}"


### PR DESCRIPTION
Fixes the dominant dashboard error class found in the logs: ~21% of runs were `ghidra_offline`, clustered into multi-hour windows (e.g. 07:00–11:00, ~100/hour) where workers **spun** instead of backing off, and **parked ~396 functions** out of the queue until a manual refresh.

## Root cause
- `process_function` returned `"failed"` on offline (no distinct signal), so the worker loop — which has exponential backoff for *rate-limiting* but **none for offline** — immediately grabbed the next function.
- Each offline run set a **sticky** `last_result="ghidra_offline"` + `last_processed`, parking the function despite the failure being environmental.

## Fix
- `process_function` now returns the distinct result **`ghidra_offline`** from all three offline paths and **no longer parks** the function (re-picked automatically once Ghidra recovers). Still logged + dashboard-evented.
- The `web.py` worker loop handles `ghidra_offline` with **capped exponential backoff (15→300s) that polls `/check_connection`** and resumes promptly — mirroring the rate-limit backoff. CLI tallies updated.

## Verification
`test_ghidra_offline` updated to the new contract (distinct result, not parked). Full offline perf suite **428 tests green**.

Note: this is operational resilience (not doc-quality), so the --mock benchmark doesn't exercise it; the worker/selector/state/offline perf tests are the relevant gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)