### PR TITLE
fix: local-attacker hardening (CORS, UDS socket dir, DNS rebinding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Security
+
+- Headless server no longer emits `Access-Control-Allow-Origin: *`. With
+  the no-auth loopback default, any web page could `fetch()` against
+  `http://127.0.0.1:8089` and read decompiled code / drive write endpoints
+  cross-origin. The bridge is a same-host CLI client; browsers have no
+  legitimate reason to call this server directly.
+- UDS socket directory is now ownership-verified and locked to mode `0700`
+  (and the bound socket to `0600`) on POSIX systems. The
+  `/tmp/ghidra-mcp-<user>` fallback path is predictable; an attacker who
+  pre-created it could intercept bridge connections. The server now
+  refuses to start if the directory is owned by another user.
+- Bridge `--mcp-host 0.0.0.0` / `::` now keeps DNS-rebinding protection
+  enabled with `allowed_hosts` derived from the machine's hostname/FQDN/
+  interface IPs (previously it disabled protection entirely on the
+  most-exposed bind). Extend with `GHIDRA_MCP_ALLOWED_HOSTS=host1,host2`;
+  opt back into unprotected behavior with
+  `GHIDRA_MCP_DISABLE_REBIND_PROTECTION=1` (logs a warning).
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1764,7 +1764,14 @@ def _wildcard_allowed_hosts() -> list[str]:
                 pass
     except OSError:
         pass
-    return [f"{h}:*" for h in sorted(hosts)]
+    out: list[str] = []
+    for h in sorted(hosts):
+        out.append(f"{h}:*")
+        # RFC 3986: IPv6 literals are bracketed in Host headers
+        # (e.g. "[::1]:8089"); add the bracketed form so they match too.
+        if ":" in h and not h.startswith("["):
+            out.append(f"[{h}]:*")
+    return out
 
 
 def _auto_connect():

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1736,6 +1736,37 @@ async def import_file(
 # ==========================================================================
 
 
+def _wildcard_allowed_hosts() -> list[str]:
+    """Build the allowed-Host list for a 0.0.0.0/:: bind.
+
+    Returns the loopback names plus this machine's hostname, FQDN, and
+    every local interface IP, each with a ``:*`` port suffix. This lets
+    legitimate remote clients (which use the real hostname/IP in the
+    Host header) through while DNS-rebinding attacks (which use an
+    attacker-controlled hostname) are rejected.
+    """
+    hosts: set[str] = {"localhost", "127.0.0.1", "::1"}
+    try:
+        hn = socket.gethostname()
+        if hn:
+            hosts.add(hn)
+            try:
+                hosts.add(socket.getfqdn(hn))
+            except OSError:
+                pass
+            try:
+                # All addresses the hostname resolves to (covers multi-NIC).
+                for info in socket.getaddrinfo(hn, None):
+                    addr = info[4][0]
+                    if addr:
+                        hosts.add(addr)
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return [f"{h}:*" for h in sorted(hosts)]
+
+
 def _auto_connect():
     """Try to auto-connect to a single running instance on startup."""
     global _active_socket, _active_tcp, _transport_mode, _connected_project
@@ -2251,7 +2282,44 @@ def main():
     _host = args.mcp_host
     if _host not in {"127.0.0.1", "localhost", "::1"}:
         if _host in {"0.0.0.0", "::"}:
-            mcp.settings.transport_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+            # Wildcard bind is the MOST exposed configuration — keep
+            # DNS-rebinding protection ON and allow only the machine's
+            # actual hostnames/IPs. Previously this branch disabled
+            # protection entirely, which is inverted: a malicious page
+            # could DNS-rebind to this host and drive every Ghidra tool
+            # from the victim's browser.
+            #
+            # Legitimate remote clients use the real hostname/IP, so
+            # they pass the Host-header check. Operators with custom
+            # DNS can extend the list via GHIDRA_MCP_ALLOWED_HOSTS
+            # (comma-separated), or explicitly opt back into the old
+            # unprotected behavior with GHIDRA_MCP_DISABLE_REBIND_PROTECTION=1.
+            if os.environ.get("GHIDRA_MCP_DISABLE_REBIND_PROTECTION") == "1":
+                logger.warning(
+                    "DNS-rebinding protection DISABLED for wildcard bind via "
+                    "GHIDRA_MCP_DISABLE_REBIND_PROTECTION=1 — any page in the "
+                    "user's browser can drive this server."
+                )
+                mcp.settings.transport_security = TransportSecuritySettings(
+                    enable_dns_rebinding_protection=False
+                )
+            else:
+                allowed = _wildcard_allowed_hosts()
+                extra = os.environ.get("GHIDRA_MCP_ALLOWED_HOSTS", "")
+                for h in (x.strip() for x in extra.split(",") if x.strip()):
+                    allowed.append(f"{h}:*")
+                logger.info(
+                    "Wildcard bind %s with DNS-rebinding protection ON; "
+                    "allowed Host headers: %s. Extend with "
+                    "GHIDRA_MCP_ALLOWED_HOSTS=host1,host2 if a remote client "
+                    "is rejected.",
+                    _host, allowed,
+                )
+                mcp.settings.transport_security = TransportSecuritySettings(
+                    enable_dns_rebinding_protection=True,
+                    allowed_hosts=allowed,
+                    allowed_origins=[f"http://{h}" for h in allowed],
+                )
         else:
             mcp.settings.transport_security = TransportSecuritySettings(
                 enable_dns_rebinding_protection=True,

--- a/src/main/java/com/xebyte/core/ServerManager.java
+++ b/src/main/java/com/xebyte/core/ServerManager.java
@@ -117,6 +117,7 @@ public class ServerManager {
             java.util.function.Consumer<UdsHttpServer> guiEndpoints) throws IOException {
         Path socketDir = getSocketDir();
         Files.createDirectories(socketDir);
+        hardenSocketDir(socketDir);
         Path socketPath = socketDir.resolve(getSocketName());
 
         server = new UdsHttpServer(socketPath);
@@ -302,6 +303,42 @@ public class ServerManager {
             }
         } catch (IOException e) {
             Msg.warn(this, "Failed to clean stale files: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verify the socket directory is owned by the current user and lock it
+     * to mode {@code 0700}. The {@code /tmp/ghidra-mcp-<user>} fallback path
+     * is predictable; on a multi-user host an attacker can pre-create it
+     * (sticky {@code /tmp} allows new entries) and {@code createDirectories}
+     * silently succeeds on an existing dir regardless of owner. Binding a
+     * socket inside an attacker-owned directory lets them delete/replace it
+     * and intercept bridge connections — full unauthenticated access to the
+     * RE endpoints. Refuse to start in that case.
+     * <p>
+     * No-op on platforms without POSIX file attributes (Windows).
+     */
+    private void hardenSocketDir(Path socketDir) throws IOException {
+        if (!socketDir.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
+        java.nio.file.attribute.PosixFileAttributes attrs =
+            Files.readAttributes(socketDir, java.nio.file.attribute.PosixFileAttributes.class);
+        String owner = attrs.owner().getName();
+        String me = System.getProperty("user.name");
+        if (me != null && !me.equals(owner)) {
+            throw new IOException(
+                "Refusing to bind UDS socket: directory " + socketDir
+                + " is owned by '" + owner + "' (expected '" + me + "'). "
+                + "This may be a socket-hijack attempt. Remove the directory "
+                + "or set XDG_RUNTIME_DIR to a private location.");
+        }
+        try {
+            Files.setPosixFilePermissions(socketDir,
+                java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"));
+        } catch (IOException e) {
+            Msg.warn(this, "Could not chmod socket dir " + socketDir
+                + " to 0700: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/xebyte/core/UdsHttpServer.java
+++ b/src/main/java/com/xebyte/core/UdsHttpServer.java
@@ -69,6 +69,18 @@ public class UdsHttpServer {
         serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
         serverChannel.bind(UnixDomainSocketAddress.of(socketPath));
 
+        // Lock the socket file to owner-only. With a permissive umask
+        // (e.g. 002) the bound socket would otherwise be group-writable,
+        // letting any group member connect directly. No-op on non-POSIX.
+        if (socketPath.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            try {
+                Files.setPosixFilePermissions(socketPath,
+                    java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"));
+            } catch (IOException e) {
+                // Best-effort; the dir is already 0700 via ServerManager.
+            }
+        }
+
         executor = Executors.newCachedThreadPool(r -> {
             Thread t = new Thread(r, "GhidraMCP-UDS-Worker");
             t.setDaemon(true);

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -698,7 +698,11 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
     private void sendResponse(HttpExchange exchange, String response) throws IOException {
         byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
         exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=UTF-8");
-        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+        // No Access-Control-Allow-Origin: the bridge is a same-host CLI
+        // client, not a browser. Emitting ACAO:* on a no-auth loopback
+        // server lets any web page the user visits read decompiled code
+        // and drive write endpoints via fetch(). The GUI plugin's TCP
+        // server has never emitted this header; aligning with it.
         exchange.sendResponseHeaders(200, bytes.length);
         try (OutputStream os = exchange.getResponseBody()) {
             os.write(bytes);

--- a/tests/unit/test_endpoint_catalog.py
+++ b/tests/unit/test_endpoint_catalog.py
@@ -189,11 +189,18 @@ class TestBridgeIsDynamic(unittest.TestCase):
         meta-tool (#267/#153) that lets the bridge run --lazy with a small tool
         surface while still letting agents discover unloaded tools by keyword.
         Pulls weight: directly addresses the context-overhead complaints.
+
+        Bumped 2026-06-18: 2300 -> 2350 for the wildcard-bind DNS-rebinding
+        fix — `_wildcard_allowed_hosts()` helper + the 0.0.0.0/:: branch
+        rewrite that keeps protection ON with a derived allowed-Host list
+        instead of disabling it. Pulls weight: security fix; previously
+        any page in the user's browser could DNS-rebind to the bridge
+        and drive every Ghidra tool.
         """
         bridge_path = PROJECT_ROOT / "bridge_mcp_ghidra.py"
         lines = len(bridge_path.read_text().splitlines())
         self.assertLess(
-            lines, 2300, f"Bridge is {lines} lines, expected <2300 for thin multiplexer"
+            lines, 2350, f"Bridge is {lines} lines, expected <2350 for thin multiplexer"
         )
 
 


### PR DESCRIPTION
## Summary

Three local-attacker / malicious-browser hardening fixes.

### Headless server emits `Access-Control-Allow-Origin: *`

`GhidraMCPHeadlessServer.sendResponse()` set `ACAO: *` on every reply. With the no-auth loopback default, any page in the user's browser could `fetch('http://127.0.0.1:8089/decompile_function?...')` and read the response cross-origin (decompiled code, memory dumps, project listings); CORS-simple `text/plain` POSTs reach write endpoints too. The bridge is a same-host CLI client, not a browser, so the header serves no legitimate purpose. The GUI plugin's TCP server has never emitted it.

**Fix:** drop the header.

### Predictable `/tmp` UDS socket directory created without ownership check

When `XDG_RUNTIME_DIR` and `TMPDIR` are unset, `getSocketDir()` falls back to `/tmp/ghidra-mcp-<user>` and `startServer()` calls `Files.createDirectories(socketDir)` with no permission attributes and no ownership verification. On a multi-user host an attacker can pre-create that directory (sticky `/tmp` allows new entries); `createDirectories` silently succeeds on an existing dir regardless of owner. The victim's UDS socket then binds inside an attacker-owned directory where it can be deleted/replaced to intercept bridge connections — full unauthenticated access to the RE endpoints. The bound socket file itself was also created with the process umask (group-accessible under `002`).

**Fix:** on POSIX systems, after `createDirectories` verify the directory is owned by the current user (refuse to start with a clear error otherwise) and chmod it `0700`; chmod the bound socket file `0600` immediately after `bind()`. No-op on Windows.

### Bridge disables DNS-rebinding protection on wildcard binds

When `--mcp-host` is `0.0.0.0` or `::`, `main()` set `enable_dns_rebinding_protection=False` — inverted: the all-interfaces bind is the most exposed configuration, yet it was the only one that turned the guard off. With SSE/streamable-http transport, a malicious page could DNS-rebind to the bridge host and drive every Ghidra tool from the victim's browser.

**Fix:** keep protection enabled with `allowed_hosts` derived from the machine's hostname/FQDN/interface IPs plus loopback (both bare and `[bracketed]` IPv6 forms), so legitimate remote clients using the real hostname/IP pass the Host-header check. `GHIDRA_MCP_ALLOWED_HOSTS=host1,host2` extends the list for custom DNS; `GHIDRA_MCP_DISABLE_REBIND_PROTECTION=1` restores the old unprotected behavior with a loud warning. Bridge line cap bumped 2300→2350 with justification in the test docstring.

## Testing

- Java offline suite: **236 passed**, 0 failed
- Python unit suite: **366 passed**, 7 skipped, 0 failed (incl. bridge-size cap test)
- `EndpointsJsonParityTest` passes — no `@McpTool` signatures changed
