### PR TITLE
fix(stability): bound on-demand program cache (#4 root cause) + tighten provider timeout

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -4661,14 +4661,20 @@ def _wrap_result(result):
 
 
 def _provider_timeout_seconds(provider, complexity_tier=None):
+    # Base 300s (was 900s): a hung/slow provider call previously tied up a worker for
+    # 15-25 min, which surfaced as the bridge_counter_stall "workers active, no progress"
+    # pattern. 5 min is ample for a normal documentation pass; genuinely large functions
+    # still get the extra budget below (complex +300 -> 600s, massive +600 -> 900s).
+    # Override per-provider via FUNDOC_<PROVIDER>_TIMEOUT_SECS or globally via
+    # FUNDOC_PROVIDER_TIMEOUT_SECS.
     env_key = f"FUNDOC_{str(provider or AI_PROVIDER).upper()}_TIMEOUT_SECS"
     raw_timeout = os.environ.get(env_key) or os.environ.get(
-        "FUNDOC_PROVIDER_TIMEOUT_SECS", "900"
+        "FUNDOC_PROVIDER_TIMEOUT_SECS", "300"
     )
     try:
         timeout_secs = max(60, int(raw_timeout))
     except (TypeError, ValueError):
-        timeout_secs = 900
+        timeout_secs = 300
 
     if complexity_tier == "massive":
         timeout_secs += 600

--- a/src/main/java/com/xebyte/core/FrontEndProgramProvider.java
+++ b/src/main/java/com/xebyte/core/FrontEndProgramProvider.java
@@ -44,9 +44,98 @@ public class FrontEndProgramProvider implements ProgramProvider {
     private final PluginTool tool;
     private final Map<String, Program> openPrograms = new ConcurrentHashMap<>();
     private final Map<String, String> pathToName = new ConcurrentHashMap<>(); // project path -> cache key
+    // Per-cache-key last-access time (System.nanoTime). Drives LRU eviction so the
+    // on-demand program cache stays bounded — without a cap it accumulated a consumer
+    // reference per distinct program and, when a long run documented dozens of DLLs,
+    // held them all in memory until Ghidra ran out and dropped offline for hours.
+    private final Map<String, Long> lastAccessNanos = new ConcurrentHashMap<>();
     private volatile Program currentProgram;
     private final TaskMonitor monitor;
     private final Object consumer; // DomainObject consumer for release tracking
+
+    /**
+     * Max on-demand programs held open at once. Above this, the least-recently-accessed
+     * cached program is released (the actively-used program stays recent and is never the
+     * victim). CodeBrowser-open programs are resolved before the cache and never counted
+     * here. Tunable via GHIDRA_MCP_MAX_CACHED_PROGRAMS; ~5-8 is safe (20+ crashes Ghidra).
+     */
+    private static final int MAX_CACHED_PROGRAMS = resolveMaxCachedPrograms();
+
+    private static int resolveMaxCachedPrograms() {
+        String raw = System.getenv("GHIDRA_MCP_MAX_CACHED_PROGRAMS");
+        if (raw != null && !raw.isBlank()) {
+            try {
+                return Math.max(2, Integer.parseInt(raw.trim()));
+            } catch (NumberFormatException ignored) {
+                // fall through to default
+            }
+        }
+        return 8;
+    }
+
+    /** Record an access so an in-use program stays out of the LRU eviction set. */
+    private void touch(String cacheKey) {
+        if (cacheKey != null) {
+            lastAccessNanos.put(cacheKey, System.nanoTime());
+        }
+    }
+
+    /**
+     * Pick the least-recently-accessed cache key whose Program is not protected, or null
+     * when nothing is evictable. Pure (no side effects) so it can be unit-tested offline.
+     */
+    public static String pickLruVictim(Map<String, Program> programs,
+                                       Map<String, Long> accessNanos,
+                                       java.util.Set<Program> protectedPrograms) {
+        String victim = null;
+        long oldest = Long.MAX_VALUE;
+        for (Map.Entry<String, Program> e : programs.entrySet()) {
+            if (protectedPrograms.contains(e.getValue())) {
+                continue;
+            }
+            long t = accessNanos.getOrDefault(e.getKey(), 0L);
+            if (t < oldest) {
+                oldest = t;
+                victim = e.getKey();
+            }
+        }
+        return victim;
+    }
+
+    /**
+     * Release least-recently-accessed cached programs until the cache is at or below
+     * {@link #MAX_CACHED_PROGRAMS}. Never evicts the just-opened program or the current
+     * program. Releasing our consumer reference frees the program's memory when no
+     * CodeBrowser holds it (the common dashboard case); if a CodeBrowser does, the release
+     * is a harmless ref-count decrement.
+     */
+    private void evictExcessPrograms(Program justOpened) {
+        java.util.Set<Program> protectedPrograms = new java.util.HashSet<>();
+        if (justOpened != null) protectedPrograms.add(justOpened);
+        Program cur = currentProgram;
+        if (cur != null) protectedPrograms.add(cur);
+
+        while (openPrograms.size() > MAX_CACHED_PROGRAMS) {
+            String victimKey = pickLruVictim(openPrograms, lastAccessNanos, protectedPrograms);
+            if (victimKey == null) {
+                break; // everything left is protected
+            }
+            Program victim = openPrograms.remove(victimKey);
+            lastAccessNanos.remove(victimKey);
+            pathToName.values().removeIf(v -> v.equals(victimKey));
+            if (victim == null) {
+                continue;
+            }
+            try {
+                victim.release(consumer);
+                Msg.info(this, "Evicted idle cached program (cap " + MAX_CACHED_PROGRAMS
+                        + ", " + openPrograms.size() + " remain): " + victimKey);
+            } catch (Exception ex) {
+                Msg.warn(this, "Error releasing evicted program " + victimKey + ": "
+                        + ex.getMessage());
+            }
+        }
+    }
 
     /**
      * Create a FrontEndProgramProvider for the given tool.
@@ -151,6 +240,7 @@ public class FrontEndProgramProvider implements ProgramProvider {
             if (cacheKey != null) {
                 Program cached = openPrograms.get(cacheKey);
                 if (cached != null && !cached.isClosed()) {
+                    touch(cacheKey);
                     return cached;
                 }
             }
@@ -160,6 +250,7 @@ public class FrontEndProgramProvider implements ProgramProvider {
         if (!searchName.startsWith("/")) {
             Program cached = openPrograms.get(searchName);
             if (cached != null && !cached.isClosed()) {
+                touch(searchName);
                 return cached;
             }
             // Case-insensitive cache lookup
@@ -167,6 +258,7 @@ public class FrontEndProgramProvider implements ProgramProvider {
                 if (entry.getKey().equalsIgnoreCase(searchName)) {
                     Program p = entry.getValue();
                     if (p != null && !p.isClosed()) {
+                        touch(entry.getKey());
                         return p;
                     }
                 }
@@ -311,6 +403,8 @@ public class FrontEndProgramProvider implements ProgramProvider {
             if (currentProgram == null) {
                 currentProgram = program;
             }
+            touch(cacheKey);
+            evictExcessPrograms(program);
             Msg.info(this, "Opened program from project: " + program.getName() +
                 " (" + projectPath + ")");
             return program;
@@ -338,6 +432,8 @@ public class FrontEndProgramProvider implements ProgramProvider {
                 if (currentProgram == null) {
                     currentProgram = program;
                 }
+                touch(cacheKey);
+                evictExcessPrograms(program);
                 Msg.info(this, "Opened program read-only: " + program.getName());
                 return program;
             } catch (Exception e2) {
@@ -427,6 +523,7 @@ public class FrontEndProgramProvider implements ProgramProvider {
         }
         openPrograms.clear();
         pathToName.clear();
+        lastAccessNanos.clear();
         currentProgram = null;
     }
 
@@ -461,6 +558,7 @@ public class FrontEndProgramProvider implements ProgramProvider {
         boolean released = false;
         for (String key : new ArrayList<>(keys)) {
             Program program = openPrograms.remove(key);
+            lastAccessNanos.remove(key);
             if (program == null) {
                 continue;
             }

--- a/src/test/java/com/xebyte/offline/FrontEndProgramProviderEvictionTest.java
+++ b/src/test/java/com/xebyte/offline/FrontEndProgramProviderEvictionTest.java
@@ -1,0 +1,92 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.FrontEndProgramProvider;
+import ghidra.program.model.listing.Program;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the LRU victim-selection that bounds FrontEndProgramProvider's on-demand
+ * program cache (the unbounded cache previously held a consumer reference per documented
+ * program and OOM-crashed Ghidra on long multi-binary runs). pickLruVictim is pure, so the
+ * eviction decision is verified offline without a live Ghidra.
+ */
+public class FrontEndProgramProviderEvictionTest {
+
+    private static Program prog() {
+        return mock(Program.class);
+    }
+
+    @Test
+    public void picksLeastRecentlyAccessed() {
+        Program a = prog(), b = prog(), c = prog();
+        Map<String, Program> programs = new LinkedHashMap<>();
+        programs.put("a", a);
+        programs.put("b", b);
+        programs.put("c", c);
+        Map<String, Long> access = new LinkedHashMap<>();
+        access.put("a", 300L);
+        access.put("b", 100L); // oldest
+        access.put("c", 200L);
+
+        assertEquals("b", FrontEndProgramProvider.pickLruVictim(programs, access, new HashSet<>()));
+    }
+
+    @Test
+    public void neverPicksProtectedProgram() {
+        Program a = prog(), b = prog();
+        Map<String, Program> programs = new LinkedHashMap<>();
+        programs.put("a", a);
+        programs.put("b", b);
+        Map<String, Long> access = new LinkedHashMap<>();
+        access.put("a", 100L); // oldest, but protected
+        access.put("b", 200L);
+        Set<Program> protectedProgs = new HashSet<>();
+        protectedProgs.add(a);
+
+        assertEquals("b", FrontEndProgramProvider.pickLruVictim(programs, access, protectedProgs));
+    }
+
+    @Test
+    public void returnsNullWhenAllProtected() {
+        Program a = prog(), b = prog();
+        Map<String, Program> programs = new LinkedHashMap<>();
+        programs.put("a", a);
+        programs.put("b", b);
+        Map<String, Long> access = new LinkedHashMap<>();
+        access.put("a", 100L);
+        access.put("b", 200L);
+        Set<Program> protectedProgs = new HashSet<>();
+        protectedProgs.add(a);
+        protectedProgs.add(b);
+
+        assertNull(FrontEndProgramProvider.pickLruVictim(programs, access, protectedProgs));
+    }
+
+    @Test
+    public void missingAccessTimeIsTreatedAsOldest() {
+        // A program with no recorded access (never touched) is the most evictable.
+        Program a = prog(), b = prog();
+        Map<String, Program> programs = new LinkedHashMap<>();
+        programs.put("a", a);
+        programs.put("b", b);
+        Map<String, Long> access = new LinkedHashMap<>();
+        access.put("a", 500L);
+        // "b" has no access entry -> defaults to 0 -> oldest
+
+        assertEquals("b", FrontEndProgramProvider.pickLruVictim(programs, access, new HashSet<>()));
+    }
+
+    @Test
+    public void emptyCacheReturnsNull() {
+        assertNull(FrontEndProgramProvider.pickLruVictim(
+                new LinkedHashMap<>(), new LinkedHashMap<>(), new HashSet<>()));
+    }
+}


### PR DESCRIPTION
Addresses the root cause behind the dashboard's recurring multi-hour Ghidra-offline storms, plus the provider-latency lulls.

## #4 root cause — unbounded program cache (the real fix)
`FrontEndProgramProvider.openPrograms` was **unbounded**. Every program documented via the `program` param is opened on-demand — acquiring a **consumer reference** that holds it in memory — and was only released on a same-key overwrite. A long run across dozens of DLLs held them **all** open → Ghidra OOM → offline for hours (~400 wasted runs this morning, the storm my #284 only absorbed gracefully).

**Fix:** LRU cap (`GHIDRA_MCP_MAX_CACHED_PROGRAMS`, default **8**). Over the cap, the least-recently-accessed cached program is released. The actively-documented program is `touch`ed every request → stays MRU → never evicted; just-opened + current are protected; **CodeBrowser-open programs are resolved before the cache and never evicted** (your GUI session is untouched). Victim selection (`pickLruVictim`) is pure with 5 offline unit tests.

## Provider timeout
`FUNDOC_PROVIDER_TIMEOUT_SECS` base 900 → **300s**. A hung/slow call previously tied up a worker 15-25 min (the stall surface we observed); large functions still get +300/+600.

## Verification
`mvn compile` + **226 offline Java tests** green; `fun_doc` py-compiles.
⚠️ The cache cap is a plugin change — needs a JAR **deploy** to take effect and live verification under the dashboard's multi-program load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)