### PR TITLE
fix(headless): lifecycle and ACL correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Headless `stop()` now closes the open project after releasing programs,
+  so the `.rep` project lock is released on shutdown — previously even a
+  clean exit left the project locked and the next `/open_project` (or GUI
+  open) failed with "project is locked"
+- Headless `setUserPermissions` merges the target user into the existing
+  repository ACL instead of replacing the entire user list with a single
+  entry; preserves the current anonymous-access flag. Response now
+  includes `total_users` and `anonymous_access`
+- Headless `checkinFile` / `undoCheckout` now return an explicit
+  `not_implemented` error with a hint pointing at the `DomainFile` path,
+  instead of reporting `checked_in` / `checkout_undone` without performing
+  any operation
+- `HeadlessProgramProvider` releases a previously-tracked `Program` when a
+  newly-loaded one collides on `getName()` (same leaf filename), instead
+  of silently leaking the displaced handle's DomainObject consumer
+  reference and DB buffers
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -634,8 +634,24 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
         }
 
         if (programProvider != null) {
-            System.out.println("Closing programs...");
-            programProvider.closeAllPrograms();
+            try {
+                System.out.println("Closing programs...");
+                programProvider.closeAllPrograms();
+            } finally {
+                // Release the .rep project lock. closeAllPrograms() only
+                // releases Program handles; the project lock acquired by
+                // GhidraProject.openProject() is freed by closeProject().
+                // Without this, even a clean shutdown leaves the project
+                // locked and the next /open_project (or GUI open) fails
+                // with "project is locked". try/finally so a release
+                // failure on one program doesn't skip the lock release.
+                System.out.println("Closing project...");
+                try {
+                    programProvider.closeProject();
+                } catch (Exception e) {
+                    System.err.println("Error closing project: " + e.getMessage());
+                }
+            }
         }
 
         if (scriptingBundleHostAcquired) {

--- a/src/main/java/com/xebyte/headless/GhidraServerManager.java
+++ b/src/main/java/com/xebyte/headless/GhidraServerManager.java
@@ -760,16 +760,49 @@ public class GhidraServerManager {
             if (repo == null) {
                 return "{\"error\": \"Repository not found: " + escapeJson(repoName) + "\"}";
             }
-            // Find user and set access level - create/update user entry
-            repo.setUserList(new User[]{
-                new User(userName, accessLevel)
-            }, false);
+            // setUserList REPLACES the repository ACL wholesale — passing a
+            // single-element array would silently strip every other user
+            // (including admins) from the repo. Fetch the existing list,
+            // merge/replace the one entry, and preserve the current
+            // anonymous-access flag.
+            User[] existing = repo.getUserList();
+            boolean anon = repo.anonymousAccessAllowed();
+            User[] merged = mergeUserPermission(existing, userName, accessLevel);
+            repo.setUserList(merged, anon);
             return "{\"status\": \"permissions_set\", \"repository\": \"" + escapeJson(repoName) +
-                   "\", \"user\": \"" + escapeJson(userName) + "\", \"access_level\": " + accessLevel + "}";
+                   "\", \"user\": \"" + escapeJson(userName) + "\", \"access_level\": " + accessLevel +
+                   ", \"total_users\": " + merged.length +
+                   ", \"anonymous_access\": " + anon + "}";
         } catch (Exception e) {
             lastError = e.getMessage();
             return "{\"error\": \"Failed to set permissions (admin access required): " + escapeJson(e.getMessage()) + "\"}";
         }
+    }
+
+    /**
+     * Merge a single user's permission into an existing ACL array.
+     * <p>
+     * If a user with {@code userName} already exists, that entry is replaced
+     * with the new access level and all other entries are preserved in their
+     * original order. If no such user exists, a new entry is appended.
+     * Returns a fresh array; the input is not mutated.
+     */
+    public static User[] mergeUserPermission(User[] existing, String userName, int accessLevel) {
+        User updated = new User(userName, accessLevel);
+        if (existing == null || existing.length == 0) {
+            return new User[]{ updated };
+        }
+        for (int i = 0; i < existing.length; i++) {
+            if (existing[i] != null && userName.equals(existing[i].getName())) {
+                User[] out = existing.clone();
+                out[i] = updated;
+                return out;
+            }
+        }
+        User[] out = new User[existing.length + 1];
+        System.arraycopy(existing, 0, out, 0, existing.length);
+        out[existing.length] = updated;
+        return out;
     }
 
     public boolean isConnected() {

--- a/src/main/java/com/xebyte/headless/GhidraServerManager.java
+++ b/src/main/java/com/xebyte/headless/GhidraServerManager.java
@@ -441,12 +441,20 @@ public class GhidraServerManager {
             if (item == null) {
                 return "{\"error\": \"File not found in repository: " + escapeJson(filePath) + "\"}";
             }
-            // Note: actual checkin is performed via DomainFile.checkin() on the client side.
-            // Repository adapter does not expose a direct checkin() method.
-            // Return advisory message instead.
-            if (item == null) return "{\"error\": \"Item check was null\"}"; // suppress lint
-            return "{\"status\": \"checked_in\", \"repository\": \"" + escapeJson(repoName) +
-                   "\", \"path\": \"" + escapeJson(filePath) + "\", \"keep_checked_out\": " + keepCheckedOut + "}";
+            // RepositoryAdapter does not expose a direct checkin(); the
+            // operation must go through DomainFile.checkin() on an open
+            // project. Returning a success status here would mislead an
+            // automated caller into believing the checkin happened —
+            // edits would remain un-checked-in and (per the shared-server
+            // persistence model) silently lost. Return an explicit error
+            // so the caller knows to use the project-level path instead.
+            return "{\"error\": \"checkin not supported via repository adapter\"" +
+                   ", \"status\": \"not_implemented\"" +
+                   ", \"repository\": \"" + escapeJson(repoName) + "\"" +
+                   ", \"path\": \"" + escapeJson(filePath) + "\"" +
+                   ", \"item_exists\": " + (item != null) +
+                   ", \"hint\": \"open the project and use DomainFile.checkin() — " +
+                   "in this server: /open_project then /save_program then checkin via the project file\"}";
         } catch (Exception e) {
             lastError = e.getMessage();
             return "{\"error\": \"Checkin failed: " + escapeJson(e.getMessage()) + "\"}";
@@ -472,11 +480,19 @@ public class GhidraServerManager {
             int lastSlash = filePath.lastIndexOf('/');
             String parentPath = lastSlash > 0 ? filePath.substring(0, lastSlash) : "/";
             String fileName = lastSlash >= 0 ? filePath.substring(lastSlash + 1) : filePath;
-            // undoCheckout is performed via DomainFile on the client side
-            // Return advisory - the checkout record can be terminated via terminateCheckout
-            if (repo == null) return "{\"error\": \"Repo not found\"}"; // suppress lint
-            return "{\"status\": \"checkout_undone\", \"repository\": \"" + escapeJson(repoName) +
-                   "\", \"path\": \"" + escapeJson(filePath) + "\"}";
+            // RepositoryAdapter does not expose undoCheckout; the operation
+            // must go through DomainFile.undoCheckout() on an open project
+            // (or terminateCheckout for an admin force-undo). Returning a
+            // success status here would leave the checkout live on the
+            // server while the caller believes it was undone.
+            return "{\"error\": \"undoCheckout not supported via repository adapter\"" +
+                   ", \"status\": \"not_implemented\"" +
+                   ", \"repository\": \"" + escapeJson(repoName) + "\"" +
+                   ", \"path\": \"" + escapeJson(filePath) + "\"" +
+                   ", \"parent\": \"" + escapeJson(parentPath) + "\"" +
+                   ", \"file\": \"" + escapeJson(fileName) + "\"" +
+                   ", \"hint\": \"open the project and use DomainFile.undoCheckout(), " +
+                   "or use /server/admin/terminate_checkout for an admin force-undo\"}";
         } catch (Exception e) {
             lastError = e.getMessage();
             return "{\"error\": \"Undo checkout failed: " + escapeJson(e.getMessage()) + "\"}";

--- a/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
+++ b/src/main/java/com/xebyte/headless/HeadlessProgramProvider.java
@@ -121,7 +121,39 @@ public class HeadlessProgramProvider implements ProgramProvider {
         if (program != null) {
             this.currentProgram = program;
             // Ensure it's in our map
-            openPrograms.put(program.getName(), program);
+            registerProgram(program);
+        }
+    }
+
+    /**
+     * Track a newly-opened Program in {@link #openPrograms}, releasing any
+     * prior different instance held under the same name.
+     * <p>
+     * {@code Program.getName()} is just the leaf filename (e.g.
+     * {@code D2Client.dll}), so importing two versions of the same binary —
+     * or the same filename from two folders — would otherwise overwrite the
+     * earlier map entry without {@code release()}ing it. The orphaned
+     * Program's DomainObject consumer reference and DB buffers then stay
+     * live for the JVM's lifetime, invisibly accumulating toward the
+     * ~5-open-program crash ceiling.
+     */
+    private void registerProgram(Program program) {
+        String name = program.getName();
+        Program prior = openPrograms.put(name, program);
+        if (prior != null && prior != program) {
+            Msg.warn(this, "Program name collision on '" + name
+                + "' — releasing previously-tracked instance to avoid a leak. "
+                + "Consider closing the earlier program explicitly before "
+                + "loading another with the same filename.");
+            try {
+                prior.release(this);
+            } catch (Exception e) {
+                Msg.warn(this, "Error releasing displaced program '" + name
+                    + "': " + e.getMessage());
+            }
+            if (currentProgram == prior) {
+                currentProgram = program;
+            }
         }
     }
 
@@ -154,7 +186,7 @@ public class HeadlessProgramProvider implements ProgramProvider {
             }
 
             if (program != null) {
-                openPrograms.put(program.getName(), program);
+                registerProgram(program);
                 if (currentProgram == null) {
                     currentProgram = program;
                 }
@@ -232,7 +264,7 @@ public class HeadlessProgramProvider implements ProgramProvider {
             }
 
             if (program != null) {
-                openPrograms.put(program.getName(), program);
+                registerProgram(program);
                 if (currentProgram == null) {
                     currentProgram = program;
                 }
@@ -338,7 +370,7 @@ public class HeadlessProgramProvider implements ProgramProvider {
                     "domainFile.getDomainObject returned null for: " + projectPath
                     + (serverHint.isEmpty() ? "" : " (" + serverHint + ")"));
             }
-            openPrograms.put(program.getName(), program);
+            registerProgram(program);
             if (currentProgram == null) {
                 currentProgram = program;
             }

--- a/src/test/java/com/xebyte/offline/GhidraServerManagerTest.java
+++ b/src/test/java/com/xebyte/offline/GhidraServerManagerTest.java
@@ -1,0 +1,58 @@
+package com.xebyte.offline;
+
+import com.xebyte.headless.GhidraServerManager;
+import ghidra.framework.remote.User;
+import junit.framework.TestCase;
+
+/**
+ * Offline tests for {@link GhidraServerManager} pure helpers.
+ *
+ * <p>{@code User} is a plain Serializable value class
+ * ({@code User(String, int)}, {@code getName()}, {@code getPermissionType()})
+ * with no Ghidra-init transitive chain, so it is safe to instantiate in the
+ * Maven offline suite.
+ */
+public class GhidraServerManagerTest extends TestCase {
+
+    public void testMergeUserPermission_replacesExistingEntryAndPreservesOthers() {
+        User[] existing = {
+            new User("alice", User.ADMIN),
+            new User("bob",   User.READ_ONLY),
+            new User("carol", User.WRITE),
+        };
+        User[] merged = GhidraServerManager.mergeUserPermission(existing, "bob", User.WRITE);
+
+        assertEquals("ACL size must not shrink", 3, merged.length);
+        assertEquals("alice", merged[0].getName());
+        assertEquals(User.ADMIN, merged[0].getPermissionType());
+        assertEquals("bob", merged[1].getName());
+        assertEquals("bob's level updated", User.WRITE, merged[1].getPermissionType());
+        assertEquals("carol", merged[2].getName());
+        assertEquals(User.WRITE, merged[2].getPermissionType());
+        // Input not mutated
+        assertEquals(User.READ_ONLY, existing[1].getPermissionType());
+    }
+
+    public void testMergeUserPermission_appendsNewUser() {
+        User[] existing = {
+            new User("alice", User.ADMIN),
+        };
+        User[] merged = GhidraServerManager.mergeUserPermission(existing, "dave", User.READ_ONLY);
+
+        assertEquals(2, merged.length);
+        assertEquals("alice", merged[0].getName());
+        assertEquals(User.ADMIN, merged[0].getPermissionType());
+        assertEquals("dave", merged[1].getName());
+        assertEquals(User.READ_ONLY, merged[1].getPermissionType());
+    }
+
+    public void testMergeUserPermission_handlesNullOrEmptyExisting() {
+        User[] fromNull = GhidraServerManager.mergeUserPermission(null, "alice", User.ADMIN);
+        assertEquals(1, fromNull.length);
+        assertEquals("alice", fromNull[0].getName());
+
+        User[] fromEmpty = GhidraServerManager.mergeUserPermission(new User[0], "alice", User.ADMIN);
+        assertEquals(1, fromEmpty.length);
+        assertEquals("alice", fromEmpty[0].getName());
+    }
+}


### PR DESCRIPTION
## Summary

Four headless-mode lifecycle and correctness fixes.

### `stop()` never closes the open project

`GhidraMCPHeadlessServer.stop()` called `programProvider.closeAllPrograms()` but never `closeProject()`. The `.rep` project lock acquired by `GhidraProject.openProject()` is only released by `closeProject()`, so even a clean shutdown (shutdown hook or `/exit_ghidra`) left the project locked and the next `/open_project` — or a GUI open of the same project — failed with "project is locked".

**Fix:** call `closeProject()` in a `finally` after `closeAllPrograms()` so a program-release failure doesn't skip the lock release. The second `closeAllPrograms()` inside `closeProject()` iterates an already-cleared map, so there's no double-release.

### `setUserPermissions` replaces the entire repository ACL

`/server/admin/set_permissions` called `repo.setUserList(new User[]{ new User(userName, accessLevel) }, false)`. `RepositoryAdapter.setUserList()` replaces the ACL wholesale — it isn't additive — so granting one user access stripped every other existing user (including admins) from the repository and disabled anonymous access. On a shared server this is a one-shot lockout of the whole team.

**Fix:** fetch `repo.getUserList()`, merge/replace the single entry via a new `mergeUserPermission` helper, and pass the current `repo.anonymousAccessAllowed()` flag through. Response now includes `total_users` and `anonymous_access` so the caller can see the full ACL size after the change. The merge is case-sensitive (matching Ghidra server username semantics).

### `checkinFile` / `undoCheckout` report success without acting

Both methods looked up the repository item and then returned `"status": "checked_in"` / `"status": "checkout_undone"` without performing any operation — `RepositoryAdapter` doesn't expose checkin/undoCheckout; those go through `DomainFile` on an open project. An automated caller treated these as completed: edits stayed un-checked-in (and per the shared-server persistence model, silently lost), and checkouts the caller believed undone stayed live on the server.

**Fix:** both now return an explicit `"error"` with `"status": "not_implemented"` and a `"hint"` pointing at the `DomainFile` path (or `/server/admin/terminate_checkout` for an admin force-undo), so callers don't assume success.

### `openPrograms` name-key collisions leak Program handles

`HeadlessProgramProvider` keys its `openPrograms` map by `Program.getName()` — the bare leaf filename — so loading two versions of the same binary, or the same filename from two folders, overwrote the prior map entry without `release()`ing it. The orphaned `Program`'s `DomainObject` consumer reference and DB buffers stayed live for the JVM's lifetime, invisibly accumulating, and `list_open_programs` couldn't show the leaked one.

**Fix:** add a `registerProgram()` helper that releases any prior different instance (with a warning) before tracking the new one; replace all four `openPrograms.put(getName(), ...)` sites. Re-registering the same instance is a no-op.

## Testing

- Java offline suite: **239 passed**, 0 failed, 0 errors, 0 skipped (baseline 236 + 3 new `GhidraServerManagerTest` cases covering the merge helper: replace-existing, append-new, null/empty input, input-not-mutated)
- `EndpointsJsonParityTest` passes — no `@McpTool` signatures changed
- Python unit suite: **366 passed**, 7 skipped, 0 failed
