### PR TITLE
Add GHIDRA_MCP_AUTH_TOKEN support for bridge_mcp_ghidra

### DIFF
--- a/docs/prompts/TOOL_USAGE_GUIDE.md
+++ b/docs/prompts/TOOL_USAGE_GUIDE.md
@@ -421,6 +421,8 @@ GhidraMCP defaults to localhost-unauthenticated — safe on a single-user dev bo
 
 The headless server refuses to start on a non-loopback bind address (`0.0.0.0`, explicit external IP) unless `GHIDRA_MCP_AUTH_TOKEN` is set.
 
+**The MCP bridge reads the same `GHIDRA_MCP_AUTH_TOKEN`** and attaches `Authorization: Bearer <token>` to every outbound call (UDS and TCP). Export the same token in the bridge's environment — otherwise it will hit `401 Unauthorized` on every tool call to an auth-enabled server. Unset = no header (matches the localhost default).
+
 ### Worked example — exposing to a private LAN with auth
 
 ```bash

--- a/python/bridge_mcp_ghidra/config.py
+++ b/python/bridge_mcp_ghidra/config.py
@@ -36,6 +36,9 @@ ENDPOINT_TIMEOUTS = {
 
 DEFAULT_TCP_URL = "http://127.0.0.1:8089"
 DEFAULT_TCP_PORT = 8089
+# When set, forwarded to the Ghidra server as `Authorization: Bearer <token>`.
+# Same env var the plugin/headless server enforces (v5.4.1+); unset = no header.
+AUTH_TOKEN = (os.getenv("GHIDRA_MCP_AUTH_TOKEN") or "").strip()
 # Bridge-side TCP port scan range. Mirrors the plugin's
 # TCP_PORT_FALLBACK_RANGE so a TCP-only multi-instance setup (e.g. Windows
 # 10 pre-1803 where AF_UNIX is unavailable) can still be discovered without

--- a/python/bridge_mcp_ghidra/transport.py
+++ b/python/bridge_mcp_ghidra/transport.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from urllib.parse import urlencode, urlparse
 
 from . import state
-from .config import logger
+from .config import AUTH_TOKEN, logger
+
+
+def _auth_headers() -> dict[str, str]:
+    """Authorization header for the Ghidra server, when ``AUTH_TOKEN`` is set."""
+    return {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
 
 
 # ==========================================================================
@@ -133,7 +138,7 @@ def uds_request(
     if params:
         path = f"{path}?{urlencode(params)}"
 
-    headers = {}
+    headers = _auth_headers()
     body = None
     if json_data is not None:
         body = json.dumps(json_data).encode("utf-8")
@@ -174,7 +179,7 @@ def tcp_request(
     if params:
         path = f"{path}?{urlencode(params)}"
 
-    headers = {}
+    headers = _auth_headers()
     body = None
     if json_data is not None:
         body = json.dumps(json_data).encode("utf-8")


### PR DESCRIPTION
The docker setup ends up requiring it because the default is setting GHIDRA_MCP_BIND_ADDRESS=0.0.0.0 inside the container.