### PR TITLE
Fix PIC/GOT named globals rendering as DAT_ in decompile output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Complete version history for the Ghidra MCP Server project.
 
 ## Unreleased
 
+### Fixed
+
+- **PIC/GOT-indirected named globals rendered as `DAT_`**: `decompile_function`,
+  `decompile_function_by_name`, and every other decompiler-backed operation
+  constructed a bare `new DecompInterface()` and never applied
+  `DecompileOptions`. A fresh `DecompileOptions` leaves *"Respect Read-Only
+  Flags"* OFF (the C++ decompiler-core default), so a read-only GOT/relocation
+  slot stayed an opaque `DAT_<addr>` constant instead of being folded to the
+  named global it points at (e.g. `param_1 * 9.0 * DAT_001e9ebc` rather than
+  `... * ModSlashThickness`). This silently misled ports on PIC binaries
+  (observed on an ARM32 target). All 11 decompiler construction sites in
+  `FunctionService` and `DataTypeService` now route through a shared
+  `ServiceUtils.createConfiguredDecompiler(program)` factory that applies
+  `DecompileOptions.grabFromProgram(program)` before `openProgram`, exactly
+  matching the Ghidra GUI / analysis decompiler. `force_decompile`, which was
+  previously byte-identical to the broken output (a cache refresh with the same
+  bare options), now also resolves the named global. 249 tools.
+
 ---
 
 ## v5.13.1 - 2026-06-08 (patch: launch-noise fix + class-member listing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Complete version history for the Ghidra MCP Server project.
 
 ### Fixed
 
-- **PIC/GOT-indirected named globals rendered as `DAT_`**: `decompile_function`,
-  `decompile_function_by_name`, and every other decompiler-backed operation
+- **PIC/GOT-indirected named globals rendered as `DAT_`**: `decompile_function` and every other decompiler-backed operation
   constructed a bare `new DecompInterface()` and never applied
   `DecompileOptions`. A fresh `DecompileOptions` leaves *"Respect Read-Only
   Flags"* OFF (the C++ decompiler-core default), so a read-only GOT/relocation

--- a/src/main/java/com/xebyte/core/DataTypeService.java
+++ b/src/main/java/com/xebyte/core/DataTypeService.java
@@ -2425,8 +2425,7 @@ public class DataTypeService {
 
                     // CRITICAL FIX #2: Resource management with try-finally
                     try {
-                        decomp = new DecompInterface();
-                        decomp.openProgram(program);
+                        decomp = ServiceUtils.createConfiguredDecompiler(program);
 
                         long analysisStart = System.currentTimeMillis();
                         Msg.info(this, "Analyzing struct at " + addressStr + " with " + functionsToAnalyze.size() + " functions");

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -100,8 +100,7 @@ public class FunctionService {
         Program program = pe.program();
         DecompInterface decomp = null;
         try {
-            decomp = new DecompInterface();
-            decomp.openProgram(program);
+            decomp = ServiceUtils.createConfiguredDecompiler(program);
             for (Function func : program.getFunctionManager().getFunctions(true)) {
                 if (func.getName().equals(name)) {
                     DecompileResults result =
@@ -149,8 +148,7 @@ public class FunctionService {
             Function func = ServiceUtils.resolveFunction(program, addressStr);
             if (func == null) return Response.err("No function found for " + addressStr);
 
-            decomp = new DecompInterface();
-            decomp.openProgram(program);
+            decomp = ServiceUtils.createConfiguredDecompiler(program);
             DecompileResults decompResult = decomp.decompileFunction(func, timeoutSeconds, new ConsoleTaskMonitor());
 
             if (decompResult == null) {
@@ -206,9 +204,7 @@ public class FunctionService {
     public DecompileResults decompileFunctionNoRetry(Function func, Program program) {
         DecompInterface decomp = null;
         try {
-            decomp = new DecompInterface();
-            decomp.openProgram(program);
-            decomp.setSimplificationStyle("decompile");
+            decomp = ServiceUtils.createConfiguredDecompiler(program);
             return decomp.decompileFunction(func, NO_RETRY_DECOMPILE_TIMEOUT_SECONDS, new ConsoleTaskMonitor());
         } catch (Exception e) {
             Msg.warn(this, "Single-attempt decompile failed for " + func.getName() + ": " + e.getMessage());
@@ -233,9 +229,7 @@ public class FunctionService {
 
         for (int attempt = 1; attempt <= maxRetries; attempt++) {
             try {
-                decomp = new DecompInterface();
-                decomp.openProgram(program);
-                decomp.setSimplificationStyle("decompile");
+                decomp = ServiceUtils.createConfiguredDecompiler(program);
 
                 // On retry attempts, flush cache first and increase timeout
                 if (attempt > 1) {
@@ -322,8 +316,7 @@ public class FunctionService {
                 // Decompile the function
                 DecompInterface decompiler = null;
                 try {
-                    decompiler = new DecompInterface();
-                    decompiler.openProgram(program);
+                    decompiler = ServiceUtils.createConfiguredDecompiler(program);
                     DecompileResults decompResults = decompiler.decompileFunction(function, 30, null);
 
                     if (decompResults != null && decompResults.decompileCompleted()) {
@@ -388,8 +381,7 @@ public class FunctionService {
                     }
 
                     // Create new decompiler interface
-                    DecompInterface decompiler = new DecompInterface();
-                    decompiler.openProgram(program);
+                    DecompInterface decompiler = ServiceUtils.createConfiguredDecompiler(program);
 
                     try {
                         // Flush cached results to force fresh decompilation
@@ -650,10 +642,8 @@ public class FunctionService {
             return Response.err("Function name or address is required");
         }
 
-        DecompInterface decomp = new DecompInterface();
+        DecompInterface decomp = ServiceUtils.createConfiguredDecompiler(program);
         try {
-            decomp.openProgram(program);
-
             String functionRef = (functionAddress != null && !functionAddress.isEmpty()) ? functionAddress : functionName;
             Function func = ServiceUtils.resolveFunction(program, functionRef);
             if (func == null) {
@@ -2964,8 +2954,7 @@ public class FunctionService {
                         // Use decompiler to access SSA variables (the ones that appear in decompiled code)
                         DecompInterface decomp = null;
                         try {
-                            decomp = new DecompInterface();
-                            decomp.openProgram(program);
+                            decomp = ServiceUtils.createConfiguredDecompiler(program);
 
                             DecompileResults decompResult = decomp.decompileFunction(func, DECOMPILE_TIMEOUT_SECONDS, new ConsoleTaskMonitor());
                             if (decompResult != null && decompResult.decompileCompleted()) {
@@ -3092,8 +3081,7 @@ public class FunctionService {
                         try {
                             DecompInterface tempDecomp = null;
                             try {
-                                tempDecomp = new DecompInterface();
-                                tempDecomp.openProgram(program);
+                                tempDecomp = ServiceUtils.createConfiguredDecompiler(program);
                                 tempDecomp.flushCache();
                                 tempDecomp.decompileFunction(funcRef.get(), DECOMPILE_TIMEOUT_SECONDS, new ConsoleTaskMonitor());
                             } finally {
@@ -3300,8 +3288,7 @@ public class FunctionService {
                     // Phase 2: Decompile to get fresh SSA variables for renaming
                     DecompInterface decomp = null;
                     try {
-                        decomp = new DecompInterface();
-                        decomp.openProgram(program);
+                        decomp = ServiceUtils.createConfiguredDecompiler(program);
                         DecompileResults decompResult = decomp.decompileFunction(func, DECOMPILE_TIMEOUT_SECONDS, new ConsoleTaskMonitor());
                         if (decompResult == null || !decompResult.decompileCompleted()) {
                             errors.add("Decompilation failed after type changes; renames skipped");

--- a/src/main/java/com/xebyte/core/ServiceUtils.java
+++ b/src/main/java/com/xebyte/core/ServiceUtils.java
@@ -1,5 +1,7 @@
 package com.xebyte.core;
 
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileOptions;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.data.*;
@@ -501,6 +503,39 @@ public final class ServiceUtils {
         }
 
         return null;
+    }
+
+    // ========================================================================
+    // Decompiler
+    // ========================================================================
+
+    /**
+     * Create a {@link DecompInterface} configured to match the Ghidra GUI /
+     * analysis decompiler. Applies the program's saved {@link DecompileOptions}
+     * via {@link DecompileOptions#grabFromProgram(Program)} — most importantly
+     * the "Respect Read-Only Flags" option — so that PIC/GOT- and
+     * relocation-indirected accesses fold to their named globals instead of
+     * rendering as opaque {@code DAT_} constants.
+     *
+     * <p>A bare {@code new DecompInterface()} leaves "Respect Read-Only Flags"
+     * at the C++ decompiler-core default (OFF), which makes a read-only GOT slot
+     * stay an opaque {@code DAT_} rather than being propagated and folded to the
+     * symbol it points at. {@code grabFromProgram} restores the GUI-faithful
+     * behavior while still respecting any per-program override.
+     *
+     * <p>{@code setOptions} is applied <em>before</em> {@code openProgram}, per
+     * Ghidra's decompiler contract. The returned interface is already opened on
+     * {@code program}; the caller owns its lifecycle and must call
+     * {@link DecompInterface#dispose()} when finished.
+     */
+    public static DecompInterface createConfiguredDecompiler(Program program) {
+        DecompInterface decomp = new DecompInterface();
+        DecompileOptions opts = new DecompileOptions();
+        opts.grabFromProgram(program);              // GUI-faithful; respects per-program setting
+        decomp.setOptions(opts);
+        decomp.setSimplificationStyle("decompile"); // default style; explicit for consistency
+        decomp.openProgram(program);                // openProgram AFTER setOptions
+        return decomp;
     }
 
     // ========================================================================


### PR DESCRIPTION
decompile_function, decompile_function_by_name, and every other decompiler-backed operation constructed a bare new DecompInterface() and never applied DecompileOptions. A fresh DecompileOptions leaves "Respect Read-Only Flags" OFF (the C++ decompiler-core default), so a read-only GOT/relocation slot on a PIC binary stayed an opaque DAT_<addr> constant instead of being folded to the named global it points at — silently misleading reads of position-independent code.

Add ServiceUtils.createConfiguredDecompiler(program), which applies DecompileOptions.grabFromProgram(program) before openProgram to match the Ghidra GUI / analysis decompiler exactly (respecting any per-program override). Route all 11 decompiler construction sites in FunctionService and DataTypeService through it. force_decompile, previously byte-identical to the broken output, now also resolves the named global.

Documented under CHANGELOG "Unreleased"; no version bump (left to the maintainer at release time).