### PR TITLE
feat(function): /list_class_members — enumerate a C++ class's methods (#275)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 - **Repo**: https://github.com/bethington/ghidra-mcp
 - **Version**: 5.13.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
-- **Key feature**: 248 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
+- **Key feature**: 249 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 
 ## Directory Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MCP server bridging Ghidra reverse engineering with AI tools. 248 MCP tools for binary analysis.
+MCP server bridging Ghidra reverse engineering with AI tools. 249 MCP tools for binary analysis.
 
 - **Package**: `com.xebyte` | **Version**: 5.13.0 | **Java**: 21 LTS | **Ghidra**: 12.1
 
@@ -32,7 +32,7 @@ Services use constructor injection: `ProgramProvider` + `ThreadingStrategy`.
 
 Do not try to keep the full tool list in this file.
 
-- **Authoritative repo snapshot**: `tests/endpoints.json` (248 endpoints, categories, descriptions)
+- **Authoritative repo snapshot**: `tests/endpoints.json` (249 endpoints, categories, descriptions)
 - **Authoritative runtime schema**: `/mcp/schema` from the running server
 - **Usage patterns / operator guide**: `docs/prompts/TOOL_USAGE_GUIDE.md`
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 >
 > If Ghidra MCP saves you time, consider [sponsoring the project](https://github.com/sponsors/bethington). One-time and recurring support both help fund compatibility updates, production hardening, docs, and new tooling.
 
-A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **248 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
+A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **249 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
 
 ## Why Ghidra MCP?
 
 Most Ghidra MCP implementations give you a handful of read-only tools and call it a day. This project is different — it was built by a reverse engineer who uses it daily on real binaries, not as a demo.
 
-- **248 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
+- **249 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
 - **Battle-tested AI workflows** — Proven documentation workflows (V5) refined across hundreds of functions. Includes step-by-step prompts, Hungarian notation reference, batch processing guides, and orphaned code discovery.
 - **Production-grade reliability** — Atomic transactions, batch operations (93% API call reduction), configurable timeouts, and graceful error handling. No silent failures.
 - **Cross-binary documentation transfer** — SHA-256 function hash matching propagates documentation across binary versions automatically. Document once, apply everywhere.
@@ -56,7 +56,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 ### Core MCP Integration
 - **Full MCP Compatibility** — Complete implementation of Model Context Protocol
-- **248 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
+- **249 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
 - **Production-Ready Reliability** — Atomic transactions, batch operations, configurable timeouts
 - **Real-time Analysis** — Live integration with Ghidra's analysis engine
 
@@ -508,7 +508,7 @@ python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1_PUBLIC"
 
 ## 📊 Production Performance
 
-- **MCP Tools**: 248 tools fully implemented
+- **MCP Tools**: 249 tools fully implemented
 - **Speed**: Sub-second response for most operations
 - **Efficiency**: 93% reduction in API calls via batch operations
 - **Reliability**: Atomic transactions with all-or-nothing semantics
@@ -1011,7 +1011,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 | Metric | Value |
 |--------|-------|
 | **Version** | 5.13.0 |
-| **MCP Tools** | 248 fully implemented |
+| **MCP Tools** | 249 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |
 | **Compilation** | ✅ 100% success |

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -1669,6 +1669,90 @@ public class FunctionService {
         return ServiceUtils.resolveDataType(dtm, normalized);
     }
 
+    @McpTool(path = "/list_class_members", method = "GET",
+            description = "List the member functions of a C++ class. A function counts as a member if it lives in the class's namespace (e.g. after set_function_this_type re-parents it) OR its implicit 'this' parameter types as '<class> *'. Each result reports how it matched (namespace / this_type / both). Replaces the manual 'search __thiscall functions then read each signature' workflow.",
+            category = "function")
+    public Response listClassMembers(
+            @Param(value = "class_name",
+                   description = "Class / struct name, e.g. 'UnitAny'.") String className,
+            @Param(value = "offset", defaultValue = "0") int offset,
+            @Param(value = "limit", defaultValue = "200") int limit,
+            @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
+        if (className == null || className.trim().isEmpty()) {
+            return Response.err("class_name is required");
+        }
+        final String cls = className.trim();
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        try {
+            return threadingStrategy.executeRead(() -> {
+                SymbolTable st = program.getSymbolTable();
+                Namespace global = program.getGlobalNamespace();
+                Namespace classNs = st.getNamespace(cls, global);
+                boolean isGhidraClass = classNs instanceof GhidraClass;
+
+                List<Map<String, Object>> members = new ArrayList<>();
+                for (Function func : program.getFunctionManager().getFunctions(true)) {
+                    // (1) namespace membership: function lives under a non-global namespace
+                    //     named after the class (GhidraClass or plain namespace).
+                    Namespace parent = func.getParentNamespace();
+                    boolean byNamespace = parent != null && !parent.isGlobal()
+                            && cls.equals(parent.getName());
+
+                    // (2) this-type membership: the implicit 'this' points at the class struct.
+                    boolean byThis = false;
+                    String thisTypeName = null;
+                    Parameter thisParam = findAutoThisParameter(func);
+                    if (thisParam != null) {
+                        DataType dt = thisParam.getDataType();
+                        if (dt instanceof Pointer) {
+                            DataType base = ((Pointer) dt).getDataType();
+                            if (base != null && cls.equals(base.getName())) {
+                                byThis = true;
+                                thisTypeName = dt.getDisplayName();
+                            }
+                        }
+                    }
+
+                    if (byNamespace || byThis) {
+                        Map<String, Object> m = new LinkedHashMap<>();
+                        m.put("address", func.getEntryPoint().toString(false));
+                        m.put("name", func.getName(true));
+                        m.put("matched_by", (byNamespace && byThis) ? "both"
+                                : byNamespace ? "namespace" : "this_type");
+                        if (thisTypeName != null) m.put("this_type", thisTypeName);
+                        members.add(m);
+                    }
+                }
+
+                int total = members.size();
+                int from = Math.max(0, offset);
+                int pageLimit = Math.max(1, limit);
+                int to = Math.min(total, from + pageLimit);
+                List<Map<String, Object>> page = from < to
+                        ? new ArrayList<>(members.subList(from, to)) : new ArrayList<>();
+
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put("class_name", cls);
+                result.put("class_namespace_exists", isGhidraClass);
+                result.put("total_members", total);
+                result.put("offset", from);
+                result.put("limit", pageLimit);
+                result.put("members", page);
+                if (total == 0) {
+                    result.put("note", "No members found. A function matches if it is in the '" + cls
+                            + "' namespace or its 'this' parameter types as '" + cls + " *'. Create the "
+                            + "struct (create_struct) and associate functions with set_function_this_type.");
+                }
+                return Response.ok(result);
+            });
+        } catch (Exception e) {
+            return Response.err("list_class_members failed: " + e.getMessage());
+        }
+    }
+
     /**
      * Find a high symbol by name in the given high function.
      */

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
 Plugin-Version: 5.13.0
 Plugin-Author: Ben Ethington
-Plugin-Description: GhidraMCP - HTTP server plugin with 248 MCP tools for reverse engineering automation
+Plugin-Description: GhidraMCP - HTTP server plugin with 249 MCP tools for reverse engineering automation

--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -1,5 +1,5 @@
 name=GhidraMCP
-description=A plugin that runs an embedded HTTP server to expose program data. Provides 248 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
+description=A plugin that runs an embedded HTTP server to expose program data. Provides 249 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
 author=Ben Ethington
 createdOn=2025-03-22
 version=${ghidra.version}

--- a/src/test/java/com/xebyte/offline/FunctionServiceClassMembersTest.java
+++ b/src/test/java/com/xebyte/offline/FunctionServiceClassMembersTest.java
@@ -1,0 +1,40 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.FunctionService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Validation + graceful-degradation coverage for /list_class_members (the new C++
+ * class-member listing tool, issue #275). Runs offline with a stub provider.
+ */
+public class FunctionServiceClassMembersTest extends TestCase {
+
+    private FunctionService functions;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        functions = new FunctionService(ServiceFactory.stubProvider(), ts);
+    }
+
+    public void testRequiresClassName() {
+        Response r = functions.listClassMembers("", 0, 200, "");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("class_name is required"));
+    }
+
+    public void testRequiresClassNameWhenWhitespace() {
+        Response r = functions.listClassMembers("   ", 0, 200, "");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("class_name is required"));
+    }
+
+    public void testDegradesGracefullyWithNoProgram() {
+        Response r = functions.listClassMembers("UnitAny", 0, 200, "");
+        assertNotNull(r);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+}

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.13.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 248,
+  "total_endpoints": 249,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -1553,6 +1553,18 @@
         "program"
       ],
       "description": "List available calling conventions"
+    },
+    {
+      "path": "/list_class_members",
+      "method": "GET",
+      "category": "function",
+      "params": [
+        "class_name",
+        "offset",
+        "limit",
+        "program"
+      ],
+      "description": "List the member functions of a C++ class. A function counts as a member if it lives in the class's namespace (e.g. after set_function_this_type re-parents it) OR its implicit 'this' parameter types as '<class> *'. Each result reports how it matched (namespace / this_type / both). Replaces the manual 'search __thiscall functions then read each signature' workflow."
     },
     {
       "path": "/list_classes",


### PR DESCRIPTION
Closes #275.

Previously, listing a class's member functions meant a manual workflow: search `__thiscall` named functions, then read each signature to check the `this` type. This adds a tool that does it directly.

## `/list_class_members`
A function counts as a member if **either**:
- it lives in the class's namespace (e.g. after `set_function_this_type` re-parents it into the `GhidraClass`), or
- its implicit `this` parameter types as `<class> *`.

Each result reports `matched_by` (`namespace` / `this_type` / `both`), plus address, full name, and the resolved `this_type`. Read-only, paginated (`offset`/`limit`), reuses the `findAutoThisParameter` helper from #262.

## Catalog / tests
- Regenerated `endpoints.json` (249 endpoints) and restored `/open_project`'s hand-authored params that the regenerator dropped; tool count 248 → 249.
- `FunctionServiceClassMembersTest` (required-arg + graceful-degradation). Full offline Java suite **229 green**.

Live verification happens on the next deploy (the running plugin predates this tool); the logic is straightforward and offline-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)