### PR TITLE
release: v5.14.1 — full overlay address-space support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are a coding agent working on **ghidra-mcp**, a Model Context Protocol serve
 ## Project Context
 
 - **Repo**: https://github.com/bethington/ghidra-mcp
-- **Version**: 5.14.0
+- **Version**: 5.14.1
 - **Language**: Java (Ghidra extension) + Python (MCP bridge)
 - **Key feature**: 251 MCP tools for binary analysis, knowledge database, BSim integration, headless server support, AI documentation workflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
+
+Patch release.
+
+### Fixed
+
+- **Overlay address-space support across all address-taking tools** (#313, thanks @PJ-Zetier):
+  tools could not operate on Ghidra overlay address spaces (e.g. `cli.Initial::00010000`)
+  — the space name was mangled (`0x` prepended, lowercased), `get_address_spaces` reported
+  only `ram`, and overlay addresses returned by tools came back as bare hex that re-resolved
+  into the wrong physical space. Fixed at three centralized chokepoints so overlays work
+  everywhere with no per-tool edits: the bridge `sanitize_address` regex now accepts any
+  Ghidra block name and the `::` separator (case preserved); `ServiceUtils.parseAddress` does
+  an exact-case attempt then a case-insensitive fallback (handling both `:` and `::`); and
+  enriched address responses emit `address_full`/`address_space` for overlay addresses so they
+  round-trip correctly. Supersedes and generalizes the v5.14.0 uppercase-overlay fix (#297).
+
+### Changed
+
+- Dependency bumps (Dependabot): `claude-agent-sdk` → 0.2.101 (root + `/fun-doc`, #303/#301),
+  `responses` → >=0.26.1 (#305).
+
+---
+
 ## v5.14.0 - 2026-06-18 (minor: Ghidra 12.1.2 retarget, reference write tools, tool discovery, version-compat + overlay fixes)
 
 Minor release. Retargets the extension at **Ghidra 12.1.2** (latest), bundles two

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 MCP server bridging Ghidra reverse engineering with AI tools. 251 MCP tools for binary analysis.
 
-- **Package**: `com.xebyte` | **Version**: 5.14.0 | **Java**: 21 LTS | **Ghidra**: 12.1.2
+- **Package**: `com.xebyte` | **Version**: 5.14.1 | **Java**: 21 LTS | **Ghidra**: 12.1.2
 
 ## Boil the ocean
 

--- a/README.md
+++ b/README.md
@@ -962,7 +962,7 @@ docker-compose up -d ghidra-mcp
 
 # Test connection
 curl http://localhost:8089/check_connection
-# Connection OK - GhidraMCP Headless Server v5.14.0
+# Connection OK - GhidraMCP Headless Server v5.14.1
 ```
 
 ### Headless API Workflow
@@ -1028,7 +1028,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Metric | Value |
 |--------|-------|
-| **Version** | 5.14.0 |
+| **Version** | 5.14.1 |
 | **MCP Tools** | 249 fully implemented |
 | **GUI Endpoints** | 196 (GhidraMCPPlugin) |
 | **Headless Endpoints** | 195 (GhidraMCPHeadlessServer) |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -9,7 +9,7 @@ For the release preparation runbook, see
 
 ## Current Releases
 
-### v5.14.0 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
+### v5.14.1 (Latest) — community-driven tools: /get_current_selection + GUI /open_project
 
 Minor release. Two new endpoints filed/scoped by community feedback,
 plus a quiet headless parity fix that surfaced while writing the

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.xebyte</groupId>
     <artifactId>GhidraMCP</artifactId>
     <packaging>jar</packaging>
-    <version>5.14.0</version>
+    <version>5.14.1</version>
     <name>Ghidra MCP Server</name>
     <description>Production-ready Model Context Protocol server for Ghidra reverse engineering platform. Provides MCP-based tooling and automation for reverse engineering workflows: convention-enforcing rename/type/comment endpoints, batch operations, P-code emulation, live debugger integration, headless server, and Ghidra Server multi-version support.</description>
     <url>https://github.com/bethington/ghidra-mcp</url>

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -106,7 +106,7 @@ import java.util.regex.Pattern;
 
 // Load version from properties file (populated by Maven during build)
 class VersionInfo {
-    private static String VERSION = "5.14.0"; // Default fallback
+    private static String VERSION = "5.14.1"; // Default fallback
     private static String APP_NAME = "GhidraMCP";
     private static String GHIDRA_VERSION = "unknown"; // Loaded from version.properties (Maven-filtered)
     private static String BUILD_TIMESTAMP = "dev"; // Will be replaced by Maven

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -54,7 +54,7 @@ import java.util.*;
  */
 public class GhidraMCPHeadlessServer implements GhidraLaunchable {
 
-    private static final String VERSION = "5.14.0-headless";
+    private static final String VERSION = "5.14.1-headless";
     private static final int DEFAULT_PORT = 8089;
     private static final String DEFAULT_BIND_ADDRESS = "127.0.0.1";
 

--- a/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
+++ b/src/main/java/com/xebyte/headless/HeadlessEndpointHandler.java
@@ -42,7 +42,7 @@ import ghidra.app.cmd.disassemble.DisassembleCommand;
  */
 public class HeadlessEndpointHandler {
 
-    private static final String VERSION = "5.14.0-headless";
+    private static final String VERSION = "5.14.1-headless";
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
     private final TaskMonitor monitor;

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.xebyte.GhidraMCPPlugin
 Plugin-Name: GhidraMCP
-Plugin-Version: 5.14.0
+Plugin-Version: 5.14.1
 Plugin-Author: Ben Ethington
 Plugin-Description: GhidraMCP - HTTP server plugin with 251 MCP tools for reverse engineering automation

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.0",
+  "version": "5.14.1",
   "description": "GhidraMCP REST API Endpoint Specification",
   "total_endpoints": 251,
   "categories": {


### PR DESCRIPTION
## v5.14.1 (patch)

### Fixed
- **Overlay address-space support across all address-taking tools** (#313, thanks @PJ-Zetier) — overlay addresses (e.g. `cli.Initial::00010000`) now work everywhere: bridge `sanitize_address` accepts any Ghidra block name + `::` separator (case preserved), `parseAddress` does exact-case then case-insensitive resolution, and enriched responses emit `address_full`/`address_space` so overlay addresses round-trip. Supersedes/generalizes the v5.14.0 uppercase-overlay fix (#297).

### Changed
- Dependabot: `claude-agent-sdk` → 0.2.101 (#303/#301), `responses` → >=0.26.1 (#305).

### Tests run
- Offline: 373 Python unit + **235 offline Java** (incl. new `AddressSpacesOverlayTest`), against the 12.1.2 jars.
- **Live release regression on Ghidra 12.1.2 — all tiers pass** (MCP smoke 206 tools, contract 29 tools, Benchmark YAML 50 assertion-blocks, multi-program, negative-shape, debugger-live).

Targets Ghidra 12.1.2. Built zip declares `version=12.1.2`.