### PR TITLE
Overlay address-space support across all address-taking tools

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -238,12 +238,17 @@ class GhidraValidationError(Exception):
 
 # Input validation patterns
 HEX_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]+$")
-SEGMENT_ADDRESS_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*:[0-9a-fA-F]+$")
-# Handles space:0xHEX form (e.g., mem:0x1000, code:0xFF00).
-# Must be checked BEFORE SEGMENT_ADDRESS_PATTERN because the 'x' in '0x' is not
-# in [0-9a-fA-F], so the existing pattern rejects this form entirely.
+# Space-qualified address: space:HEX, space::HEX (overlay), with optional 0x.
+# Space names may contain dots and lead with '.'/'_' (overlay spaces such as
+# '.shstrtab', '_elfHeader', 'cli.Initial'). Ghidra's AddressFactory accepts
+# both single (':') and double ('::') colon separators and is case-sensitive
+# on the name (#184), so the bridge preserves case and never adds '0x' here.
+SEGMENT_ADDRESS_PATTERN = re.compile(r"^[A-Za-z_.][A-Za-z0-9_.]*::?[0-9a-fA-F]+$")
+# Handles the space::0xHEX / space:0xHEX form. Checked BEFORE SEGMENT_ADDRESS_PATTERN
+# because the 'x' in '0x' is not in [0-9a-fA-F]. Group 1 captures the name AND the
+# colon separator; group 2 captures the bare hex offset.
 SEGMENT_ADDR_WITH_0X_PATTERN = re.compile(
-    r"^([a-zA-Z_][a-zA-Z0-9_]*):0[xX]([0-9a-fA-F]+)$"
+    r"^([A-Za-z_.][A-Za-z0-9_.]*::?)0[xX]([0-9a-fA-F]+)$"
 )
 FUNCTION_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -741,10 +746,11 @@ def sanitize_address(address: str) -> str:
         return address
     address = address.strip()
 
-    # Step 1: handle space:0xHEX form (checked first — 'x' not in [0-9a-fA-F])
+    # Step 1: handle space:0xHEX / space::0xHEX form (checked first — 'x' not in
+    # [0-9a-fA-F]). Group 1 already includes the ':'/'::' separator.
     m = SEGMENT_ADDR_WITH_0X_PATTERN.match(address)
     if m:
-        return f"{m.group(1)}:{m.group(2)}"  # case preserved (#184)
+        return f"{m.group(1)}{m.group(2)}"  # case + separator preserved (#184, overlays)
 
     # Step 2: valid space:HEX — pass through unchanged (#184)
     if SEGMENT_ADDRESS_PATTERN.match(address):

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -738,6 +738,7 @@ def sanitize_address(address: str) -> str:
 
     Handles:
     - space:0xHEX  -> space:HEX   (strip 0x; AddressFactory rejects 0x after colon)
+    - space::0xHEX -> space::HEX  (overlay; '::' separator and case preserved)
     - SPACE:HEX    -> SPACE:HEX   (preserve case — AddressFactory is case-sensitive; see #184)
     - 0xHEX        -> 0xhex       (lowercase)
     - HEX          -> 0xHEX       (add 0x prefix)

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -238,17 +238,18 @@ class GhidraValidationError(Exception):
 
 # Input validation patterns
 HEX_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]+$")
-# Space-qualified address: space:HEX, space::HEX (overlay), with optional 0x.
-# Space names may contain dots and lead with '.'/'_' (overlay spaces such as
-# '.shstrtab', '_elfHeader', 'cli.Initial'). Ghidra's AddressFactory accepts
-# both single (':') and double ('::') colon separators and is case-sensitive
+# Space-qualified address: space:HEX or space::HEX (overlay), with optional 0x.
+# Ghidra memory-block (and therefore overlay-space) names are essentially
+# unconstrained, so the space-name class is "anything except colon or
+# whitespace" — the ':'/'::' separator is what distinguishes this from plain
+# hex. Ghidra's AddressFactory accepts both ':' and '::' and is case-sensitive
 # on the name (#184), so the bridge preserves case and never adds '0x' here.
-SEGMENT_ADDRESS_PATTERN = re.compile(r"^[A-Za-z_.][A-Za-z0-9_.]*::?[0-9a-fA-F]+$")
+SEGMENT_ADDRESS_PATTERN = re.compile(r"^[^\s:]+::?[0-9a-fA-F]+$")
 # Handles the space::0xHEX / space:0xHEX form. Checked BEFORE SEGMENT_ADDRESS_PATTERN
 # because the 'x' in '0x' is not in [0-9a-fA-F]. Group 1 captures the name AND the
 # colon separator; group 2 captures the bare hex offset.
 SEGMENT_ADDR_WITH_0X_PATTERN = re.compile(
-    r"^([A-Za-z_.][A-Za-z0-9_.]*::?)0[xX]([0-9a-fA-F]+)$"
+    r"^([^\s:]+::?)0[xX]([0-9a-fA-F]+)$"
 )
 FUNCTION_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -4,6 +4,7 @@ import ghidra.app.services.ProgramManager;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.address.OverlayAddressSpace;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryBlock;
@@ -403,10 +404,10 @@ public class ProgramScriptService {
     }
 
     /**
-     * List all physical address spaces in the program.
-     * Returns only RAM and CODE spaces; excludes pseudo-spaces (EXTERNAL, STACK, etc.)
-     * and overlay spaces. Useful for embedded/microcontroller targets where multiple
-     * address spaces exist and plain hex addresses may be ambiguous.
+     * List the program's address spaces. Returns physical RAM/CODE spaces plus
+     * overlay spaces (marked is_overlay). Excludes pseudo-spaces (EXTERNAL, STACK,
+     * etc.). Useful for embedded/microcontroller and overlay-bearing targets where
+     * plain hex addresses may be ambiguous.
      */
     @McpTool(path = "/get_address_spaces",
              description = "List all physical address spaces in the program. On programs with multiple "
@@ -415,7 +416,10 @@ public class ProgramScriptService {
                          + "Also check addressable_unit_size: a value > 1 means the space is word-addressed "
                          + "(e.g., AVR code space uses 2-byte words). MCP tools and Ghidra both use word "
                          + "addresses natively for such spaces — code:001478 is word 0x1478, not byte 0x1478. "
-                         + "Do NOT multiply or divide addresses seen in Ghidra output; use them as-is.",
+                         + "Do NOT multiply or divide addresses seen in Ghidra output; use them as-is. "
+                         + "Overlay spaces are also listed, each marked is_overlay=true with its "
+                         + "overlayed_space (base). Address an overlay location as <overlay>::<hex> "
+                         + "(e.g., cli.Initial::00010000) — overlay names are case-sensitive.",
              category = "program")
     public Response getAddressSpaces(
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
@@ -424,6 +428,7 @@ public class ProgramScriptService {
         Program program = pe.program();
 
         List<Map<String, Object>> spaces = buildAddressSpacesList(program);
+        spaces.addAll(buildOverlaySpacesList(program));
         return Response.ok(JsonHelper.mapOf("address_spaces", spaces, "count", spaces.size()));
     }
 
@@ -455,6 +460,35 @@ public class ProgramScriptService {
                 "size_bytes",            sizeBytes,
                 "address_size_bits",     space.getSize(),
                 "is_default",            space == defaultSpace
+            ));
+        }
+        return spaces;
+    }
+
+    /**
+     * Build JSON entries for the program's overlay address spaces, each marked
+     * is_overlay=true with the name of the physical space it overlays. Kept
+     * SEPARATE from buildAddressSpacesList so get_current_program_info's
+     * has_multiple_address_spaces flag continues to reflect PHYSICAL ambiguity only.
+     */
+    private List<Map<String, Object>> buildOverlaySpacesList(Program program) {
+        List<Map<String, Object>> spaces = new ArrayList<>();
+        for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
+            if (!space.isOverlaySpace()) continue;
+            String base = "";
+            if (space instanceof OverlayAddressSpace) {
+                AddressSpace overlayed = ((OverlayAddressSpace) space).getOverlayedSpace();
+                if (overlayed != null) base = overlayed.getName();
+            }
+            int unitSize = space.getAddressableUnitSize();
+            spaces.add(JsonHelper.mapOf(
+                "name",                  space.getName(),
+                "start",                 space.getMinAddress().toString(false),
+                "end",                   space.getMaxAddress().toString(false),
+                "addressable_unit_size", unitSize,
+                "address_size_bits",     space.getSize(),
+                "is_overlay",            Boolean.TRUE,
+                "overlayed_space",       base
             ));
         }
         return spaces;

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -459,7 +459,8 @@ public class ProgramScriptService {
                 "addressable_unit_size", unitSize,
                 "size_bytes",            sizeBytes,
                 "address_size_bits",     space.getSize(),
-                "is_default",            space == defaultSpace
+                "is_default",            space == defaultSpace,
+                "is_overlay",            Boolean.FALSE
             ));
         }
         return spaces;

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -631,45 +631,49 @@ public final class ServiceUtils {
         // Detect if this is a segment:offset form for better error messages
         boolean hasColon = addressStr.contains(":");
 
-        // Normalize space:offset form: AddressFactory is case-sensitive and rejects "0x" prefix.
-        // Resolve the canonical space name first so overlays like "CODE_BANK1" keep their case.
+        // Build a resolution candidate. AddressFactory rejects a "0x" prefix on the
+        // OFFSET, so strip it from the part after the last colon. The SPACE NAME is
+        // left untouched — overlay space names (e.g. "cli.Initial") are case-sensitive
+        // and Ghidra accepts both ':' and '::' separators.
+        String candidate = addressStr;
         if (hasColon) {
-            int colonIdx = addressStr.indexOf(':');
-            String rawSpace = addressStr.substring(0, colonIdx);
-            String spaceName = rawSpace.toLowerCase();
-            String offset = addressStr.substring(colonIdx + 1);
+            int lastColon = addressStr.lastIndexOf(':');
+            String prefix = addressStr.substring(0, lastColon + 1); // includes ':' or trailing of '::'
+            String offset = addressStr.substring(lastColon + 1);
             if (offset.startsWith("0x") || offset.startsWith("0X")) {
                 offset = offset.substring(2);
             }
-
-            AddressSpace matchedSpace = program.getAddressFactory().getAddressSpace(rawSpace);
-            if (matchedSpace == null) {
-                for (AddressSpace candidate : program.getAddressFactory().getAddressSpaces()) {
-                    if (candidate.getName().equalsIgnoreCase(rawSpace)) {
-                        matchedSpace = candidate;
-                        break;
-                    }
-                }
-            }
-            if (matchedSpace != null) {
-                spaceName = matchedSpace.getName();
-            }
-            addressStr = spaceName + ":" + offset;
+            candidate = prefix + offset;
         }
 
+        // 1) Exact-case attempt (handles overlays and correctly-cased physical spaces).
         try {
-            Address addr = program.getAddressFactory().getAddress(addressStr);
+            Address addr = program.getAddressFactory().getAddress(candidate);
             if (addr != null) return addr;
         } catch (Exception ignored) {}
 
-        // Build a rich error message listing available spaces
+        // 2) Case-insensitive space-name fallback. Preserves the forgiving behavior for
+        //    physical input like "MEM:0x1000" without blindly lowercasing (which would
+        //    break case-sensitive overlay names).
+        if (hasColon) {
+            int firstColon = candidate.indexOf(':');
+            String spaceName = candidate.substring(0, firstColon);
+            String offset = candidate.substring(candidate.lastIndexOf(':') + 1);
+            AddressSpace match = findSpaceIgnoreCase(program, spaceName);
+            if (match != null && !match.getName().equals(spaceName)) {
+                try {
+                    Address addr = program.getAddressFactory().getAddress(match.getName() + ":" + offset);
+                    if (addr != null) return addr;
+                } catch (Exception ignored) {}
+            }
+        }
+
+        // Build a rich error message listing available spaces (including overlays)
         String available = buildAvailableSpacesHint(program);
         if (hasColon) {
-            String spaceName = addressStr.substring(0, addressStr.indexOf(':'));
-            String offsetPart = addressStr.substring(addressStr.indexOf(':') + 1);
+            String spaceName = candidate.substring(0, candidate.indexOf(':'));
+            String offsetPart = candidate.substring(candidate.lastIndexOf(':') + 1);
             if (isKnownSpace(program, spaceName)) {
-                // The space is valid; the failure is the offset. Don't blame the space
-                // (which produced the contradictory "Unknown space 'ram'. Available: ram").
                 lastParseError.set("Could not resolve offset '" + offsetPart
                     + "' in address space '" + spaceName + "'. Check that it is valid hex "
                     + "within that space's range. Available spaces: " + available + ".");
@@ -694,7 +698,11 @@ public final class ServiceUtils {
      */
     public static Map<String, Object> addressToJson(Address address, Program program) {
         String plainHex = address.toString(false);
-        if (program == null || getPhysicalSpaceCount(program) <= 1) {
+        boolean isOverlay = address.getAddressSpace().isOverlaySpace();
+        // Overlay addresses must ALWAYS carry the qualifier: their bare hex re-resolves
+        // into the underlying physical space, not the overlay. For non-overlay addresses
+        // keep the existing rule (qualify only when there is real physical ambiguity).
+        if (!isOverlay && (program == null || getPhysicalSpaceCount(program) <= 1)) {
             return JsonHelper.mapOf("address", plainHex);
         }
         String spaceName = address.getAddressSpace().getName();
@@ -724,34 +732,64 @@ public final class ServiceUtils {
     }
 
     /**
-     * True if {@code spaceName} (case-insensitive) names a real physical address space
-     * (TYPE_RAM/TYPE_CODE, non-overlay) in the program. Used to distinguish a genuinely
-     * unknown space from a known space with a bad offset when building parse errors.
+     * True if {@code spaceName} (case-insensitive) names a known address space in the
+     * program — a physical RAM/CODE space OR an overlay space (overlays carry their own
+     * types, e.g. TYPE_OTHER for ".shstrtab"). Used to distinguish a genuinely unknown
+     * space from a known space with a bad offset when building parse errors.
      */
     private static boolean isKnownSpace(Program program, String spaceName) {
         if (spaceName == null || spaceName.isEmpty()) return false;
         for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
-            if (space.isOverlaySpace()) continue;
-            int type = space.getType();
-            if ((type == AddressSpace.TYPE_RAM || type == AddressSpace.TYPE_CODE)
-                    && space.getName().equalsIgnoreCase(spaceName)) {
+            boolean eligible = space.isOverlaySpace()
+                    || space.getType() == AddressSpace.TYPE_RAM
+                    || space.getType() == AddressSpace.TYPE_CODE;
+            if (eligible && space.getName().equalsIgnoreCase(spaceName)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static String buildAvailableSpacesHint(Program program) {
-        StringBuilder sb = new StringBuilder();
+    /**
+     * Find the address space whose name matches {@code spaceName} case-insensitively.
+     * Considers overlay spaces (any type) and physical RAM/CODE spaces. Returns null
+     * if none match. Used by parseAddress's case-insensitive fallback.
+     */
+    private static AddressSpace findSpaceIgnoreCase(Program program, String spaceName) {
+        if (spaceName == null || spaceName.isEmpty()) return null;
         for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
-            if (space.isOverlaySpace()) continue;
-            int type = space.getType();
-            if (type == AddressSpace.TYPE_RAM || type == AddressSpace.TYPE_CODE) {
-                if (sb.length() > 0) sb.append(", ");
-                sb.append(space.getName());
+            boolean eligible = space.isOverlaySpace()
+                    || space.getType() == AddressSpace.TYPE_RAM
+                    || space.getType() == AddressSpace.TYPE_CODE;
+            if (eligible && space.getName().equalsIgnoreCase(spaceName)) {
+                return space;
             }
         }
-        return sb.length() > 0 ? sb.toString() : "(none)";
+        return null;
+    }
+
+    private static String buildAvailableSpacesHint(Program program) {
+        StringBuilder physical = new StringBuilder();
+        StringBuilder overlays = new StringBuilder();
+        for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
+            if (space.isOverlaySpace()) {
+                if (overlays.length() > 0) overlays.append(", ");
+                overlays.append(space.getName());
+                continue;
+            }
+            int type = space.getType();
+            if (type == AddressSpace.TYPE_RAM || type == AddressSpace.TYPE_CODE) {
+                if (physical.length() > 0) physical.append(", ");
+                physical.append(space.getName());
+            }
+        }
+        if (physical.length() == 0 && overlays.length() == 0) return "(none)";
+        StringBuilder out = new StringBuilder(physical.length() > 0 ? physical.toString() : "");
+        if (overlays.length() > 0) {
+            if (out.length() > 0) out.append(", ");
+            out.append("[overlays] ").append(overlays);
+        }
+        return out.toString();
     }
 
     private static String buildSpaceSuggestion(Program program, String rawOffset) {

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -693,8 +693,9 @@ public final class ServiceUtils {
     /**
      * Return enriched address fields as a Map for JSON responses.
      * Always includes "address" (plain hex, no space prefix).
-     * Includes "address_full" and "address_space" only when the program has >1 physical space.
-     * If program is null, emits only the "address" field.
+     * Includes "address_full" and "address_space" when the address is in an overlay
+     * space (so it round-trips correctly) OR when the program has >1 physical space.
+     * If program is null and the address is non-overlay, emits only "address".
      */
     public static Map<String, Object> addressToJson(Address address, Program program) {
         String plainHex = address.toString(false);
@@ -738,16 +739,7 @@ public final class ServiceUtils {
      * space from a known space with a bad offset when building parse errors.
      */
     private static boolean isKnownSpace(Program program, String spaceName) {
-        if (spaceName == null || spaceName.isEmpty()) return false;
-        for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
-            boolean eligible = space.isOverlaySpace()
-                    || space.getType() == AddressSpace.TYPE_RAM
-                    || space.getType() == AddressSpace.TYPE_CODE;
-            if (eligible && space.getName().equalsIgnoreCase(spaceName)) {
-                return true;
-            }
-        }
-        return false;
+        return findSpaceIgnoreCase(program, spaceName) != null;
     }
 
     /**

--- a/src/test/java/com/xebyte/offline/AddressSpacesOverlayTest.java
+++ b/src/test/java/com/xebyte/offline/AddressSpacesOverlayTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.*;
  */
 public class AddressSpacesOverlayTest {
 
-    private AddressSpace physical(String name, int type, boolean isDefault) {
+    private AddressSpace physical(String name, int type) {
         AddressSpace s = mock(AddressSpace.class);
         when(s.isOverlaySpace()).thenReturn(false);
         when(s.getType()).thenReturn(type);
@@ -67,10 +67,10 @@ public class AddressSpacesOverlayTest {
     public void getAddressSpaces_includesOverlaysMarked() {
         Program program = mock(Program.class);
         AddressFactory factory = mock(AddressFactory.class);
-        AddressSpace ram = physical("ram", AddressSpace.TYPE_RAM, true);
+        AddressSpace ram = physical("ram", AddressSpace.TYPE_RAM);
         // OTHER-backed base space: not RAM/CODE, so it is NOT emitted as a
         // physical entry — but it must still resolve as an overlay's base name.
-        AddressSpace other = physical("OTHER", AddressSpace.TYPE_OTHER, false);
+        AddressSpace other = physical("OTHER", AddressSpace.TYPE_OTHER);
         OverlayAddressSpace ov = overlay("cli.Initial", ram);
         OverlayAddressSpace shstrtab = overlay(".shstrtab", other);
         when(program.getAddressFactory()).thenReturn(factory);

--- a/src/test/java/com/xebyte/offline/AddressSpacesOverlayTest.java
+++ b/src/test/java/com/xebyte/offline/AddressSpacesOverlayTest.java
@@ -68,10 +68,14 @@ public class AddressSpacesOverlayTest {
         Program program = mock(Program.class);
         AddressFactory factory = mock(AddressFactory.class);
         AddressSpace ram = physical("ram", AddressSpace.TYPE_RAM, true);
+        // OTHER-backed base space: not RAM/CODE, so it is NOT emitted as a
+        // physical entry — but it must still resolve as an overlay's base name.
+        AddressSpace other = physical("OTHER", AddressSpace.TYPE_OTHER, false);
         OverlayAddressSpace ov = overlay("cli.Initial", ram);
+        OverlayAddressSpace shstrtab = overlay(".shstrtab", other);
         when(program.getAddressFactory()).thenReturn(factory);
         when(factory.getDefaultAddressSpace()).thenReturn(ram);
-        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ram, ov});
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ram, other, ov, shstrtab});
 
         // Provider returns the mocked program for an empty (active-program) request.
         ProgramProvider provider = mock(ProgramProvider.class);
@@ -84,17 +88,34 @@ public class AddressSpacesOverlayTest {
         Map<String, Object> body = (Map<String, Object>) ((Response.Ok) resp).data();
         List<Map<String, Object>> spaces = (List<Map<String, Object>>) body.get("address_spaces");
 
-        // ram (physical) + cli.Initial (overlay)
-        assertEquals(2, spaces.size());
-        assertEquals(2, body.get("count"));
+        // ram (physical RAM) + cli.Initial (overlay) + .shstrtab (overlay).
+        // OTHER is NOT emitted (not RAM/CODE) but backs the .shstrtab overlay.
+        assertEquals(3, spaces.size());
+        assertEquals(3, body.get("count"));
+
         Map<String, Object> overlayEntry = spaces.stream()
             .filter(m -> "cli.Initial".equals(m.get("name"))).findFirst().orElse(null);
         assertNotNull("overlay space must be listed", overlayEntry);
         assertEquals(Boolean.TRUE, overlayEntry.get("is_overlay"));
         assertEquals("ram", overlayEntry.get("overlayed_space"));
+
+        // OTHER-backed overlay links to its OTHER base by name.
+        Map<String, Object> otherOverlayEntry = spaces.stream()
+            .filter(m -> ".shstrtab".equals(m.get("name"))).findFirst().orElse(null);
+        assertNotNull("OTHER-backed overlay space must be listed", otherOverlayEntry);
+        assertEquals(Boolean.TRUE, otherOverlayEntry.get("is_overlay"));
+        assertEquals("OTHER", otherOverlayEntry.get("overlayed_space"));
+
+        // The OTHER base itself is not surfaced as a physical entry.
+        assertNull("OTHER base must not be emitted as a physical space",
+            spaces.stream().filter(m -> "OTHER".equals(m.get("name"))).findFirst().orElse(null));
+
+        // Physical ram entry is unperturbed by the overlay append AND now carries
+        // the symmetric is_overlay=false flag (Fix 1) alongside its size_bytes.
         Map<String, Object> ramEntry = spaces.stream()
             .filter(m -> "ram".equals(m.get("name"))).findFirst().orElse(null);
         assertNotNull(ramEntry);
-        assertNotEquals(Boolean.TRUE, ramEntry.get("is_overlay"));
+        assertNotNull("physical entry must retain size_bytes", ramEntry.get("size_bytes"));
+        assertEquals(Boolean.FALSE, ramEntry.get("is_overlay"));
     }
 }

--- a/src/test/java/com/xebyte/offline/AddressSpacesOverlayTest.java
+++ b/src/test/java/com/xebyte/offline/AddressSpacesOverlayTest.java
@@ -1,0 +1,100 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.ProgramProvider;
+import com.xebyte.core.ProgramScriptService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressFactory;
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.address.OverlayAddressSpace;
+import ghidra.program.model.listing.Program;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that get_address_spaces also lists overlay spaces (marked is_overlay
+ * with overlayed_space = the physical base space name), in addition to the
+ * physical RAM/CODE spaces. The physical-only buildAddressSpacesList — shared with
+ * get_current_program_info's has_multiple_address_spaces flag — must remain
+ * unchanged; overlays are appended only in the endpoint method.
+ */
+public class AddressSpacesOverlayTest {
+
+    private AddressSpace physical(String name, int type, boolean isDefault) {
+        AddressSpace s = mock(AddressSpace.class);
+        when(s.isOverlaySpace()).thenReturn(false);
+        when(s.getType()).thenReturn(type);
+        when(s.getName()).thenReturn(name);
+        Address min = mock(Address.class);
+        Address max = mock(Address.class);
+        when(min.getOffset()).thenReturn(0L);
+        when(max.getOffset()).thenReturn(0xffffffffL);
+        when(min.toString(false)).thenReturn("00000000");
+        when(max.toString(false)).thenReturn("ffffffff");
+        when(s.getMinAddress()).thenReturn(min);
+        when(s.getMaxAddress()).thenReturn(max);
+        when(s.getAddressableUnitSize()).thenReturn(1);
+        when(s.getSize()).thenReturn(32);
+        return s;
+    }
+
+    private OverlayAddressSpace overlay(String name, AddressSpace base) {
+        OverlayAddressSpace s = mock(OverlayAddressSpace.class);
+        when(s.isOverlaySpace()).thenReturn(true);
+        when(s.getName()).thenReturn(name);
+        when(s.getOverlayedSpace()).thenReturn(base);
+        Address min = mock(Address.class);
+        Address max = mock(Address.class);
+        when(min.getOffset()).thenReturn(0x10000L);
+        when(max.getOffset()).thenReturn(0xaafffL);
+        when(min.toString(false)).thenReturn("00010000");
+        when(max.toString(false)).thenReturn("000aafff");
+        when(s.getMinAddress()).thenReturn(min);
+        when(s.getMaxAddress()).thenReturn(max);
+        when(s.getAddressableUnitSize()).thenReturn(1);
+        when(s.getSize()).thenReturn(32);
+        return s;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getAddressSpaces_includesOverlaysMarked() {
+        Program program = mock(Program.class);
+        AddressFactory factory = mock(AddressFactory.class);
+        AddressSpace ram = physical("ram", AddressSpace.TYPE_RAM, true);
+        OverlayAddressSpace ov = overlay("cli.Initial", ram);
+        when(program.getAddressFactory()).thenReturn(factory);
+        when(factory.getDefaultAddressSpace()).thenReturn(ram);
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ram, ov});
+
+        // Provider returns the mocked program for an empty (active-program) request.
+        ProgramProvider provider = mock(ProgramProvider.class);
+        when(provider.getCurrentProgram()).thenReturn(program);
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+
+        ProgramScriptService svc = new ProgramScriptService(provider, ts);
+        Response resp = svc.getAddressSpaces("");
+        assertTrue("expected Response.Ok, got " + resp, resp instanceof Response.Ok);
+        Map<String, Object> body = (Map<String, Object>) ((Response.Ok) resp).data();
+        List<Map<String, Object>> spaces = (List<Map<String, Object>>) body.get("address_spaces");
+
+        // ram (physical) + cli.Initial (overlay)
+        assertEquals(2, spaces.size());
+        assertEquals(2, body.get("count"));
+        Map<String, Object> overlayEntry = spaces.stream()
+            .filter(m -> "cli.Initial".equals(m.get("name"))).findFirst().orElse(null);
+        assertNotNull("overlay space must be listed", overlayEntry);
+        assertEquals(Boolean.TRUE, overlayEntry.get("is_overlay"));
+        assertEquals("ram", overlayEntry.get("overlayed_space"));
+        Map<String, Object> ramEntry = spaces.stream()
+            .filter(m -> "ram".equals(m.get("name"))).findFirst().orElse(null);
+        assertNotNull(ramEntry);
+        assertNotEquals(Boolean.TRUE, ramEntry.get("is_overlay"));
+    }
+}

--- a/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
+++ b/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
@@ -44,11 +44,10 @@ public class ServiceUtilsAddressTest {
         when(codeSpace.getName()).thenReturn("code");
 
         // mem space: TYPE_RAM, not overlay, lowercase canonical name "mem"
-        AddressSpace memSpace = mock(AddressSpace.class);
+        memSpace = mock(AddressSpace.class);
         when(memSpace.getType()).thenReturn(AddressSpace.TYPE_RAM);
         when(memSpace.isOverlaySpace()).thenReturn(false);
         when(memSpace.getName()).thenReturn("mem");
-        this.memSpace = memSpace;
 
         when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace, codeSpace, memSpace});
         when(factory.getDefaultAddressSpace()).thenReturn(ramSpace);
@@ -137,6 +136,29 @@ public class ServiceUtilsAddressTest {
         assertTrue("Should name the valid space: " + err, err.contains("ram"));
         assertFalse("Must not call a valid space unknown: " + err,
                 err.contains("Unknown address space"));
+    }
+
+    @Test
+    public void parseAddress_knownOverlayBadOffset_blamesOffsetAndListsOverlay() {
+        // isKnownSpace + buildAvailableSpacesHint now include overlay spaces.
+        AddressSpace ovSpace = mock(AddressSpace.class);
+        when(ovSpace.isOverlaySpace()).thenReturn(true);
+        when(ovSpace.getName()).thenReturn("cli.Initial");
+        when(factory.getAddressSpaces()).thenReturn(
+            new AddressSpace[]{ramSpace, codeSpace, memSpace, ovSpace});
+        // Offset is unresolvable in the (known) overlay space.
+        when(factory.getAddress("cli.Initial::zzzz")).thenReturn(null);
+
+        Address result = ServiceUtils.parseAddress(program, "cli.Initial::zzzz");
+        assertNull(result);
+        String err = ServiceUtils.getLastParseError();
+        assertNotNull(err);
+        assertTrue("Should blame the offset: " + err, err.contains("Could not resolve offset"));
+        assertTrue("Should name the valid overlay space: " + err, err.contains("cli.Initial"));
+        assertFalse("Must not call a known overlay unknown: " + err,
+                err.contains("Unknown address space"));
+        assertTrue("Available-spaces hint should label overlays: " + err,
+                err.contains("[overlays]"));
     }
 
     @Test

--- a/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
+++ b/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
@@ -20,6 +20,7 @@ public class ServiceUtilsAddressTest {
     private AddressFactory factory;
     private AddressSpace ramSpace;
     private AddressSpace codeSpace;
+    private AddressSpace memSpace;
     private Address mockAddr;
 
     @Before
@@ -42,7 +43,14 @@ public class ServiceUtilsAddressTest {
         when(codeSpace.isOverlaySpace()).thenReturn(false);
         when(codeSpace.getName()).thenReturn("code");
 
-        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace, codeSpace});
+        // mem space: TYPE_RAM, not overlay, lowercase canonical name "mem"
+        AddressSpace memSpace = mock(AddressSpace.class);
+        when(memSpace.getType()).thenReturn(AddressSpace.TYPE_RAM);
+        when(memSpace.isOverlaySpace()).thenReturn(false);
+        when(memSpace.getName()).thenReturn("mem");
+        this.memSpace = memSpace;
+
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace, codeSpace, memSpace});
         when(factory.getDefaultAddressSpace()).thenReturn(ramSpace);
 
         // Mock address behaviour
@@ -151,18 +159,21 @@ public class ServiceUtilsAddressTest {
     }
 
     @Test
-    public void parseAddress_uppercaseSpaceWithHex_normalizesAndResolves() {
-        // Batch endpoints pass raw user input like "MEM:1000" bypassing bridge sanitization.
-        // parseAddress must lowercase the space name before calling AddressFactory.
+    public void parseAddress_uppercaseSpace_resolvesViaCaseInsensitiveFallback() {
+        // Exact case is tried first (getAddress("MEM:1000") -> null here), then a
+        // case-insensitive match against real program spaces retries with the
+        // canonical name "mem". Space names are NOT blindly lowercased anymore.
+        when(factory.getAddress("MEM:1000")).thenReturn(null);
         when(factory.getAddress("mem:1000")).thenReturn(mockAddr);
         Address result = ServiceUtils.parseAddress(program, "MEM:1000");
-        assertNotNull("Uppercase space name must be normalized to lowercase", result);
+        assertNotNull("Uppercase space name must resolve via case-insensitive fallback", result);
         assertNull(ServiceUtils.getLastParseError());
     }
 
     @Test
-    public void parseAddress_uppercaseSpaceWith0xOffset_stripsPrefix() {
-        // Input like "MEM:0x1000" must become "mem:1000" before hitting AddressFactory.
+    public void parseAddress_uppercaseSpaceWith0xOffset_stripsPrefixThenFallback() {
+        // "MEM:0x1000" -> strip 0x -> exact "MEM:1000" (null) -> fallback "mem:1000".
+        when(factory.getAddress("MEM:1000")).thenReturn(null);
         when(factory.getAddress("mem:1000")).thenReturn(mockAddr);
         Address result = ServiceUtils.parseAddress(program, "MEM:0x1000");
         assertNotNull("0x prefix in space:offset form must be stripped", result);
@@ -170,11 +181,36 @@ public class ServiceUtilsAddressTest {
     }
 
     @Test
-    public void parseAddress_lowercase0XVariant_stripsPrefix() {
-        // "0X" (uppercase X) must also be stripped.
+    public void parseAddress_mixedCase0XVariant_stripsPrefixThenFallback() {
+        // "Code:0XFF00" -> strip 0X -> exact "Code:FF00" (null) -> fallback "code:FF00".
+        when(factory.getAddress("Code:FF00")).thenReturn(null);
         when(factory.getAddress("code:FF00")).thenReturn(mockAddr);
         Address result = ServiceUtils.parseAddress(program, "Code:0XFF00");
-        assertNotNull("0X (uppercase X) prefix must also be stripped", result);
+        assertNotNull("0X (uppercase X) prefix must be stripped and resolve via fallback", result);
+        assertNull(ServiceUtils.getLastParseError());
+    }
+
+    @Test
+    public void parseAddress_exactCaseOverlay_resolvesWithoutLowercasing() {
+        // Overlay names are case-sensitive: "cli.Initial::10000" must be tried verbatim.
+        Address ovAddr = mock(Address.class);
+        AddressSpace ovSpace = mock(AddressSpace.class);
+        when(ovSpace.isOverlaySpace()).thenReturn(true);
+        when(ovSpace.getName()).thenReturn("cli.Initial");
+        when(ovAddr.getAddressSpace()).thenReturn(ovSpace);
+        when(factory.getAddress("cli.Initial::10000")).thenReturn(ovAddr);
+        Address result = ServiceUtils.parseAddress(program, "cli.Initial::10000");
+        assertNotNull("Exact-case overlay address must resolve", result);
+        assertTrue(result.getAddressSpace().isOverlaySpace());
+        assertNull(ServiceUtils.getLastParseError());
+    }
+
+    @Test
+    public void parseAddress_overlay0xOffset_strippedAndResolved() {
+        Address ovAddr = mock(Address.class);
+        when(factory.getAddress("cli.Initial::10000")).thenReturn(ovAddr);
+        Address result = ServiceUtils.parseAddress(program, "cli.Initial::0x10000");
+        assertNotNull("0x in overlay offset must be stripped", result);
         assertNull(ServiceUtils.getLastParseError());
     }
 
@@ -240,6 +276,25 @@ public class ServiceUtilsAddressTest {
         assertEquals("00001000", result.get("address"));
         assertEquals("ram:00001000", result.get("address_full"));
         assertEquals("ram", result.get("address_space"));
+    }
+
+    @Test
+    public void addressToJson_overlayAddress_alwaysEmitsQualifier() {
+        // Even on a single-physical-space program, an overlay address must round-trip:
+        // emit address_full (cli.Initial::00010000) and address_space.
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace});
+        AddressSpace ovSpace = mock(AddressSpace.class);
+        when(ovSpace.isOverlaySpace()).thenReturn(true);
+        when(ovSpace.getName()).thenReturn("cli.Initial");
+        Address ovAddr = mock(Address.class);
+        when(ovAddr.getAddressSpace()).thenReturn(ovSpace);
+        when(ovAddr.toString(false)).thenReturn("00010000");
+        when(ovAddr.toString()).thenReturn("cli.Initial::00010000");
+
+        Map<String, Object> result = ServiceUtils.addressToJson(ovAddr, program);
+        assertEquals("00010000", result.get("address"));
+        assertEquals("cli.Initial::00010000", result.get("address_full"));
+        assertEquals("cli.Initial", result.get("address_space"));
     }
 
     @Test

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1110,7 +1110,7 @@
       "params": [
         "program"
       ],
-      "description": "List all physical address spaces in the program"
+      "description": "List all physical and overlay address spaces in the program (overlays include is_overlay flag and overlayed_space name)"
     },
     {
       "path": "/get_assembly_context",

--- a/tests/integration/test_readonly_endpoints.py
+++ b/tests/integration/test_readonly_endpoints.py
@@ -793,3 +793,24 @@ class TestResponseFormats:
         assert response.status_code == 200
         # Should be non-empty
         assert len(response.text) > 0
+
+
+class TestOverlayAddressSpaces:
+    """Overlay-space round-trip. Auto-skips on programs without overlay spaces."""
+
+    def test_get_address_spaces_lists_overlays_and_round_trips(self, http_client):
+        import json
+        resp = http_client.get("/get_address_spaces")
+        assert resp.status_code == 200
+        spaces = json.loads(resp.text)["address_spaces"]
+        overlays = [s for s in spaces if s.get("is_overlay")]
+        if not overlays:
+            pytest.skip("program has no overlay address spaces")
+
+        ov = overlays[0]
+        assert ov.get("overlayed_space"), "overlay entry must name its base space"
+        # Address the overlay at its start; read_memory must resolve it (no error).
+        addr = f"{ov['name']}::{ov['start']}"
+        result = json.loads(http_client.get(
+            "/read_memory", params={"address": addr, "length": "4"}).text)
+        assert "error" not in result, f"overlay read failed for {addr}: {result}"

--- a/tests/integration/test_readonly_endpoints.py
+++ b/tests/integration/test_readonly_endpoints.py
@@ -811,6 +811,7 @@ class TestOverlayAddressSpaces:
         assert ov.get("overlayed_space"), "overlay entry must name its base space"
         # Address the overlay at its start; read_memory must resolve it (no error).
         addr = f"{ov['name']}::{ov['start']}"
-        result = json.loads(http_client.get(
-            "/read_memory", params={"address": addr, "length": "4"}).text)
+        r = http_client.get("/read_memory", params={"address": addr, "length": "4"})
+        assert r.status_code == 200, r.text
+        result = json.loads(r.text)
         assert "error" not in result, f"overlay read failed for {addr}: {result}"

--- a/tests/test_address_spaces.py
+++ b/tests/test_address_spaces.py
@@ -61,6 +61,22 @@ class TestSanitizeAddress:
     def test_plain_hex_adds_prefix(self):
         assert sanitize_address("1000") == "0x1000"
 
+    # Overlay address forms (dotted / leading-dot names, :: separator)
+    def test_overlay_double_colon_passes_through(self):
+        assert sanitize_address("cli.Initial::00010000") == "cli.Initial::00010000"
+
+    def test_overlay_single_colon_passes_through(self):
+        assert sanitize_address("cli.Initial:00010000") == "cli.Initial:00010000"
+
+    def test_overlay_strips_0x_from_offset_preserving_case(self):
+        assert sanitize_address("cli.Initial::0x10000") == "cli.Initial::10000"
+
+    def test_overlay_leading_dot_name(self):
+        assert sanitize_address(".shstrtab::00000000") == ".shstrtab::00000000"
+
+    def test_overlay_leading_underscore_name(self):
+        assert sanitize_address("_elfHeader::0x33") == "_elfHeader::33"
+
 
 class TestValidateHexAddress:
     """validate_hex_address accepts post-sanitized forms only."""
@@ -83,6 +99,15 @@ class TestValidateHexAddress:
 
     def test_rejects_garbage(self):
         assert validate_hex_address("not_an_address") is False
+
+    def test_accepts_overlay_double_colon(self):
+        assert validate_hex_address("cli.Initial::00010000") is True
+
+    def test_accepts_overlay_leading_dot(self):
+        assert validate_hex_address(".shstrtab::0") is True
+
+    def test_accepts_overlay_with_0x_offset(self):
+        assert validate_hex_address("cli.Initial::0x10000") is True
 
 
 class TestBuildToolFunctionSanitization:

--- a/tests/test_address_spaces.py
+++ b/tests/test_address_spaces.py
@@ -77,6 +77,10 @@ class TestSanitizeAddress:
     def test_overlay_leading_underscore_name(self):
         assert sanitize_address("_elfHeader::0x33") == "_elfHeader::33"
 
+    def test_overlay_preserves_case_and_strips_0x_together(self):
+        # Headline behavior: '::' separator preserved, 0x stripped, name case kept.
+        assert sanitize_address("cli.Initial::0xFEED") == "cli.Initial::FEED"
+
 
 class TestValidateHexAddress:
     """validate_hex_address accepts post-sanitized forms only."""

--- a/tests/test_address_spaces.py
+++ b/tests/test_address_spaces.py
@@ -81,6 +81,28 @@ class TestSanitizeAddress:
         # Headline behavior: '::' separator preserved, 0x stripped, name case kept.
         assert sanitize_address("cli.Initial::0xFEED") == "cli.Initial::FEED"
 
+    # Space names may contain ANY non-colon, non-whitespace char (Ghidra
+    # memory-block names are unconstrained; overlay names derive from them).
+    def test_overlay_hyphenated_name(self):
+        assert sanitize_address("BANK-2::0x1000") == "BANK-2::1000"
+
+    def test_overlay_name_with_dollar(self):
+        assert sanitize_address("seg$init::00") == "seg$init::00"
+
+    def test_overlay_name_with_at_sign(self):
+        assert sanitize_address("rom@v2:1000") == "rom@v2:1000"
+
+    def test_overlay_name_with_leading_digit(self):
+        # A space name MAY start with a digit (e.g. "8051_BANK1"); the ':'
+        # separator is what distinguishes it from plain hex.
+        assert sanitize_address("8051_BANK1::0xff") == "8051_BANK1::ff"
+
+    def test_plain_hex_with_no_colon_still_unaffected(self):
+        # Regression guard: broadening the name class must NOT capture
+        # colon-free hex strings (they have no ':' so the pattern can't match).
+        assert sanitize_address("deadbeef") == "0xdeadbeef"
+        assert sanitize_address("0xCAFE") == "0xcafe"
+
 
 class TestValidateHexAddress:
     """validate_hex_address accepts post-sanitized forms only."""


### PR DESCRIPTION
## Problem

Tools that accept an `address` parameter cannot operate on Ghidra **overlay
address spaces**. On a program with overlays (e.g. an embedded ELF whose
loader created `cli.Initial::`, `.shstrtab::`, `_elfHeader::` blocks):

    read_memory("cli.Initial::00010000")
    → {"error":"Unknown address space '0xcli.initial' in '0xcli.initial::00010000'. Available spaces: ram."}

The address was mangled (`0x` prepended, name lowercased), `get_address_spaces`
reported only `ram`, and overlay addresses returned by tools came back as bare
hex that re-resolves into the wrong (underlying physical) space.

Ghidra's `AddressFactory.getAddress()` accepts `name::offset` and `name:offset`
correctly when the name's case is preserved — the breakage was entirely on our
side.

## Fix

Three centralized chokepoints carry every address into and out of the tools;
fixing the three makes overlays work everywhere with no per-tool edits:

1. **Bridge `sanitize_address`** (`bridge_mcp_ghidra.py`) — broaden the segment
   regex to accept any non-colon, non-whitespace space name (Ghidra
   memory-block / overlay names are essentially unconstrained: dots, hyphens,
   `$`, `@`, leading digits, leading `.`/`_`) and accept the `::` separator.
   Overlay-shaped strings now pass through with case preserved instead of
   falling into the plain-hex branch.

2. **`ServiceUtils.parseAddress`** — strip `0x` only from the offset (after the
   *last* colon); leave the case-sensitive space name untouched. Try exact
   case first, then a case-insensitive fallback against real program spaces
   (preserves the existing forgiving behavior for `MEM:0x1000`-style input,
   subsuming the partial fix that landed in v5.14.0). Error hints and
   `isKnownSpace` now include overlay spaces.

3. **`ServiceUtils.addressToJson`** — emit `address_full` / `address_space`
   whenever the address is in an overlay space, regardless of physical-space
   count, so overlay addresses round-trip correctly.

Plus: `get_address_spaces` now lists overlay spaces (each marked
`is_overlay: true` with `overlayed_space` naming the base), so they're
discoverable.

## Visible behavior changes (non-overlay programs)

Two purely-additive JSON changes are visible even on programs without overlays:

- Every physical entry in `get_address_spaces` (and the `address_spaces` array
  inside `get_current_program_info`) now carries `is_overlay: false`.
- When overlays exist, parse-error hints group them under an `[overlays]`
  label after the physical spaces.

Overlay entries omit `size` / `size_bytes` / `is_default` (overlays are never
default; their `start`/`end` reflect the address-space range, same as physical
entries — use `list_segments` for actual block extents).

## Verified

- Bridge: 35 tests (`tests/test_address_spaces.py`)
- Java offline: 236 tests including 22 in `ServiceUtilsAddressTest` and a new
  `AddressSpacesOverlayTest`
- Python unit: 366 passed
- Live, against an ELF with 14 overlay spaces:
  - `get_address_spaces` → 1 physical + 14 overlays listed
  - `read_memory cli.Initial::00010000` → ✅ `{address_full: "cli.Initial::00010000", ...}`
  - `read_memory cli.Initial:0x10000` → ✅ (single-colon + `0x` form)
  - Integration test `TestOverlayAddressSpaces` (auto-skips on overlay-free
    programs) → ✅ passes
