### PR TITLE
release: v5.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.12.0
+- **Version**: 5.13.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
 - **Key feature**: 248 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ Complete version history for the Ghidra MCP Server project.
 
 ## Unreleased
 
+---
+
+## v5.13.0 - 2026-06-08 (audit hardening: correctness, resilience, test coverage)
+
+Minor release packaging a large project-audit hardening pass — service-layer threading and
+transaction correctness, clearer address/variable error handling, a bounded on-demand program
+cache that ends the long-run Ghidra out-of-memory stalls, graceful offline/provider handling in
+the fun-doc dashboard, CI gates, and ~77 new offline tests. ~248 tools.
+
+### Fixed
+
+- **Service-layer threading/transactions** (#276): `DataTypeService` and `AnalysisService`
+  mutations now route through the injected `ThreadingStrategy` (EDT marshaling in GUI mode, the
+  global write lock in headless) instead of hand-rolled `invokeAndWait` + `startTransaction`. Fixes
+  off-EDT GUI writes (`create_enum`, `apply_data_type`, `run_analysis`) and the headless
+  write-lock bypass.
+- **`recreate_struct` no longer loses data on partial failure** (#276): it captures a restorable
+  copy of the original type before the destructive delete and re-adds it if the re-create fails.
+- **Address parsing** (#278): a multi-address string (`addr1;addr2;...`) in a single `address`
+  field now fails fast with a clear hint pointing at the comment-list arrays, instead of the old
+  misleading "try `<space>:<hex>`" suggestion that produced a contradictory "Unknown address
+  space" loop. A bad offset under a valid space now reports the offset, not the space.
+- **`set_local_variable_type`** (#279): when a decompiler default name (`uVarN`/`puVarN`) is
+  missing and none remain, the error explains the variables were renamed / are register-resident
+  and points to `set_variables`, instead of repeating an unrecoverable failure.
+- **fun-doc resilience**: workers back off and poll for recovery on `ghidra_offline` instead of
+  spinning the queue and parking functions (#284); the on-demand program cache is now LRU-bounded
+  (`GHIDRA_MCP_MAX_CACHED_PROGRAMS`, default 8) so long multi-binary runs no longer exhaust
+  Ghidra's memory and drop it offline for hours (#286).
+- **Security hardening** (#276): GUI `/import_file` now enforces `GHIDRA_MCP_FILE_ROOT`;
+  non-idempotent bridge POSTs are no longer blindly retried (double-apply safety); `provider_pause`
+  writes use an interprocess lock + Windows `PermissionError` retry; the dashboard's SocketIO CORS
+  is scoped to the localhost origin instead of `*`.
+- **Catalog accuracy** (#280): removed 4 stale `tests/endpoints.json` entries (old names of
+  renamed tools) and corrected the advertised tool count (252 → 248).
+
+### Changed
+
+- **fun-doc provider timeout** default lowered 900s → 300s (#286); a hung/slow provider call now
+  frees a worker in 5 min instead of 15–25 (complex/massive functions still get +300/+600).
+- **fun-doc `ghidra_http.jsonl`** logs errors/timeouts only by default (#285), with
+  `FUN_DOC_HTTP_LOG_VERBOSE=1` to record every call — cutting the ~1 GB success-event bulk.
+- **pytest coverage** now measures the real Python (`bridge_mcp_ghidra` / `tools` / `debugger`)
+  instead of the Java-only `src/` tree.
+
+### Added
+
+- **~77 offline tests**: validation + graceful-degradation suites for every previously-untested
+  service (#281, #282), address-parser regressions, the variable-type recovery hint, the
+  program-cache eviction logic, and a behavioral `set_function_this_type` integration test.
+- **CI**: a `python-offline-regression` job runs the fun-doc offline tier on PRs; the
+  release/pre-release paths are gated on offline tests before building; `ServiceUtilsAddressTest`
+  moved into the offline tier; a reverse catalog-parity check catches orphaned `endpoints.json`
+  entries.
+- **Docs/tooling**: a Ghidra 12.1 deprecation backlog, a structural/tech-debt backlog, and a
+  server health-check script.
+
+The following entries were already on `main` since 5.12.0 and ship in this release:
+
 ### Security
 
 - **`/load_program` now enforces the `GHIDRA_MCP_FILE_ROOT` allow-list.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 248 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.12.0 | **Java**: 21 LTS | **Ghidra**: 12.1
+- **Package**: `com.xebyte` | **Version**: 5.13.0 | **Java**: 21 LTS | **Ghidra**: 12.1
 
 ## Boil the ocean
 

--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.12.0
+# Connection OK - GhidraMCP Headless Server v5.13.0
 ```
 
 ### Headless API Workflow
@@ -1010,7 +1010,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.12.0 |
+| **Version** | 5.13.0 |
 | **MCP Tools** | 248 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,7 +9,7 @@ For the release preparation runbook, see
 
 ## Current Releases
 
-### v5.12.0 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
+### v5.13.0 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
 
 Minor release. Two new endpoints filed/scoped by community feedback,
 plus a quiet headless parity fix that surfaced while writing the

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.12.0</version>
+    <version>5.13.0</version>
     <name>Ghidra MCP Server</name>
     <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. Provides MCP-based tooling and automation for reverse engineering workflows: convention-enforcing rename/type/comment endpoints, batch operations, P-code emulation, live debugger integration, headless server, and Ghidra Server multi-version support.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -106,7 +106,7 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.12.0"; // Default fallback
+    private static String VERSION = "5.13.0"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -54,7 +54,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.12.0-headless";
+    private static final String VERSION = "5.13.0-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -42,7 +42,7 @@ import ghidra.app.cmd.disassemble.DisassembleCommand;
  */
 public class HeadlessEndpointHandler {
 
-    private static final String VERSION = "5.12.0-headless";
+    private static final String VERSION = "5.13.0-headless";
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
     private final TaskMonitor monitor;

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.12.0
+Plugin-Version: 5.13.0
 Plugin-Author: Ben Ethington
 Plugin-Description: GhidraMCP - HTTP server plugin with 248 MCP tools for reverse engineering automation

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.12.0",
+  "version": "5.13.0",
   "description": "GhidraMCP REST API Endpoint Specification",
   "total_endpoints": 248,
   "categories": {


### PR DESCRIPTION
Cuts **v5.13.0**, packaging the project-audit hardening pass merged since 5.12.0 (#276–#286).

## Version
Bumped 5.12.0 → 5.13.0 across all maintained references (pom, MANIFEST, plugin/headless version strings, endpoints.json, README, CLAUDE.md, AGENTS.md, docs). `verify-version` passes.

## Highlights (full detail in CHANGELOG)
- **Correctness:** service-layer threading/transactions (#276); `recreate_struct` data-loss guard; address/variable error UX (#278/#279).
- **Resilience:** LRU-bounded program cache ends the long-run Ghidra OOM offline-storms (#286); graceful `ghidra_offline` backoff (#284); provider timeout 900→300s; error-only HTTP logging (#285).
- **Quality:** catalog accuracy + count 252→248 (#280); ~77 new offline tests (#281/#282); CI offline-regression job + release test gate; reverse catalog-parity check.
- **Security:** GUI `/import_file` FILE_ROOT enforcement, safe POST retry, provider_pause locking, localhost-scoped SocketIO CORS.

## Release floor (verified)
`verify-version` OK · `mvn build` OK · 226 offline Java tests + Python unit tests green · `GhidraMCP-5.13.0.zip` built.

Merging this, then tagging `v5.13.0` on main triggers the release workflow (offline test gate → build → publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)