### PR TITLE
fix: emulate_function max_steps no-op and HARDWARE breakpoint plants int3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- `emulate_function` now honors `max_steps` with a bounded step loop.
+  Previously `effectiveMaxSteps` was computed but never used — `emu.run()`
+  was unbounded, so an infinite-looping target would hang the HTTP handler
+  thread forever. Response now includes `steps_executed`, `max_steps`, and
+  `stop_reason`.
+- `debugger_set_breakpoint type="hardware"` now arms a debug register
+  (`DEBUG_BREAKPOINT_DATA` + `DEBUG_BREAK_EXECUTE`) instead of planting a
+  software `int3`. Previously the HARDWARE branch passed
+  `DEBUG_BREAKPOINT_CODE` and only re-enabled it, so anti-debug-aware
+  targets would detect the int3 and checksummed/self-modifying code
+  regions would be corrupted exactly where a HW bp was requested.
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -605,18 +605,22 @@ class DebugEngine:
                               handler: Optional[Callable]) -> int:
         self._require_attached()
         if bp_type == BreakpointType.HARDWARE:
+            # Hardware *execute* breakpoint: a DATA breakpoint with
+            # DEBUG_BREAK_EXECUTE access — this is what arms a debug
+            # register (DR0-DR3) instead of patching an int3 into the
+            # target. Previously this branch passed DEBUG_BREAKPOINT_CODE
+            # (the *software* int3 type) and only re-enabled it, so
+            # type="hardware" planted an int3 that anti-debug-aware
+            # targets detect and that corrupts checksummed/self-modifying
+            # code regions where a HW bp was specifically requested.
             bp_id = self._base.breakpoints.set(
                 expr=address,
-                type=DbgEng.DEBUG_BREAKPOINT_CODE,
+                type=DbgEng.DEBUG_BREAKPOINT_DATA,
+                size=1,
+                access=DbgEng.DEBUG_BREAK_EXECUTE,
                 oneshot=oneshot,
                 handler=handler,
             )
-            # For HW exec, convert to hardware after creation
-            try:
-                bp_obj = self._base._control.GetBreakpointById(bp_id)
-                bp_obj.AddFlags(DbgEng.DEBUG_BREAKPOINT_ENABLED)
-            except Exception:
-                pass
         else:
             bp_id = self._base.breakpoints.set(
                 expr=address,

--- a/src/main/java/com/xebyte/core/EmulationService.java
+++ b/src/main/java/com/xebyte/core/EmulationService.java
@@ -48,6 +48,7 @@ import java.util.*;
 public class EmulationService {
 
     private static final int DEFAULT_TIMEOUT_MS = 10_000;
+    private static final int DEFAULT_MAX_STEPS = 10_000;
     private static final int MAX_STEPS = 100_000;
     private static final int MAX_CANDIDATES = 10_000;
     // Scratch memory for writing candidate strings during emulation
@@ -163,22 +164,57 @@ public class EmulationService {
                     }
                 }
 
-                // Run emulation
-                int effectiveMaxSteps = Math.min(maxSteps, MAX_STEPS);
-                emu.setBreakpoint(program.getAddressFactory()
-                        .getDefaultAddressSpace().getAddress(returnSentinel));
+                // Run emulation with a hard step bound. emu.run(...) is
+                // unbounded — it loops until a breakpoint or fault — so a
+                // target with an infinite loop (or one that never executes
+                // RET to hit the returnSentinel) would hang the HTTP
+                // handler thread forever. Step explicitly so the advertised
+                // max_steps parameter is actually honored.
+                int effectiveMaxSteps = Math.min(
+                        maxSteps > 0 ? maxSteps : DEFAULT_MAX_STEPS, MAX_STEPS);
+                ghidra.util.task.TaskMonitor monitor =
+                        new ghidra.util.task.ConsoleTaskMonitor();
 
-                boolean success = emu.run(entryAddr, null, new ghidra.util.task.ConsoleTaskMonitor());
+                // Position PC at the entry point, then step.
+                emu.writeRegister(emu.getPCRegister(), entryAddr.getOffset());
+
+                int steps = 0;
+                boolean success = true;
+                boolean hitReturn = false;
+                String stopReason = "max_steps_exceeded";
+                Address pc = null;
+                while (steps < effectiveMaxSteps) {
+                    steps++;
+                    if (!emu.step(monitor)) {
+                        success = false;
+                        stopReason = "fault: " + emu.getLastError();
+                        break;
+                    }
+                    pc = emu.getExecutionAddress();
+                    if (pc != null && pc.getOffset() == returnSentinel) {
+                        hitReturn = true;
+                        stopReason = "return";
+                        break;
+                    }
+                }
+                if (steps >= effectiveMaxSteps && !hitReturn && success) {
+                    // Step cap reached without RET or fault — likely an
+                    // infinite loop or a path that never returns.
+                    success = false;
+                }
 
                 // Collect results
                 Map<String, Object> result = new LinkedHashMap<>();
                 result.put("success", success);
                 result.put("function", func.getName());
                 result.put("entry_address", entryAddr.toString());
+                result.put("steps_executed", steps);
+                result.put("max_steps", effectiveMaxSteps);
+                result.put("stop_reason", stopReason);
 
-                Address pc = emu.getExecutionAddress();
+                pc = emu.getExecutionAddress();
                 result.put("final_pc", pc != null ? pc.toString() : "unknown");
-                result.put("hit_return", pc != null && pc.getOffset() == returnSentinel);
+                result.put("hit_return", hitReturn);
 
                 // Read registers
                 Map<String, String> regValues = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary

Two no-op parameters that silently did the wrong thing.

### `emulate_function` `max_steps` is a no-op — emulator can run forever

`effectiveMaxSteps` was computed (`Math.min(maxSteps, MAX_STEPS)`) but never used; the next line called `emu.run(entryAddr, null, monitor)`, which loops unbounded until a breakpoint or fault. A target with an infinite loop — or one that never executes RET to hit the `0xDEADBEEF` return-sentinel breakpoint — hung the HTTP handler thread forever. The advertised `max_steps` `@Param` (default 10000) and the `MAX_STEPS` constant were dead.

**Fix:** position PC at the entry via `writeRegister(getPCRegister(), entryAddr.getOffset())` and step explicitly with `emu.step(monitor)` in a bounded loop, stopping at the return sentinel, on fault (`emu.getLastError()`), or when the step cap is hit. Response now includes `steps_executed`, `max_steps`, and `stop_reason` (`"return"` / `"fault: …"` / `"max_steps_exceeded"`) so the caller can tell which.

### `BreakpointType.HARDWARE` plants a software int3

The HARDWARE branch in `_set_breakpoint_impl` passed `type=DbgEng.DEBUG_BREAKPOINT_CODE` — the *software* int3 type — and the "convert to hardware after creation" follow-up only called `AddFlags(DEBUG_BREAKPOINT_ENABLED)`, which merely re-enables the bp. So `debugger_set_breakpoint type="hardware"` planted an int3 that anti-debug-aware targets detect and that corrupts checksummed/self-modifying code regions where a hardware breakpoint was specifically requested.

**Fix:** create with `type=DEBUG_BREAKPOINT_DATA`, `size=1`, `access=DEBUG_BREAK_EXECUTE` — the standard DbgEng way to arm a DR0-3 execute breakpoint. Same pattern `_set_data_breakpoint_impl` already uses for read/write watchpoints.

## Testing

- Java offline suite: **236 passed**, 0 failed
- Python unit suite: **366 passed**, 7 skipped, 0 failed (incl. `test_debugger_engine.py`)
- `EndpointsJsonParityTest` passes — no `@McpTool` signatures changed (the `max_steps` param was already advertised; it just works now)
