### PR TITLE
fix(fun-doc): serialize storage-repo bootstrap; idempotent schema version record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@ Complete version history for the Ghidra MCP Server project.
   with a bare INSERT, so two threads bootstrapping the same fresh SQLite
   (worker/watchdog + main) could die with `UNIQUE constraint failed:
   schema_versions.version`. Now double-check-locked, with
-  `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` version recording; 3 new
-  race-regression tests in `test_migrate_sqlite_idempotent.py`.
+  `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` version recording. `migrate()`
+  is additionally serialized with a module-level lock: the PRAGMA-based
+  `ADD COLUMN` skip can't win a cross-connection TOCTOU race (two threads both
+  read an empty schema and race the same `ALTER TABLE ADD COLUMN`, the loser
+  dying with "duplicate column name"), so the lock lets the second caller
+  observe the first's committed schema and no-op. 3 race-regression tests in
+  `test_migrate_sqlite_idempotent.py`.
 - **libclang/clang version mismatch.** The `clang` bindings (21.x) had outrun
   the `libclang` DLL wheel (18.1.1, the newest published on PyPI), breaking
   `benchmark/extract_truth.py` with `clang_getOffsetOfBase not found`. Both are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Complete version history for the Ghidra MCP Server project.
 
 ### Fixed
 
+- **fun-doc storage bootstrap race.** `_get_storage_repo()` was an unlocked
+  check-then-build singleton and `db/migrate.py` recorded schema versions
+  with a bare INSERT, so two threads bootstrapping the same fresh SQLite
+  (worker/watchdog + main) could die with `UNIQUE constraint failed:
+  schema_versions.version`. Now double-check-locked, with
+  `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING` version recording; 3 new
+  race-regression tests in `test_migrate_sqlite_idempotent.py`.
 - **libclang/clang version mismatch.** The `clang` bindings (21.x) had outrun
   the `libclang` DLL wheel (18.1.1, the newest published on PyPI), breaking
   `benchmark/extract_truth.py` with `clang_getOffsetOfBase not found`. Both are

--- a/fun-doc/db/migrate.py
+++ b/fun-doc/db/migrate.py
@@ -27,6 +27,7 @@ import argparse
 import os
 import re
 import sys
+import threading
 from pathlib import Path
 from typing import Optional
 
@@ -248,27 +249,38 @@ class _PgConnAdapter:
         self._conn.close()
 
 
+# Serializes concurrent migrate() calls within a process. The PRAGMA-based
+# ADD COLUMN skip and INSERT-OR-IGNORE version record make a *retry* idempotent,
+# but they cannot win a cross-connection TOCTOU race: two threads that both read
+# an empty schema race the same `ALTER TABLE ADD COLUMN`, and the loser dies with
+# "duplicate column name". fun-doc migrates in-process (main + worker/watchdog
+# threads), so serializing here lets the second caller observe the first's
+# committed schema and no-op instead of colliding.
+_migrate_lock = threading.Lock()
+
+
 def migrate(backend: str, url: Optional[str] = None) -> int:
     """Apply all unapplied migrations for ``backend``. Returns count applied."""
-    conn, target = _connect(backend, url)
-    applied_count = 0
-    try:
-        _ensure_versions_table(conn, backend)
-        already = _applied_versions(conn, backend)
-        for version, name, path in _migration_files(backend):
-            if version in already:
-                continue
-            sql = path.read_text(encoding="utf-8")
-            conn.executescript(sql)
-            _record_applied(conn, backend, version, name)
-            applied_count += 1
-            print(f"[migrate] applied {version:04d}_{name} ({backend}) at {target}")
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-    finally:
-        conn.close()
+    with _migrate_lock:
+        conn, target = _connect(backend, url)
+        applied_count = 0
+        try:
+            _ensure_versions_table(conn, backend)
+            already = _applied_versions(conn, backend)
+            for version, name, path in _migration_files(backend):
+                if version in already:
+                    continue
+                sql = path.read_text(encoding="utf-8")
+                conn.executescript(sql)
+                _record_applied(conn, backend, version, name)
+                applied_count += 1
+                print(f"[migrate] applied {version:04d}_{name} ({backend}) at {target}")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
     if applied_count == 0:
         print(f"[migrate] {backend} schema already up to date at {target}")
     return applied_count

--- a/fun-doc/db/migrate.py
+++ b/fun-doc/db/migrate.py
@@ -86,14 +86,23 @@ def _applied_versions(conn, backend: str) -> set[int]:
 
 
 def _record_applied(conn, backend: str, version: int, name: str) -> None:
+    # Conflict-tolerant on purpose: two migrators can race the
+    # read-versions -> apply -> record window (e.g. two threads
+    # bootstrapping the same fresh SQLite). The migration SQL itself is
+    # idempotent by design (CREATE TABLE IF NOT EXISTS + the ALTER ADD
+    # COLUMN rewrite below), so the loser of the race just skips the
+    # duplicate version row instead of blowing up with a UNIQUE failure.
     table = "fun_doc.schema_versions" if backend == "postgres" else "schema_versions"
     if backend == "postgres":
         conn.execute(
-            f"INSERT INTO {table} (version, name) VALUES (%s, %s)", (version, name)
+            f"INSERT INTO {table} (version, name) VALUES (%s, %s) "
+            "ON CONFLICT (version) DO NOTHING",
+            (version, name),
         )
     else:
         conn.execute(
-            f"INSERT INTO {table} (version, name) VALUES (?, ?)", (version, name)
+            f"INSERT OR IGNORE INTO {table} (version, name) VALUES (?, ?)",
+            (version, name),
         )
 
 

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -931,6 +931,10 @@ def _default_state():
 
 _storage_repo = None
 _storage_repo_failed = False  # cache import-time failure to avoid retry storm
+# Serializes lazy construction: without it, a worker/watchdog thread and the
+# main thread can both see _storage_repo is None and race bootstrap_schema()
+# against the same SQLite file (UNIQUE failure on schema_versions).
+_storage_repo_lock = threading.Lock()
 
 
 def _get_storage_repo():
@@ -958,6 +962,18 @@ def _get_storage_repo():
         return _storage_repo
     if _storage_repo_failed:
         return None
+    with _storage_repo_lock:
+        # Double-checked: another thread may have built it while we waited.
+        if _storage_repo is not None:
+            return _storage_repo
+        if _storage_repo_failed:
+            return None
+        return _build_storage_repo()
+
+
+def _build_storage_repo():
+    """Build the repository. Caller must hold _storage_repo_lock."""
+    global _storage_repo, _storage_repo_failed
     try:
         # Read storage block from priority_queue.json if present.
         config_block = None

--- a/tests/performance/test_migrate_sqlite_idempotent.py
+++ b/tests/performance/test_migrate_sqlite_idempotent.py
@@ -145,6 +145,107 @@ def test_non_alter_statements_unaffected(migrate_module, tmp_path):
         conn.close()
 
 
+def test_record_applied_duplicate_version_is_tolerant(migrate_module, tmp_path):
+    """Regression: two migrators racing the read-versions -> apply -> record
+    window (e.g. two threads bootstrapping the same fresh SQLite) used to
+    blow up with `UNIQUE constraint failed: schema_versions.version` when
+    the loser recorded a version the winner already inserted. INSERT OR
+    IGNORE makes the loser a no-op."""
+    conn = sqlite3.connect(str(tmp_path / "state.db"))
+    conn.isolation_level = None
+    adapter = migrate_module._SqliteConnAdapter(conn)
+    try:
+        migrate_module._ensure_versions_table(adapter, "sqlite")
+        migrate_module._record_applied(adapter, "sqlite", 1, "initial")
+        migrate_module._record_applied(adapter, "sqlite", 1, "initial")  # loser of the race
+        rows = conn.execute("SELECT version FROM schema_versions").fetchall()
+        assert [r[0] for r in rows] == [1]
+    finally:
+        conn.close()
+
+
+def test_concurrent_migrate_same_db_no_unique_failure(migrate_module, tmp_path):
+    """Full-stack version of the race: two threads run migrate() against the
+    same fresh SQLite simultaneously. Both must finish without raising, and
+    schema_versions must hold each version exactly once."""
+    import threading
+
+    db_path = str(tmp_path / "race.db")
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def run():
+        try:
+            barrier.wait(timeout=10)
+            migrate_module.migrate("sqlite", db_path)
+        except BaseException as e:  # noqa: BLE001 — collect for assertion
+            errors.append(e)
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, f"concurrent migrate raised: {errors!r}"
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT version, COUNT(*) FROM schema_versions GROUP BY version HAVING COUNT(*) > 1"
+        ).fetchall()
+        assert rows == [], f"duplicate schema_versions rows: {rows}"
+    finally:
+        conn.close()
+
+
+def test_get_storage_repo_singleton_is_threadsafe(tmp_path, monkeypatch):
+    """Regression for the in-process half of the race: _get_storage_repo()
+    was an unlocked check-then-build singleton, so a worker/watchdog thread
+    and the main thread could both bootstrap the same SQLite. All concurrent
+    callers must now get the SAME repository instance with no error."""
+    import threading
+
+    fundoc_dir = _REPO_ROOT / "fun-doc"
+    if str(fundoc_dir) not in sys.path:
+        sys.path.insert(0, str(fundoc_dir))
+    import fun_doc as fd
+
+    monkeypatch.setenv("FUN_DOC_DB_URL", f"sqlite:///{tmp_path / 'singleton_race.db'}")
+    fd._storage_repo = None
+    fd._storage_repo_failed = False
+
+    n = 8
+    barrier = threading.Barrier(n)
+    results: list[object] = []
+    errors: list[BaseException] = []
+
+    def grab():
+        try:
+            barrier.wait(timeout=10)
+            results.append(fd._get_storage_repo())
+        except BaseException as e:  # noqa: BLE001 — collect for assertion
+            errors.append(e)
+
+    threads = [threading.Thread(target=grab) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    try:
+        assert not errors, f"_get_storage_repo raised under concurrency: {errors!r}"
+        assert len(results) == n
+        assert len({id(r) for r in results}) == 1, "threads got different repo instances"
+        assert results[0] is not None
+    finally:
+        if fd._storage_repo is not None:
+            try:
+                fd._storage_repo.engine.dispose()
+            except Exception:
+                pass
+            fd._storage_repo = None
+
+
 def test_strip_helper_in_isolation(migrate_module, tmp_path):
     """The regex helper rewrites a duplicate ADD COLUMN to a comment;
     pin that behavior so a future regex tweak can't silently regress."""


### PR DESCRIPTION
## What

`_get_storage_repo()` was an unlocked check-then-build singleton and
`db/migrate.py` recorded schema versions with a bare `INSERT`, so two threads
bootstrapping the same fresh SQLite (fun-doc worker/watchdog + main) could die
with `UNIQUE constraint failed: schema_versions.version`.

## Fix

- Double-checked lock around lazy repo construction (`_build_storage_repo`).
- Version recording is now `INSERT OR IGNORE` (sqlite) / `ON CONFLICT DO NOTHING`
  (postgres); migrations are already idempotent, so the race-loser just skips.

## Verification

`tests/performance/test_migrate_sqlite_idempotent.py` — **8 passed** (incl. 3
new concurrent-bootstrap race-regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
