### PR TITLE
Fix TCP fallback when Windows socket discovery has no project metadata

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -1364,18 +1364,18 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
     # Try TCP fallback. The behavior depends on what UDS discovery returned:
     #
     #   * If GHIDRA_MCP_URL is set, it always wins (explicit user override).
-    #   * If UDS found one or more instances and none matched the project,
-    #     refuse to fall back to TCP -- that's how we previously silently
-    #     connected to the wrong instance (Copilot #196 review item).
-    #   * If UDS found NOTHING (no instances at all), scan the TCP port range
+    #   * If UDS found one or more instances with project metadata and none
+    #     matched the project, refuse to fall back to TCP -- that's how we
+    #     previously silently connected to the wrong instance (Copilot #196
+    #     review item).
+    #   * If UDS found no usable project metadata, scan the TCP port range
     #     looking for a /mcp/instance_info that matches the project. Handles
-    #     the TCP-only multi-instance case (e.g. Windows pre-1803 without
-    #     AF_UNIX).
+    #     TCP-only and native Windows cases where AF_UNIX is unavailable.
     #   * If no scan match either, try the default port as a last resort.
     env_tcp = os.getenv("GHIDRA_MCP_URL")
     if env_tcp:
         tcp_url = env_tcp
-    elif instances:
+    elif instances and any(inst.get("project") for inst in instances):
         # UDS found instances but none matched the requested project. Don't
         # randomly pick another instance's tcp_port — that connects to the
         # wrong project. Return the "no match" error directly.
@@ -1392,9 +1392,9 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
             }
         )
     else:
-        # No UDS instances. Scan the TCP port range to find one matching
-        # the project. _scan_tcp_for_project returns the URL of the first
-        # matching instance, or None if nothing matched.
+        # No usable UDS project metadata. Scan the TCP port range to find one
+        # matching the project. _scan_tcp_for_project returns the URL of the
+        # first matching instance, or None if nothing matched.
         scanned = _scan_tcp_for_project(project)
         tcp_url = scanned if scanned else DEFAULT_TCP_URL
     if not validate_server_url(tcp_url):

--- a/tests/unit/test_bridge_utils.py
+++ b/tests/unit/test_bridge_utils.py
@@ -10,6 +10,7 @@ import os
 import inspect
 import re
 import unittest
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -170,6 +171,53 @@ class TestTcpPortScan(unittest.TestCase):
 
         self.assertIsNone(bridge._scan_tcp_for_project(""))
         self.assertIsNone(bridge._scan_tcp_for_project(None))
+
+
+class TestConnectInstanceTcpFallback(unittest.TestCase):
+    """Test connect_instance project matching across UDS and TCP discovery."""
+
+    def test_projectless_uds_instances_fall_back_to_tcp_scan(self):
+        import bridge_mcp_ghidra as bridge
+
+        instances = [{"socket": "/tmp/ghidra-123.sock", "pid": 123}]
+
+        with patch.object(bridge, "discover_instances", return_value=instances), \
+             patch.object(bridge, "_scan_tcp_for_project", return_value="http://127.0.0.1:8090") as scan, \
+             patch.object(bridge, "validate_server_url", return_value=True), \
+             patch.object(bridge, "_fetch_and_register_schema", return_value=0), \
+             patch.object(bridge, "os") as mock_os:
+            mock_os.getenv.return_value = None
+            bridge._full_schema = []
+            bridge._loaded_groups.clear()
+
+            result = asyncio.run(bridge.connect_instance("wanted"))
+
+        data = json.loads(result)
+        self.assertTrue(data["connected"])
+        self.assertEqual(data["transport"], "tcp")
+        self.assertEqual(data["url"], "http://127.0.0.1:8090")
+        scan.assert_called_once_with("wanted")
+
+    def test_real_nonmatching_uds_projects_refuse_tcp_fallback(self):
+        import bridge_mcp_ghidra as bridge
+
+        instances = [
+            {"socket": "/tmp/ghidra-123.sock", "pid": 123, "project": "other"},
+            {"socket": "/tmp/ghidra-456.sock", "pid": 456, "project": "also_other"},
+        ]
+
+        with patch.object(bridge, "discover_instances", return_value=instances), \
+             patch.object(bridge, "_scan_tcp_for_project") as scan, \
+             patch.object(bridge, "os") as mock_os:
+            mock_os.getenv.return_value = None
+
+            result = asyncio.run(bridge.connect_instance("wanted"))
+
+        data = json.loads(result)
+        self.assertIn("error", data)
+        self.assertIn("No instance matching 'wanted'", data["error"])
+        self.assertEqual(data["available"], ["other", "also_other"])
+        scan.assert_not_called()
 
 
 class TestGetSocketDirCandidates(unittest.TestCase):


### PR DESCRIPTION
﻿## Summary

This PR fixes a Windows connection edge case in `connect_instance(project)`.

When local socket discovery reports running instances but those instances do not include usable project metadata, the bridge currently treats that as enough information to refuse TCP fallback. On Windows, that can leave a valid local Ghidra plugin unreachable even though the plugin is healthy and can identify the requested project over TCP.

The fix keeps the existing safety behavior for real project mismatches, but allows TCP project scanning when socket discovery only produced projectless metadata.

## Connection Flow

```mermaid
flowchart TD
    A[connect_instance project] --> B[discover local socket instances]
    B --> C{Matching project over socket?}
    C -->|Yes| D[Connect over socket]
    C -->|No| E{Any socket instance has project metadata?}
    E -->|Yes| F[Return no-match error]
    E -->|No| G[Scan local TCP plugin ports]
    G --> H{Matching project over TCP?}
    H -->|Yes| I[Connect over TCP]
    H -->|No| J[Try default local TCP URL]
```

## What Changed

- Narrowed the TCP fallback refusal condition in `connect_instance(project)`.
- If socket discovery returns real nonmatching project metadata, the bridge still refuses TCP fallback to avoid connecting to the wrong project.
- If socket discovery returns only projectless metadata, the bridge now scans local TCP plugin ports for the requested project.
- Added regression coverage for both paths.

## Validation

- `python -m pytest tests/unit/test_bridge_utils.py -v --no-cov`
  - 47 passed
- `python -m pytest tests/unit/ -v --no-cov`
  - 374 passed, 1 skipped
- `python -m tools.setup build`
  - BUILD SUCCESS
- Live Windows smoke against a local Ghidra project:
  - Ghidra plugin healthy on `127.0.0.1:8089`
  - `connect_instance("<local_project>")` returned `connected: true`
  - transport was `tcp`
  - read-only project listing and metadata calls succeeded

## Checklist

- [x] Tests added/updated
- [x] Python unit tests passed
- [x] Build passed
- [x] No breaking config/default change
- [x] PR body and diff avoid private project details
