### PR TITLE
fix(extension): empty Module.manifest to stop the launch-time manifest error (#265)

### DIFF
--- a/src/main/resources/Module.manifest
+++ b/src/main/resources/Module.manifest
@@ -1,2 +1,0 @@
-GHIDRA_MODULE_NAME=GhidraMCP
-GHIDRA_MODULE_DESC=An HTTP server plugin for Ghidra


### PR DESCRIPTION
Fixes #265.

The shipped `Module.manifest` used `GHIDRA_MODULE_NAME=` / `GHIDRA_MODULE_DESC=` lines, which aren't valid Ghidra module-manifest syntax — so Ghidra logged `Module manifest file error on line 2 of file: .../Extensions/GhidraMCP/Module.manifest` on **every launch**.

Ghidra's own modules and the official **Skeleton extension template** ship an **empty** `Module.manifest` (valid directives are colon-separated like `MODULE FILE LICENSE: <path> <license>`, none of which a simple HTTP-server extension needs). The extension name/description/version already come from `extension.properties`, so the content was redundant *and* malformed.

**Fix:** emptied `Module.manifest` to match the Skeleton. Verified the packaged `GhidraMCP/Module.manifest` is now 0 bytes; `mvn package` OK. The line-2 error disappears on the next install/launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)