### PR TITLE
fix(bridge): multi-UDS auto-connect fall-through and dead address-map sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Bridge `_auto_connect` no longer falls through to the TCP fallback after
+  logging "Multiple UDS instances found — use `connect_instance()` to
+  choose"; previously it would silently connect to whichever Ghidra was on
+  port 8089 right after telling the user it hadn't. The log now includes
+  the instance names.
+- `debugger_attach` address-map auto-sync now reads `image_base` directly
+  from `/list_open_programs` entries. Previously it fetched `/get_metadata`
+  (plain text) and `json.loads()`'d it, which always raised, was silently
+  swallowed, and the Ghidra↔runtime address map was never seeded on
+  attach. Now logs whether the sync fired.
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1758,9 +1758,19 @@ def _auto_connect():
             _active_socket = None
             _transport_mode = "none"
     elif len(instances) > 1:
-        logger.info(
-            f"Multiple UDS instances found ({len(instances)}). Use connect_instance() to choose."
+        names = ", ".join(
+            i.get("project") or i.get("socket") or "?" for i in instances
         )
+        logger.info(
+            f"Multiple UDS instances found ({len(instances)}: {names}). "
+            "Use connect_instance() to choose."
+        )
+        # Do NOT fall through to the TCP fallback — that would silently
+        # connect to whichever Ghidra happened to bind 8089 (possibly a
+        # third instance entirely) right after telling the user to choose.
+        # Stay unconnected until connect_instance() is called explicitly,
+        # matching connect_instance's own multi-instance refusal logic.
+        return
 
     # Try TCP fallback
     tcp_url = os.getenv("GHIDRA_MCP_URL", DEFAULT_TCP_URL)
@@ -1853,27 +1863,40 @@ def debugger_attach(target: str) -> str:
                     if isinstance(programs_data, list)
                     else programs_data.get("programs", [])
                 )
+                # image_base is already present on each /list_open_programs
+                # entry (ProgramScriptService.listOpenPrograms emits it) —
+                # use it directly. The previous /get_metadata round-trip
+                # was dead: that endpoint returns plain text, so
+                # json.loads() always raised, the bare except swallowed
+                # it, and ghidra_bases stayed empty so auto-sync never
+                # fired.
                 ghidra_bases = {}
                 for prog in programs:
-                    prog_path = (
-                        prog
-                        if isinstance(prog, str)
-                        else prog.get("path", prog.get("name", ""))
-                    )
-                    if prog_path:
-                        try:
-                            meta_text = dispatch_get(
-                                "/get_metadata", params={"program": prog_path}
-                            )
-                            meta = json.loads(meta_text)
-                            image_base = meta.get("imageBase", meta.get("image_base"))
-                            if image_base:
-                                ghidra_bases[prog_path] = image_base
-                        except Exception:
-                            pass
+                    if isinstance(prog, str):
+                        # Legacy plain-string list shape — no image_base
+                        # available without a second call. Skip; the
+                        # operator can run debugger_resolve_ordinal /
+                        # sync manually.
+                        continue
+                    prog_path = prog.get("path") or prog.get("name") or ""
+                    image_base = prog.get("image_base") or prog.get("imageBase")
+                    if prog_path and image_base:
+                        ghidra_bases[prog_path] = image_base
                 if ghidra_bases:
                     _debugger_request(
                         "POST", "/debugger/sync_modules", {"ghidra_bases": ghidra_bases}
+                    )
+                    logger.info(
+                        "debugger_attach: auto-synced %d Ghidra image base(s) "
+                        "to the debugger address map",
+                        len(ghidra_bases),
+                    )
+                else:
+                    logger.info(
+                        "debugger_attach: no Ghidra image bases available "
+                        "from /list_open_programs — address-map auto-sync "
+                        "skipped (set up manually via debugger_resolve_ordinal "
+                        "or /debugger/sync_modules)"
                     )
         except Exception as e:
             logger.warning(f"Auto-sync address map failed (non-fatal): {e}")

--- a/tests/unit/test_bridge_utils.py
+++ b/tests/unit/test_bridge_utils.py
@@ -401,6 +401,77 @@ class TestDiscoverInstancesMultiDir(unittest.TestCase):
             self.assertEqual(len(instances), 1)
 
 
+class TestAutoConnectMultiInstance(unittest.TestCase):
+    """When discover_instances() finds >1 UDS instance, _auto_connect must
+    log the choose-one message and STOP — not fall through to the TCP
+    fallback and silently connect to whatever's on port 8089."""
+
+    def test_multi_uds_does_not_fall_through_to_tcp(self):
+        import bridge_mcp_ghidra as bridge
+
+        two = [
+            {"project": "ProjA", "socket": "/tmp/a.sock", "pid": 111},
+            {"project": "ProjB", "socket": "/tmp/b.sock", "pid": 222},
+        ]
+        fetch_calls = []
+        with patch.object(bridge, "discover_instances", return_value=two), \
+             patch.object(bridge, "_fetch_and_register_schema",
+                          side_effect=lambda *a, **kw: fetch_calls.append(1) or 0):
+            # Reset connection state so the test is hermetic.
+            bridge._active_socket = None
+            bridge._active_tcp = None
+            bridge._transport_mode = "none"
+            bridge._auto_connect()
+
+        self.assertEqual(
+            fetch_calls, [],
+            "schema fetch was called — _auto_connect fell through to TCP "
+            "after the multi-UDS warning"
+        )
+        self.assertEqual(bridge._transport_mode, "none")
+        self.assertIsNone(bridge._active_tcp)
+
+
+class TestDebuggerAttachAddressSync(unittest.TestCase):
+    """debugger_attach must read image_base directly from
+    /list_open_programs entries (not the plain-text /get_metadata
+    endpoint, where json.loads() always failed and the auto-sync
+    silently never fired)."""
+
+    def test_uses_image_base_from_list_open_programs(self):
+        import bridge_mcp_ghidra as bridge
+
+        programs_payload = json.dumps([
+            {"path": "/proj/Foo.exe", "name": "Foo.exe", "image_base": "0x400000"},
+            {"path": "/proj/Bar.dll", "name": "Bar.dll", "image_base": "0x10000000"},
+        ])
+        debugger_calls = []
+
+        def fake_debugger_request(method, path, body=None, **kw):
+            debugger_calls.append((method, path, body))
+            return '{"status":"ok"}'
+
+        def fake_dispatch_get(path, params=None):
+            if path == "/list_open_programs":
+                return programs_payload
+            raise AssertionError(
+                f"unexpected GET {path} — auto-sync must not call "
+                "/get_metadata or any other endpoint"
+            )
+
+        with patch.object(bridge, "_debugger_request",
+                          side_effect=fake_debugger_request), \
+             patch.object(bridge, "dispatch_get", side_effect=fake_dispatch_get), \
+             patch.object(bridge, "_transport_mode", "tcp"):
+            bridge.debugger_attach("12345")
+
+        sync = [c for c in debugger_calls if c[1] == "/debugger/sync_modules"]
+        self.assertEqual(len(sync), 1, "auto-sync did not fire")
+        bases = sync[0][2].get("ghidra_bases", {})
+        self.assertEqual(bases.get("/proj/Foo.exe"), "0x400000")
+        self.assertEqual(bases.get("/proj/Bar.dll"), "0x10000000")
+
+
 class TestIsPidAlive(unittest.TestCase):
     """Test PID liveness check."""
 


### PR DESCRIPTION
## Summary

Two `bridge_mcp_ghidra.py` bugs where the bridge silently did the wrong thing.

### `_auto_connect` falls through to TCP after the multi-UDS warning

When `discover_instances()` returned more than one UDS instance, `_auto_connect` logged "Multiple UDS instances found — use `connect_instance()` to choose" but did not `return`. Execution fell through to the TCP fallback, which connected to whatever Ghidra happened to bind port 8089 (or `GHIDRA_MCP_URL`) and registered its full schema — possibly a third instance entirely — right after telling the user it hadn't connected. This contradicted `connect_instance`'s own deliberate multi-instance refusal logic.

**Fix:** `return` after the multi-instance log so the bridge stays unconnected until `connect_instance()` is called explicitly. The log now includes the instance project names.

### `debugger_attach` address-map auto-sync was silently dead

After attaching, the bridge tried to seed the debugger's Ghidra↔runtime address map by fetching `/get_metadata` for each open program and reading `imageBase` from the JSON. But `/get_metadata` returns a newline-delimited plain-text blob, not JSON — `json.loads()` raised `JSONDecodeError` every time, the bare `except` swallowed it, `ghidra_bases` stayed empty, and `/debugger/sync_modules` was never called. Every subsequent breakpoint/memory-read needed a manual address-map setup the user thought had already happened.

**Fix:** drop the `/get_metadata` round-trip — `image_base` is already on each `/list_open_programs` entry. Read it directly, and log whether the sync fired (and how many bases) so the operator knows the map is seeded (or knows to set it up manually).

## Testing

- New `TestAutoConnectMultiInstance`: mocks 2 UDS instances, asserts `_fetch_and_register_schema` is never called and `_transport_mode` stays `"none"`
- New `TestDebuggerAttachAddressSync`: asserts `/debugger/sync_modules` is called with bases extracted from `/list_open_programs`, and that `/get_metadata` is never hit
- Python unit suite: **368 passed**, 7 skipped, 0 failed
- Bridge line count: 2294 (under cap)
