### PR TITLE
feat: require program selectors via GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Complete version history for the Ghidra MCP Server project.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Strict program routing in the bridge** (`GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS`): set the env
+  var to `1` and the bridge refuses any program-scoped call that omits a program selector,
+  returning a clear error instead of letting the call ride the server's shared "current
+  program" (the one `switch_program` and the active GUI tab move). Catches a forgotten selector
+  as a loud failure on the first bad call instead of a silent write to the wrong binary. Covers
+  every selector that picks an open program: plain `program=` plus the cross-program tools'
+  `source_program`/`target_program` and `program_a`/`program_b` (which the server otherwise
+  resolves to the current program when left empty). Useful when several programs are open at
+  once, especially when more than one client shares a server. Off by default: with the variable
+  unset the bridge sends calls unchanged. Tools with no program selector (`open_program` and
+  `close_program` take `path`/`name`) are unaffected.
+
+---
+
 ## v5.14.1 - 2026-06-18 (patch: full overlay address-space support)
 
 Patch release.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,33 @@ python bridge_mcp_ghidra.py --transport sse --mcp-host 127.0.0.1 --mcp-port 8081
 | `--no-lazy` | (default) | Load all tool groups immediately on connect. Required for most AI clients. |
 | `--default-groups` | `listing,function,program` | Comma-separated groups loaded on connect when `--lazy` is set. |
 
+#### Strict program routing (multi-program safety)
+
+Set `GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS=1` to make the bridge refuse any program-scoped
+call that omits a program selector, returning a clear error instead of letting the call
+ride the server's shared "current program" (the one `switch_program` and the
+active GUI tab move).
+
+```bash
+export GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS=1
+python bridge_mcp_ghidra.py
+```
+
+Without this, a call that leaves `program=` out runs against whichever program
+is current, which is fine for a single-program workflow but a hazard once
+several programs are open: the call can read or edit the wrong binary with no
+error. The hazard is worse when more than one client shares a server, since
+each one moves that current-program global out from under the others.
+
+With strict mode on, every program-scoped call must name its target. This
+covers every selector that picks an open program: plain `program=` and the
+cross-program tools' `source_program`/`target_program` or `program_a`/`program_b`
+(declared required, but the server still falls back to the current program when
+one arrives empty). A forgotten selector surfaces as a loud error on the first
+bad call instead of a silent write to the wrong binary. Tools with no program
+selector (`open_program` and `close_program` take `path`/`name`) are unaffected.
+Off by default: with the variable unset the bridge sends calls unchanged.
+
 #### Reducing tool-context overhead
 
 The bridge exposes a large catalog. To keep the model's tool surface small, run

--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -84,6 +84,29 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+# Strict program routing: when GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS=1, the bridge
+# refuses any program-scoped call that omits a program selector, so a forgotten
+# one fails loudly instead of silently running against the server's mutable
+# "current program" and hitting the wrong binary. Off by default. (Full rationale
+# in the commit/README.)
+_require_selectors = False
+
+
+def _init_require_selectors() -> None:
+    """Read GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS once, at import. Set it to 1 to enable."""
+    global _require_selectors
+    _require_selectors = (os.getenv("GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS") or "").strip() == "1"
+    if _require_selectors:
+        logger.info(
+            "Strict program routing enabled (GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS=1); "
+            "program-scoped calls missing a program selector will be refused"
+        )
+
+
+_init_require_selectors()
+
+
 # Global state
 mcp = FastMCP("ghidra-mcp")
 
@@ -985,6 +1008,19 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
     """Build a callable that dispatches to the Ghidra HTTP endpoint."""
     properties = params_schema.get("properties", {})
     required = set(params_schema.get("required", []))
+    # Program selectors: params that pick which open program a call operates on.
+    # Most tools use plain `program=`; the cross-program tools (diff_functions,
+    # bulk_fuzzy_match, find_similar_functions_fuzzy) use `source_program`/
+    # `target_program` or `program_a`/`program_b`. All match this name pattern.
+    # We deliberately do NOT filter by the schema's `required` flag: those
+    # selectors are declared required yet the server still falls back to the
+    # *current* program when one arrives empty (getProgramOrError), which is the
+    # wrong-binary hazard strict mode closes. (open_program/close_program use
+    # path/name, so they have no selector here and are unaffected.)
+    program_selectors = [
+        name for name in properties
+        if name == "program" or name.endswith("_program") or name.startswith("program_")
+    ]
     is_post = http_method.upper() == "POST"
     has_schema_dry_run = "dry_run" in properties
     use_synthetic_dry_run = is_post and not has_schema_dry_run
@@ -1019,6 +1055,21 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
             for k, v in kwargs.items()
             if v is not None and not (isinstance(v, str) and v == "")
         }
+        # Strict mode: refuse if any program selector is missing, so a forgotten
+        # one fails loudly instead of running against the server's current
+        # program. filtered has already dropped None and "", so absence is the
+        # test (an empty selector counts as omitted).
+        if _require_selectors and program_selectors:
+            missing = [p for p in program_selectors if p not in filtered]
+            if missing:
+                names = ", ".join(f"`{p}=`" for p in missing)
+                return json.dumps({
+                    "error": (
+                        f"Missing required program selector(s): {names} "
+                        "(GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS is set). "
+                        "Pass each explicitly to target the intended open program(s)."
+                    )
+                })
         if http_method == "GET":
             str_params = {k: str(v) for k, v in filtered.items()}
             if use_synthetic_dry_run and is_truthy(dry_run):

--- a/tests/unit/test_endpoint_catalog.py
+++ b/tests/unit/test_endpoint_catalog.py
@@ -189,11 +189,14 @@ class TestBridgeIsDynamic(unittest.TestCase):
         meta-tool (#267/#153) that lets the bridge run --lazy with a small tool
         surface while still letting agents discover unloaded tools by keyword.
         Pulls weight: directly addresses the context-overhead complaints.
+
+        Bumped 2026-06-21: 2300 -> 2350 for GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS,
+        an opt-in mode that refuses program-scoped calls omitting a program selector.
         """
         bridge_path = PROJECT_ROOT / "bridge_mcp_ghidra.py"
         lines = len(bridge_path.read_text().splitlines())
         self.assertLess(
-            lines, 2300, f"Bridge is {lines} lines, expected <2300 for thin multiplexer"
+            lines, 2350, f"Bridge is {lines} lines, expected <2350 for thin multiplexer"
         )
 
 

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -8,12 +8,27 @@ GET/POST requests with proper parameter handling.
 
 import json
 import inspect
+import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+
+def setUpModule():
+    """Force strict mode off for tests that don't manage it explicitly.
+
+    The bridge reads GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS at module import. If
+    the variable happens to be set in the surrounding shell or CI, that import
+    would flip _require_selectors=True and leak into tests that assume the
+    default off state (i.e. every test outside TestProgramRequired). Clamp the
+    module state here so the suite is deterministic regardless of the
+    environment; TestProgramRequired manages its own state via setUp/tearDown.
+    """
+    import bridge_mcp_ghidra
+    bridge_mcp_ghidra._require_selectors = False
 
 
 class TestGetToolDispatch(unittest.TestCase):
@@ -283,6 +298,206 @@ class TestToolRegistrationRoundTrip(unittest.TestCase):
         # The tool should be registered in the MCP server
         tools = mcp._tool_manager._tools
         self.assertIn("roundtrip_test_tool", tools)
+
+
+class TestProgramRequired(unittest.TestCase):
+    """GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS: refuse calls missing a program selector."""
+
+    def setUp(self):
+        import bridge_mcp_ghidra as bridge
+        self.bridge = bridge
+        self._saved = bridge._require_selectors
+
+    def tearDown(self):
+        self.bridge._require_selectors = self._saved
+
+    _OPTIONAL_PROGRAM_TOOL = {
+        "properties": {
+            "address": {"type": "string"},
+            "program": {"type": "string", "source": "query"},
+        },
+        "required": ["address"],
+    }
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_get_refuses_when_program_omitted(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        self.bridge._require_selectors = True
+
+        fn = _build_tool_function("/decompile_function", "GET", self._OPTIONAL_PROGRAM_TOOL)
+        result = fn(address="0x401000")
+
+        mock_get.assert_not_called()
+        data = json.loads(result)
+        self.assertIn("error", data)
+        self.assertIn("program=", data["error"])
+        self.assertIn("GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS", data["error"])
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_get_allows_explicit_program(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        mock_get.return_value = "{}"
+        self.bridge._require_selectors = True
+
+        fn = _build_tool_function("/decompile_function", "GET", self._OPTIONAL_PROGRAM_TOOL)
+        fn(address="0x401000", program="game.exe")
+
+        mock_get.assert_called_once_with(
+            "/decompile_function",
+            params={"address": "0x401000", "program": "game.exe"},
+        )
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_pass_through_when_strict_mode_disabled(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        mock_get.return_value = "{}"
+        self.bridge._require_selectors = False
+
+        fn = _build_tool_function("/decompile_function", "GET", self._OPTIONAL_PROGRAM_TOOL)
+        fn(address="0x401000")
+
+        mock_get.assert_called_once_with(
+            "/decompile_function", params={"address": "0x401000"}
+        )
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_no_refusal_for_tools_without_program_param(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        mock_get.return_value = "{}"
+        self.bridge._require_selectors = True
+
+        # Some tools have no program= selector at all.
+        schema = {"properties": {"address": {"type": "string"}}, "required": ["address"]}
+        fn = _build_tool_function("/some_tool", "GET", schema)
+        fn(address="0x401000")
+
+        mock_get.assert_called_once_with("/some_tool", params={"address": "0x401000"})
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_empty_program_counts_as_omitted(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        self.bridge._require_selectors = True
+
+        # An empty string is filtered upstream of the strict check, so the
+        # check should treat it as a missing program=.
+        fn = _build_tool_function("/decompile_function", "GET", self._OPTIONAL_PROGRAM_TOOL)
+        result = fn(address="0x401000", program="")
+
+        mock_get.assert_not_called()
+        self.assertIn("error", json.loads(result))
+
+    # Cross-program tools (diff_functions, bulk_fuzzy_match,
+    # find_similar_functions_fuzzy) take source_program/target_program or
+    # program_a/program_b. These are schema-required, yet the server falls back
+    # to the current program when one arrives empty (getProgramOrError), so
+    # strict mode enforces them regardless of the required flag. The tests pass
+    # empty strings to mirror that path: the bridge filter drops "" so the
+    # selector is absent in `filtered` and the call is refused.
+
+    _FUZZY_SCHEMA = {
+        "properties": {
+            "address": {"type": "string"},
+            "source_program": {"type": "string", "source": "query"},
+            "target_program": {"type": "string", "source": "query"},
+        },
+        "required": ["address", "source_program", "target_program"],
+    }
+    _DIFF_SCHEMA = {
+        "properties": {
+            "address_a": {"type": "string"},
+            "address_b": {"type": "string"},
+            "program_a": {"type": "string", "source": "query"},
+            "program_b": {"type": "string", "source": "query"},
+        },
+        "required": ["address_a", "address_b", "program_a", "program_b"],
+    }
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_multi_program_refuses_when_both_selectors_empty(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        self.bridge._require_selectors = True
+
+        fn = _build_tool_function("/bulk_fuzzy_match", "GET", self._FUZZY_SCHEMA)
+        result = fn(address="0x401000", source_program="", target_program="")
+
+        mock_get.assert_not_called()
+        data = json.loads(result)
+        self.assertIn("source_program=", data["error"])
+        self.assertIn("target_program=", data["error"])
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_multi_program_refuses_when_one_selector_empty(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        self.bridge._require_selectors = True
+
+        fn = _build_tool_function("/bulk_fuzzy_match", "GET", self._FUZZY_SCHEMA)
+        result = fn(address="0x401000", source_program="game.exe", target_program="")
+
+        mock_get.assert_not_called()
+        data = json.loads(result)
+        # Only the missing one is named.
+        self.assertIn("target_program=", data["error"])
+        self.assertNotIn("source_program=", data["error"])
+
+    @patch("bridge_mcp_ghidra.dispatch_get")
+    def test_multi_program_allows_when_all_present(self, mock_get):
+        from bridge_mcp_ghidra import _build_tool_function
+        mock_get.return_value = "{}"
+        self.bridge._require_selectors = True
+
+        fn = _build_tool_function("/bulk_fuzzy_match", "GET", self._FUZZY_SCHEMA)
+        fn(address="0x401000", source_program="game.exe", target_program="test.dll")
+
+        mock_get.assert_called_once_with(
+            "/bulk_fuzzy_match",
+            params={
+                "address": "0x401000",
+                "source_program": "game.exe",
+                "target_program": "test.dll",
+            },
+        )
+
+    @patch("bridge_mcp_ghidra.dispatch_post")
+    def test_program_a_b_pattern_enforced(self, mock_post):
+        from bridge_mcp_ghidra import _build_tool_function
+        self.bridge._require_selectors = True
+
+        fn = _build_tool_function("/diff_functions", "POST", self._DIFF_SCHEMA)
+        result = fn(address_a="0x401000", address_b="0x402000", program_a="", program_b="")
+
+        mock_post.assert_not_called()
+        data = json.loads(result)
+        self.assertIn("program_a=", data["error"])
+        self.assertIn("program_b=", data["error"])
+
+    def test_init_value_1_enables_strict_mode(self):
+        for val in ("1", " 1 "):  # only "1" (surrounding whitespace tolerated)
+            self.bridge._require_selectors = False
+            with patch.dict("os.environ", {"GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS": val}):
+                # assertLogs captures the enable-time INFO line (keeping it out
+                # of test output) and doubles as an assertion that it fires.
+                with self.assertLogs("bridge_mcp_ghidra", level="INFO"):
+                    self.bridge._init_require_selectors()
+            self.assertTrue(
+                self.bridge._require_selectors, f"{val!r} should enable strict mode"
+            )
+
+    def test_init_non_1_values_leave_strict_mode_off(self):
+        # Only "1" enables; other spellings (true/yes/on) and falsy values don't.
+        for val in ("true", "yes", "on", "TRUE", "0", "2", "", "anything"):
+            self.bridge._require_selectors = True
+            with patch.dict("os.environ", {"GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS": val}):
+                self.bridge._init_require_selectors()
+            self.assertFalse(
+                self.bridge._require_selectors, f"{val!r} should not enable strict mode"
+            )
+
+    def test_init_unset_env_leaves_strict_mode_off(self):
+        self.bridge._require_selectors = True
+        env = {k: v for k, v in os.environ.items() if k != "GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS"}
+        with patch.dict("os.environ", env, clear=True):
+            self.bridge._init_require_selectors()
+        self.assertFalse(self.bridge._require_selectors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this does

Adds a bridge-side strict mode for program routing. Set `GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS=1` and the bridge refuses any program-scoped call that omits a program selector, returning a clear error.

```bash
export GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS=1
python bridge_mcp_ghidra.py
```

It's off by default: with the variable unset the bridge sends calls exactly as before.

## Why

Program-scoped tools take an optional `program=` selector. When it's omitted, the server resolves the call against its "current program", a single global that moves whenever a program is switched (`switch_program`) or, in the GUI, when the active tab changes. That's fine with one program open, or when a single caller works through programs serially. With several open it's a trap: a call that leaves `program=` out runs against whichever program is current, so it can read or edit the wrong binary with no error. The hazard is worse when more than one client shares a server, since each one moves that current-program global out from under the others.

Strict mode gives operators who need explicit routing a single env var to flip. A forgotten selector then surfaces as a loud failure on the first bad call instead of a silent write to the wrong binary. Each call carries its own program, so the check holds no state and works the same whether one process or many use the bridge.

## What's covered

Every program selector, not just plain `program=`. The bridge enforces any param named `program`, `program_*`, or `*_program`. That covers the cross-program tools (`diff_functions`, `bulk_fuzzy_match`, `find_similar_functions_fuzzy`), which take `source_program` / `target_program` or `program_a` / `program_b` — those are declared *required*, but the server still resolves an empty one to the current program (`getProgramOrError`), so they must be enforced too. Tools with no such param (`open_program` and `close_program` take `path` / `name`) are unaffected.

## How it works

- The bridge reads `GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS` once at startup; only `1` enables it (surrounding whitespace tolerated).
- For each tool, it collects the params named `program`, `program_*`, or `*_program` — the selectors that pick which open program a call operates on.
- At call time, when strict mode is on and any of those selectors is missing or empty, the bridge returns `{"error": "Missing required program selector(s): ..."}` (naming the missing ones) without dispatching to the server.

## Why a bridge mode, not a server policy

The same check on the server would defeat `switch_program`: right after a switch, the next call without a selector would error instead of running against the program just chosen. Putting the check in the bridge keeps the server's behavior identical (`switch_program` still works for everyone who doesn't opt in) and lets operators who need explicit routing flip a single env var per bridge process.

## Scope

Bridge only (`bridge_mcp_ghidra.py`). No server, schema, endpoint, or `@McpTool`/`@Param` changes, so `program=` stays optional in `/mcp/schema` and the endpoints parity test is unaffected.

## Testing

- `tests/unit/test_mcp_tool_functions.py::TestProgramRequired` (12 cases): single-program refusal / allow / pass-through-when-off / empty-counts-as-omitted / no-selector-never-refused; multi-program (`source_program`/`target_program` and `program_a`/`program_b`) refused when a selector is empty and allowed when all present; and env-var parsing (only `1` enables; other values and unset don't; surrounding whitespace tolerated).
- All bridge unit suites pass: `test_mcp_tool_functions`, `test_endpoint_catalog` (bridge line cap bumped 2300 -> 2350), `test_bridge_utils`, `test_mcp_tools`, `test_response_schemas`.
- Verified live against a Ghidra session with several programs open: a program-scoped call with no `program=` is refused, and the same call with an explicit `program=` resolves normally.

## Compatibility

Fully backward-compatible. With `GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS` unset the bridge behaves exactly as before, so no existing user sees a behavior change. When the variable is set, the only change is that program-scoped calls omitting a program selector get refused at the bridge instead of running against the current program, which is the point.

---

_This pull request was generated with Claude Code using Claude Opus 4.8 (1M context)._
