### PR TITLE
fix(setup): accept patch-level Ghidra versions within pinned minor series (#293)

### DIFF
--- a/tests/unit/test_versioning.py
+++ b/tests/unit/test_versioning.py
@@ -1,0 +1,53 @@
+"""Unit tests for tools.setup.versioning — Ghidra version compatibility (#293).
+
+The pom pins ``ghidra.version`` to a major.minor series; an installed Ghidra of
+any patch release in that series must be accepted instead of hard-failing the
+preflight/verify-version check (firefart's ``12.1`` pinned vs ``12.1.2`` install).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.setup.versioning import is_ghidra_version_compatible
+
+
+@pytest.mark.parametrize(
+    "required,installed",
+    [
+        ("12.1", "12.1.2"),   # #293: pinned minor, patch install
+        ("12.1", "12.1"),     # exact
+        ("12.1", "12.1.0"),   # explicit .0 patch
+        ("12.1.2", "12.1"),   # pinned patch, minor install — same series
+        ("12.1.0", "12.1.9"), # patch drift within series
+        ("12.1", "12.1.2.1"), # four-component build install
+    ],
+)
+def test_compatible_within_minor_series(required: str, installed: str) -> None:
+    assert is_ghidra_version_compatible(required, installed) is True
+
+
+@pytest.mark.parametrize(
+    "required,installed",
+    [
+        ("12.1", "12.2"),    # different minor
+        ("12.1", "12.0.4"),  # different minor (older)
+        ("12.1", "11.1"),    # different major
+        ("12.1", "13.1.2"),  # different major (newer)
+    ],
+)
+def test_incompatible_across_minor_or_major(required: str, installed: str) -> None:
+    assert is_ghidra_version_compatible(required, installed) is False
+
+
+@pytest.mark.parametrize(
+    "required,installed,expected",
+    [
+        ("", "12.1", False),       # unparseable required -> exact-string fallback
+        ("12.1", "", False),       # unparseable installed -> exact-string fallback
+        ("weird", "weird", True),  # identical unparseable strings still match
+    ],
+)
+def test_unparseable_falls_back_to_exact_match(
+    required: str, installed: str, expected: bool
+) -> None:
+    assert is_ghidra_version_compatible(required, installed) is expected

--- a/tools/setup/cli.py
+++ b/tools/setup/cli.py
@@ -24,7 +24,11 @@ from .requirements import (
     resolve_requirements_files,
 )
 from .version_bump import apply_version_bump
-from .versioning import infer_ghidra_version_from_path, read_pom_versions
+from .versioning import (
+    infer_ghidra_version_from_path,
+    is_ghidra_version_compatible,
+    read_pom_versions,
+)
 
 
 def _get_backend() -> str:
@@ -358,12 +362,17 @@ def cmd_verify_version(args: argparse.Namespace) -> int:
         print("Unable to infer Ghidra version from the provided path.")
         return 1
     print(f"Ghidra version from path: {inferred_version}")
-    if inferred_version != versions.ghidra_version:
+    if not is_ghidra_version_compatible(versions.ghidra_version, inferred_version):
         print(
             "Version mismatch detected between pom.xml and Ghidra path.",
             file=sys.stderr,
         )
         return 1
+    if inferred_version != versions.ghidra_version:
+        print(
+            f"Note: Ghidra path is {inferred_version}, pom.xml pins "
+            f"{versions.ghidra_version} — same minor series, treated as compatible."
+        )
     print("Version check passed.")
     return 0
 
@@ -414,12 +423,17 @@ def cmd_preflight(args: argparse.Namespace) -> int:
         print("Unable to infer Ghidra version from the provided path.", file=sys.stderr)
         return 1
     print(f"Ghidra version from path: {inferred_version}")
-    if inferred_version != repo_versions.ghidra_version:
+    if not is_ghidra_version_compatible(repo_versions.ghidra_version, inferred_version):
         print(
             "Version mismatch detected between pom.xml and Ghidra path.",
             file=sys.stderr,
         )
         return 1
+    if inferred_version != repo_versions.ghidra_version:
+        print(
+            f"Note: Ghidra path is {inferred_version}, pom.xml pins "
+            f"{repo_versions.ghidra_version} — same minor series, treated as compatible."
+        )
     issues = collect_preflight_issues(
         repo_root,
         ghidra_path,

--- a/tools/setup/versioning.py
+++ b/tools/setup/versioning.py
@@ -74,3 +74,29 @@ def infer_ghidra_install_meta(ghidra_path: Path) -> tuple[str | None, str | None
 
 def infer_ghidra_version_from_path(ghidra_path: Path) -> str | None:
     return infer_ghidra_install_meta(ghidra_path)[0]
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for chunk in version.strip().split("."):
+        match = re.match(r"\d+", chunk)
+        if not match:
+            break
+        parts.append(int(match.group()))
+    return tuple(parts)
+
+
+def is_ghidra_version_compatible(required: str, installed: str) -> bool:
+    """Return True when an installed Ghidra version satisfies the pom requirement.
+
+    The pom pins ``ghidra.version`` to a major.minor series (e.g. ``12.1``).
+    Ghidra's API is stable within a minor series, so any patch release of that
+    series — ``12.1.0``, ``12.1.2``, ... — is compatible (see #293: ``12.1``
+    pinned vs a ``12.1.2`` install should not error). Compatibility is decided
+    on the shared major.minor prefix; patch and build components are ignored.
+    """
+    req = _version_tuple(required)[:2]
+    inst = _version_tuple(installed)[:2]
+    if not req or not inst:
+        return required.strip() == installed.strip()
+    return req == inst


### PR DESCRIPTION
Closes #293.

## Problem
`verify-version` / `preflight` compared the pom's pinned `ghidra.version` (e.g. `12.1`) against the installed version (e.g. `12.1.2`) with exact string equality, hard-failing on any patch drift. As @firefart noted, under semver a `12.1.2` install should satisfy a `12.1` pin — Ghidra's API is stable within a minor series.

## Fix
- Add `is_ghidra_version_compatible(required, installed)` in `tools/setup/versioning.py`, which decides compatibility on the shared **major.minor** prefix (patch/build ignored).
- Wire both `cli.py` call sites (`cmd_verify_version`, `cmd_preflight`) to use it, printing an informational note instead of erroring when only the patch differs.

## Tests
New `tests/unit/test_versioning.py` covers same-series patch drift (`12.1` vs `12.1.2`), cross-minor/major rejection, and the unparseable exact-match fallback. Full unit suite green.

Note: this makes PR #296 (bump pin to `12.1.2`) optional — the `12.1` pin now accepts a `12.1.2` install either way.