### PR TITLE
release: v5.14.0 — Ghidra 12.1.2 retarget, reference write tools, tool discovery

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,11 +17,11 @@ on:
       ghidra_path:
         description: 'Ghidra path for live regression self-hosted runner'
         required: false
-        default: 'F:\ghidra_12.1_PUBLIC'
+        default: 'F:\ghidra_12.1.2_PUBLIC'
 
 env:
-  GHIDRA_VERSION: 12.1
-  GHIDRA_DATE: 20260513
+  GHIDRA_VERSION: 12.1.2
+  GHIDRA_DATE: 20260605
 
 # OSSF Scorecard Token-Permissions: default to read-only. The
 # create-prerelease job elevates to contents:write for the GitHub

--- a/.github/workflows/release-regression.yml
+++ b/.github/workflows/release-regression.yml
@@ -8,7 +8,7 @@ on:
       ghidra_path:
         description: "Path to the Ghidra install on the self-hosted runner"
         required: true
-        default: "F:\\ghidra_12.1_PUBLIC"
+        default: "F:\\ghidra_12.1.2_PUBLIC"
       test_tier:
         description: "Deploy regression tier to run"
         required: true
@@ -48,7 +48,7 @@ jobs:
     runs-on: [self-hosted, Windows]
     timeout-minutes: 30
     env:
-      GHIDRA_REGRESSION_PATH: ${{ inputs.ghidra_path || vars.GHIDRA_PATH || 'F:\ghidra_12.1_PUBLIC' }}
+      GHIDRA_REGRESSION_PATH: ${{ inputs.ghidra_path || vars.GHIDRA_PATH || 'F:\ghidra_12.1.2_PUBLIC' }}
       GHIDRA_REGRESSION_TIER: ${{ inputs.test_tier || 'release' }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ on:
       ghidra_path:
         description: 'Ghidra path for live regression self-hosted runner'
         required: false
-        default: 'F:\ghidra_12.1_PUBLIC'
+        default: 'F:\ghidra_12.1.2_PUBLIC'
 
 env:
-  GHIDRA_VERSION: 12.1
-  GHIDRA_DATE: 20260513
+  GHIDRA_VERSION: 12.1.2
+  GHIDRA_DATE: 20260605
 
 # OSSF Scorecard Token-Permissions: default to read-only. The
 # create-release job elevates to contents:write for tag + asset

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,14 +36,14 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: /tmp/ghidra
-        key: ghidra-12.1-PUBLIC-20260513
+        key: ghidra-12.1.2-PUBLIC-20260605
 
     - name: Download Ghidra
       if: steps.cache-ghidra.outputs.cache-hit != 'true'
       run: |
-        echo "Downloading Ghidra 12.1..."
+        echo "Downloading Ghidra 12.1.2..."
         curl -sL -o /tmp/ghidra.zip \
-          "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1_build/ghidra_12.1_PUBLIC_20260513.zip"
+          "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.1.2_build/ghidra_12.1.2_PUBLIC_20260605.zip"
         mkdir -p /tmp/ghidra
         unzip -q /tmp/ghidra.zip -d /tmp/ghidra
         rm /tmp/ghidra.zip
@@ -51,7 +51,7 @@ jobs:
     - name: Install Ghidra JARs to Maven local repository
       run: |
         GHIDRA_DIR=$(find /tmp/ghidra -maxdepth 1 -type d -name 'ghidra_*' | head -1)
-        GHIDRA_VERSION="12.1"
+        GHIDRA_VERSION="12.1.2"
         echo "Using Ghidra directory: $GHIDRA_DIR"
 
         # Install Framework JARs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.13.1
+- **Version**: 5.14.0
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
 - **Key feature**: 251 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 - **Repo**: https://github.com/bethington/ghidra-mcp
 - **Version**: 5.13.1
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
-- **Key feature**: 249 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
+- **Key feature**: 251 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 
 ## Directory Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,6 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 - Build: `mvn clean package assembly:single -DskipTests`
 - Quick compile: `mvn clean compile -q`
 - Test (Python): `pytest tests/unit/ -v --no-cov`
-- Preflight: `python -m tools.setup preflight --ghidra-path F:\ghidra_12.1_PUBLIC`
-- Deploy: `python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.1_PUBLIC` then `python -m tools.setup build` then `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC`
+- Preflight: `python -m tools.setup preflight --ghidra-path F:\ghidra_12.1.2_PUBLIC`
+- Deploy: `python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.1.2_PUBLIC` then `python -m tools.setup build` then `python -m tools.setup deploy --ghidra-path F:\ghidra_12.1.2_PUBLIC`
 - Version bump: `python -m tools.setup bump-version --new X.Y.Z`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Complete version history for the Ghidra MCP Server project.
 
 ## Unreleased
 
+### Added
+
+- **`/add_memory_reference`**: create a user-defined cross-reference between two memory
+  addresses that the auto-analyzer can't infer — runtime-populated dispatch tables, vtables,
+  late-bound function pointers, and missed jump/switch tables — with proper bidirectional
+  navigation and without touching the underlying bytes. Previously the only path was
+  `run_script_inline` with a Java snippet calling `ReferenceManager.addMemoryReference`, gated
+  behind `GHIDRA_MCP_ALLOW_SCRIPTS=1` (arbitrary Java execution). `ref_type` accepts any
+  case-insensitive `RefType` name (data refs `DATA`/`READ`/`WRITE` and flow refs
+  `COMPUTED_CALL`/`UNCONDITIONAL_JUMP`/...); `source_type` defaults to `USER_DEFINED` so added
+  refs stay visually distinct and survive re-analysis. Supports `set_primary`, `operand_index`,
+  `dry_run`, and space-prefixed addresses (`mem:1000`). 250 tools.
+
 ---
 
 ## v5.13.1 - 2026-06-08 (patch: launch-noise fix + class-member listing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
-## v5.14.0 - 2026-06-14 (minor: reference write tools, tool discovery, version-compat + overlay fixes)
+## v5.14.0 - 2026-06-14 (minor: Ghidra 12.1.2 retarget, reference write tools, tool discovery, version-compat + overlay fixes)
 
-Minor release. Bundles two community PRs (#299, #297) plus tool-discovery and
-setup fixes responding to maintainer-feedback issues (#267, #153, #293).
+Minor release. Retargets the extension at **Ghidra 12.1.2** (latest), bundles two
+community PRs (#299, #297), and adds tool-discovery plus setup fixes responding to
+maintainer-feedback issues (#267, #153, #293).
+
+### Changed
+
+- **Retargeted to Ghidra 12.1.2** (#296): bumped `ghidra.version` 12.1 → 12.1.2 so the
+  built extension's `extension.properties` declares 12.1.2 and loads in the latest Ghidra
+  (Ghidra enforces an exact extension-version gate at load time). Rebuilt + offline Java
+  suite re-run against the 12.1.2 jars. README badge, docs, and install-path examples updated.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
-## v5.14.0 - 2026-06-14 (minor: Ghidra 12.1.2 retarget, reference write tools, tool discovery, version-compat + overlay fixes)
+## v5.14.0 - 2026-06-18 (minor: Ghidra 12.1.2 retarget, reference write tools, tool discovery, version-compat + overlay fixes)
 
 Minor release. Retargets the extension at **Ghidra 12.1.2** (latest), bundles two
 community PRs (#299, #297), and adds tool-discovery plus setup fixes responding to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ Complete version history for the Ghidra MCP Server project.
   case-insensitive `RefType` name (data refs `DATA`/`READ`/`WRITE` and flow refs
   `COMPUTED_CALL`/`UNCONDITIONAL_JUMP`/...); `source_type` defaults to `USER_DEFINED` so added
   refs stay visually distinct and survive re-analysis. Supports `set_primary`, `operand_index`,
-  `dry_run`, and space-prefixed addresses (`mem:1000`).
+  and space-prefixed addresses (`mem:1000`).
 - **`/remove_reference`**: the inverse of `add_memory_reference` — remove memory cross-reference(s)
   from one address to another. Removes every reference `from_address -> to_address` regardless of
   operand by default; pass `operand_index >= 0` to target a single operand. Reports each removed
   reference's `source_type` (it can clear analyzer-inferred references too, not just user-defined
-  ones). Supports `dry_run` and space-prefixed addresses. 251 tools.
+  ones). Accepts space-prefixed addresses. 251 tools.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Complete version history for the Ghidra MCP Server project.
   behind `GHIDRA_MCP_ALLOW_SCRIPTS=1` (arbitrary Java execution). `ref_type` accepts any
   case-insensitive `RefType` name (data refs `DATA`/`READ`/`WRITE` and flow refs
   `COMPUTED_CALL`/`UNCONDITIONAL_JUMP`/...); `source_type` defaults to `USER_DEFINED` so added
-  refs stay visually distinct and survive re-analysis. Supports `set_primary`, `operand_index`,
-  and space-prefixed addresses (`mem:1000`).
+  refs stay visually distinct and survive re-analysis. Supports `operand_index` and
+  space-prefixed addresses (`mem:1000`).
 - **`/remove_reference`**: the inverse of `add_memory_reference` — remove memory cross-reference(s)
   from one address to another. Removes every reference `from_address -> to_address` regardless of
   operand by default; pass `operand_index >= 0` to target a single operand. Reports each removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ Complete version history for the Ghidra MCP Server project.
   case-insensitive `RefType` name (data refs `DATA`/`READ`/`WRITE` and flow refs
   `COMPUTED_CALL`/`UNCONDITIONAL_JUMP`/...); `source_type` defaults to `USER_DEFINED` so added
   refs stay visually distinct and survive re-analysis. Supports `set_primary`, `operand_index`,
-  `dry_run`, and space-prefixed addresses (`mem:1000`). 250 tools.
+  `dry_run`, and space-prefixed addresses (`mem:1000`).
+- **`/remove_reference`**: the inverse of `add_memory_reference` — remove memory cross-reference(s)
+  from one address to another. Removes every reference `from_address -> to_address` regardless of
+  operand by default; pass `operand_index >= 0` to target a single operand. Reports each removed
+  reference's `source_type` (it can clear analyzer-inferred references too, not just user-defined
+  ones). Supports `dry_run` and space-prefixed addresses. 251 tools.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
-## Unreleased
+## v5.14.0 - 2026-06-14 (minor: reference write tools, tool discovery, version-compat + overlay fixes)
+
+Minor release. Bundles two community PRs (#299, #297) plus tool-discovery and
+setup fixes responding to maintainer-feedback issues (#267, #153, #293).
 
 ### Added
 
+- **`search_tools(query, limit)`** (#267, #153): a bridge meta-tool that keyword-searches the
+  full Ghidra tool catalog — including tools whose group is not currently loaded — ranking by
+  name/description/category and returning the exact `load_tool_group(...)` call to enable any
+  unloaded match. Lets the bridge run `--lazy` with a small tool surface while agents discover
+  the rest on demand, cutting tool-context overhead. New README section documents the
+  `--lazy` + `search_tools`/`load_tool_group`/`check_tools` workflow; `ROADMAP.md` added.
 - **`/add_memory_reference`**: create a user-defined cross-reference between two memory
   addresses that the auto-analyzer can't infer — runtime-populated dispatch tables, vtables,
   late-bound function pointers, and missed jump/switch tables — with proper bidirectional
@@ -23,6 +32,19 @@ Complete version history for the Ghidra MCP Server project.
   operand by default; pass `operand_index >= 0` to target a single operand. Reports each removed
   reference's `source_type` (it can clear analyzer-inferred references too, not just user-defined
   ones). Accepts space-prefixed addresses. 251 tools.
+
+### Fixed
+
+- **Uppercase overlay address spaces** (#297, thanks @robbederks): `parseAddress` lowercased the
+  entire `space:offset` input, breaking banked-code binaries whose overlay spaces use uppercase
+  names (e.g. `CODE_BANK1`). It now resolves the canonical address-space name via `AddressFactory`
+  (exact match, then case-insensitive scan) and preserves its real case, while keeping the
+  lowercased fallback for the standard `mem:`/`MEM:` forms.
+- **Ghidra version preflight too strict** (#293, thanks @firefart): `verify-version` / `preflight`
+  compared the pom's pinned `ghidra.version` (e.g. `12.1`) against the installed version
+  (e.g. `12.1.2`) with exact string equality and hard-failed on patch drift. Compatibility is now
+  decided on the shared major.minor prefix — any patch release of the pinned minor series is
+  accepted, with an informational note when only the patch differs.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 251 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.14.0 | **Java**: 21 LTS | **Ghidra**: 12.1
+- **Package**: `com.xebyte` | **Version**: 5.14.0 | **Java**: 21 LTS | **Ghidra**: 12.1.2
 
 ## Boil the ocean
 
@@ -46,29 +46,29 @@ Two backends are supported. Maven is the default used by `tools.setup`; Gradle i
 
 ```text
 # Direct Gradle invocation — no tools.setup required
-./gradlew buildExtension -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
-./gradlew preflight      -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
-./gradlew deploy         -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
-./gradlew startGhidra    -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
+./gradlew buildExtension -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1.2_PUBLIC
+./gradlew preflight      -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1.2_PUBLIC
+./gradlew deploy         -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1.2_PUBLIC
+./gradlew startGhidra    -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1.2_PUBLIC
 
 # Via tools.setup facade (same commands, Gradle backend)
 $env:TOOLS_SETUP_BACKEND = "gradle"
 python -m tools.setup build
-python -m tools.setup preflight --ghidra-path F:\ghidra_12.1_PUBLIC
-python -m tools.setup deploy    --ghidra-path F:\ghidra_12.1_PUBLIC
+python -m tools.setup preflight --ghidra-path F:\ghidra_12.1.2_PUBLIC
+python -m tools.setup deploy    --ghidra-path F:\ghidra_12.1.2_PUBLIC
 ```
 
 **Maven (default — existing tooling unchanged):**
 
 ```text
 python -m tools.setup build
-python -m tools.setup preflight      --ghidra-path F:\ghidra_12.1_PUBLIC
-python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.1_PUBLIC
-python -m tools.setup deploy         --ghidra-path F:\ghidra_12.1_PUBLIC
+python -m tools.setup preflight      --ghidra-path F:\ghidra_12.1.2_PUBLIC
+python -m tools.setup ensure-prereqs --ghidra-path F:\ghidra_12.1.2_PUBLIC
+python -m tools.setup deploy         --ghidra-path F:\ghidra_12.1.2_PUBLIC
 ```
 
 - Maven: `C:\Users\benam\tools\apache-maven-3.9.6\bin\mvn.cmd`
-- Ghidra install: `F:\ghidra_12.1_PUBLIC`
+- Ghidra install: `F:\ghidra_12.1.2_PUBLIC`
 - `tools.setup` delegates to Maven by default; set `TOOLS_SETUP_BACKEND=gradle` to route the same commands to Gradle
 - Deploy handles: build, extension install, FrontEndTool.xml patching, Ghidra restart
 - Migration plan: `docs/project-management/GRADLE_MIGRATION_CHECKLIST.md`
@@ -85,7 +85,7 @@ Release floor before tagging or publishing:
 python -m tools.setup verify-version
 python -m tools.setup build
 pytest tests/unit/ -v --no-cov
-python -m tools.setup deploy --ghidra-path F:\ghidra_12.1_PUBLIC --test release
+python -m tools.setup deploy --ghidra-path F:\ghidra_12.1.2_PUBLIC --test release
 ```
 
 Run UI-touching deploy/regression only after confirming the current Ghidra UI
@@ -183,7 +183,7 @@ pytest tests/unit/ --no-cov
 
 ```text
 # Gradle
-./gradlew test --tests 'com.xebyte.offline.*' -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC
+./gradlew test --tests 'com.xebyte.offline.*' -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1.2_PUBLIC
 # Maven
 mvn test -Dtest='com.xebyte.offline.*Test'
 ```
@@ -205,7 +205,7 @@ pytest tests/performance/ \
 
 ```text
 # Java
-./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1_PUBLIC   # or: mvn test
+./gradlew test -PGHIDRA_INSTALL_DIR=F:\ghidra_12.1.2_PUBLIC   # or: mvn test
 # Python — subset by marker
 pytest tests/ -m readonly          # safe, no writes
 pytest tests/ -m safe_write        # identity writes only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MCP server bridging Ghidra reverse engineering with AI tools. 249 MCP tools for binary analysis.
+MCP server bridging Ghidra reverse engineering with AI tools. 251 MCP tools for binary analysis.
 
 - **Package**: `com.xebyte` | **Version**: 5.13.1 | **Java**: 21 LTS | **Ghidra**: 12.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 251 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.13.1 | **Java**: 21 LTS | **Ghidra**: 12.1
+- **Package**: `com.xebyte` | **Version**: 5.14.0 | **Java**: 21 LTS | **Ghidra**: 12.1
 
 ## Boil the ocean
 
@@ -32,7 +32,7 @@ Services use constructor injection: `ProgramProvider` + `ThreadingStrategy`.
 
 Do not try to keep the full tool list in this file.
 
-- **Authoritative repo snapshot**: `tests/endpoints.json` (249 endpoints, categories, descriptions)
+- **Authoritative repo snapshot**: `tests/endpoints.json` (251 endpoints, categories, descriptions)
 - **Authoritative runtime schema**: `/mcp/schema` from the running server
 - **Usage patterns / operator guide**: `docs/prompts/TOOL_USAGE_GUIDE.md`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
 [![Java](https://img.shields.io/badge/Java-21-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/21/)
-[![Ghidra](https://img.shields.io/badge/Ghidra-12.1-brightgreen?style=for-the-badge&logoColor=white)](https://ghidra-sre.org/)
+[![Ghidra](https://img.shields.io/badge/Ghidra-12.1.2-brightgreen?style=for-the-badge&logoColor=white)](https://ghidra-sre.org/)
 [![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-6C5CE7?style=for-the-badge&logoColor=white)](https://modelcontextprotocol.io/)
 
 [![Stars](https://img.shields.io/github/stars/bethington/ghidra-mcp?style=for-the-badge&logo=github&logoColor=white&color=yellow)](https://github.com/bethington/ghidra-mcp/stargazers)
@@ -100,14 +100,14 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 - **Java 21 LTS** (OpenJDK recommended)
 - **Apache Maven 3.9+**
-- **Ghidra 12.1** (or compatible version)
+- **Ghidra 12.1.2** (or compatible version)
 - **Python 3.10+** with pip
 
-> Shared Ghidra Server users: Ghidra 12.1 clients require a Ghidra
+> Shared Ghidra Server users: Ghidra 12.1.2 clients require a Ghidra
 > Server at 12.1, 12.0.5, or a newer compatible version. Upgrade the
 > server before using this plugin from a 12.1 client.
 >
-> Ghidra 12.1 ships Jython as an optional extension. Java scripts work
+> Ghidra 12.1.2 ships Jython as an optional extension. Java scripts work
 > by default, but `.py` scripts in `ghidra_scripts/` require installing
 > the Jython extension from **File > Install Extensions** and restarting
 > Ghidra.
@@ -127,14 +127,14 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 2. **Recommended: run environment preflight first:**
    ```text
-   python -m tools.setup preflight --ghidra-path "F:\ghidra_12.1_PUBLIC"
+   python -m tools.setup preflight --ghidra-path "F:\ghidra_12.1.2_PUBLIC"
    ```
 
 3. **Build and deploy to Ghidra:**
    ```text
-   python -m tools.setup ensure-prereqs --ghidra-path "F:\ghidra_12.1_PUBLIC"
+   python -m tools.setup ensure-prereqs --ghidra-path "F:\ghidra_12.1.2_PUBLIC"
    python -m tools.setup build
-   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC"
+   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1.2_PUBLIC"
    ```
 
    `deploy` saves/closes an already-running matching Ghidra instance when
@@ -145,7 +145,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
    ```text
    # Skip automatic prerequisite setup
    python -m tools.setup build
-   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1_PUBLIC"
+   python -m tools.setup deploy --ghidra-path "F:\ghidra_12.1.2_PUBLIC"
    ```
 
 5. **Show command help**:
@@ -185,14 +185,14 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 3. **Run environment preflight:**
    ```bash
-   python -m tools.setup preflight --ghidra-path ~/ghidra_12.1_PUBLIC
+   python -m tools.setup preflight --ghidra-path ~/ghidra_12.1.2_PUBLIC
    ```
 
 4. **Build and deploy to Ghidra (single command):**
    ```bash
-   python -m tools.setup ensure-prereqs --ghidra-path ~/ghidra_12.1_PUBLIC
+   python -m tools.setup ensure-prereqs --ghidra-path ~/ghidra_12.1.2_PUBLIC
    python -m tools.setup build
-   python -m tools.setup deploy --ghidra-path ~/ghidra_12.1_PUBLIC
+   python -m tools.setup deploy --ghidra-path ~/ghidra_12.1.2_PUBLIC
    ```
 
    This will:
@@ -204,7 +204,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 5. **Optional: setup only Maven dependencies:**
    ```bash
-   python -m tools.setup install-ghidra-deps --ghidra-path ~/ghidra_12.1_PUBLIC
+   python -m tools.setup install-ghidra-deps --ghidra-path ~/ghidra_12.1.2_PUBLIC
    ```
 
 6. **Show command help:**
@@ -242,7 +242,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
     python -m tools.setup deploy \
        --ghidra-path /opt/homebrew/opt/ghidra/libexec
    ```
-   The extension is installed to `~/Library/ghidra/ghidra_12.1_PUBLIC/Extensions/GhidraMCP/`.
+   The extension is installed to `~/Library/ghidra/ghidra_12.1.2_PUBLIC/Extensions/GhidraMCP/`.
 
    > **Note:** `--ghidra-version` is required when using the Homebrew path because the path contains no version string.
 
@@ -417,7 +417,7 @@ java -jar GhidraMCPHeadless.jar --bind 0.0.0.0 --port 8089
 
 When connecting to a shared Ghidra Server, GhidraMCP can suppress the password dialog automatically. It resolves credentials in this order (first non-empty value wins):
 
-Compatibility note: Ghidra 12.1 clients require Ghidra Server 12.1,
+Compatibility note: Ghidra 12.1.2 clients require Ghidra Server 12.1.2,
 12.0.5, or a newer compatible server. Older shared servers are not safe
 targets for a 12.1 client upgrade.
 
@@ -496,7 +496,7 @@ into and run from the same interpreter.
 
 ### Python Ghidra scripts fail with "No script provider found"
 
-**Cause:** In Ghidra 12.1, Jython support is no longer enabled by
+**Cause:** In Ghidra 12.1.2, Jython support is no longer enabled by
 default. `.py` scripts need the bundled Jython extension; Python 3
 scripts should use PyGhidra instead of the Ghidra Script Manager.
 
@@ -510,7 +510,7 @@ scripts should use PyGhidra instead of the Ghidra Script Manager.
 **Cause:** JAR file in wrong location.
 
 **Solution:**
-1. Manual install location: `~/.ghidra/ghidra_12.1_PUBLIC/Extensions/GhidraMCP/lib/GhidraMCP.jar`
+1. Manual install location: `~/.ghidra/ghidra_12.1.2_PUBLIC/Extensions/GhidraMCP/lib/GhidraMCP.jar`
 2. Or use: **File > Install Extensions > Add** and select the ZIP file
 3. Ensure JAR/ZIP was built for your Ghidra version
 
@@ -521,7 +521,7 @@ scripts should use PyGhidra instead of the Ghidra Script Manager.
 **Solution:**
 ```text
 # Windows (recommended)
-python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 ```
 
 ## 📊 Production Performance
@@ -777,9 +777,9 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 ### Building from Source
 ```bash
 # Recommended: direct Python-first workflow
-python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 python -m tools.setup build
-python -m tools.setup deploy --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup deploy --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 
 # Version bump (updates all maintained version references atomically)
 python -m tools.setup bump-version --new X.Y.Z
@@ -825,12 +825,12 @@ on your machine to run the live benchmark regression. See
 
 ```text
 # Standard first-time setup and deploy
-python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup ensure-prereqs --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 python -m tools.setup build
-python -m tools.setup deploy --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup deploy --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 
 # Preflight check before deploying
-python -m tools.setup preflight --strict --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup preflight --strict --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 
 # Version bump and tag
 python -m tools.setup bump-version --new X.Y.Z --tag
@@ -875,7 +875,7 @@ This is a one-time setup per machine, and again when your Ghidra version changes
 
 The tool enforces version consistency between:
 - `pom.xml` (`ghidra.version`)
-- `--ghidra-path` version segment (e.g., `ghidra_12.1_PUBLIC`)
+- `--ghidra-path` version segment (e.g., `ghidra_12.1.2_PUBLIC`)
 
 If these do not match, deployment fails fast with a clear error.
 
@@ -888,12 +888,12 @@ If you see a version mismatch error, align both values:
 Then rerun:
 
 ```text
-python -m tools.setup preflight --ghidra-path "C:\ghidra_12.1_PUBLIC"
+python -m tools.setup preflight --ghidra-path "C:\ghidra_12.1.2_PUBLIC"
 ```
 
 ```text
 # Windows
-python -m tools.setup install-ghidra-deps --ghidra-path "C:\path\to\ghidra_12.1_PUBLIC"
+python -m tools.setup install-ghidra-deps --ghidra-path "C:\path\to\ghidra_12.1.2_PUBLIC"
 ```
 
 **Required Libraries (14 JARs, ~37MB):**

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1_PUBLIC"
 
 ## 📊 Production Performance
 
-- **MCP Tools**: 249 tools fully implemented
+- **MCP Tools**: 251 tools fully implemented
 - **Speed**: Sub-second response for most operations
 - **Efficiency**: 93% reduction in API calls via batch operations
 - **Reliability**: Atomic transactions with all-or-nothing semantics
@@ -962,7 +962,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.13.1
+# Connection OK - GhidraMCP Headless Server v5.14.0
 ```
 
 ### Headless API Workflow
@@ -1028,7 +1028,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.13.1 |
+| **Version** | 5.14.0 |
 | **MCP Tools** | 249 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 >
 > If Ghidra MCP saves you time, consider [sponsoring the project](https://github.com/sponsors/bethington). One-time and recurring support both help fund compatibility updates, production hardening, docs, and new tooling.
 
-A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **249 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
+A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **251 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
 
 ## Why Ghidra MCP?
 
 Most Ghidra MCP implementations give you a handful of read-only tools and call it a day. This project is different — it was built by a reverse engineer who uses it daily on real binaries, not as a demo.
 
-- **249 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
+- **251 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
 - **Battle-tested AI workflows** — Proven documentation workflows (V5) refined across hundreds of functions. Includes step-by-step prompts, Hungarian notation reference, batch processing guides, and orphaned code discovery.
 - **Production-grade reliability** — Atomic transactions, batch operations (93% API call reduction), configurable timeouts, and graceful error handling. No silent failures.
 - **Cross-binary documentation transfer** — SHA-256 function hash matching propagates documentation across binary versions automatically. Document once, apply everywhere.
@@ -56,7 +56,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 ### Core MCP Integration
 - **Full MCP Compatibility** — Complete implementation of Model Context Protocol
-- **249 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
+- **251 MCP Tools** — Comprehensive API surface covering every aspect of binary analysis
 - **Production-Ready Reliability** — Atomic transactions, batch operations, configurable timeouts
 - **Real-time Analysis** — Live integration with Ghidra's analysis engine
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Last commit](https://img.shields.io/github/last-commit/bethington/ghidra-mcp?style=for-the-badge&logo=git&logoColor=white)](https://github.com/bethington/ghidra-mcp/commits/main)
 [![Discussions](https://img.shields.io/badge/discussions-join-7B68EE?style=for-the-badge&logo=github&logoColor=white)](https://github.com/bethington/ghidra-mcp/discussions)
 [![Issues](https://img.shields.io/github/issues/bethington/ghidra-mcp?style=for-the-badge&logo=github&logoColor=white&color=orange)](https://github.com/bethington/ghidra-mcp/issues)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bethington/ghidra-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/bethington/ghidra-mcp)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/bethington/ghidra-mcp?style=for-the-badge&logo=securityscorecard&logoColor=white&label=OpenSSF%20Scorecard)](https://scorecard.dev/viewer/?uri=github.com/bethington/ghidra-mcp)
 
 > If you find this useful, please ⭐ star the repo — it helps others discover it!
 >
@@ -315,6 +315,24 @@ python bridge_mcp_ghidra.py --transport sse --mcp-host 127.0.0.1 --mcp-port 8081
 | `--lazy` | off | Load only the default tool groups on connect. Faster startup, but MCP clients that don't support `tools/list_changed` will see an incomplete tool list. Not recommended for Claude Code. |
 | `--no-lazy` | (default) | Load all tool groups immediately on connect. Required for most AI clients. |
 | `--default-groups` | `listing,function,program` | Comma-separated groups loaded on connect when `--lazy` is set. |
+
+#### Reducing tool-context overhead
+
+The bridge exposes a large catalog. To keep the model's tool surface small, run
+with `--lazy` (loads only `listing,function,program` on connect) and let the
+model **discover** the rest on demand instead of registering everything:
+
+- `search_tools("rename function")` — keyword-search the **entire** catalog,
+  including tools whose group isn't loaded. Each result says whether it's
+  callable now and, if not, the exact `load_tool_group(...)` call to enable it.
+- `list_tool_groups()` — list all categories and their load state.
+- `load_tool_group("datatype")` / `unload_tool_group("datatype")` — load or
+  drop a category at runtime.
+- `check_tools("rename_or_label,batch_set_comments")` — confirm specific tools
+  are callable right now.
+
+`search_tools` works in both eager and `--lazy` modes, so agents that honor
+`tools/list_changed` get full discovery without the upfront context cost.
 
 #### Optional: Start the standalone debugger server
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,54 @@
+# Ghidra MCP — Roadmap & Project Direction
+
+This document exists to make the project's direction legible. It is intentionally
+short and is updated as priorities shift. For the full tool inventory see
+[`tests/endpoints.json`](tests/endpoints.json); for architecture see
+[`CLAUDE.md`](CLAUDE.md).
+
+_Last updated: 2026-06-14._
+
+## Guiding principles
+
+- **Thin bridge, fat plugin.** Tool logic lives in the Java service layer and is
+  auto-discovered from `@McpTool` annotations. The Python bridge is a generic
+  HTTP multiplexer that registers tools dynamically from `/mcp/schema` — there
+  is no hand-maintained tool list to keep in sync.
+- **Conventions enforced in the tool layer**, not in prompts, so documentation
+  output stays consistent across large-scale runs.
+- **Bug reports from real users are first-class.** Issues are triaged with a
+  reproduction or a clear "can't reproduce / need info" — not closed silently.
+
+## Now (in progress)
+
+- **Tool-context overhead (#267, #153).** The catalog is large. The levers
+  already exist — tool groups (`load_tool_group` / `unload_tool_group`),
+  `--lazy` startup, and as of v5.x a `search_tools` catalog-search meta-tool so
+  agents can run lazy and discover unloaded tools by keyword. Next step:
+  evaluate making `--lazy + search_tools` the recommended default once the
+  `tools/list_changed` story is solid across common clients.
+- **Transport modernization.** `streamable-http` is supported and recommended;
+  `sse` is deprecated and retained only for backward compatibility. Tracking a
+  reported MCP Inspector preflight/`OPTIONS` issue on the HTTP transport.
+- **API parameter-name consistency (#210).** Normalize `address` vs
+  `function_address`, `new_name` vs `newName` across endpoints.
+
+## Next
+
+- **Reference write tools (#298).** `add_memory_reference` / `remove_reference`
+  to complement the read-side xref tools (community PR #299 under review).
+- **Reduce surface area further.** Audit for redundant/overlapping tools that
+  can be merged now that `search_tools` exists.
+- **Single-process option.** Investigate serving MCP-over-streamable-HTTP
+  directly from the Ghidra Java extension to make the Python bridge optional.
+  Larger architectural change — scoped as a future direction, not a quick fix.
+
+## Process commitments
+
+- A pinned issue tracks current direction; this file is the canonical source.
+- Issues are not auto-closed by templated messages without a human decision.
+- Dependency bumps flow through Dependabot and are batched after CI is green.
+
+## How to influence the roadmap
+
+Open an issue describing the problem (not just the solution) with a concrete
+repro or use case. Feature requests with a PR attached move fastest.

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -931,6 +931,7 @@ STATIC_TOOL_NAMES = {
     "load_tool_group",
     "unload_tool_group",
     "check_tools",
+    "search_tools",
     "import_file",
     # Debugger tools (Phase 1+2+3)
     "debugger_attach",
@@ -1587,6 +1588,62 @@ async def check_tools(tools: str) -> str:
         {
             "results": results,
             "summary": f"{callable_count}/{len(tool_names)} callable",
+        }
+    )
+
+
+@mcp.tool()
+async def search_tools(query: str, limit: int = 15) -> str:
+    """
+    Search the full Ghidra tool catalog by keyword — including tools whose group
+    is not currently loaded. Use this to discover the right tool without paying
+    the context cost of loading all groups (run the bridge with --lazy and search
+    on demand). Matches against tool name, description, and category.
+
+    Each result reports whether the tool is callable right now; if not, it
+    includes the exact load_tool_group(...) call needed to make it callable.
+
+    Args:
+        query: Space-separated keywords, e.g. "rename function" or "xref struct".
+        limit: Maximum number of results to return (default 15).
+    """
+    terms = [t.lower() for t in query.split() if t.strip()]
+    if not terms:
+        return json.dumps({"error": "Provide one or more search keywords"})
+
+    scored: list[tuple[int, dict]] = []
+    for td in _full_schema:
+        name = td.get("name", "")
+        category = td.get("category", "unknown")
+        desc = td.get("description", "") or ""
+        haystack = f"{name} {category} {desc}".lower()
+        score = 0
+        for term in terms:
+            if term in name.lower():
+                score += 3  # name hits rank highest
+            elif term in haystack:
+                score += 1
+        if score == 0:
+            continue
+        loaded = name in _dynamic_tool_names or name in STATIC_TOOL_NAMES
+        result = {
+            "name": name,
+            "group": category,
+            "status": "callable" if loaded else "not_loaded",
+            "description": desc[:160],
+        }
+        if not loaded:
+            result["fix"] = f'load_tool_group("{category}")'
+        scored.append((score, result))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    matches = [r for _, r in scored[: max(1, limit)]]
+    return json.dumps(
+        {
+            "query": query,
+            "match_count": len(scored),
+            "returned": len(matches),
+            "matches": matches,
         }
     )
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -206,7 +206,7 @@ community-reported fixes plus the gemini-cli-sdk reconciliation.
   pom bumped 12.0.4 → 12.1; CI / release / Docker download metadata
   pointed at the Ghidra 12.1 20260513 upstream asset; setup docs,
   examples, defaults, and compatibility tests refreshed for
-  `ghidra_12.1_PUBLIC`. Documents the 12.1 shared-server requirement
+  `ghidra_12.1.2_PUBLIC`. Documents the 12.1 shared-server requirement
   (clients on 12.1 need server 12.1 or 12.0.5+) and that Jython is
   optional in 12.1 (install via File → Install Extensions if you run
   `.py` Ghidra scripts).

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,7 +9,7 @@ For the release preparation runbook, see
 
 ## Current Releases
 
-### v5.13.1 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
+### v5.14.0 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
 
 Minor release. Two new endpoints filed/scoped by community feedback,
 plus a quiet headless parity fix that surfaced while writing the

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.13.1</version>
+    <version>5.14.0</version>
     <name>Ghidra MCP Server</name>
     <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. Provides MCP-based tooling and automation for reverse engineering workflows: convention-enforcing rename/type/comment endpoints, batch operations, P-code emulation, live debugger integration, headless server, and Ghidra Server multi-version support.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ghidra.version>12.1</ghidra.version>
+        <ghidra.version>12.1.2</ghidra.version>
         <!-- Build timestamp generated at compile time (format: yyyyMMdd-HHmmss) -->
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -106,7 +106,7 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.13.1"; // Default fallback
+    private static String VERSION = "5.14.0"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -632,15 +632,27 @@ public final class ServiceUtils {
         boolean hasColon = addressStr.contains(":");
 
         // Normalize space:offset form: AddressFactory is case-sensitive and rejects "0x" prefix.
-        // Lowercase the space name and strip leading "0x"/"0X" from the offset so that inputs
-        // like "MEM:0x1000", "MEM:1000", and "Code:FF00" all resolve correctly — including
-        // addresses carried inside batch/container params that bypass bridge sanitization.
+        // Resolve the canonical space name first so overlays like "CODE_BANK1" keep their case.
         if (hasColon) {
             int colonIdx = addressStr.indexOf(':');
-            String spaceName = addressStr.substring(0, colonIdx).toLowerCase();
+            String rawSpace = addressStr.substring(0, colonIdx);
+            String spaceName = rawSpace.toLowerCase();
             String offset = addressStr.substring(colonIdx + 1);
             if (offset.startsWith("0x") || offset.startsWith("0X")) {
                 offset = offset.substring(2);
+            }
+
+            AddressSpace matchedSpace = program.getAddressFactory().getAddressSpace(rawSpace);
+            if (matchedSpace == null) {
+                for (AddressSpace candidate : program.getAddressFactory().getAddressSpaces()) {
+                    if (candidate.getName().equalsIgnoreCase(rawSpace)) {
+                        matchedSpace = candidate;
+                        break;
+                    }
+                }
+            }
+            if (matchedSpace != null) {
+                spaceName = matchedSpace.getName();
             }
             addressStr = spaceName + ":" + offset;
         }

--- a/src/main/java/com/xebyte/core/XrefCallGraphService.java
+++ b/src/main/java/com/xebyte/core/XrefCallGraphService.java
@@ -160,8 +160,6 @@ public class XrefCallGraphService {
                    description = "Operand index the reference attaches to. -1 = mnemonic/data operand.") int operandIndex,
             @Param(value = "set_primary", source = ParamSource.BODY, defaultValue = "false",
                    description = "If true, mark this reference as the primary reference for the operand.") boolean setPrimary,
-            @Param(value = "dry_run", source = ParamSource.BODY, defaultValue = "false",
-                   description = "If true, validate and report what would be created without writing.") boolean dryRun,
             @Param(value = "program", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -187,20 +185,6 @@ public class XrefCallGraphService {
         } catch (Exception e) {
             return Response.err("Unknown source_type '" + sourceTypeStr
                     + "'. Valid values: USER_DEFINED, ANALYSIS, IMPORTED, DEFAULT.");
-        }
-
-        if (dryRun) {
-            Reference existing = program.getReferenceManager().getReference(fromAddr, toAddr, operandIndex);
-            return Response.ok(JsonHelper.mapOf(
-                    "status", "dry_run",
-                    "would_create", existing == null,
-                    "already_exists", existing != null,
-                    "from_address", fromAddr.toString(),
-                    "to_address", toAddr.toString(),
-                    "ref_type", refType.getName(),
-                    "source_type", sourceType.toString(),
-                    "operand_index", operandIndex,
-                    "set_primary", setPrimary));
         }
 
         try {
@@ -248,8 +232,6 @@ public class XrefCallGraphService {
             @Param(value = "operand_index", source = ParamSource.BODY, defaultValue = "-1",
                    description = "Operand index to match. -1 (default) = remove references on any operand; "
                                + ">= 0 = remove only the reference on that operand.") int operandIndex,
-            @Param(value = "dry_run", source = ParamSource.BODY, defaultValue = "false",
-                   description = "If true, report which references would be removed without deleting them.") boolean dryRun,
             @Param(value = "program", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -263,7 +245,7 @@ public class XrefCallGraphService {
         Address toAddr = ServiceUtils.parseAddress(program, toAddressStr);
         if (toAddr == null) return Response.err("to_address: " + ServiceUtils.getLastParseError());
 
-        // Collect the matching references up front (same for dry_run and the real delete).
+        // Collect the matching references up front, then delete inside the transaction.
         List<Reference> matches = new ArrayList<>();
         for (Reference ref : program.getReferenceManager().getReferencesFrom(fromAddr)) {
             if (!ref.getToAddress().equals(toAddr)) continue;
@@ -278,15 +260,6 @@ public class XrefCallGraphService {
                     "operand_index", ref.getOperandIndex(),
                     "ref_type", ref.getReferenceType().getName(),
                     "source_type", ref.getSource().toString()));
-        }
-
-        if (dryRun) {
-            return Response.ok(JsonHelper.mapOf(
-                    "status", "dry_run",
-                    "from_address", fromAddr.toString(),
-                    "to_address", toAddr.toString(),
-                    "match_count", matches.size(),
-                    "would_remove", details));
         }
 
         if (matches.isEmpty()) {

--- a/src/main/java/com/xebyte/core/XrefCallGraphService.java
+++ b/src/main/java/com/xebyte/core/XrefCallGraphService.java
@@ -228,6 +228,93 @@ public class XrefCallGraphService {
     }
 
     /**
+     * Remove memory cross-reference(s) between two addresses — the inverse of
+     * {@link #addMemoryReference}. Useful for clearing references the analyzer got wrong
+     * or for undoing a manual reference.
+     */
+    @McpTool(path = "/remove_reference", method = "POST",
+            description = "Remove memory cross-reference(s) from one address to another (the inverse of "
+                        + "add_memory_reference). Removes every reference from_address -> to_address "
+                        + "regardless of operand by default; pass operand_index >= 0 to remove only the "
+                        + "reference on that operand. Removes both user-defined and analyzer-inferred "
+                        + "references — the response reports each removed reference's source_type. "
+                        + "On multi-space programs, prefix addresses with the space name (mem:1000).",
+            category = "xref")
+    public Response removeReference(
+            @Param(value = "from_address", paramType = "address", source = ParamSource.BODY,
+                   description = "Source address the reference originates from. Accepts 0x<hex> or <space>:<hex>.") String fromAddressStr,
+            @Param(value = "to_address", paramType = "address", source = ParamSource.BODY,
+                   description = "Target address the reference points to. Accepts 0x<hex> or <space>:<hex>.") String toAddressStr,
+            @Param(value = "operand_index", source = ParamSource.BODY, defaultValue = "-1",
+                   description = "Operand index to match. -1 (default) = remove references on any operand; "
+                               + ">= 0 = remove only the reference on that operand.") int operandIndex,
+            @Param(value = "dry_run", source = ParamSource.BODY, defaultValue = "false",
+                   description = "If true, report which references would be removed without deleting them.") boolean dryRun,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        if (fromAddressStr == null || fromAddressStr.isEmpty()) return Response.err("from_address is required");
+        if (toAddressStr == null || toAddressStr.isEmpty()) return Response.err("to_address is required");
+
+        Address fromAddr = ServiceUtils.parseAddress(program, fromAddressStr);
+        if (fromAddr == null) return Response.err("from_address: " + ServiceUtils.getLastParseError());
+        Address toAddr = ServiceUtils.parseAddress(program, toAddressStr);
+        if (toAddr == null) return Response.err("to_address: " + ServiceUtils.getLastParseError());
+
+        // Collect the matching references up front (same for dry_run and the real delete).
+        List<Reference> matches = new ArrayList<>();
+        for (Reference ref : program.getReferenceManager().getReferencesFrom(fromAddr)) {
+            if (!ref.getToAddress().equals(toAddr)) continue;
+            if (operandIndex >= 0 && ref.getOperandIndex() != operandIndex) continue;
+            matches.add(ref);
+        }
+
+        List<Map<String, Object>> details = new ArrayList<>();
+        for (Reference ref : matches) {
+            details.add(JsonHelper.mapOf(
+                    "to_address", ref.getToAddress().toString(),
+                    "operand_index", ref.getOperandIndex(),
+                    "ref_type", ref.getReferenceType().getName(),
+                    "source_type", ref.getSource().toString()));
+        }
+
+        if (dryRun) {
+            return Response.ok(JsonHelper.mapOf(
+                    "status", "dry_run",
+                    "from_address", fromAddr.toString(),
+                    "to_address", toAddr.toString(),
+                    "match_count", matches.size(),
+                    "would_remove", details));
+        }
+
+        if (matches.isEmpty()) {
+            return Response.ok(JsonHelper.mapOf(
+                    "status", "success",
+                    "removed", 0,
+                    "message", "No reference found from " + fromAddr + " to " + toAddr));
+        }
+
+        try {
+            return threadingStrategy.executeWrite(program, "Remove memory reference", () -> {
+                ReferenceManager refMgr = program.getReferenceManager();
+                for (Reference ref : matches) {
+                    refMgr.delete(ref);
+                }
+                return Response.ok(JsonHelper.mapOf(
+                        "status", "success",
+                        "from_address", fromAddr.toString(),
+                        "to_address", toAddr.toString(),
+                        "removed", matches.size(),
+                        "references", details));
+            });
+        } catch (Exception e) {
+            return Response.err("Error removing reference: " + e.getMessage());
+        }
+    }
+
+    /**
      * Resolve a case-insensitive {@link RefType} name to its static constant.
      * Reflects over RefType's public static fields so every valid name (data + flow types)
      * is accepted, matching the names callers see in the listing.

--- a/src/main/java/com/xebyte/core/XrefCallGraphService.java
+++ b/src/main/java/com/xebyte/core/XrefCallGraphService.java
@@ -133,6 +133,123 @@ public class XrefCallGraphService {
     }
 
     /**
+     * Create a user-defined memory cross-reference that the analyzer could not infer
+     * (e.g. runtime-populated dispatch tables, late-bound function pointers, missed jump tables).
+     */
+    @McpTool(path = "/add_memory_reference", method = "POST",
+            description = "Create a cross-reference between two memory addresses that the auto-analyzer "
+                        + "can't infer (runtime-populated pointer tables, vtables, late-bound function "
+                        + "pointers, missed jump/switch tables). Leaves the underlying bytes untouched and "
+                        + "adds proper bidirectional navigation. On programs with multiple address spaces "
+                        + "(e.g. embedded targets), prefix addresses with the space name (mem:1000).",
+            category = "xref")
+    public Response addMemoryReference(
+            @Param(value = "from_address", paramType = "address", source = ParamSource.BODY,
+                   description = "Source address the reference originates from (the table slot / instruction). "
+                               + "Accepts 0x<hex> or <space>:<hex> (e.g. mem:1000).") String fromAddressStr,
+            @Param(value = "to_address", paramType = "address", source = ParamSource.BODY,
+                   description = "Target address the reference points to. Accepts 0x<hex> or <space>:<hex>.") String toAddressStr,
+            @Param(value = "ref_type", source = ParamSource.BODY, defaultValue = "DATA",
+                   description = "Reference type (case-insensitive RefType name): DATA, READ, WRITE, READ_WRITE, "
+                               + "COMPUTED_CALL, UNCONDITIONAL_CALL, COMPUTED_JUMP, UNCONDITIONAL_JUMP, "
+                               + "CONDITIONAL_JUMP, INDIRECTION, etc.") String refTypeStr,
+            @Param(value = "source_type", source = ParamSource.BODY, defaultValue = "USER_DEFINED",
+                   description = "SourceType: USER_DEFINED (default — distinct from analyzer refs and survives "
+                               + "re-analysis), ANALYSIS, IMPORTED, DEFAULT.") String sourceTypeStr,
+            @Param(value = "operand_index", source = ParamSource.BODY, defaultValue = "-1",
+                   description = "Operand index the reference attaches to. -1 = mnemonic/data operand.") int operandIndex,
+            @Param(value = "set_primary", source = ParamSource.BODY, defaultValue = "false",
+                   description = "If true, mark this reference as the primary reference for the operand.") boolean setPrimary,
+            @Param(value = "dry_run", source = ParamSource.BODY, defaultValue = "false",
+                   description = "If true, validate and report what would be created without writing.") boolean dryRun,
+            @Param(value = "program", defaultValue = "") String programName) {
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        if (fromAddressStr == null || fromAddressStr.isEmpty()) return Response.err("from_address is required");
+        if (toAddressStr == null || toAddressStr.isEmpty()) return Response.err("to_address is required");
+
+        Address fromAddr = ServiceUtils.parseAddress(program, fromAddressStr);
+        if (fromAddr == null) return Response.err("from_address: " + ServiceUtils.getLastParseError());
+        Address toAddr = ServiceUtils.parseAddress(program, toAddressStr);
+        if (toAddr == null) return Response.err("to_address: " + ServiceUtils.getLastParseError());
+
+        RefType refType = resolveMemoryRefType(refTypeStr);
+        if (refType == null) {
+            return Response.err("Unknown ref_type '" + refTypeStr + "'. Valid names include: "
+                    + "DATA, READ, WRITE, READ_WRITE, COMPUTED_CALL, UNCONDITIONAL_CALL, CONDITIONAL_CALL, "
+                    + "COMPUTED_JUMP, UNCONDITIONAL_JUMP, CONDITIONAL_JUMP, INDIRECTION");
+        }
+        SourceType sourceType;
+        try {
+            sourceType = SourceType.valueOf(sourceTypeStr == null ? "" : sourceTypeStr.trim().toUpperCase(Locale.ROOT));
+        } catch (Exception e) {
+            return Response.err("Unknown source_type '" + sourceTypeStr
+                    + "'. Valid values: USER_DEFINED, ANALYSIS, IMPORTED, DEFAULT.");
+        }
+
+        if (dryRun) {
+            Reference existing = program.getReferenceManager().getReference(fromAddr, toAddr, operandIndex);
+            return Response.ok(JsonHelper.mapOf(
+                    "status", "dry_run",
+                    "would_create", existing == null,
+                    "already_exists", existing != null,
+                    "from_address", fromAddr.toString(),
+                    "to_address", toAddr.toString(),
+                    "ref_type", refType.getName(),
+                    "source_type", sourceType.toString(),
+                    "operand_index", operandIndex,
+                    "set_primary", setPrimary));
+        }
+
+        try {
+            return threadingStrategy.executeWrite(program, "Add memory reference", () -> {
+                ReferenceManager refMgr = program.getReferenceManager();
+                Reference ref = refMgr.addMemoryReference(fromAddr, toAddr, refType, sourceType, operandIndex);
+                if (ref == null) {
+                    return Response.err("Failed to create reference from " + fromAddr + " to " + toAddr);
+                }
+                if (setPrimary) {
+                    refMgr.setPrimary(ref, true);
+                }
+                return Response.ok(JsonHelper.mapOf(
+                        "status", "success",
+                        "from_address", fromAddr.toString(),
+                        "to_address", toAddr.toString(),
+                        "ref_type", refType.getName(),
+                        "source_type", sourceType.toString(),
+                        "operand_index", operandIndex,
+                        "is_primary", ref.isPrimary()));
+            });
+        } catch (Exception e) {
+            return Response.err("Error adding memory reference: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolve a case-insensitive {@link RefType} name to its static constant.
+     * Reflects over RefType's public static fields so every valid name (data + flow types)
+     * is accepted, matching the names callers see in the listing.
+     */
+    private static RefType resolveMemoryRefType(String name) {
+        if (name == null || name.trim().isEmpty()) return null;
+        String want = name.trim().toUpperCase(Locale.ROOT);
+        for (java.lang.reflect.Field f : RefType.class.getFields()) {
+            if (java.lang.reflect.Modifier.isStatic(f.getModifiers())
+                    && RefType.class.isAssignableFrom(f.getType())
+                    && f.getName().equals(want)) {
+                try {
+                    return (RefType) f.get(null);
+                } catch (IllegalAccessException e) {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Get all references to a specific function by name
      */
     @McpTool(path = "/get_function_xrefs", description = "Get cross-references to a function. Accepts function name or address (pass address as 'address' param, or as 'name').", category = "xref")

--- a/src/main/java/com/xebyte/core/XrefCallGraphService.java
+++ b/src/main/java/com/xebyte/core/XrefCallGraphService.java
@@ -158,8 +158,6 @@ public class XrefCallGraphService {
                                + "re-analysis), ANALYSIS, IMPORTED, DEFAULT.") String sourceTypeStr,
             @Param(value = "operand_index", source = ParamSource.BODY, defaultValue = "-1",
                    description = "Operand index the reference attaches to. -1 = mnemonic/data operand.") int operandIndex,
-            @Param(value = "set_primary", source = ParamSource.BODY, defaultValue = "false",
-                   description = "If true, mark this reference as the primary reference for the operand.") boolean setPrimary,
             @Param(value = "program", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -193,9 +191,6 @@ public class XrefCallGraphService {
                 Reference ref = refMgr.addMemoryReference(fromAddr, toAddr, refType, sourceType, operandIndex);
                 if (ref == null) {
                     return Response.err("Failed to create reference from " + fromAddr + " to " + toAddr);
-                }
-                if (setPrimary) {
-                    refMgr.setPrimary(ref, true);
                 }
                 return Response.ok(JsonHelper.mapOf(
                         "status", "success",

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -54,7 +54,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.13.1-headless";
+    private static final String VERSION = "5.14.0-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -42,7 +42,7 @@ import ghidra.app.cmd.disassemble.DisassembleCommand;
  */
 public class HeadlessEndpointHandler {
 
-    private static final String VERSION = "5.13.1-headless";
+    private static final String VERSION = "5.14.0-headless";
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
     private final TaskMonitor monitor;

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.13.1
+Plugin-Version: 5.14.0
 Plugin-Author: Ben Ethington
 Plugin-Description: GhidraMCP - HTTP server plugin with 251 MCP tools for reverse engineering automation

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
 Plugin-Version: 5.13.1
 Plugin-Author: Ben Ethington
-Plugin-Description: GhidraMCP - HTTP server plugin with 249 MCP tools for reverse engineering automation
+Plugin-Description: GhidraMCP - HTTP server plugin with 251 MCP tools for reverse engineering automation

--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -1,5 +1,5 @@
 name=GhidraMCP
-description=A plugin that runs an embedded HTTP server to expose program data. Provides 249 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
+description=A plugin that runs an embedded HTTP server to expose program data. Provides 251 MCP tools for reverse engineering automation (including P-code emulation, live debugger integration, and PCode-graph data flow analysis). Plugin version ${project.version}.
 author=Ben Ethington
 createdOn=2025-03-22
 version=${ghidra.version}

--- a/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
+++ b/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
@@ -179,6 +179,26 @@ public class ServiceUtilsAddressTest {
     }
 
     @Test
+    public void parseAddress_overlaySpace_resolvesWithCanonicalCaseParser() throws Exception {
+        AddressSpace overlaySpace = mock(AddressSpace.class);
+        Address bank1Addr = mock(Address.class);
+
+        when(overlaySpace.getType()).thenReturn(AddressSpace.TYPE_RAM);
+        when(overlaySpace.isOverlaySpace()).thenReturn(true);
+        when(overlaySpace.getName()).thenReturn("CODE_BANK1");
+        when(bank1Addr.getAddressSpace()).thenReturn(overlaySpace);
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace, codeSpace, overlaySpace});
+        when(factory.getAddressSpace("CODE_BANK1")).thenReturn(overlaySpace);
+        when(factory.getAddress("CODE_BANK1:a066")).thenReturn(bank1Addr);
+
+        Address result = ServiceUtils.parseAddress(program, "CODE_BANK1:a066");
+
+        assertSame("Overlay address must resolve in the CODE_BANK1 space", bank1Addr, result);
+        assertEquals("CODE_BANK1", result.getAddressSpace().getName());
+        assertNull(ServiceUtils.getLastParseError());
+    }
+
+    @Test
     public void convertToMapList_acceptsStringifiedArrayPayload() {
         List<Map<String, String>> result = ServiceUtils.convertToMapList(
             "[{\"address\":\"0x401000\",\"comment\":\"alpha\"},{\"address\":\"0x401004\",\"comment\":\"beta\"}]"

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.13.1",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 250,
+  "total_endpoints": 251,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -1986,6 +1986,19 @@
         "program"
       ],
       "description": "Detach one or more tags from a function. Does not delete the program-wide tag definition — use delete_function_tag for that."
+    },
+    {
+      "path": "/remove_reference",
+      "method": "POST",
+      "category": "xref",
+      "params": [
+        "from_address",
+        "to_address",
+        "operand_index",
+        "dry_run",
+        "program"
+      ],
+      "description": "Remove memory cross-reference(s) from one address to another — the inverse of add_memory_reference. Removes every reference from_address -> to_address regardless of operand by default; pass operand_index >= 0 to remove only the reference on that operand. Removes both user-defined and analyzer-inferred references and reports each removed reference's source_type. Supports dry_run and space-prefixed addresses (mem:1000)."
     },
     {
       "path": "/remove_struct_field",

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.13.1",
+  "version": "5.14.0",
   "description": "GhidraMCP REST API Endpoint Specification",
   "total_endpoints": 251,
   "categories": {

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -41,7 +41,6 @@
         "ref_type",
         "source_type",
         "operand_index",
-        "set_primary",
         "program"
       ],
       "description": "Create a user-defined cross-reference between two memory addresses that the auto-analyzer can't infer (runtime-populated pointer tables, vtables, late-bound function pointers, missed jump/switch tables). Leaves the underlying bytes untouched while adding proper bidirectional navigation. ref_type accepts any RefType name (DATA, READ, WRITE, COMPUTED_CALL, UNCONDITIONAL_JUMP, ...); source_type defaults to USER_DEFINED so refs are distinct from analyzer output and survive re-analysis. Accepts space-prefixed addresses (mem:1000)."

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -42,10 +42,9 @@
         "source_type",
         "operand_index",
         "set_primary",
-        "dry_run",
         "program"
       ],
-      "description": "Create a user-defined cross-reference between two memory addresses that the auto-analyzer can't infer (runtime-populated pointer tables, vtables, late-bound function pointers, missed jump/switch tables). Leaves the underlying bytes untouched while adding proper bidirectional navigation. ref_type accepts any RefType name (DATA, READ, WRITE, COMPUTED_CALL, UNCONDITIONAL_JUMP, ...); source_type defaults to USER_DEFINED so refs are distinct from analyzer output and survive re-analysis. Supports dry_run and space-prefixed addresses (mem:1000)."
+      "description": "Create a user-defined cross-reference between two memory addresses that the auto-analyzer can't infer (runtime-populated pointer tables, vtables, late-bound function pointers, missed jump/switch tables). Leaves the underlying bytes untouched while adding proper bidirectional navigation. ref_type accepts any RefType name (DATA, READ, WRITE, COMPUTED_CALL, UNCONDITIONAL_JUMP, ...); source_type defaults to USER_DEFINED so refs are distinct from analyzer output and survive re-analysis. Accepts space-prefixed addresses (mem:1000)."
     },
     {
       "path": "/add_struct_field",
@@ -1995,10 +1994,9 @@
         "from_address",
         "to_address",
         "operand_index",
-        "dry_run",
         "program"
       ],
-      "description": "Remove memory cross-reference(s) from one address to another — the inverse of add_memory_reference. Removes every reference from_address -> to_address regardless of operand by default; pass operand_index >= 0 to remove only the reference on that operand. Removes both user-defined and analyzer-inferred references and reports each removed reference's source_type. Supports dry_run and space-prefixed addresses (mem:1000)."
+      "description": "Remove memory cross-reference(s) from one address to another — the inverse of add_memory_reference. Removes every reference from_address -> to_address regardless of operand by default; pass operand_index >= 0 to remove only the reference on that operand. Removes both user-defined and analyzer-inferred references and reports each removed reference's source_type. Accepts space-prefixed addresses (mem:1000)."
     },
     {
       "path": "/remove_struct_field",

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.13.1",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 249,
+  "total_endpoints": 250,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -30,6 +30,22 @@
         "program"
       ],
       "description": "Attach one or more tags to a function. Tags are comma-separated and will be auto-created if they do not already exist."
+    },
+    {
+      "path": "/add_memory_reference",
+      "method": "POST",
+      "category": "xref",
+      "params": [
+        "from_address",
+        "to_address",
+        "ref_type",
+        "source_type",
+        "operand_index",
+        "set_primary",
+        "dry_run",
+        "program"
+      ],
+      "description": "Create a user-defined cross-reference between two memory addresses that the auto-analyzer can't infer (runtime-populated pointer tables, vtables, late-bound function pointers, missed jump/switch tables). Leaves the underlying bytes untouched while adding proper bidirectional navigation. ref_type accepts any RefType name (DATA, READ, WRITE, COMPUTED_CALL, UNCONDITIONAL_JUMP, ...); source_type defaults to USER_DEFINED so refs are distinct from analyzer output and survive re-analysis. Supports dry_run and space-prefixed addresses (mem:1000)."
     },
     {
       "path": "/add_struct_field",

--- a/tests/integration/test_reference_endpoints.py
+++ b/tests/integration/test_reference_endpoints.py
@@ -52,7 +52,7 @@ def test_add_memory_reference_declares_core_params(endpoints):
     assert entry is not None
     params = set(entry.get("params", []))
     for required in ("from_address", "to_address", "ref_type", "source_type",
-                     "operand_index", "set_primary", "program"):
+                     "operand_index", "program"):
         assert required in params, f"{required} missing from catalog params {params}"
 
 
@@ -163,7 +163,6 @@ def test_create_then_remove_reference_round_trip(http_client, endpoint_available
             "to_address": dst,
             "ref_type": "DATA",
             "source_type": "USER_DEFINED",
-            "set_primary": True,
         },
     )
     assert resp.status_code == 200, resp.text

--- a/tests/integration/test_reference_endpoints.py
+++ b/tests/integration/test_reference_endpoints.py
@@ -1,0 +1,192 @@
+"""
+Integration tests for /add_memory_reference.
+
+Covers the user-defined cross-reference tool: catalog/parity, the non-mutating
+dry_run path, input validation, and a real create -> get_xrefs_to round-trip.
+
+The catalog tests run without a server. The live tests auto-skip when the
+server/program is unavailable or when the endpoint isn't registered (older JAR).
+
+Run with: pytest tests/integration/test_reference_endpoints.py -v
+"""
+
+import json
+import re
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.safe_write,
+]
+
+
+# ---------- catalog / parity (no server needed) ----------
+
+
+def test_add_memory_reference_in_endpoint_catalog(endpoints):
+    """Must be in tests/endpoints.json so EndpointsJsonParityTest passes and
+    the bridge registers it dynamically."""
+    paths = {e["path"] for e in endpoints}
+    assert "/add_memory_reference" in paths, "add_memory_reference missing from endpoints.json"
+
+
+def test_add_memory_reference_categorized_as_xref(endpoints):
+    by_path = {e["path"]: e for e in endpoints}
+    entry = by_path.get("/add_memory_reference")
+    assert entry is not None
+    assert entry.get("category") == "xref"
+
+
+def test_add_memory_reference_is_post(endpoints):
+    by_path = {e["path"]: e for e in endpoints}
+    entry = by_path.get("/add_memory_reference")
+    assert entry is not None
+    assert entry.get("method") == "POST"
+
+
+def test_add_memory_reference_declares_core_params(endpoints):
+    by_path = {e["path"]: e for e in endpoints}
+    entry = by_path.get("/add_memory_reference")
+    assert entry is not None
+    params = set(entry.get("params", []))
+    for required in ("from_address", "to_address", "ref_type", "source_type",
+                     "operand_index", "set_primary", "dry_run", "program"):
+        assert required in params, f"{required} missing from catalog params {params}"
+
+
+# ---------- live fixtures ----------
+
+
+@pytest.fixture(scope="module")
+def require_server_and_program(server_available, program_loaded):
+    if not server_available:
+        pytest.skip("MCP server is not running")
+    if not program_loaded:
+        pytest.skip("No program loaded in Ghidra")
+
+
+@pytest.fixture
+def endpoint_available(http_client, require_server_and_program):
+    """Probe the endpoint with a harmless dry_run; skip if not registered."""
+    resp = http_client.post(
+        "/add_memory_reference",
+        json_data={"from_address": "0x0", "to_address": "0x0", "dry_run": True},
+    )
+    if resp.status_code == 404:
+        pytest.skip("/add_memory_reference not registered (deploy the updated JAR)")
+    return True
+
+
+@pytest.fixture
+def two_addresses(http_client, require_server_and_program):
+    """Return two distinct, mapped function-entry addresses from the program."""
+    resp = http_client.get("/list_functions", params={"limit": 50})
+    if resp.status_code != 200:
+        pytest.skip("Cannot list functions")
+    addrs = re.findall(r"at\s+(?:0x)?([0-9a-fA-F]+)", resp.text)
+    # de-dup preserving order
+    seen, uniq = set(), []
+    for a in addrs:
+        key = a.lower().lstrip("0") or "0"
+        if key not in seen:
+            seen.add(key)
+            uniq.append(a)
+    if len(uniq) < 2:
+        pytest.skip("Need at least two functions to build a reference")
+    return {"from": f"0x{uniq[0]}", "to": f"0x{uniq[1]}"}
+
+
+def _bare(addr_hex: str) -> str:
+    """Normalize '0x00401000' -> '401000' for substring matching."""
+    return addr_hex.lower().removeprefix("0x").lstrip("0") or "0"
+
+
+# ---------- validation (no mutation) ----------
+
+
+def test_unknown_ref_type_rejected(http_client, endpoint_available):
+    resp = http_client.post(
+        "/add_memory_reference",
+        json_data={"from_address": "0x1000", "to_address": "0x2000",
+                   "ref_type": "NOT_A_REAL_TYPE", "dry_run": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "Unknown ref_type" in resp.text
+
+
+def test_unknown_source_type_rejected(http_client, endpoint_available):
+    resp = http_client.post(
+        "/add_memory_reference",
+        json_data={"from_address": "0x1000", "to_address": "0x2000",
+                   "source_type": "BOGUS", "dry_run": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "Unknown source_type" in resp.text
+
+
+def test_missing_to_address_rejected(http_client, endpoint_available):
+    resp = http_client.post(
+        "/add_memory_reference",
+        json_data={"from_address": "0x1000", "dry_run": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "to_address is required" in resp.text
+
+
+# ---------- dry_run (no mutation) ----------
+
+
+def test_dry_run_reports_shape_without_writing(http_client, endpoint_available, two_addresses):
+    resp = http_client.post(
+        "/add_memory_reference",
+        json_data={
+            "from_address": two_addresses["from"],
+            "to_address": two_addresses["to"],
+            "ref_type": "DATA",
+            "dry_run": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = json.loads(resp.text)
+    assert body.get("status") == "dry_run"
+    assert body.get("ref_type") == "DATA"
+    assert body.get("source_type") == "USER_DEFINED"
+    assert "would_create" in body and "already_exists" in body
+
+    # dry_run must not have created anything: the from-address should not yet
+    # appear in the target's xrefs (only meaningful when it didn't pre-exist).
+    if body.get("would_create"):
+        xrefs = http_client.get("/get_xrefs_to", params={"address": two_addresses["to"]})
+        assert _bare(two_addresses["from"]) not in xrefs.text.lower()
+
+
+# ---------- real create -> round-trip ----------
+
+
+def test_create_reference_appears_in_xrefs_to(http_client, endpoint_available, two_addresses):
+    """Create a USER_DEFINED reference and confirm bidirectional navigation:
+    it shows up in get_xrefs_to for the target."""
+    resp = http_client.post(
+        "/add_memory_reference",
+        json_data={
+            "from_address": two_addresses["from"],
+            "to_address": two_addresses["to"],
+            "ref_type": "DATA",
+            "source_type": "USER_DEFINED",
+            "set_primary": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = json.loads(resp.text)
+    assert body.get("status") == "success", f"unexpected: {body}"
+    assert body.get("ref_type") == "DATA"
+    assert body.get("source_type") == "USER_DEFINED"
+
+    xrefs = http_client.get("/get_xrefs_to", params={"address": two_addresses["to"]})
+    assert xrefs.status_code == 200, xrefs.text
+    assert _bare(two_addresses["from"]) in xrefs.text.lower(), (
+        f"created reference from {two_addresses['from']} not found in "
+        f"get_xrefs_to({two_addresses['to']}): {xrefs.text[:300]}"
+    )

--- a/tests/integration/test_reference_endpoints.py
+++ b/tests/integration/test_reference_endpoints.py
@@ -56,6 +56,19 @@ def test_add_memory_reference_declares_core_params(endpoints):
         assert required in params, f"{required} missing from catalog params {params}"
 
 
+def test_remove_reference_in_endpoint_catalog(endpoints):
+    paths = {e["path"] for e in endpoints}
+    assert "/remove_reference" in paths, "remove_reference missing from endpoints.json"
+
+
+def test_remove_reference_categorized_as_xref_post(endpoints):
+    by_path = {e["path"]: e for e in endpoints}
+    entry = by_path.get("/remove_reference")
+    assert entry is not None
+    assert entry.get("category") == "xref"
+    assert entry.get("method") == "POST"
+
+
 # ---------- live fixtures ----------
 
 
@@ -165,14 +178,18 @@ def test_dry_run_reports_shape_without_writing(http_client, endpoint_available, 
 # ---------- real create -> round-trip ----------
 
 
-def test_create_reference_appears_in_xrefs_to(http_client, endpoint_available, two_addresses):
-    """Create a USER_DEFINED reference and confirm bidirectional navigation:
-    it shows up in get_xrefs_to for the target."""
+def test_create_then_remove_reference_round_trip(http_client, endpoint_available, two_addresses):
+    """Full round-trip: create a USER_DEFINED reference, confirm it shows up in
+    get_xrefs_to (bidirectional navigation), then remove it and confirm it's gone.
+    The remove step also leaves the test binary clean."""
+    src, dst = two_addresses["from"], two_addresses["to"]
+
+    # Create
     resp = http_client.post(
         "/add_memory_reference",
         json_data={
-            "from_address": two_addresses["from"],
-            "to_address": two_addresses["to"],
+            "from_address": src,
+            "to_address": dst,
             "ref_type": "DATA",
             "source_type": "USER_DEFINED",
             "set_primary": True,
@@ -184,9 +201,51 @@ def test_create_reference_appears_in_xrefs_to(http_client, endpoint_available, t
     assert body.get("ref_type") == "DATA"
     assert body.get("source_type") == "USER_DEFINED"
 
-    xrefs = http_client.get("/get_xrefs_to", params={"address": two_addresses["to"]})
-    assert xrefs.status_code == 200, xrefs.text
-    assert _bare(two_addresses["from"]) in xrefs.text.lower(), (
-        f"created reference from {two_addresses['from']} not found in "
-        f"get_xrefs_to({two_addresses['to']}): {xrefs.text[:300]}"
+    try:
+        xrefs = http_client.get("/get_xrefs_to", params={"address": dst})
+        assert xrefs.status_code == 200, xrefs.text
+        assert _bare(src) in xrefs.text.lower(), (
+            f"created reference from {src} not found in get_xrefs_to({dst}): {xrefs.text[:300]}"
+        )
+    finally:
+        # Remove (also serves as the dedicated remove_reference assertion + cleanup)
+        rm = http_client.post(
+            "/remove_reference",
+            json_data={"from_address": src, "to_address": dst},
+        )
+        assert rm.status_code == 200, rm.text
+        rm_body = json.loads(rm.text)
+        assert rm_body.get("status") == "success", f"unexpected: {rm_body}"
+        assert rm_body.get("removed", 0) >= 1, f"expected >=1 removed: {rm_body}"
+
+    # Confirm it's gone
+    xrefs_after = http_client.get("/get_xrefs_to", params={"address": dst})
+    assert _bare(src) not in xrefs_after.text.lower(), (
+        f"reference from {src} still present after remove_reference: {xrefs_after.text[:300]}"
     )
+
+
+def test_remove_reference_dry_run_shape(http_client, endpoint_available, two_addresses):
+    """remove_reference dry_run reports a consistent, non-mutating shape."""
+    resp = http_client.post(
+        "/remove_reference",
+        json_data={
+            "from_address": two_addresses["to"],
+            "to_address": two_addresses["from"],
+            "dry_run": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = json.loads(resp.text)
+    assert body.get("status") == "dry_run"
+    # match_count must agree with the detail list length (no mutation either way).
+    assert body.get("match_count") == len(body.get("would_remove", []))
+
+
+def test_remove_reference_missing_from_address_rejected(http_client, endpoint_available):
+    resp = http_client.post(
+        "/remove_reference",
+        json_data={"to_address": "0x1000", "dry_run": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert "from_address is required" in resp.text

--- a/tests/integration/test_reference_endpoints.py
+++ b/tests/integration/test_reference_endpoints.py
@@ -1,8 +1,8 @@
 """
-Integration tests for /add_memory_reference.
+Integration tests for /add_memory_reference and /remove_reference.
 
-Covers the user-defined cross-reference tool: catalog/parity, the non-mutating
-dry_run path, input validation, and a real create -> get_xrefs_to round-trip.
+Covers the user-defined cross-reference tools: catalog/parity, input validation,
+a real create -> get_xrefs_to -> remove round-trip, and the empty-match no-op.
 
 The catalog tests run without a server. The live tests auto-skip when the
 server/program is unavailable or when the endpoint isn't registered (older JAR).
@@ -52,7 +52,7 @@ def test_add_memory_reference_declares_core_params(endpoints):
     assert entry is not None
     params = set(entry.get("params", []))
     for required in ("from_address", "to_address", "ref_type", "source_type",
-                     "operand_index", "set_primary", "dry_run", "program"):
+                     "operand_index", "set_primary", "program"):
         assert required in params, f"{required} missing from catalog params {params}"
 
 
@@ -82,11 +82,9 @@ def require_server_and_program(server_available, program_loaded):
 
 @pytest.fixture
 def endpoint_available(http_client, require_server_and_program):
-    """Probe the endpoint with a harmless dry_run; skip if not registered."""
-    resp = http_client.post(
-        "/add_memory_reference",
-        json_data={"from_address": "0x0", "to_address": "0x0", "dry_run": True},
-    )
+    """Probe registration with an empty body (no mutation: returns the
+    'from_address is required' error if registered, 404 if not)."""
+    resp = http_client.post("/add_memory_reference", json_data={})
     if resp.status_code == 404:
         pytest.skip("/add_memory_reference not registered (deploy the updated JAR)")
     return True
@@ -123,7 +121,7 @@ def test_unknown_ref_type_rejected(http_client, endpoint_available):
     resp = http_client.post(
         "/add_memory_reference",
         json_data={"from_address": "0x1000", "to_address": "0x2000",
-                   "ref_type": "NOT_A_REAL_TYPE", "dry_run": True},
+                   "ref_type": "NOT_A_REAL_TYPE"},
     )
     assert resp.status_code == 200, resp.text
     assert "Unknown ref_type" in resp.text
@@ -133,7 +131,7 @@ def test_unknown_source_type_rejected(http_client, endpoint_available):
     resp = http_client.post(
         "/add_memory_reference",
         json_data={"from_address": "0x1000", "to_address": "0x2000",
-                   "source_type": "BOGUS", "dry_run": True},
+                   "source_type": "BOGUS"},
     )
     assert resp.status_code == 200, resp.text
     assert "Unknown source_type" in resp.text
@@ -142,37 +140,10 @@ def test_unknown_source_type_rejected(http_client, endpoint_available):
 def test_missing_to_address_rejected(http_client, endpoint_available):
     resp = http_client.post(
         "/add_memory_reference",
-        json_data={"from_address": "0x1000", "dry_run": True},
+        json_data={"from_address": "0x1000"},
     )
     assert resp.status_code == 200, resp.text
     assert "to_address is required" in resp.text
-
-
-# ---------- dry_run (no mutation) ----------
-
-
-def test_dry_run_reports_shape_without_writing(http_client, endpoint_available, two_addresses):
-    resp = http_client.post(
-        "/add_memory_reference",
-        json_data={
-            "from_address": two_addresses["from"],
-            "to_address": two_addresses["to"],
-            "ref_type": "DATA",
-            "dry_run": True,
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    body = json.loads(resp.text)
-    assert body.get("status") == "dry_run"
-    assert body.get("ref_type") == "DATA"
-    assert body.get("source_type") == "USER_DEFINED"
-    assert "would_create" in body and "already_exists" in body
-
-    # dry_run must not have created anything: the from-address should not yet
-    # appear in the target's xrefs (only meaningful when it didn't pre-exist).
-    if body.get("would_create"):
-        xrefs = http_client.get("/get_xrefs_to", params={"address": two_addresses["to"]})
-        assert _bare(two_addresses["from"]) not in xrefs.text.lower()
 
 
 # ---------- real create -> round-trip ----------
@@ -225,27 +196,26 @@ def test_create_then_remove_reference_round_trip(http_client, endpoint_available
     )
 
 
-def test_remove_reference_dry_run_shape(http_client, endpoint_available, two_addresses):
-    """remove_reference dry_run reports a consistent, non-mutating shape."""
+def test_remove_nonexistent_reference_is_clean_no_op(http_client, endpoint_available, two_addresses):
+    """Removing a reference that isn't there returns removed=0 without erroring
+    (the reversed direction is virtually never a real reference)."""
     resp = http_client.post(
         "/remove_reference",
         json_data={
             "from_address": two_addresses["to"],
             "to_address": two_addresses["from"],
-            "dry_run": True,
         },
     )
     assert resp.status_code == 200, resp.text
     body = json.loads(resp.text)
-    assert body.get("status") == "dry_run"
-    # match_count must agree with the detail list length (no mutation either way).
-    assert body.get("match_count") == len(body.get("would_remove", []))
+    assert body.get("status") == "success", f"unexpected: {body}"
+    assert body.get("removed", -1) == 0
 
 
 def test_remove_reference_missing_from_address_rejected(http_client, endpoint_available):
     resp = http_client.post(
         "/remove_reference",
-        json_data={"to_address": "0x1000", "dry_run": True},
+        json_data={"to_address": "0x1000"},
     )
     assert resp.status_code == 200, resp.text
     assert "from_address is required" in resp.text

--- a/tests/unit/test_endpoint_catalog.py
+++ b/tests/unit/test_endpoint_catalog.py
@@ -184,11 +184,16 @@ class TestBridgeIsDynamic(unittest.TestCase):
         (`_scan_tcp_for_project` + new helpers + docstrings). Both pull
         weight: bug fixes for real reproducible user reports with associated
         unit test coverage.
+
+        Bumped 2026-06-14: 2250 -> 2300 to add `search_tools`, a catalog-search
+        meta-tool (#267/#153) that lets the bridge run --lazy with a small tool
+        surface while still letting agents discover unloaded tools by keyword.
+        Pulls weight: directly addresses the context-overhead complaints.
         """
         bridge_path = PROJECT_ROOT / "bridge_mcp_ghidra.py"
         lines = len(bridge_path.read_text().splitlines())
         self.assertLess(
-            lines, 2250, f"Bridge is {lines} lines, expected <2250 for thin multiplexer"
+            lines, 2300, f"Bridge is {lines} lines, expected <2300 for thin multiplexer"
         )
 
 

--- a/tests/unit/test_versioning.py
+++ b/tests/unit/test_versioning.py
@@ -1,0 +1,53 @@
+"""Unit tests for tools.setup.versioning — Ghidra version compatibility (#293).
+
+The pom pins ``ghidra.version`` to a major.minor series; an installed Ghidra of
+any patch release in that series must be accepted instead of hard-failing the
+preflight/verify-version check (firefart's ``12.1`` pinned vs ``12.1.2`` install).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.setup.versioning import is_ghidra_version_compatible
+
+
+@pytest.mark.parametrize(
+    "required,installed",
+    [
+        ("12.1", "12.1.2"),   # #293: pinned minor, patch install
+        ("12.1", "12.1"),     # exact
+        ("12.1", "12.1.0"),   # explicit .0 patch
+        ("12.1.2", "12.1"),   # pinned patch, minor install — same series
+        ("12.1.0", "12.1.9"), # patch drift within series
+        ("12.1", "12.1.2.1"), # four-component build install
+    ],
+)
+def test_compatible_within_minor_series(required: str, installed: str) -> None:
+    assert is_ghidra_version_compatible(required, installed) is True
+
+
+@pytest.mark.parametrize(
+    "required,installed",
+    [
+        ("12.1", "12.2"),    # different minor
+        ("12.1", "12.0.4"),  # different minor (older)
+        ("12.1", "11.1"),    # different major
+        ("12.1", "13.1.2"),  # different major (newer)
+    ],
+)
+def test_incompatible_across_minor_or_major(required: str, installed: str) -> None:
+    assert is_ghidra_version_compatible(required, installed) is False
+
+
+@pytest.mark.parametrize(
+    "required,installed,expected",
+    [
+        ("", "12.1", False),       # unparseable required -> exact-string fallback
+        ("12.1", "", False),       # unparseable installed -> exact-string fallback
+        ("weird", "weird", True),  # identical unparseable strings still match
+    ],
+)
+def test_unparseable_falls_back_to_exact_match(
+    required: str, installed: str, expected: bool
+) -> None:
+    assert is_ghidra_version_compatible(required, installed) is expected

--- a/tools/setup/cli.py
+++ b/tools/setup/cli.py
@@ -24,7 +24,11 @@ from .requirements import (
     resolve_requirements_files,
 )
 from .version_bump import apply_version_bump
-from .versioning import infer_ghidra_version_from_path, read_pom_versions
+from .versioning import (
+    infer_ghidra_version_from_path,
+    is_ghidra_version_compatible,
+    read_pom_versions,
+)
 
 
 def _get_backend() -> str:
@@ -358,12 +362,17 @@ def cmd_verify_version(args: argparse.Namespace) -> int:
         print("Unable to infer Ghidra version from the provided path.")
         return 1
     print(f"Ghidra version from path: {inferred_version}")
-    if inferred_version != versions.ghidra_version:
+    if not is_ghidra_version_compatible(versions.ghidra_version, inferred_version):
         print(
             "Version mismatch detected between pom.xml and Ghidra path.",
             file=sys.stderr,
         )
         return 1
+    if inferred_version != versions.ghidra_version:
+        print(
+            f"Note: Ghidra path is {inferred_version}, pom.xml pins "
+            f"{versions.ghidra_version} — same minor series, treated as compatible."
+        )
     print("Version check passed.")
     return 0
 
@@ -414,12 +423,17 @@ def cmd_preflight(args: argparse.Namespace) -> int:
         print("Unable to infer Ghidra version from the provided path.", file=sys.stderr)
         return 1
     print(f"Ghidra version from path: {inferred_version}")
-    if inferred_version != repo_versions.ghidra_version:
+    if not is_ghidra_version_compatible(repo_versions.ghidra_version, inferred_version):
         print(
             "Version mismatch detected between pom.xml and Ghidra path.",
             file=sys.stderr,
         )
         return 1
+    if inferred_version != repo_versions.ghidra_version:
+        print(
+            f"Note: Ghidra path is {inferred_version}, pom.xml pins "
+            f"{repo_versions.ghidra_version} — same minor series, treated as compatible."
+        )
     issues = collect_preflight_issues(
         repo_root,
         ghidra_path,

--- a/tools/setup/ghidra.py
+++ b/tools/setup/ghidra.py
@@ -63,6 +63,10 @@ DEFAULT_BENCHMARK_FOLDER = "/testing/benchmark"
 DEFAULT_BENCHMARK_PROGRAM = f"{DEFAULT_BENCHMARK_FOLDER}/Benchmark.dll"
 DEFAULT_BENCHMARK_DEBUG_PROGRAM = f"{DEFAULT_BENCHMARK_FOLDER}/BenchmarkDebug.exe"
 DEFAULT_BENCHMARK_FUNCTION = "calc_crc16"
+# Max seconds to wait for post-import benchmark analysis to settle before the
+# YAML regression asserts. Sized for a cold install (freshly-created Ghidra
+# user-config dir), where the first analysis pass runs well past a minute.
+BENCHMARK_ANALYSIS_TIMEOUT_S = 240
 BENCHMARK_DEPLOY_TEST_MODES = {
     "benchmark-read",
     "benchmark-write",
@@ -1808,7 +1812,13 @@ def _bench_ensure_full_analysis(repo_root: Path, mcp_url: str, program_path: str
     /run_analysis returns in milliseconds — analysis happens on a background
     thread. Without polling for completion the YAML asserts race the analyzer
     and see partial state. Poll /analysis_status.analyzing until it flips
-    back to false (or 60s timeout).
+    back to false (or BENCHMARK_ANALYSIS_TIMEOUT_S timeout).
+
+    The timeout must cover a *cold* install: on a freshly-created Ghidra
+    user-config dir (e.g. the first deploy to a newly-installed Ghidra patch
+    release) the initial analysis of Benchmark.dll + BenchmarkDebug.exe can run
+    well past a minute, so a 60s cap raced the analyzer and produced spurious
+    `param_count: 0` / `undefined` signature failures.
     """
     try:
         _, _ = _mcp_request(repo_root, mcp_url, "/run_analysis",
@@ -1818,7 +1828,7 @@ def _bench_ensure_full_analysis(repo_root: Path, mcp_url: str, program_path: str
         print(f"WARNING: /run_analysis on {program_path} failed: {exc}")
         return
 
-    deadline = time.monotonic() + 60
+    deadline = time.monotonic() + BENCHMARK_ANALYSIS_TIMEOUT_S
     while time.monotonic() < deadline:
         try:
             _, status = _mcp_request(repo_root, mcp_url, "/analysis_status",
@@ -1828,8 +1838,9 @@ def _bench_ensure_full_analysis(repo_root: Path, mcp_url: str, program_path: str
             continue
         if isinstance(status, dict) and status.get("analyzing") is False:
             return
-        time.sleep(1)
-    print(f"WARNING: /analysis_status on {program_path} still busy after 60s; proceeding anyway")
+        time.sleep(2)
+    print(f"WARNING: /analysis_status on {program_path} still busy after "
+          f"{BENCHMARK_ANALYSIS_TIMEOUT_S}s; proceeding anyway")
 
 
 def run_benchmark_yaml_regression(repo_root: Path, mcp_url: str) -> None:

--- a/tools/setup/versioning.py
+++ b/tools/setup/versioning.py
@@ -74,3 +74,29 @@ def infer_ghidra_install_meta(ghidra_path: Path) -> tuple[str | None, str | None
 
 def infer_ghidra_version_from_path(ghidra_path: Path) -> str | None:
     return infer_ghidra_install_meta(ghidra_path)[0]
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for chunk in version.strip().split("."):
+        match = re.match(r"\d+", chunk)
+        if not match:
+            break
+        parts.append(int(match.group()))
+    return tuple(parts)
+
+
+def is_ghidra_version_compatible(required: str, installed: str) -> bool:
+    """Return True when an installed Ghidra version satisfies the pom requirement.
+
+    The pom pins ``ghidra.version`` to a major.minor series (e.g. ``12.1``).
+    Ghidra's API is stable within a minor series, so any patch release of that
+    series — ``12.1.0``, ``12.1.2``, ... — is compatible (see #293: ``12.1``
+    pinned vs a ``12.1.2`` install should not error). Compatibility is decided
+    on the shared major.minor prefix; patch and build components are ignored.
+    """
+    req = _version_tuple(required)[:2]
+    inst = _version_tuple(installed)[:2]
+    if not req or not inst:
+        return required.strip() == installed.strip()
+    return req == inst


### PR DESCRIPTION
## v5.14.0 — retargeted at **Ghidra 12.1.2** (latest)

Minor release. Bundles two community PRs plus tool-discovery and setup fixes responding to maintainer-feedback issues.

### Included
- **Retarget to Ghidra 12.1.2** (#296): `ghidra.version` 12.1 → 12.1.2 so `extension.properties` declares 12.1.2 and the extension loads in the latest Ghidra (which enforces an exact extension-version gate). README badge + docs swept.
- **`/add_memory_reference` + `/remove_reference`** (#299, thanks @dpusceddu — closes #298): write-side cross-reference tools.
- **Uppercase overlay address spaces fix** (#297, thanks @robbederks): `parseAddress` preserves canonical overlay-space case (e.g. `CODE_BANK1`).
- **`search_tools` catalog-search meta-tool** (#267, #153): discover unloaded tools by keyword so the bridge can run `--lazy` with a small surface. + `ROADMAP.md`.
- **Ghidra version-compat preflight fix** (#293, thanks @firefart — was PR #308): `tools.setup` accepts patch-level installs within the pinned minor series.
- **Cold-install analysis-wait fix**: release-regression benchmark analysis wait 60s → 240s (was racing the analyzer on fresh installs).

### Tests run
- Offline: **373 Python unit** + **230 offline Java** (compiled against the 12.1.2 jars) — all pass.
- Live release regression on **Ghidra 12.1.2** — all tiers pass: MCP smoke (206 tools), endpoint contract (29 tools), Benchmark YAML (50 assertion-blocks), multi-program, negative/error-shape, **debugger-live**.

### Deferred
- #264 (headless GZF/Jython) — separate release.

Endpoint count 249 → **251** (`tests/endpoints.json`).