### PR TITLE
fix(fun-doc): stop ghidra_offline run-log spam + reclaim 1 GB stale HTTP logs

### DIFF
--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -7026,6 +7026,30 @@ def process_function(
         if run_log_written:
             return
         run_log_written = True
+        # Ghidra being offline is an infrastructure outage, not a documentation
+        # outcome. During a multi-hour outage the worker re-picks the same
+        # function on every backoff cycle (by design — it must stay re-pickable,
+        # not parked), so writing a full ~40-field run row per attempt floods
+        # runs.jsonl with hundreds of identical rows per function (one 2026-06-07
+        # outage wrote 210 rows for a single address) and spams the dashboard run
+        # feed. Record a single lightweight event for the audit trail and skip the
+        # row. The worker's own check_ghidra_online() backoff drives recovery, and
+        # the function_complete bus event (emitted at the call site) keeps the
+        # dashboard's offline state in sync.
+        if logged_result == "ghidra_offline":
+            try:
+                from event_log import log_event
+
+                log_event(
+                    "ghidra.offline",
+                    run_id=run_id,
+                    program=program,
+                    address=address,
+                    reason=reason,
+                )
+            except Exception:
+                pass
+            return
         final_score = new_score if score_after is None else score_after
         score_delta = (
             (final_score - live_score)

--- a/tests/performance/test_ghidra_offline.py
+++ b/tests/performance/test_ghidra_offline.py
@@ -236,10 +236,17 @@ def test_process_function_skips_model_when_ghidra_offline(monkeypatch, tmp_path)
         model_invoked.append(True)
         return "should not be called"
 
+    offline_events = []
+
+    def _capture_event(event, **fields):
+        if event == "ghidra.offline":
+            offline_events.append(fields)
+
     with (
         patch("fun_doc.requests.get", side_effect=_make_offline_requests_get),
         patch("fun_doc.update_function_state", return_value=None),
         patch("fun_doc.bus_emit", return_value=None),
+        patch("event_log.log_event", side_effect=_capture_event),
         patch("fun_doc._invoke_minimax", side_effect=_fake_invoke),
         patch("fun_doc.invoke_claude", side_effect=_fake_invoke),
         patch("fun_doc.try_launch_ghidra", return_value=False),
@@ -253,9 +260,18 @@ def test_process_function_skips_model_when_ghidra_offline(monkeypatch, tmp_path)
     assert func.get("last_result") != "ghidra_offline", (
         "function was parked as ghidra_offline; it should be left re-pickable"
     )
-    entry = json.loads(log_file.read_text(encoding="utf-8").splitlines()[0])
-    assert entry["result"] == "ghidra_offline"
-    assert entry["reason"] == f"server not reachable at {fun_doc.GHIDRA_URL}"
+    # An infra outage must NOT write a heavyweight run-log row — during a long
+    # outage that would flood runs.jsonl with hundreds of identical rows per
+    # function. The row is skipped; a single lightweight ghidra.offline event
+    # carries the audit trail instead.
+    assert not log_file.exists() or log_file.read_text(encoding="utf-8").strip() == "", (
+        "ghidra_offline must not append a run-log row"
+    )
+    assert offline_events, "expected a lightweight ghidra.offline event to be emitted"
+    assert offline_events[0].get("reason") == (
+        f"server not reachable at {fun_doc.GHIDRA_URL}"
+    )
+    assert offline_events[0].get("address") == func["address"]
 
 
 def test_process_function_resumes_after_ghidra_comes_online():


### PR DESCRIPTION
## What the logs showed

Diagnosing a long worker run surfaced three things. This PR lands the two safe, high-value ones; #3 is scoped as a follow-up below.

### 1. Ghidra-offline outage = run-log spam (fixed here)
A ~4-hour Ghidra outage on 2026-06-07 (07:00–11:00) generated **~400 `ghidra_offline` outcomes** on binkw32 alone; **2,035 total** in `runs.jsonl`. The #284 backoff correctly prevented CPU spin and (correctly) kept offline functions re-pickable rather than parking them — but every backoff cycle re-attempted the same function and wrote a full ~40-field run row. One address (`0x10020280`) logged **210 identical `ghidra_offline` rows** before Ghidra recovered and it completed in one shot (0→92).

An infra outage isn't a documentation outcome. `process_function`'s `_log_run_once` now **skips the run-log row for the `ghidra_offline` result** and emits a single lightweight `ghidra.offline` event for the audit trail instead. The `function_complete` bus event at the call site still syncs the dashboard's offline state, and the worker's `check_ghidra_online()` backoff still drives recovery — no behavior lost, only the per-attempt row spam.

### 2. Reclaimed 1 GB of stale HTTP logs (ops, done out-of-band)
`logs/` had grown to 2.1 GB, dominated by `ghidra_http.jsonl.1`–`.5` (~1 GB of rotated history). #285's "skip ok=True entries" guard is confirmed live (the HTTP log went silent at the 06-08 restart), so the current series is dormant and those rotations were pure history. Removed → `logs/` back to 1.1 GB. No code change needed; growth is already bounded by #285 + log rotation.

## Tests
- Updated `test_process_function_skips_model_when_ghidra_offline` to assert **no run row is written** and a `ghidra.offline` event is emitted.
- `test_ghidra_offline.py` (12) + `test_state_atomicity.py` + `test_selector_invariants.py` + `test_provider_selection.py` → **72 passed**.
- Benchmark intentionally **not** rerun: this change is in the offline-logging path, orthogonal to prompt/scoring, and rerunning would clobber uncommitted `runs/latest.json` WIP.

## Follow-up (NOT in this PR): #3 FIX-mode regression oscillation
18 `run.regression` events (all binkw32) where minimax's `FIX` pass *lowered* the score (e.g. 78→50). The guard at `fun_doc.py:8030` detects it but only **re-labels the result to "partial"** — it does **not roll back the degraded writes**. Functions stuck below `good_enough` (80) with ≥3 fixable points then oscillate: `0x100058a0` cycled 71→56→72→62→71→67→64→70→78… across **17 runs**. Two candidate fixes to evaluate:
- **(a) snapshot doc-state before FIX, restore on regression** — true fix, but touches the save path and needs a benchmark rerun.
- **(b) plateau circuit-breaker** — after K non-improving FIX attempts below `good_enough`, park/dequeue as "plateaued" — purely selector-side, lower risk, kills the wasted churn without rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)