### PR TITLE
fix(gradle): deploy stops Ghidra and patches only the target user dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Gradle `deploy` now stops any Ghidra running from `GHIDRA_INSTALL_DIR`
+  before installing the extension or patching `FrontEndTool.xml` (graceful
+  `/save_all_programs` + `/exit_ghidra` via the MCP endpoint, poll for
+  process death matching the install path, force-kill survivors). Previously
+  on Windows the running JVM file-locked `GhidraMCP-*.jar` so the install
+  failed, and on any OS Ghidra rewrites `FrontEndTool.xml` on exit so the
+  config patch was silently discarded. Also adds explicit `mustRunAfter`
+  ordering so `patchGhidraUserConfig` runs after the extension is installed.
+- Gradle `patchGhidraUserConfig` now restricts its file walk to the single
+  versioned Ghidra user directory instead of recursing the parent
+  (`%APPDATA%\ghidra`), which was stamping the plugin INCLUDE — and stripping
+  the `Developer` PACKAGE block — into every sibling `ghidra_<ver>_*`
+  directory, corrupting unrelated installs. Brings the Gradle backend in line
+  with the Maven backend's #217 fix.
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/build.gradle
+++ b/build.gradle
@@ -240,6 +240,50 @@ def resolveGhidraUserDir = {
 
 def pluginClass = 'com.xebyte.GhidraMCPPlugin'
 
+// ----------------------------------------------------------------------
+// stopGhidra: graceful exit + poll + force-kill. Mirrors
+// tools/setup/ghidra.py:close_running_ghidra_for_deploy. Required before
+// deploy because (a) on Windows the running JVM file-locks GhidraMCP-*.jar
+// so installUserExtension's overwrite fails, and (b) on any OS Ghidra
+// rewrites FrontEndTool.xml on exit, silently discarding patchGhidraUserConfig.
+// ----------------------------------------------------------------------
+
+def mcpUrl = (System.getenv('GHIDRA_MCP_URL') ?: 'http://127.0.0.1:8089').replaceAll('/+$', '')
+
+def httpRequest = { String path, int timeoutSec ->
+    try {
+        def url = new URI(mcpUrl + path).toURL()
+        def conn = url.openConnection()
+        conn.connectTimeout = 2000
+        conn.readTimeout    = timeoutSec * 1000
+        conn.requestMethod  = 'GET'
+        return conn.responseCode
+    } catch (Exception e) {
+        return -1  // unreachable / refused
+    }
+}
+
+def findRunningGhidraPids = {
+    if (!ghidraRoot) return [] as List<Long>
+    def installPath = ghidraRoot.canonicalPath
+    def os = org.gradle.internal.os.OperatingSystem.current()
+    // Path separators may differ in process command lines on Windows.
+    def needle = os.isWindows()
+        ? installPath.replace('/', '\\').toLowerCase()
+        : installPath
+    def pids = [] as List<Long>
+    ProcessHandle.allProcesses().forEach { ph ->
+        try {
+            def cmd = ph.info().commandLine().orElse('')
+            def hay = os.isWindows() ? cmd.toLowerCase() : cmd
+            if (hay.contains(needle) && cmd.toLowerCase().contains('ghidra')) {
+                pids << ph.pid()
+            }
+        } catch (Exception ignored) {}
+    }
+    return pids
+}
+
 // Returns [patchedContent, wasModified]. Mirrors patch_frontend_tool_config() in ghidra.py.
 def patchFrontEndXml = { String content ->
     def updated = content
@@ -435,10 +479,61 @@ tasks.register('patchGhidraUserConfig') {
     }
 }
 
+tasks.register('stopGhidra') {
+    group       = 'deploy'
+    description = 'Stops any Ghidra running from GHIDRA_INSTALL_DIR (graceful via /exit_ghidra, then poll, then force-kill).'
+    doLast {
+        requireGhidraInstallDir()
+        def pids = findRunningGhidraPids()
+        if (pids.isEmpty()) {
+            println "stopGhidra: no Ghidra process running from ${ghidraRoot}"
+            return
+        }
+        println "stopGhidra: detected running Ghidra PID(s) ${pids} from ${ghidraRoot}"
+        // Best-effort save + graceful exit via the MCP HTTP endpoint.
+        if (httpRequest('/save_all_programs', 60) >= 200) {
+            println "stopGhidra: requested save_all_programs via ${mcpUrl}"
+        }
+        if (httpRequest('/exit_ghidra', 10) >= 200) {
+            println "stopGhidra: requested graceful exit via ${mcpUrl}/exit_ghidra"
+        } else {
+            println "stopGhidra: ${mcpUrl}/exit_ghidra unreachable — will force-kill if needed"
+        }
+        // Poll for clean exit (default 30s; override with -PstopGhidraWaitSec=N).
+        int waitSec = (findProperty('stopGhidraWaitSec') ?: '30') as int
+        long deadline = System.currentTimeMillis() + waitSec * 1000L
+        while (System.currentTimeMillis() < deadline) {
+            if (findRunningGhidraPids().isEmpty()) {
+                println "stopGhidra: Ghidra exited cleanly"
+                return
+            }
+            Thread.sleep(1000)
+        }
+        // Force-kill survivors.
+        findRunningGhidraPids().each { pid ->
+            println "stopGhidra: force-killing Ghidra PID ${pid}"
+            ProcessHandle.of(pid).ifPresent { it.destroyForcibly() }
+        }
+        // Brief settle so file locks are released before install/overwrite.
+        Thread.sleep(1000)
+    }
+}
+
+// Deploy ordering: stopGhidra must run before anything writes into the
+// Ghidra install/user trees, and config patching must follow extension
+// installation. dependsOn alone imposes no order between siblings —
+// mustRunAfter makes the sequence explicit.
+tasks.named('deployExtension')      { dependsOn 'stopGhidra' }
+tasks.named('installUserExtension') { dependsOn 'stopGhidra' }
+tasks.named('patchGhidraUserConfig') {
+    dependsOn 'stopGhidra'
+    mustRunAfter 'deployExtension', 'installUserExtension'
+}
+
 tasks.register('deploy') {
     group       = 'deploy'
-    description = 'Full deploy: build extension, install to Ghidra install tree and user profile, patch configs.'
-    dependsOn 'deployExtension', 'installUserExtension', 'patchGhidraUserConfig'
+    description = 'Full deploy: stop Ghidra, build extension, install to Ghidra install tree and user profile, patch configs.'
+    dependsOn 'stopGhidra', 'deployExtension', 'installUserExtension', 'patchGhidraUserConfig'
 }
 
 tasks.register('startGhidra') {

--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,13 @@ def findRunningGhidraPids = {
         try {
             def cmd = ph.info().commandLine().orElse('')
             def hay = os.isWindows() ? cmd.toLowerCase() : cmd
-            if (hay.contains(needle) && cmd.toLowerCase().contains('ghidra')) {
+            def lc  = cmd.toLowerCase()
+            // Match the install path AND the Ghidra launcher signature
+            // (ghidra.Ghidra main class or ghidraRun script) — same
+            // discriminator as tools/setup/ghidra.py so we don't pick
+            // up an editor or shell that merely has the path in argv.
+            if (hay.contains(needle)
+                    && (lc.contains('ghidra.ghidra') || lc.contains('ghidrarun'))) {
                 pids << ph.pid()
             }
         } catch (Exception ignored) {}
@@ -450,7 +456,7 @@ tasks.register('installUserExtension') {
 
 tasks.register('patchGhidraUserConfig') {
     group       = 'deploy'
-    description = 'Patches FrontEndTool.xml to activate GhidraMCPPlugin; removes plugin from _code_browser.tcd.'
+    description = 'Patches FrontEndTool.xml to activate GhidraMCPPlugin; removes plugin from tool .tcd files.'
     doLast {
         requireGhidraInstallDir()
         // #217: restrict to the SINGLE versioned user dir — never recurse the

--- a/build.gradle
+++ b/build.gradle
@@ -409,20 +409,27 @@ tasks.register('patchGhidraUserConfig') {
     description = 'Patches FrontEndTool.xml to activate GhidraMCPPlugin; removes plugin from _code_browser.tcd.'
     doLast {
         requireGhidraInstallDir()
-        def userBase = resolveGhidraUserDir().parentFile
-        if (!userBase?.isDirectory()) {
-            println "Ghidra user base dir not found (${userBase}) — skipping config patch"
+        // #217: restrict to the SINGLE versioned user dir — never recurse the
+        // parent. Recursing %APPDATA%\ghidra would stamp the plugin INCLUDE
+        // (and strip the Developer package block) into every sibling
+        // ghidra_<ver>_* dir, corrupting unrelated installs. Mirrors
+        // tools/setup/ghidra.py:patch_ghidra_user_configs(target_user_dir=…).
+        def userDir = resolveGhidraUserDir()
+        if (!userDir?.isDirectory()) {
+            println "Ghidra user dir not found (${userDir}) — skipping config patch"
             return
         }
-        def pycacheDirs = []
-        userBase.eachFileRecurse { f ->
-            if (f.name == 'FrontEndTool.xml') {
-                def (updated, modified) = patchFrontEndXml(f.text)
-                if (modified) { f.text = updated; println "Patched FrontEnd config: ${f}" }
-            }
-            if (f.name == '_code_browser.tcd') {
-                def (updated, modified) = patchCodeBrowserTcd(f.text)
-                if (modified) { f.text = updated; println "Cleaned CodeBrowser config: ${f}" }
+        println "Patching Ghidra user config under ${userDir} (single version dir only)"
+        def frontEnd = new File(userDir, 'FrontEndTool.xml')
+        if (frontEnd.isFile()) {
+            def (updated, modified) = patchFrontEndXml(frontEnd.text)
+            if (modified) { frontEnd.text = updated; println "Patched FrontEnd config: ${frontEnd}" }
+        }
+        def toolsDir = new File(userDir, 'tools')
+        if (toolsDir.isDirectory()) {
+            toolsDir.listFiles({ f -> f.isFile() && f.name.endsWith('.tcd') } as FileFilter)?.each { tcd ->
+                def (updated, modified) = patchCodeBrowserTcd(tcd.text)
+                if (modified) { tcd.text = updated; println "Cleaned tool config: ${tcd}" }
             }
         }
     }

--- a/tests/unit/test_gradle_tasks.py
+++ b/tests/unit/test_gradle_tasks.py
@@ -46,12 +46,42 @@ def test_gradlew_tasks_lists_all_custom_tasks():
         "deployExtension",
         "installUserExtension",
         "patchGhidraUserConfig",
+        "stopGhidra",
         "deploy",
         "startGhidra",
         "cleanAll",
     ]
     missing = [t for t in expected if t not in result.stdout]
     assert not missing, f"Custom Gradle tasks not found in task list: {missing}"
+
+
+@pytest.mark.slow
+def test_gradlew_deploy_task_order():
+    """`./gradlew deploy --dry-run` must schedule stopGhidra before any
+    write-into-Ghidra task, and patchGhidraUserConfig after the extension
+    is installed. Without the stop, Windows holds a file lock on
+    GhidraMCP-*.jar (install fails) and Ghidra rewrites FrontEndTool.xml
+    on exit (config patch silently discarded)."""
+    result = _run_gradlew("deploy", "--dry-run", "-PGHIDRA_INSTALL_DIR=nonexistent")
+    assert result.returncode == 0, (
+        f"deploy --dry-run failed:\n{result.stdout}\n{result.stderr}"
+    )
+    plan = [
+        ln.split()[0].lstrip(":")
+        for ln in result.stdout.splitlines()
+        if ln.startswith(":")
+    ]
+
+    def idx(t):
+        assert t in plan, f"task :{t} not in deploy plan: {plan}"
+        return plan.index(t)
+
+    assert idx("stopGhidra") < idx("deployExtension")
+    assert idx("stopGhidra") < idx("installUserExtension")
+    assert idx("stopGhidra") < idx("patchGhidraUserConfig")
+    assert idx("installUserExtension") < idx("patchGhidraUserConfig"), (
+        "config patch must run AFTER extension is installed"
+    )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

Two fixes that bring the Gradle `deploy` path to parity with the Maven backend.

### `deploy` doesn't stop the running Ghidra and has no inter-task ordering

The `deploy` task only listed `dependsOn deployExtension, installUserExtension, patchGhidraUserConfig` — no stop step, and `dependsOn` alone imposes no order between siblings. With Ghidra still running:

- On Windows the JVM file-locks `GhidraMCP-*.jar`, so `installUserExtension`'s overwrite fails.
- On any OS, Ghidra rewrites `FrontEndTool.xml` on exit, silently discarding `patchGhidraUserConfig`'s edit so the plugin is never activated.
- And without ordering, the config patch could run before the extension was installed.

**Fix:** add a `stopGhidra` task — graceful `/save_all_programs` + `/exit_ghidra` via the MCP HTTP endpoint (`GHIDRA_MCP_URL` env or `http://127.0.0.1:8089`), poll for process death via `ProcessHandle` matching the install path + Ghidra launcher signature (`ghidra.Ghidra` main class or `ghidraRun` script), force-kill survivors after a timeout (default 30s, override with `-PstopGhidraWaitSec=N`). Wire it as a dependency of every write-into-Ghidra task; `patchGhidraUserConfig` additionally `mustRunAfter` the install tasks. Mirrors `tools/setup/ghidra.py:close_running_ghidra_for_deploy`.

`./gradlew deploy --dry-run` task plan is now:
```
:buildExtension → :stopGhidra → :deployExtension → :installUserExtension → :patchGhidraUserConfig → :deploy
```

### `patchGhidraUserConfig` recurses into every Ghidra version directory

The task computed `userBase = resolveGhidraUserDir().parentFile` (i.e. `%APPDATA%\ghidra`) and ran `eachFileRecurse` over it, stamping the plugin `INCLUDE` — and stripping the `Developer` `PACKAGE` block — into every sibling `ghidra_<ver>_*` directory's `FrontEndTool.xml`, corrupting unrelated installs. The Maven backend was deliberately narrowed to a single target directory in #217.

**Fix:** walk only `resolveGhidraUserDir()` itself — `FrontEndTool.xml` directly in it, `tools/*.tcd` under it. The tcd patch is a no-op on files that don't contain the GhidraMCP package block, so the broader `*.tcd` glob (matching the Maven backend's) is safe. Mirrors `tools/setup/ghidra.py:patch_ghidra_user_configs(target_user_dir=…)`.

## Testing

- New `test_gradlew_deploy_task_order` asserts the `deploy --dry-run` task plan has `stopGhidra` before all install/patch tasks and `installUserExtension` before `patchGhidraUserConfig`
- `tests/unit/test_gradle_tasks.py`: 5 passed (4 existing + 1 new)
- Java offline suite: 236 passed (unchanged — no Java touched)
- Python unit suite: 367 passed, 7 skipped, 0 failed
