### PR TITLE
release: v5.13.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.13.0
+- **Version**: 5.13.1
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
 - **Key feature**: 249 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## v5.13.1 - 2026-06-08 (patch: launch-noise fix + class-member listing)
+
+Patch release.
+
+### Fixed
+
+- **Module.manifest launch error** (#265): the shipped `Module.manifest` used
+  `GHIDRA_MODULE_NAME=` / `GHIDRA_MODULE_DESC=` lines, which aren't valid Ghidra
+  module-manifest syntax, so Ghidra logged `Module manifest file error on line 2 of file:
+  .../Extensions/GhidraMCP/Module.manifest` on every launch. Emptied it to match Ghidra's
+  Skeleton extension template (the name/description/version already come from
+  `extension.properties`).
+
+### Added
+
+- **`/list_class_members`** (#275): list the member functions of a C++ class. A function
+  counts as a member if it lives in the class's namespace (e.g. after `set_function_this_type`
+  re-parents it) or its implicit `this` parameter types as `<class> *`; each result reports how
+  it matched (`namespace` / `this_type` / `both`). Replaces the manual "search `__thiscall`
+  functions, then read each signature" workflow. 249 tools.
+
+---
+
 ## v5.13.0 - 2026-06-08 (audit hardening: correctness, resilience, test coverage)
 
 Minor release packaging a large project-audit hardening pass — service-layer threading and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 249 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.13.0 | **Java**: 21 LTS | **Ghidra**: 12.1
+- **Package**: `com.xebyte` | **Version**: 5.13.1 | **Java**: 21 LTS | **Ghidra**: 12.1
 
 ## Boil the ocean
 

--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.13.0
+# Connection OK - GhidraMCP Headless Server v5.13.1
 ```
 
 ### Headless API Workflow
@@ -1010,7 +1010,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.13.0 |
+| **Version** | 5.13.1 |
 | **MCP Tools** | 249 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,7 +9,7 @@ For the release preparation runbook, see
 
 ## Current Releases
 
-### v5.13.0 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
+### v5.13.1 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
 
 Minor release. Two new endpoints filed/scoped by community feedback,
 plus a quiet headless parity fix that surfaced while writing the

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.13.0</version>
+    <version>5.13.1</version>
     <name>Ghidra MCP Server</name>
     <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. Provides MCP-based tooling and automation for reverse engineering workflows: convention-enforcing rename/type/comment endpoints, batch operations, P-code emulation, live debugger integration, headless server, and Ghidra Server multi-version support.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -106,7 +106,7 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.13.0"; // Default fallback
+    private static String VERSION = "5.13.1"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -54,7 +54,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.13.0-headless";
+    private static final String VERSION = "5.13.1-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -42,7 +42,7 @@ import ghidra.app.cmd.disassemble.DisassembleCommand;
  */
 public class HeadlessEndpointHandler {
 
-    private static final String VERSION = "5.13.0-headless";
+    private static final String VERSION = "5.13.1-headless";
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
     private final TaskMonitor monitor;

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.13.0
+Plugin-Version: 5.13.1
 Plugin-Author: Ben Ethington
 Plugin-Description: GhidraMCP - HTTP server plugin with 249 MCP tools for reverse engineering automation

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.13.0",
+  "version": "5.13.1",
   "description": "GhidraMCP REST API Endpoint Specification",
   "total_endpoints": 249,
   "categories": {


### PR DESCRIPTION
Patch release on v5.13.0.

- **#265** — empty `Module.manifest` (the invalid `GHIDRA_MODULE_*=` lines caused a `Module manifest file error on line 2` on every launch).
- **#275** — new `/list_class_members` tool to enumerate a C++ class's member functions (matched by class namespace or `this`-type).

**Floor (verified):** `verify-version` OK · `mvn build` OK · 229 offline Java + Python unit tests green · `GhidraMCP-5.13.1.zip` built.

Merging then tagging `v5.13.1` triggers the release workflow (offline gate → build → publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)