### PR TITLE
Fix uppercase overlay space names

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -238,12 +238,19 @@ class GhidraValidationError(Exception):
 
 # Input validation patterns
 HEX_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]+$")
-SEGMENT_ADDRESS_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*:[0-9a-fA-F]+$")
-# Handles space:0xHEX form (e.g., mem:0x1000, code:0xFF00).
+# Space/segment-qualified addresses accept ONE or TWO colons between the space
+# name and the offset. Ghidra's overlay symbols render as "CODE_BANK1::e461"
+# (namespace "::" separator), which is exactly what search_functions returns and
+# what AddressFactory accepts — so the bridge must not mangle it (issue: the old
+# single-colon-only pattern fell through to the plain-hex branch and produced
+# "0xcode_bank1::e461", which Ghidra then rejected).
+SEGMENT_ADDRESS_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*:{1,2}[0-9a-fA-F]+$")
+# Handles space:0xHEX form (e.g., mem:0x1000, code:0xFF00, CODE_BANK1::0xe461).
 # Must be checked BEFORE SEGMENT_ADDRESS_PATTERN because the 'x' in '0x' is not
-# in [0-9a-fA-F], so the existing pattern rejects this form entirely.
+# in [0-9a-fA-F], so the existing pattern rejects this form entirely. Group 1
+# captures the space name *with* its colon(s) so the colon count is preserved.
 SEGMENT_ADDR_WITH_0X_PATTERN = re.compile(
-    r"^([a-zA-Z_][a-zA-Z0-9_]*):0[xX]([0-9a-fA-F]+)$"
+    r"^([a-zA-Z_][a-zA-Z0-9_]*:{1,2})0[xX]([0-9a-fA-F]+)$"
 )
 FUNCTION_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -732,21 +739,23 @@ def sanitize_address(address: str) -> str:
     """Normalize address format for Ghidra AddressFactory.
 
     Handles:
-    - space:0xHEX  -> space:HEX   (strip 0x; AddressFactory rejects 0x after colon)
-    - SPACE:HEX    -> SPACE:HEX   (preserve case — AddressFactory is case-sensitive; see #184)
-    - 0xHEX        -> 0xhex       (lowercase)
-    - HEX          -> 0xHEX       (add 0x prefix)
+    - space:0xHEX     -> space:HEX      (strip 0x; AddressFactory rejects 0x after colon)
+    - SPACE:HEX       -> SPACE:HEX      (preserve case — AddressFactory is case-sensitive; see #184)
+    - SPACE::HEX      -> SPACE::HEX     (overlay namespace "::" form, e.g. CODE_BANK1::e461)
+    - 0xHEX           -> 0xhex          (lowercase)
+    - HEX             -> 0xHEX          (add 0x prefix)
     """
     if not address:
         return address
     address = address.strip()
 
-    # Step 1: handle space:0xHEX form (checked first — 'x' not in [0-9a-fA-F])
+    # Step 1: handle space:0xHEX form (checked first — 'x' not in [0-9a-fA-F]).
+    # Group 1 already includes the colon(s), so the one-/two-colon form is preserved.
     m = SEGMENT_ADDR_WITH_0X_PATTERN.match(address)
     if m:
-        return f"{m.group(1)}:{m.group(2)}"  # case preserved (#184)
+        return f"{m.group(1)}{m.group(2)}"  # case + colon count preserved (#184)
 
-    # Step 2: valid space:HEX — pass through unchanged (#184)
+    # Step 2: valid space:HEX / space::HEX — pass through unchanged (#184)
     if SEGMENT_ADDRESS_PATTERN.match(address):
         return address
 

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -632,15 +632,27 @@ public final class ServiceUtils {
         boolean hasColon = addressStr.contains(":");
 
         // Normalize space:offset form: AddressFactory is case-sensitive and rejects "0x" prefix.
-        // Lowercase the space name and strip leading "0x"/"0X" from the offset so that inputs
-        // like "MEM:0x1000", "MEM:1000", and "Code:FF00" all resolve correctly — including
-        // addresses carried inside batch/container params that bypass bridge sanitization.
+        // Resolve the canonical space name first so overlays like "CODE_BANK1" keep their case.
         if (hasColon) {
             int colonIdx = addressStr.indexOf(':');
-            String spaceName = addressStr.substring(0, colonIdx).toLowerCase();
+            String rawSpace = addressStr.substring(0, colonIdx);
+            String spaceName = rawSpace.toLowerCase();
             String offset = addressStr.substring(colonIdx + 1);
             if (offset.startsWith("0x") || offset.startsWith("0X")) {
                 offset = offset.substring(2);
+            }
+
+            AddressSpace matchedSpace = program.getAddressFactory().getAddressSpace(rawSpace);
+            if (matchedSpace == null) {
+                for (AddressSpace candidate : program.getAddressFactory().getAddressSpaces()) {
+                    if (candidate.getName().equalsIgnoreCase(rawSpace)) {
+                        matchedSpace = candidate;
+                        break;
+                    }
+                }
+            }
+            if (matchedSpace != null) {
+                spaceName = matchedSpace.getName();
             }
             addressStr = spaceName + ":" + offset;
         }

--- a/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
+++ b/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
@@ -179,6 +179,26 @@ public class ServiceUtilsAddressTest {
     }
 
     @Test
+    public void parseAddress_overlaySpace_resolvesWithCanonicalCaseParser() throws Exception {
+        AddressSpace overlaySpace = mock(AddressSpace.class);
+        Address bank1Addr = mock(Address.class);
+
+        when(overlaySpace.getType()).thenReturn(AddressSpace.TYPE_RAM);
+        when(overlaySpace.isOverlaySpace()).thenReturn(true);
+        when(overlaySpace.getName()).thenReturn("CODE_BANK1");
+        when(bank1Addr.getAddressSpace()).thenReturn(overlaySpace);
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace, codeSpace, overlaySpace});
+        when(factory.getAddressSpace("CODE_BANK1")).thenReturn(overlaySpace);
+        when(factory.getAddress("CODE_BANK1:a066")).thenReturn(bank1Addr);
+
+        Address result = ServiceUtils.parseAddress(program, "CODE_BANK1:a066");
+
+        assertSame("Overlay address must resolve in the CODE_BANK1 space", bank1Addr, result);
+        assertEquals("CODE_BANK1", result.getAddressSpace().getName());
+        assertNull(ServiceUtils.getLastParseError());
+    }
+
+    @Test
     public void convertToMapList_acceptsStringifiedArrayPayload() {
         List<Map<String, String>> result = ServiceUtils.convertToMapList(
             "[{\"address\":\"0x401000\",\"comment\":\"alpha\"},{\"address\":\"0x401004\",\"comment\":\"beta\"}]"

--- a/tests/test_address_spaces.py
+++ b/tests/test_address_spaces.py
@@ -54,6 +54,18 @@ class TestSanitizeAddress:
     def test_8051_extmem_space_preserved(self):
         assert sanitize_address("EXTMEM:0xfeed") == "EXTMEM:feed"
 
+    # Overlay namespace "::" form — what search_functions returns for overlay
+    # functions (e.g. CODE_BANK1::e461). Must pass through, not get mangled into
+    # "0xcode_bank1::e461" by the plain-hex fallback.
+    def test_overlay_namespace_double_colon_preserved(self):
+        assert sanitize_address("CODE_BANK1::e461") == "CODE_BANK1::e461"
+
+    def test_overlay_namespace_double_colon_strips_0x(self):
+        assert sanitize_address("CODE_BANK1::0xe461") == "CODE_BANK1::e461"
+
+    def test_overlay_namespace_preserves_case(self):
+        assert sanitize_address("Code_Bank1::FF00") == "Code_Bank1::FF00"
+
     # Plain hex path (unchanged behaviour)
     def test_plain_hex_lowercase(self):
         assert sanitize_address("0xABCD") == "0xabcd"
@@ -80,6 +92,12 @@ class TestValidateHexAddress:
 
     def test_sanitize_uppercase_then_validate(self):
         assert validate_hex_address(sanitize_address("MEM:1000")) is True
+
+    def test_accepts_overlay_namespace_double_colon(self):
+        assert validate_hex_address("CODE_BANK1::e461") is True
+
+    def test_sanitize_then_validate_overlay_namespace(self):
+        assert validate_hex_address(sanitize_address("CODE_BANK1::0xe461")) is True
 
     def test_rejects_garbage(self):
         assert validate_hex_address("not_an_address") is False


### PR DESCRIPTION
`parseAddress` would produce the wrong results for banked code binaries that have uppercase overlay names