### PR TITLE
fix: TCP server route handoff on owner dispose; bound reference walk to function body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- When the CodeBrowser window that started the shared TCP server is closed
+  while other windows survive, the server is now restarted on a surviving
+  window so its route handlers re-bind to live services. Previously the
+  routes stayed bound to the disposed window's `PluginTool` and every
+  subsequent HTTP request executed against stale services. Each disposed
+  instance also now releases its own `programProvider` (previously only
+  the last one did).
+
+### Performance
+
+- `analyze_for_documentation` now walks only references originating inside
+  the function body (`getReferenceSourceIterator(body, true)`) instead of
+  iterating every reference from the function's start address through the
+  end of the program. For functions near the start of a large binary this
+  was millions of references per call.
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -199,6 +199,13 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     private static final AtomicInteger activeRequests = new AtomicInteger(0);
     private static final long serverStartMillis = System.currentTimeMillis();
     private static int instanceCount = 0;
+    // Live plugin instances. The TCP server's route lambdas capture the
+    // owning instance's services (programProvider, listingService, …); when
+    // that instance is disposed first while others survive, the routes are
+    // left bound to a dead PluginTool. dispose() consults this list to hand
+    // ownership to a survivor by restarting the server with its services.
+    private static final java.util.List<GhidraMCPPlugin> liveInstances =
+        new java.util.concurrent.CopyOnWriteArrayList<>();
     private boolean ownsServer = false; // true if this instance started the server
     private static final String OPTION_CATEGORY_NAME = "GhidraMCP HTTP Server";
     private static final String PORT_OPTION_NAME = "Server Port";
@@ -278,6 +285,7 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
     public GhidraMCPPlugin(PluginTool tool) {
         super(tool);
         instanceCount++;
+        liveInstances.add(this);
 
         // Initialize service layer — FrontEnd mode: opens programs on-demand from project
         this.programProvider = new FrontEndProgramProvider(tool, this);
@@ -4303,14 +4311,46 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         // Deregister from UDS ServerManager
         ServerManager.getInstance().deregisterTool(tool);
 
+        liveInstances.remove(this);
         instanceCount--;
-        // Only stop the server when the last plugin instance is disposed
+
+        // This instance's programProvider is dead either way — release the
+        // programs it was holding, regardless of whether other windows
+        // survive. (Previously only the last-disposed instance released.)
+        try {
+            programProvider.releaseAll();
+        } catch (Exception e) {
+            Msg.warn(this, "GhidraMCP: releaseAll on dispose: " + e.getMessage());
+        }
+
         if (instanceCount <= 0) {
             stopServer();
-            programProvider.releaseAll();
             instanceCount = 0;
+        } else if (ownsServer) {
+            // The TCP routes (createContext lambdas) captured THIS
+            // instance's services. With this PluginTool now disposed,
+            // every subsequent HTTP request would execute against stale
+            // services. Hand the server to a surviving instance by
+            // restarting it so the routes re-bind to live services.
+            Msg.info(this, "GhidraMCP: owning tool window closed with "
+                + instanceCount + " other window(s) still active — handing "
+                + "TCP server ownership to a survivor.");
+            stopServer();
+            ownsServer = false;
+            GhidraMCPPlugin survivor = liveInstances.isEmpty() ? null : liveInstances.get(0);
+            if (survivor != null) {
+                try {
+                    survivor.startServer();
+                    survivor.ownsServer = true;
+                } catch (IOException e) {
+                    Msg.error(this, "GhidraMCP: failed to restart TCP server "
+                        + "on surviving tool window: " + e.getMessage()
+                        + " — use Tools > GhidraMCP > Start Server.");
+                }
+            }
         } else {
-            Msg.info(this, "GhidraMCP: " + instanceCount + " tool window(s) still active, keeping server running.");
+            Msg.info(this, "GhidraMCP: " + instanceCount
+                + " tool window(s) still active, keeping server running.");
         }
         if (startServerAction != null) {
             tool.removeAction(startServerAction);

--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -4,6 +4,7 @@ import ghidra.app.decompiler.DecompileResults;
 import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
 import ghidra.framework.options.Options;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressIterator;
 import ghidra.program.model.address.AddressRange;
 import ghidra.program.model.address.AddressRangeIterator;
 import ghidra.program.model.address.AddressSet;
@@ -4382,16 +4383,25 @@ public class AnalysisService {
                     }
                     data.put("locals", localList);
 
-                    // DAT global count (unrenamed globals referenced)
+                    // DAT global count (unrenamed globals referenced).
+                    // getReferenceIterator(minAddr) yields ALL outgoing
+                    // references from that address through the end of the
+                    // program — for a function near the start of a large
+                    // binary the old loop walked millions of references per
+                    // call. getReferenceSourceIterator(body, true) is bounded
+                    // to addresses inside the function body (and handles
+                    // non-contiguous bodies correctly).
                     int datGlobalCount = 0;
-                    ReferenceIterator refIter = program.getReferenceManager().getReferenceIterator(func.getBody().getMinAddress());
-                    while (refIter.hasNext()) {
-                        Reference ref = refIter.next();
-                        if (!func.getBody().contains(ref.getFromAddress())) continue;
-                        Address toAddr = ref.getToAddress();
-                        Symbol sym = program.getSymbolTable().getPrimarySymbol(toAddr);
-                        if (sym != null && sym.getName().startsWith("DAT_")) {
-                            datGlobalCount++;
+                    ReferenceManager refMgr = program.getReferenceManager();
+                    AddressIterator srcIter = refMgr.getReferenceSourceIterator(func.getBody(), true);
+                    while (srcIter.hasNext()) {
+                        Address fromAddr = srcIter.next();
+                        for (Reference ref : refMgr.getReferencesFrom(fromAddr)) {
+                            Address toAddr = ref.getToAddress();
+                            Symbol sym = program.getSymbolTable().getPrimarySymbol(toAddr);
+                            if (sym != null && sym.getName().startsWith("DAT_")) {
+                                datGlobalCount++;
+                            }
                         }
                     }
                     data.put("dat_global_count", datGlobalCount);


### PR DESCRIPTION
## Summary

One performance fix and one plugin-lifecycle correctness fix.

### `analyze_for_documentation` walks every reference to end-of-program

The DAT-global counter obtained `program.getReferenceManager().getReferenceIterator(func.getBody().getMinAddress())`, which yields all outgoing references from that address through the end of the program in address order. The loop filtered with `if (!func.getBody().contains(ref.getFromAddress())) continue;` but never `break`ed, so for a function near the start of a large binary this walked millions of references per call.

**Fix:** use `getReferenceSourceIterator(func.getBody(), true)` — bounded to addresses inside the function body and correct for non-contiguous bodies — then `getReferencesFrom(addr)` per source address. Same result; O(references-in-function) instead of O(references-in-program).

### Shared TCP server's routes stay bound to a disposed `PluginTool`

`server` is a static singleton so multiple CodeBrowser windows share one HTTP listener. Only the first plugin instance runs `startServer()`; later instances skip via the `server != null` check. Every `server.createContext(...)` lambda registered there closes over the FIRST instance's `programProvider`/`listingService`/etc., which were constructed with that instance's `PluginTool`. In `dispose()` the server was kept running while `instanceCount > 0`, but nothing rebound the routes to a surviving instance — so closing the owning window first left every subsequent HTTP request executing against a disposed `PluginTool` and stale services. The `ownsServer` flag was set on start but never read.

**Fix:** track live plugin instances in a static list; on `dispose()` of the owning instance with survivors present, stop the server and restart it on a survivor (its `startServer()` re-registers all routes against its own live services). Also release each instance's `programProvider` on its own dispose — previously only the last-disposed instance released, leaking the others' opened programs.

There is a brief (<1s) server outage during the handoff; clients see a connection refused on the next request and retry. This is the same window the existing `Tools > GhidraMCP > Restart Server` action already exposes.

## Testing

- Java offline suite: **236 passed**, 0 failed
- Python unit suite: **366 passed**, 7 skipped, 0 failed
- `EndpointsJsonParityTest` passes — no `@McpTool` signatures changed
