### PR TITLE
Surface overlay-space presence in list_open_programs and get_current_program_info

### DIFF
--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -320,6 +320,7 @@ public class ProgramScriptService {
         List<Map<String, Object>> programList = new ArrayList<>();
         for (Program prog : programs) {
             int physicalSpaceCount = ServiceUtils.getPhysicalSpaceCount(prog);
+            int overlaySpaceCount  = ServiceUtils.getOverlaySpaceCount(prog);
             programList.add(JsonHelper.mapOf(
                 "name", prog.getName(),
                 "path", prog.getDomainFile().getPathname(),
@@ -330,7 +331,12 @@ public class ProgramScriptService {
                 "image_base", prog.getImageBase().toString(),
                 "memory_size", prog.getMemory().getSize(),
                 "function_count", prog.getFunctionManager().getFunctionCount(),
-                "has_multiple_address_spaces", physicalSpaceCount > 1
+                // Physical-space ambiguity (true on 8051/AVR with separate
+                // CODE/RAM spaces). Overlays do NOT make plain hex ambiguous,
+                // so this stays false on single-RAM programs with overlays.
+                "has_multiple_address_spaces", physicalSpaceCount > 1,
+                "has_overlay_spaces",          overlaySpaceCount > 0,
+                "overlay_space_count",         overlaySpaceCount
             ));
         }
 
@@ -511,6 +517,11 @@ public class ProgramScriptService {
 
         List<Map<String, Object>> addressSpaces = buildAddressSpacesList(program);
         boolean multiSpace = addressSpaces.size() > 1;
+        List<Map<String, Object>> overlaySpaces = buildOverlaySpacesList(program);
+        // Combine for the address_spaces array so overlays are visible here too
+        // (matches /get_address_spaces). multiSpace is computed BEFORE the
+        // append so it continues to reflect physical ambiguity only.
+        addressSpaces.addAll(overlaySpaces);
 
         Map<String, Object> info = new java.util.LinkedHashMap<>();
         info.put("name", program.getName());
@@ -531,11 +542,18 @@ public class ProgramScriptService {
         info.put("memory_block_count", program.getMemory().getBlocks().length);
         info.put("address_spaces", addressSpaces);
         info.put("has_multiple_address_spaces", multiSpace);
+        info.put("has_overlay_spaces", !overlaySpaces.isEmpty());
+        info.put("overlay_space_count", overlaySpaces.size());
         if (multiSpace) {
             info.put("address_space_warning",
-                "This program has multiple address spaces. Plain hex addresses will resolve to the "
-                + "default space and may be incorrect. Use <space>:<hex> format (e.g., mem:1000) "
+                "This program has multiple physical address spaces. Plain hex addresses will resolve "
+                + "to the default space and may be incorrect. Use <space>:<hex> format (e.g., mem:1000) "
                 + "or call get_address_spaces first.");
+        } else if (!overlaySpaces.isEmpty()) {
+            info.put("address_space_warning",
+                "This program has overlay address spaces. Overlay addresses must be qualified as "
+                + "<overlay>::<hex> (e.g., " + overlaySpaces.get(0).get("name") + "::<hex>) — overlay "
+                + "names are case-sensitive. Plain hex resolves to the default physical space.");
         }
         return Response.ok(info);
     }

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -733,6 +733,20 @@ public final class ServiceUtils {
     }
 
     /**
+     * Count the program's overlay address spaces (regardless of base type).
+     * Overlay addresses must be qualified with their space name; this is
+     * orthogonal to {@link #getPhysicalSpaceCount} (which measures physical
+     * ambiguity for plain hex addresses).
+     */
+    public static int getOverlaySpaceCount(Program program) {
+        int count = 0;
+        for (AddressSpace space : program.getAddressFactory().getAddressSpaces()) {
+            if (space.isOverlaySpace()) count++;
+        }
+        return count;
+    }
+
+    /**
      * True if {@code spaceName} (case-insensitive) names a known address space in the
      * program — a physical RAM/CODE space OR an overlay space (overlays carry their own
      * types, e.g. TYPE_OTHER for ".shstrtab"). Used to distinguish a genuinely unknown

--- a/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
+++ b/src/test/java/com/xebyte/offline/ServiceUtilsAddressTest.java
@@ -353,4 +353,25 @@ public class ServiceUtilsAddressTest {
         when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace});
         assertEquals(1, ServiceUtils.getPhysicalSpaceCount(program));
     }
+
+    @Test
+    public void getOverlaySpaceCount_countsOnlyOverlays() {
+        AddressSpace ov1 = mock(AddressSpace.class);
+        when(ov1.isOverlaySpace()).thenReturn(true);
+        AddressSpace ov2 = mock(AddressSpace.class);
+        when(ov2.isOverlaySpace()).thenReturn(true);
+        AddressSpace ext = mock(AddressSpace.class);
+        when(ext.isOverlaySpace()).thenReturn(false);
+        when(factory.getAddressSpaces()).thenReturn(
+            new AddressSpace[]{ramSpace, codeSpace, ov1, ov2, ext});
+        assertEquals(2, ServiceUtils.getOverlaySpaceCount(program));
+        // Physical count unchanged by overlays
+        assertEquals(2, ServiceUtils.getPhysicalSpaceCount(program));
+    }
+
+    @Test
+    public void getOverlaySpaceCount_zeroWhenNone() {
+        when(factory.getAddressSpaces()).thenReturn(new AddressSpace[]{ramSpace});
+        assertEquals(0, ServiceUtils.getOverlaySpaceCount(program));
+    }
 }


### PR DESCRIPTION
Follow-up to #313. After overlay support landed, `list_open_programs` and
`get_current_program_info` still report `has_multiple_address_spaces: false`
on a program with overlays — which is technically correct (the flag measures
*physical*-space ambiguity for plain hex addresses, and overlays don't make
plain hex ambiguous) but reads as misleading on a binary with 14 overlay
spaces. The overlay entries also weren't shown in
`get_current_program_info.address_spaces`.

This makes overlay presence explicit without changing the existing flag's
semantics:

- Adds `has_overlay_spaces: bool` and `overlay_space_count: int` to each
  `list_open_programs` entry and to `get_current_program_info`.
- Includes overlay entries in `get_current_program_info.address_spaces`
  (matching `/get_address_spaces`). `has_multiple_address_spaces` is
  computed *before* the append, so it keeps its physical-only meaning.
- Emits an overlay-specific `address_space_warning` ("overlay addresses
  must be qualified as `<overlay>::<hex>`; names are case-sensitive") when
  the program has overlays but only one physical space.
- New `ServiceUtils.getOverlaySpaceCount(Program)` helper alongside
  `getPhysicalSpaceCount`, with unit coverage.

3 files, +56/−3. 238 offline Java tests pass.
