### PR TITLE
fix(bridge): Windows cross-drive UDS discovery + AF_UNIX TCP fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ Complete version history for the Ghidra MCP Server project.
   `benchmark/extract_truth.py` with `clang_getOffsetOfBase not found`. Both are
   now pinned to LLVM 18.1.x (`clang>=18.1.8,<19`, `libclang>=18.1.1,<19`); the
   3 erroring extract-truth tests pass.
+- **Windows cross-drive UDS discovery + AF_UNIX fallback.** On Windows the
+  plugin's socket-dir fallback (`/tmp`, drive-relative) resolved against the
+  JVM's working drive (e.g. `F:\tmp` when Ghidra runs from F:) while the bridge
+  scanned its own drive's `\tmp`, so `list_instances` always reported "No
+  running Ghidra instances" and the bridge never auto-connected after a Ghidra
+  restart. Three-part fix:
+  - Plugin: `ServerManager.getSocketDir()` now falls back to `java.io.tmpdir`
+    (honors `%TEMP%`) before the literal `/tmp`, giving both sides an absolute,
+    agreed-on location.
+  - Bridge: `get_socket_dir_candidates()` sweeps every mounted drive root for
+    `<drive>:\tmp\ghidra-mcp-<user>` (backward compat with older JARs).
+  - Bridge: on Windows CPython, which doesn't expose `socket.AF_UNIX`
+    (python/cpython#77589), discovery enriches socket-file hits with
+    project/programs/url fetched over the plugin's TCP listener (joined by PID),
+    and `connect_instance` / startup auto-connect / post-restart reconnect all
+    route the connection over that TCP url instead of failing the UDS handshake.
+  - Tests: real-socket transport tests (`test_transport_network.py`) and bridge
+    CLI / DNS-rebinding tests (`test_bridge_cli.py`), plus
+    `ServerManagerSocketDirTest.java` for the plugin fallback.
 
 ### Changed
 

--- a/python/bridge_mcp_ghidra/discovery.py
+++ b/python/bridge_mcp_ghidra/discovery.py
@@ -30,6 +30,8 @@ def discover_instances() -> list[dict]:
     """
     seen_paths: set[str] = set()
     instances: list[dict] = []
+    uds_ok = transport.uds_supported()
+    tcp_by_pid: dict[int, dict] | None = None
 
     for socket_dir in transport.get_socket_dir_candidates():
         if not socket_dir.exists():
@@ -58,42 +60,43 @@ def discover_instances() -> list[dict]:
                 continue
 
             info: dict = {"socket": str(sock_file), "pid": pid}
-            try:
-                text, status = transport.uds_request(
-                    str(sock_file), "GET", "/mcp/instance_info", timeout=5
-                )
-                if status == 200:
-                    info.update(_unwrap_response_data(text))
-            except Exception as e:
-                logger.debug(f"Could not query {sock_file}: {e}")
+            if uds_ok:
+                try:
+                    text, status = transport.uds_request(
+                        str(sock_file), "GET", "/mcp/instance_info", timeout=5
+                    )
+                    if status == 200:
+                        info.update(_unwrap_response_data(text))
+                except Exception as e:
+                    logger.debug(f"Could not query {sock_file}: {e}")
+            else:
+                # CPython on Windows can't dial UDS (see
+                # transport.uds_supported), so the socket file only proves
+                # the instance is alive. Fetch its metadata — project name,
+                # programs, tcp_port — over the plugin's TCP listener
+                # instead, matched by PID.
+                if tcp_by_pid is None:
+                    tcp_by_pid = _tcp_instances_by_pid()
+                if pid in tcp_by_pid:
+                    info.update(tcp_by_pid[pid])
 
             instances.append(info)
 
     return instances
 
 
-def _scan_tcp_for_project(project: str, start_port: int = DEFAULT_TCP_PORT,
-                          range_size: int = TCP_PORT_SCAN_RANGE,
-                          timeout: float = 1.0) -> str | None:
-    """Scan a small TCP port range for a Ghidra plugin matching `project`.
+def _iter_tcp_instances(start_port: int = DEFAULT_TCP_PORT,
+                        range_size: int = TCP_PORT_SCAN_RANGE,
+                        timeout: float = 1.0):
+    """Yield (url, instance_info) for every Ghidra plugin in the TCP scan range.
 
-    Used when UDS discovery returns nothing (e.g., TCP-only multi-instance
-    setups on Windows pre-1803). For each port in [start_port, start_port +
-    range_size), issues `GET /mcp/instance_info` with a short timeout. The
-    first one whose `project` field matches (exact wins; substring used as
-    fallback) returns its URL. Returns None if no match found.
-
-    Project matching mirrors connect_instance's UDS match order so the same
-    `connect_instance("D2Common")` call selects the same instance regardless
-    of which transport found it.
+    For each port in [start_port, start_port + range_size), issues
+    `GET /mcp/instance_info` with a short timeout; unreachable ports and
+    non-JSON responders are skipped silently.
 
     Uses http.client (stdlib) rather than `requests` to keep the bridge's
     dependency footprint minimal -- see test_project_consistency.
     """
-    if not project:
-        return None
-    project_lower = project.lower()
-    substring_url: str | None = None
     for port in range(start_port, start_port + range_size):
         url = f"http://127.0.0.1:{port}"
         try:
@@ -107,17 +110,56 @@ def _scan_tcp_for_project(project: str, start_port: int = DEFAULT_TCP_PORT,
             finally:
                 conn.close()
             info = _unwrap_response_data(body)
-            if not isinstance(info, dict):
-                continue
-            inst_project = info.get("project", "")
-            if inst_project == project:
-                # Exact match — return immediately.
-                return url
-            if not substring_url and project_lower in inst_project.lower():
-                substring_url = url
+            if isinstance(info, dict):
+                yield url, info
         except Exception:
             # Connection refused / timeout / non-JSON response — try next port.
             continue
+
+
+def _tcp_instances_by_pid(start_port: int = DEFAULT_TCP_PORT,
+                          range_size: int = TCP_PORT_SCAN_RANGE,
+                          timeout: float = 1.0) -> dict[int, dict]:
+    """Map pid -> {"url": ..., **instance_info} for TCP-reachable instances.
+
+    Used to enrich UDS socket-file discovery on hosts where Python can't
+    dial UDS (Windows CPython): the socket filename carries the plugin's
+    PID, and /mcp/instance_info reports its own pid, so the two can be
+    joined without guessing.
+    """
+    by_pid: dict[int, dict] = {}
+    for url, info in _iter_tcp_instances(start_port, range_size, timeout):
+        pid = info.get("pid")
+        if isinstance(pid, int) and pid not in by_pid:
+            by_pid[pid] = {"url": url, **info}
+    return by_pid
+
+
+def _scan_tcp_for_project(project: str, start_port: int = DEFAULT_TCP_PORT,
+                          range_size: int = TCP_PORT_SCAN_RANGE,
+                          timeout: float = 1.0) -> str | None:
+    """Scan a small TCP port range for a Ghidra plugin matching `project`.
+
+    Used when UDS discovery returns nothing (e.g., TCP-only multi-instance
+    setups on Windows pre-1803). The first instance whose `project` field
+    matches exactly wins; a substring match is used as fallback. Returns
+    None if no match found.
+
+    Project matching mirrors connect_instance's UDS match order so the same
+    `connect_instance("D2Common")` call selects the same instance regardless
+    of which transport found it.
+    """
+    if not project:
+        return None
+    project_lower = project.lower()
+    substring_url: str | None = None
+    for url, info in _iter_tcp_instances(start_port, range_size, timeout):
+        inst_project = info.get("project", "")
+        if inst_project == project:
+            # Exact match — return immediately.
+            return url
+        if not substring_url and project_lower in inst_project.lower():
+            substring_url = url
     return substring_url
 
 

--- a/python/bridge_mcp_ghidra/dispatch.py
+++ b/python/bridge_mcp_ghidra/dispatch.py
@@ -64,11 +64,39 @@ def _normalize_post_payload(endpoint: str, data: dict) -> dict:
     return data
 
 
+def _reconnect_via(inst: dict) -> bool:
+    """Point the active transport at `inst` and re-fetch the schema.
+
+    Uses UDS when this Python can dial it; otherwise falls back to the TCP
+    url discovery recorded for the instance (Windows CPython lacks AF_UNIX).
+    Returns True on success.
+    """
+    if transport.uds_supported():
+        state._active_socket = inst["socket"]
+        state._active_tcp = None
+        state._transport_mode = "uds"
+        target = inst["socket"]
+    elif inst.get("url"):
+        state._active_tcp = inst["url"]
+        state._active_socket = None
+        state._transport_mode = "tcp"
+        target = inst["url"]
+    else:
+        return False
+    try:
+        registry._fetch_and_register_schema()
+        logger.info(f"Reconnected to project '{inst.get('project')}' via {target}")
+        return True
+    except Exception as e:
+        logger.warning(f"Reconnect schema fetch failed: {e}")
+        return False
+
+
 def _try_reconnect() -> bool:
     """Try to reconnect to the previously connected project after Ghidra restarts.
 
-    Scans for UDS instances matching _connected_project. If found, updates the
-    active socket and re-fetches the schema. Returns True if reconnected.
+    Scans for instances matching _connected_project. If found, updates the
+    active transport and re-fetches the schema. Returns True if reconnected.
     """
     if not state._connected_project:
         return False
@@ -76,34 +104,12 @@ def _try_reconnect() -> bool:
     instances = discovery.discover_instances()
     for inst in instances:
         if inst.get("project", "") == state._connected_project:
-            state._active_socket = inst["socket"]
-            state._active_tcp = None
-            state._transport_mode = "uds"
-            try:
-                registry._fetch_and_register_schema()
-                logger.info(
-                    f"Reconnected to project '{state._connected_project}' via {inst['socket']}"
-                )
-                return True
-            except Exception as e:
-                logger.warning(f"Reconnect schema fetch failed: {e}")
-                return False
+            return _reconnect_via(inst)
 
     # Exact match failed, try substring
     for inst in instances:
         if state._connected_project.lower() in inst.get("project", "").lower():
-            state._active_socket = inst["socket"]
-            state._active_tcp = None
-            state._transport_mode = "uds"
-            try:
-                registry._fetch_and_register_schema()
-                logger.info(
-                    f"Reconnected to project '{inst.get('project')}' via {inst['socket']}"
-                )
-                return True
-            except Exception as e:
-                logger.warning(f"Reconnect schema fetch failed: {e}")
-                return False
+            return _reconnect_via(inst)
 
     return False
 

--- a/python/bridge_mcp_ghidra/static_tools.py
+++ b/python/bridge_mcp_ghidra/static_tools.py
@@ -8,6 +8,7 @@ from . import discovery
 from . import dispatch
 from . import registry
 from . import state
+from . import transport
 from .config import DEFAULT_TCP_URL, STATIC_TOOL_NAMES, logger
 from .server import Context, mcp
 from .validation import validate_server_url
@@ -37,7 +38,13 @@ def list_instances() -> str:
                 state._transport_mode == "tcp" and inst.get("url") == state._active_tcp
             )
         else:
-            inst["connected"] = inst["socket"] == state._active_socket
+            # UDS-discovered instances may carry a TCP url too (Windows
+            # enrichment) — either transport counts as connected.
+            inst["connected"] = inst["socket"] == state._active_socket or (
+                state._transport_mode == "tcp"
+                and bool(inst.get("url"))
+                and inst.get("url") == state._active_tcp
+            )
 
     return json.dumps({"instances": instances}, indent=2)
 
@@ -65,8 +72,9 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
     instances = discovery.discover_instances()
 
     # Try UDS instances first
+    match = None
+    matched_tcp_url = None
     if instances:
-        match = None
         for inst in instances:
             if inst.get("project", "") == project:
                 match = inst
@@ -76,7 +84,12 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
                 if project.lower() in inst.get("project", "").lower():
                     match = inst
                     break
-        if match:
+        if match and not transport.uds_supported():
+            # Windows CPython can't dial the socket it just matched; the
+            # discovery enrichment recorded the instance's TCP url — route
+            # the connection there instead of failing the UDS handshake.
+            matched_tcp_url = match.get("url")
+        elif match:
             state._active_socket = match["socket"]
             state._active_tcp = None
             state._transport_mode = "uds"
@@ -112,6 +125,8 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
     # Try TCP fallback. The behavior depends on what UDS discovery returned:
     #
     #   * If GHIDRA_MCP_URL is set, it always wins (explicit user override).
+    #   * If a UDS instance matched but Python can't dial UDS (Windows), use
+    #     the TCP url discovery recorded for that exact instance.
     #   * If UDS found one or more instances with project metadata and none
     #     matched the project, refuse to fall back to TCP -- that's how we
     #     previously silently connected to the wrong instance (Copilot #196
@@ -123,7 +138,9 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
     env_tcp = os.getenv("GHIDRA_MCP_URL")
     if env_tcp:
         tcp_url = env_tcp
-    elif instances and any(inst.get("project") for inst in instances):
+    elif matched_tcp_url:
+        tcp_url = matched_tcp_url
+    elif match is None and instances and any(inst.get("project") for inst in instances):
         # UDS found instances but none matched the requested project. Don't
         # randomly pick another instance's tcp_port — that connects to the
         # wrong project. Return the "no match" error directly.
@@ -155,6 +172,7 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
         state._active_tcp = tcp_url
         state._active_socket = None
         state._transport_mode = "tcp"
+        state._connected_project = match.get("project") if match else None
         count = registry._fetch_and_register_schema()
         total = len(state._full_schema)
         note = (
@@ -484,20 +502,42 @@ def _auto_connect():
     # Try UDS first
     instances = discovery.discover_instances()
     if len(instances) == 1:
-        state._active_socket = instances[0]["socket"]
-        state._transport_mode = "uds"
-        state._connected_project = instances[0].get("project")
-        logger.info(f"Auto-connecting via UDS to {state._connected_project or 'unknown'}")
-        try:
-            count = registry._fetch_and_register_schema()
+        inst = instances[0]
+        if transport.uds_supported():
+            state._active_socket = inst["socket"]
+            state._transport_mode = "uds"
+            state._connected_project = inst.get("project")
+            logger.info(f"Auto-connecting via UDS to {state._connected_project or 'unknown'}")
+            try:
+                count = registry._fetch_and_register_schema()
+                logger.info(
+                    f"Auto-registered {count} tools from {state._connected_project or 'unknown'}"
+                )
+                return
+            except Exception as e:
+                logger.warning(f"UDS auto-connect schema fetch failed: {e}")
+                state._active_socket = None
+                state._transport_mode = "none"
+        elif inst.get("url") and validate_server_url(inst["url"]):
+            # Windows CPython can't dial the discovered socket; discovery
+            # enriched it with the instance's TCP url — connect there.
+            state._active_tcp = inst["url"]
+            state._transport_mode = "tcp"
+            state._connected_project = inst.get("project")
             logger.info(
-                f"Auto-registered {count} tools from {state._connected_project or 'unknown'}"
+                f"Auto-connecting via TCP ({inst['url']}) to "
+                f"{state._connected_project or 'unknown'} (UDS unavailable on this Python)"
             )
-            return
-        except Exception as e:
-            logger.warning(f"UDS auto-connect schema fetch failed: {e}")
-            state._active_socket = None
-            state._transport_mode = "none"
+            try:
+                count = registry._fetch_and_register_schema()
+                logger.info(
+                    f"Auto-registered {count} tools from {state._connected_project or 'unknown'}"
+                )
+                return
+            except Exception as e:
+                logger.warning(f"TCP auto-connect schema fetch failed: {e}")
+                state._active_tcp = None
+                state._transport_mode = "none"
     elif len(instances) > 1:
         names = ", ".join(
             i.get("project") or i.get("socket") or "?" for i in instances

--- a/python/bridge_mcp_ghidra/transport.py
+++ b/python/bridge_mcp_ghidra/transport.py
@@ -33,6 +33,17 @@ class UnixHTTPConnection(http.client.HTTPConnection):
         self.sock.connect(self.socket_path)
 
 
+def uds_supported() -> bool:
+    """Whether this Python can dial Unix domain sockets.
+
+    CPython on Windows doesn't expose socket.AF_UNIX (python/cpython#77589)
+    even though the OS and the Java plugin support them. On such hosts the
+    socket file still marks a live instance, but all traffic must go over
+    the plugin's TCP listener.
+    """
+    return hasattr(socket, "AF_UNIX")
+
+
 def get_socket_dir() -> Path:
     """Get the primary GhidraMCP socket runtime directory.
 
@@ -116,7 +127,41 @@ def get_socket_dir_candidates() -> list[Path]:
     if win_temp:
         _add(Path(win_temp) / f"ghidra-mcp-{user}")
 
+    if os.name == "nt":
+        for candidate in _windows_drive_tmp_candidates(user):
+            _add(candidate)
+
     return candidates
+
+
+def _windows_drive_tmp_candidates(user: str) -> list[Path]:
+    """Backward-compat sweep of every mounted drive for <drive>:\\tmp\\ghidra-mcp-<user>.
+
+    Plugin JARs before the java.io.tmpdir fallback resolved the literal
+    "/tmp" against the JVM's working drive (e.g. F:\\tmp when Ghidra runs
+    from F:), while the bare /tmp candidate resolves against the *bridge's*
+    working drive. Scanning every drive root finds sockets on other drives.
+    Only existing directories are returned so the candidate list isn't
+    flooded with junk paths for every drive letter.
+    """
+    listdrives = getattr(os, "listdrives", None)  # Python 3.12+
+    if callable(listdrives):
+        try:
+            drives = listdrives()
+        except OSError:
+            drives = []
+    else:
+        drives = [f"{letter}:\\" for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+
+    hits: list[Path] = []
+    for drive in drives:
+        candidate = Path(drive) / "tmp" / f"ghidra-mcp-{user}"
+        try:
+            if candidate.exists():
+                hits.append(candidate)
+        except OSError:
+            pass
+    return hits
 
 
 def uds_request(

--- a/src/main/java/com/xebyte/core/ServerManager.java
+++ b/src/main/java/com/xebyte/core/ServerManager.java
@@ -343,11 +343,38 @@ public class ServerManager {
     }
 
     private Path getSocketDir() {
-        String xdg = System.getenv("XDG_RUNTIME_DIR");
-        if (xdg != null && !xdg.isEmpty()) return Path.of(xdg, "ghidra-mcp");
-        String tmpdir = System.getenv("TMPDIR");
-        String user = System.getProperty("user.name", "unknown");
-        if (tmpdir != null && !tmpdir.isEmpty()) return Path.of(tmpdir, "ghidra-mcp-" + user);
+        return resolveSocketDir(
+            System.getenv("XDG_RUNTIME_DIR"),
+            System.getenv("TMPDIR"),
+            System.getProperty("java.io.tmpdir"),
+            System.getProperty("user.name", "unknown"));
+    }
+
+    /**
+     * Resolve the UDS socket directory: XDG_RUNTIME_DIR, then TMPDIR, then
+     * java.io.tmpdir, then literal /tmp.
+     *
+     * The java.io.tmpdir step matters on Windows, where TMPDIR is unset and
+     * the literal "/tmp" is drive-relative: it resolves against the JVM's
+     * working drive (e.g. F:\tmp when Ghidra runs from F:), which a bridge
+     * running from another drive never scans. java.io.tmpdir honors %TEMP%,
+     * giving both sides the same absolute location; the Python side lists
+     * %TEMP%\ghidra-mcp-&lt;user&gt; among its discovery candidates.
+     */
+    public static Path resolveSocketDir(String xdgRuntimeDir, String tmpdirEnv,
+            String javaIoTmpdir, String user) {
+        if (xdgRuntimeDir != null && !xdgRuntimeDir.isEmpty()) {
+            return Path.of(xdgRuntimeDir, "ghidra-mcp");
+        }
+        if (user == null || user.isEmpty()) {
+            user = "unknown";
+        }
+        if (tmpdirEnv != null && !tmpdirEnv.isEmpty()) {
+            return Path.of(tmpdirEnv, "ghidra-mcp-" + user);
+        }
+        if (javaIoTmpdir != null && !javaIoTmpdir.isEmpty()) {
+            return Path.of(javaIoTmpdir, "ghidra-mcp-" + user);
+        }
         return Path.of("/tmp", "ghidra-mcp-" + user);
     }
 

--- a/src/test/java/com/xebyte/offline/ServerManagerSocketDirTest.java
+++ b/src/test/java/com/xebyte/offline/ServerManagerSocketDirTest.java
@@ -1,0 +1,64 @@
+package com.xebyte.offline;
+
+import java.nio.file.Path;
+
+import com.xebyte.core.ServerManager;
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for ServerManager.resolveSocketDir — the UDS socket directory
+ * resolution order: XDG_RUNTIME_DIR → TMPDIR → java.io.tmpdir → /tmp.
+ *
+ * The java.io.tmpdir step is the cross-drive Windows fix: TMPDIR is unset on
+ * Windows and the literal "/tmp" is drive-relative (F:\tmp when Ghidra runs
+ * from F:), which a bridge running from another drive never scans.
+ * java.io.tmpdir honors %TEMP%, an absolute path both sides agree on.
+ *
+ * Pure-logic test, no Ghidra runtime required.
+ */
+public class ServerManagerSocketDirTest extends TestCase {
+
+    public void testXdgRuntimeDirWins() {
+        Path dir = ServerManager.resolveSocketDir(
+            "/run/user/1000", "/custom/tmp", "/java/tmp", "alice");
+        assertEquals(Path.of("/run/user/1000", "ghidra-mcp"), dir);
+    }
+
+    public void testTmpdirEnvBeatsJavaIoTmpdir() {
+        Path dir = ServerManager.resolveSocketDir(
+            null, "/custom/tmp", "/java/tmp", "alice");
+        assertEquals(Path.of("/custom/tmp", "ghidra-mcp-alice"), dir);
+    }
+
+    public void testJavaIoTmpdirUsedWhenTmpdirUnset() {
+        // The Windows case: XDG_RUNTIME_DIR and TMPDIR both unset,
+        // java.io.tmpdir = %TEMP%. Must NOT fall through to the
+        // drive-relative "/tmp" literal.
+        Path dir = ServerManager.resolveSocketDir(
+            null, null, "C:\\Users\\alice\\AppData\\Local\\Temp", "alice");
+        assertEquals(
+            Path.of("C:\\Users\\alice\\AppData\\Local\\Temp", "ghidra-mcp-alice"),
+            dir);
+    }
+
+    public void testEmptyStringsTreatedAsUnset() {
+        Path dir = ServerManager.resolveSocketDir("", "", "/java/tmp", "alice");
+        assertEquals(Path.of("/java/tmp", "ghidra-mcp-alice"), dir);
+    }
+
+    public void testTmpLiteralIsLastResort() {
+        Path dir = ServerManager.resolveSocketDir(null, null, null, "alice");
+        assertEquals(Path.of("/tmp", "ghidra-mcp-alice"), dir);
+
+        Path dirEmpty = ServerManager.resolveSocketDir(null, null, "", "alice");
+        assertEquals(Path.of("/tmp", "ghidra-mcp-alice"), dirEmpty);
+    }
+
+    public void testNullOrEmptyUserFallsBackToUnknown() {
+        Path dirNull = ServerManager.resolveSocketDir(null, null, "/java/tmp", null);
+        assertEquals(Path.of("/java/tmp", "ghidra-mcp-unknown"), dirNull);
+
+        Path dirEmpty = ServerManager.resolveSocketDir(null, null, "/java/tmp", "");
+        assertEquals(Path.of("/java/tmp", "ghidra-mcp-unknown"), dirEmpty);
+    }
+}

--- a/tests/unit/test_bridge_cli.py
+++ b/tests/unit/test_bridge_cli.py
@@ -1,0 +1,142 @@
+"""Tests for the bridge CLI entry point (python/bridge_mcp_ghidra/cli.py).
+
+cli.py was at 14% coverage: argument parsing, lazy-mode/default-group wiring,
+and the DNS-rebinding-protection matrix were exercised only manually. These
+tests drive main() with mcp.run and _auto_connect patched out, then assert
+the settings that would have governed the real server.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from bridge_mcp_ghidra import cli, state  # noqa: E402
+from bridge_mcp_ghidra.server import mcp  # noqa: E402
+
+
+class _CliHarness(unittest.TestCase):
+    """Run cli.main() with side effects stubbed; restore shared state after."""
+
+    def setUp(self):
+        self._saved_lazy = state._lazy_mode
+        self._saved_groups = set(state._default_groups)
+        self._saved_security = getattr(mcp.settings, "transport_security", None)
+        self._saved_host = mcp.settings.host
+        self._saved_port = mcp.settings.port
+
+    def tearDown(self):
+        state._lazy_mode = self._saved_lazy
+        state._default_groups = self._saved_groups
+        mcp.settings.transport_security = self._saved_security
+        mcp.settings.host = self._saved_host
+        mcp.settings.port = self._saved_port
+
+    def run_main(self, *argv, env=None):
+        """Invoke cli.main() with the given argv; returns the mcp.run mock."""
+        patches = [
+            patch.object(sys, "argv", ["bridge-mcp-ghidra", *argv]),
+            patch.object(cli, "_auto_connect"),
+            patch.object(mcp, "run"),
+        ]
+        if env:
+            import os
+
+            patches.append(patch.dict(os.environ, env))
+        started = []
+        for p in patches:
+            started.append(p.start())
+        try:
+            cli.main()
+            return started[2]  # the mcp.run mock
+        finally:
+            for p in patches:
+                p.stop()
+
+
+class TestCliArguments(_CliHarness):
+    def test_defaults_stdio_and_eager_loading(self):
+        run = self.run_main()
+        run.assert_called_once_with(transport="stdio")
+        self.assertFalse(state._lazy_mode)
+
+    def test_lazy_flag_sets_lazy_mode(self):
+        self.run_main("--lazy")
+        self.assertTrue(state._lazy_mode)
+
+    def test_no_lazy_overrides_lazy(self):
+        self.run_main("--lazy", "--no-lazy")
+        self.assertFalse(state._lazy_mode)
+
+    def test_default_groups_parsed_and_stripped(self):
+        self.run_main("--default-groups", " function , datatype ,")
+        self.assertEqual(state._default_groups, {"function", "datatype"})
+
+    def test_transport_and_port_applied(self):
+        run = self.run_main("--transport", "streamable-http", "--mcp-port", "9905")
+        run.assert_called_once_with(transport="streamable-http")
+        self.assertEqual(mcp.settings.port, 9905)
+
+    def test_invalid_transport_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.run_main("--transport", "carrier-pigeon")
+
+
+class TestCliRebindProtection(_CliHarness):
+    def test_loopback_host_leaves_security_untouched(self):
+        sentinel = object()
+        mcp.settings.transport_security = sentinel
+        self.run_main("--mcp-host", "127.0.0.1")
+        self.assertIs(mcp.settings.transport_security, sentinel)
+
+    def test_specific_remote_host_enables_protection(self):
+        self.run_main("--mcp-host", "192.168.1.50")
+        sec = mcp.settings.transport_security
+        self.assertTrue(sec.enable_dns_rebinding_protection)
+        self.assertIn("192.168.1.50:*", sec.allowed_hosts)
+        self.assertIn("localhost:*", sec.allowed_hosts)
+
+    def test_wildcard_bind_keeps_protection_on(self):
+        """0.0.0.0 is the most exposed configuration — protection must stay
+        ON with the machine's real hostnames allowed (the old behavior of
+        disabling protection entirely was the vulnerability)."""
+        self.run_main("--mcp-host", "0.0.0.0")
+        sec = mcp.settings.transport_security
+        self.assertTrue(sec.enable_dns_rebinding_protection)
+        self.assertIn("localhost:*", sec.allowed_hosts)
+        self.assertIn("127.0.0.1:*", sec.allowed_hosts)
+
+    def test_wildcard_bind_extra_hosts_from_env(self):
+        self.run_main(
+            "--mcp-host", "0.0.0.0",
+            env={"GHIDRA_MCP_ALLOWED_HOSTS": "re-lab.internal, bench01"},
+        )
+        sec = mcp.settings.transport_security
+        self.assertIn("re-lab.internal:*", sec.allowed_hosts)
+        self.assertIn("bench01:*", sec.allowed_hosts)
+
+    def test_wildcard_bind_explicit_optout_disables_protection(self):
+        self.run_main(
+            "--mcp-host", "0.0.0.0",
+            env={"GHIDRA_MCP_DISABLE_REBIND_PROTECTION": "1"},
+        )
+        sec = mcp.settings.transport_security
+        self.assertFalse(sec.enable_dns_rebinding_protection)
+
+
+class TestWildcardAllowedHosts(unittest.TestCase):
+    def test_includes_loopbacks_with_port_wildcards(self):
+        hosts = cli._wildcard_allowed_hosts()
+        self.assertIn("localhost:*", hosts)
+        self.assertIn("127.0.0.1:*", hosts)
+
+    def test_ipv6_literals_get_bracketed_forms(self):
+        hosts = cli._wildcard_allowed_hosts()
+        self.assertIn("::1:*", hosts)
+        self.assertIn("[::1]:*", hosts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_bridge_utils.py
+++ b/tests/unit/test_bridge_utils.py
@@ -176,6 +176,16 @@ class TestTcpPortScan(unittest.TestCase):
 class TestConnectInstanceTcpFallback(unittest.TestCase):
     """Test connect_instance project matching across UDS and TCP discovery."""
 
+    def tearDown(self):
+        # connect_instance mutates global connection state; reset it so
+        # later tests (e.g. TestDispatchErrors) see a disconnected bridge.
+        import bridge_mcp_ghidra as bridge
+
+        bridge.state._active_socket = None
+        bridge.state._active_tcp = None
+        bridge.state._transport_mode = "none"
+        bridge.state._connected_project = None
+
     def test_projectless_uds_instances_fall_back_to_tcp_scan(self):
         import bridge_mcp_ghidra as bridge
 
@@ -218,6 +228,193 @@ class TestConnectInstanceTcpFallback(unittest.TestCase):
         self.assertIn("No instance matching 'wanted'", data["error"])
         self.assertEqual(data["available"], ["other", "also_other"])
         scan.assert_not_called()
+
+    def test_uds_match_connects_via_uds_when_supported(self):
+        import bridge_mcp_ghidra as bridge
+
+        instances = [{"socket": "/tmp/ghidra-123.sock", "pid": 123, "project": "wanted"}]
+
+        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
+             patch.object(bridge.transport, "uds_supported", return_value=True), \
+             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0):
+            bridge.state._full_schema = []
+            bridge.state._loaded_groups.clear()
+
+            result = asyncio.run(bridge.connect_instance("wanted"))
+
+        data = json.loads(result)
+        self.assertTrue(data["connected"])
+        self.assertEqual(data["transport"], "uds")
+        self.assertEqual(data["socket"], "/tmp/ghidra-123.sock")
+
+    def test_windows_uds_match_routes_via_enriched_tcp_url(self):
+        """Windows CPython can't dial the socket it matched — the connection
+        must go to the TCP url discovery recorded for that exact instance,
+        with no port scan (the scan could pick a different instance)."""
+        import bridge_mcp_ghidra as bridge
+
+        instances = [{
+            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+            "pid": 9020,
+            "project": "diablo2",
+            "url": "http://127.0.0.1:8089",
+        }]
+
+        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
+             patch.object(bridge.transport, "uds_supported", return_value=False), \
+             patch.object(bridge.discovery, "_scan_tcp_for_project") as scan, \
+             patch.object(bridge.static_tools, "validate_server_url", return_value=True), \
+             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0), \
+             patch.object(bridge.static_tools, "os") as mock_os:
+            mock_os.getenv.return_value = None
+            bridge.state._full_schema = []
+            bridge.state._loaded_groups.clear()
+
+            result = asyncio.run(bridge.connect_instance("diablo2"))
+
+        data = json.loads(result)
+        self.assertTrue(data["connected"])
+        self.assertEqual(data["transport"], "tcp")
+        self.assertEqual(data["url"], "http://127.0.0.1:8089")
+        self.assertEqual(bridge.state._connected_project, "diablo2")
+        scan.assert_not_called()
+
+    def test_windows_uds_match_without_url_falls_back_to_scan(self):
+        """Matched instance but TCP enrichment found no port for it (e.g.
+        bound outside the scan range) — fall back to the project-name scan
+        rather than refusing outright."""
+        import bridge_mcp_ghidra as bridge
+
+        instances = [{
+            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+            "pid": 9020,
+            "project": "diablo2",
+        }]
+
+        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
+             patch.object(bridge.transport, "uds_supported", return_value=False), \
+             patch.object(bridge.discovery, "_scan_tcp_for_project",
+                          return_value="http://127.0.0.1:8093") as scan, \
+             patch.object(bridge.static_tools, "validate_server_url", return_value=True), \
+             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0), \
+             patch.object(bridge.static_tools, "os") as mock_os:
+            mock_os.getenv.return_value = None
+            bridge.state._full_schema = []
+            bridge.state._loaded_groups.clear()
+
+            result = asyncio.run(bridge.connect_instance("diablo2"))
+
+        data = json.loads(result)
+        self.assertTrue(data["connected"])
+        self.assertEqual(data["transport"], "tcp")
+        self.assertEqual(data["url"], "http://127.0.0.1:8093")
+        scan.assert_called_once_with("diablo2")
+
+
+class TestAutoConnectWindowsTcp(unittest.TestCase):
+    """_auto_connect with a single discovered instance on a host without
+    AF_UNIX must connect over the instance's enriched TCP url instead of
+    attempting (and failing) a UDS schema fetch."""
+
+    def tearDown(self):
+        import bridge_mcp_ghidra as bridge
+
+        bridge.state._active_socket = None
+        bridge.state._active_tcp = None
+        bridge.state._transport_mode = "none"
+        bridge.state._connected_project = None
+
+    def test_single_instance_auto_connects_via_enriched_url(self):
+        import bridge_mcp_ghidra as bridge
+
+        one = [{
+            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+            "pid": 9020,
+            "project": "diablo2",
+            "url": "http://127.0.0.1:8089",
+        }]
+        with patch.object(bridge.discovery, "discover_instances", return_value=one), \
+             patch.object(bridge.transport, "uds_supported", return_value=False), \
+             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=7):
+            bridge.state._active_socket = None
+            bridge.state._active_tcp = None
+            bridge.state._transport_mode = "none"
+
+            bridge._auto_connect()
+
+        self.assertEqual(bridge.state._transport_mode, "tcp")
+        self.assertEqual(bridge.state._active_tcp, "http://127.0.0.1:8089")
+        self.assertEqual(bridge.state._connected_project, "diablo2")
+        self.assertIsNone(bridge.state._active_socket)
+
+
+class TestTryReconnectTransportRouting(unittest.TestCase):
+    """dispatch._try_reconnect (the post-Ghidra-restart recovery path) must
+    route by transport capability: UDS when this Python can dial it, the
+    instance's enriched TCP url when it can't (Windows CPython), and give up
+    cleanly when neither is possible."""
+
+    def setUp(self):
+        import bridge_mcp_ghidra as bridge
+
+        bridge.state._active_socket = None
+        bridge.state._active_tcp = None
+        bridge.state._transport_mode = "none"
+        bridge.state._connected_project = "diablo2"
+
+    def tearDown(self):
+        import bridge_mcp_ghidra as bridge
+
+        bridge.state._active_socket = None
+        bridge.state._active_tcp = None
+        bridge.state._transport_mode = "none"
+        bridge.state._connected_project = None
+
+    def _instance(self, **extra):
+        return {
+            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+            "pid": 9020,
+            "project": "diablo2",
+            **extra,
+        }
+
+    def test_reconnects_via_uds_when_supported(self):
+        import bridge_mcp_ghidra as bridge
+
+        inst = self._instance(url="http://127.0.0.1:8089")
+        with patch.object(bridge.discovery, "discover_instances", return_value=[inst]), \
+             patch.object(bridge.transport, "uds_supported", return_value=True), \
+             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0):
+            self.assertTrue(bridge.dispatch._try_reconnect())
+
+        self.assertEqual(bridge.state._transport_mode, "uds")
+        self.assertEqual(bridge.state._active_socket, inst["socket"])
+        self.assertIsNone(bridge.state._active_tcp)
+
+    def test_reconnects_via_tcp_url_when_uds_unsupported(self):
+        import bridge_mcp_ghidra as bridge
+
+        inst = self._instance(url="http://127.0.0.1:8089")
+        with patch.object(bridge.discovery, "discover_instances", return_value=[inst]), \
+             patch.object(bridge.transport, "uds_supported", return_value=False), \
+             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0):
+            self.assertTrue(bridge.dispatch._try_reconnect())
+
+        self.assertEqual(bridge.state._transport_mode, "tcp")
+        self.assertEqual(bridge.state._active_tcp, "http://127.0.0.1:8089")
+        self.assertIsNone(bridge.state._active_socket)
+
+    def test_gives_up_when_uds_unsupported_and_no_url(self):
+        import bridge_mcp_ghidra as bridge
+
+        inst = self._instance()  # no url — TCP enrichment found nothing
+        with patch.object(bridge.discovery, "discover_instances", return_value=[inst]), \
+             patch.object(bridge.transport, "uds_supported", return_value=False), \
+             patch.object(bridge.registry, "_fetch_and_register_schema") as fetch:
+            self.assertFalse(bridge.dispatch._try_reconnect())
+
+        fetch.assert_not_called()
+        self.assertEqual(bridge.state._transport_mode, "none")
 
 
 class TestGetSocketDirCandidates(unittest.TestCase):
@@ -341,6 +538,64 @@ class TestGetSocketDirCandidates(unittest.TestCase):
                 f"old one-level glob must not match: {candidates}",
             )
 
+    def test_windows_drive_sweep_finds_cross_drive_socket(self):
+        """Backward-compat: plugin JARs without the java.io.tmpdir fallback
+        resolved the literal "/tmp" against the JVM's working drive (e.g.
+        F:\\tmp when Ghidra runs from F:). The mounted-drive sweep must
+        return a socket dir at <other-drive>:\\tmp\\ghidra-mcp-<user> and
+        exclude drive roots where the dir doesn't exist (exists-gated, so
+        the candidate list isn't flooded with 26 junk paths)."""
+        from bridge_mcp_ghidra import transport
+
+        cross_drive_dir = Path("F:\\") / "tmp" / "ghidra-mcp-testuser"
+        same_drive_dir = Path("C:\\") / "tmp" / "ghidra-mcp-testuser"
+        orig_exists = Path.exists
+
+        def fake_exists(self):
+            if self == cross_drive_dir:
+                return True
+            if self == same_drive_dir:
+                return False
+            return orig_exists(self)
+
+        with patch.object(os, "listdrives", create=True,
+                          return_value=["C:\\", "F:\\"]), \
+             patch.object(Path, "exists", fake_exists):
+            hits = transport._windows_drive_tmp_candidates("testuser")
+
+        self.assertIn(
+            cross_drive_dir, hits,
+            f"cross-drive socket dir missing: {hits}",
+        )
+        self.assertNotIn(
+            same_drive_dir, hits,
+            f"nonexistent drive-sweep dir must be excluded: {hits}",
+        )
+
+    @unittest.skipUnless(os.name == "nt", "drive sweep only wired on Windows")
+    def test_windows_candidates_include_drive_sweep_hits(self):
+        """On Windows, get_socket_dir_candidates() must include whatever
+        the drive sweep found."""
+        from bridge_mcp_ghidra import transport
+
+        sweep_hit = Path("Q:\\") / "tmp" / "ghidra-mcp-testuser"
+        with patch.object(transport, "_windows_drive_tmp_candidates",
+                          return_value=[sweep_hit]) as sweep:
+            candidates = transport.get_socket_dir_candidates()
+        sweep.assert_called_once()
+        self.assertIn(sweep_hit, candidates)
+
+    @unittest.skipUnless(os.name != "nt", "POSIX-only negative check")
+    def test_posix_does_not_probe_drive_letters(self):
+        """The drive sweep is Windows-only: on POSIX the helper must never
+        be consulted."""
+        from bridge_mcp_ghidra import transport
+
+        with patch.object(transport, "_windows_drive_tmp_candidates",
+                          return_value=[]) as sweep:
+            transport.get_socket_dir_candidates()
+        sweep.assert_not_called()
+
     def test_macos_private_var_folders_also_covered(self):
         """macOS symlinks /var → /private/var. If the resolved socket
         appears under /private/var/folders/.../T/ghidra-mcp-<user>, the
@@ -403,10 +658,14 @@ class TestDiscoverInstancesMultiDir(unittest.TestCase):
             import bridge_mcp_ghidra as bridge
 
             # Patch both `get_socket_dir_candidates` and the UDS info query so
-            # the test doesn't actually try to connect.
+            # the test doesn't actually try to connect. Pin uds_supported to
+            # True so the UDS query path runs even on Windows CPython (which
+            # lacks AF_UNIX and would otherwise take the TCP enrichment path).
             with patch.object(
                 bridge.transport, "get_socket_dir_candidates",
                 return_value=[Path(d1), Path(d2)],
+            ), patch.object(
+                bridge.transport, "uds_supported", return_value=True,
             ), patch.object(
                 bridge.transport, "uds_request",
                 return_value=("{}", 500),  # info query fails — that's fine
@@ -438,6 +697,8 @@ class TestDiscoverInstancesMultiDir(unittest.TestCase):
                 bridge.transport, "get_socket_dir_candidates",
                 return_value=[Path(d), Path(d)],  # same dir twice
             ), patch.object(
+                bridge.transport, "uds_supported", return_value=True,
+            ), patch.object(
                 bridge.transport, "uds_request",
                 return_value=("{}", 500),
             ), patch.object(
@@ -447,6 +708,107 @@ class TestDiscoverInstancesMultiDir(unittest.TestCase):
                 instances = discover_instances()
 
             self.assertEqual(len(instances), 1)
+
+
+class TestDiscoverInstancesWindowsTcpEnrichment(unittest.TestCase):
+    """On hosts where Python can't dial UDS (Windows CPython lacks AF_UNIX,
+    python/cpython#77589), discover_instances must enrich socket-file hits
+    with metadata fetched over the plugin's TCP listener, joined by PID —
+    otherwise list_instances shows projectless entries and connect_instance
+    can't match by project name."""
+
+    def test_enriches_by_pid_when_uds_unsupported(self):
+        import tempfile
+        import bridge_mcp_ghidra as bridge
+
+        with tempfile.TemporaryDirectory() as d:
+            pid_alive = os.getpid()
+            (Path(d) / f"ghidra-{pid_alive}.sock").touch()
+
+            tcp_info = {
+                pid_alive: {
+                    "url": "http://127.0.0.1:8089",
+                    "pid": pid_alive,
+                    "project": "diablo2",
+                }
+            }
+            with patch.object(
+                bridge.transport, "get_socket_dir_candidates",
+                return_value=[Path(d)],
+            ), patch.object(
+                bridge.transport, "uds_supported", return_value=False,
+            ), patch.object(
+                bridge.transport, "uds_request",
+            ) as uds_req, patch.object(
+                bridge.discovery, "_tcp_instances_by_pid", return_value=tcp_info,
+            ), patch.object(
+                bridge.validation, "is_pid_alive",
+                side_effect=lambda p: p == pid_alive,
+            ):
+                instances = bridge.discover_instances()
+
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0]["project"], "diablo2")
+        self.assertEqual(instances[0]["url"], "http://127.0.0.1:8089")
+        self.assertEqual(instances[0]["pid"], pid_alive)
+        uds_req.assert_not_called()
+
+    def test_no_tcp_scan_when_uds_supported(self):
+        """When AF_UNIX works, discovery must query over UDS and never pay
+        for a TCP port scan."""
+        import tempfile
+        import bridge_mcp_ghidra as bridge
+
+        with tempfile.TemporaryDirectory() as d:
+            pid_alive = os.getpid()
+            (Path(d) / f"ghidra-{pid_alive}.sock").touch()
+
+            with patch.object(
+                bridge.transport, "get_socket_dir_candidates",
+                return_value=[Path(d)],
+            ), patch.object(
+                bridge.transport, "uds_supported", return_value=True,
+            ), patch.object(
+                bridge.transport, "uds_request",
+                return_value=(json.dumps({"project": "diablo2"}), 200),
+            ), patch.object(
+                bridge.discovery, "_tcp_instances_by_pid",
+            ) as tcp_scan, patch.object(
+                bridge.validation, "is_pid_alive",
+                side_effect=lambda p: p == pid_alive,
+            ):
+                instances = bridge.discover_instances()
+
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0]["project"], "diablo2")
+        tcp_scan.assert_not_called()
+
+    def test_unenriched_when_pid_not_in_tcp_scan(self):
+        """A socket whose PID has no TCP responder stays a bare
+        {socket, pid} record — discovery must not crash or misattribute."""
+        import tempfile
+        import bridge_mcp_ghidra as bridge
+
+        with tempfile.TemporaryDirectory() as d:
+            pid_alive = os.getpid()
+            (Path(d) / f"ghidra-{pid_alive}.sock").touch()
+
+            with patch.object(
+                bridge.transport, "get_socket_dir_candidates",
+                return_value=[Path(d)],
+            ), patch.object(
+                bridge.transport, "uds_supported", return_value=False,
+            ), patch.object(
+                bridge.discovery, "_tcp_instances_by_pid", return_value={},
+            ), patch.object(
+                bridge.validation, "is_pid_alive",
+                side_effect=lambda p: p == pid_alive,
+            ):
+                instances = bridge.discover_instances()
+
+        self.assertEqual(len(instances), 1)
+        self.assertNotIn("project", instances[0])
+        self.assertNotIn("url", instances[0])
 
 
 class TestAutoConnectMultiInstance(unittest.TestCase):

--- a/tests/unit/test_transport_network.py
+++ b/tests/unit/test_transport_network.py
@@ -1,0 +1,284 @@
+"""Exercise the bridge's real network code paths against live local servers.
+
+Historically transport.py/dispatch.py were tested only through mocks, which
+left the actual socket/HTTP code (uds_request, tcp_request, do_request, the
+dispatch retry ladder) at ~50% coverage — precisely the code that talks to
+Ghidra. These tests run the real request path end-to-end:
+
+* TCP: a ThreadingHTTPServer on 127.0.0.1:<ephemeral>.
+* UDS: the same handler served over a real AF_UNIX socket (POSIX runners;
+  Windows CPython has no AF_UNIX — see transport.uds_supported()).
+
+No Ghidra required; everything binds loopback/tmp and tears down per class.
+"""
+
+import http.server
+import json
+import os
+import socket
+import socketserver
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import bridge_mcp_ghidra as bridge  # noqa: E402
+from bridge_mcp_ghidra import dispatch, state, transport  # noqa: E402
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    """Tiny scriptable endpoint set shared by the TCP and UDS servers."""
+
+    def _reply(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler API
+        self.server.hits.setdefault(self.path.split("?")[0], 0)
+        self.server.hits[self.path.split("?")[0]] += 1
+        if self.path.startswith("/ok"):
+            self._reply(200, {"ok": True, "path": self.path})
+        elif self.path.startswith("/flaky"):
+            # 500 twice, then 200 — drives the dispatch_get retry ladder.
+            if self.server.hits["/flaky"] <= 2:
+                self._reply(500, {"error": "transient"})
+            else:
+                self._reply(200, {"ok": True, "recovered": True})
+        elif self.path.startswith("/boom"):
+            self._reply(500, {"error": "permanent"})
+        else:
+            self._reply(404, {"error": "not found"})
+
+    def do_POST(self):  # noqa: N802
+        self.server.hits.setdefault(self.path.split("?")[0], 0)
+        self.server.hits[self.path.split("?")[0]] += 1
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length).decode("utf-8") if length else ""
+        if self.path.startswith("/echo"):
+            self._reply(200, {
+                "content_type": self.headers.get("Content-Type"),
+                "received": json.loads(raw) if raw else None,
+                "path": self.path,
+            })
+        elif self.path.startswith("/boom"):
+            self._reply(500, {"error": "write failed"})
+        else:
+            self._reply(404, {"error": "not found"})
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+    def address_string(self):
+        # AF_UNIX client_address is b''/'' — BaseHTTPRequestHandler's
+        # default implementation would crash indexing it.
+        return "local"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _TcpServerMixin:
+    """Start/stop a real HTTP server; expose base_url + hit counters."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        cls.server.hits = {}
+        cls.base_url = f"http://127.0.0.1:{cls.server.server_address[1]}"
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def setUp(self):
+        self.server.hits.clear()
+
+
+class TestTcpRequest(_TcpServerMixin, unittest.TestCase):
+    """transport.tcp_request over a real socket."""
+
+    def test_get_returns_body_and_status(self):
+        text, status = transport.tcp_request(self.base_url, "GET", "/ok")
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(text)["ok"])
+
+    def test_get_encodes_query_params(self):
+        text, _ = transport.tcp_request(
+            self.base_url, "GET", "ok", params={"program": "D2Common.dll", "n": 5}
+        )
+        path = json.loads(text)["path"]
+        self.assertIn("program=D2Common.dll", path)
+        self.assertIn("n=5", path)
+        # Endpoint without a leading slash must be normalized to one.
+        self.assertTrue(path.startswith("/ok?"))
+
+    def test_post_sends_json_content_type_and_body(self):
+        payload = {"address": "0x6fd50000", "name": "GetUnitPosition"}
+        text, status = transport.tcp_request(
+            self.base_url, "POST", "/echo", json_data=payload
+        )
+        self.assertEqual(status, 200)
+        data = json.loads(text)
+        self.assertEqual(data["content_type"], "application/json")
+        self.assertEqual(data["received"], payload)
+
+    def test_non_200_is_returned_not_raised(self):
+        text, status = transport.tcp_request(self.base_url, "GET", "/boom")
+        self.assertEqual(status, 500)
+        self.assertIn("permanent", text)
+
+    def test_connection_refused_raises(self):
+        dead_url = f"http://127.0.0.1:{_free_port()}"
+        with self.assertRaises(OSError):
+            transport.tcp_request(dead_url, "GET", "/ok", timeout=2)
+
+
+class TestDoRequestRouting(_TcpServerMixin, unittest.TestCase):
+    """transport.do_request routes by state and refuses when disconnected."""
+
+    def tearDown(self):
+        state._active_tcp = None
+        state._active_socket = None
+        state._transport_mode = "none"
+
+    def test_routes_to_tcp_when_active(self):
+        state._transport_mode = "tcp"
+        state._active_tcp = self.base_url
+        text, status = transport.do_request("GET", "/ok")
+        self.assertEqual(status, 200)
+
+    def test_raises_connection_error_when_disconnected(self):
+        state._transport_mode = "none"
+        with self.assertRaises(ConnectionError):
+            transport.do_request("GET", "/ok")
+
+
+class TestDispatchAgainstLiveServer(_TcpServerMixin, unittest.TestCase):
+    """The dispatch retry ladder, driven through a real server."""
+
+    def setUp(self):
+        super().setUp()
+        state._transport_mode = "tcp"
+        state._active_tcp = self.base_url
+        state._connected_project = None
+
+    def tearDown(self):
+        state._active_tcp = None
+        state._transport_mode = "none"
+        state._connected_project = None
+
+    def test_get_success_returns_raw_text(self):
+        text = dispatch.dispatch_get("/ok")
+        self.assertTrue(json.loads(text)["ok"])
+
+    def test_get_retries_5xx_until_success(self):
+        # /flaky returns 500 twice then 200; the backoff sleep is patched out
+        # so the test doesn't pay 1s+2s of wall clock.
+        with patch.object(dispatch.time, "sleep"):
+            text = dispatch.dispatch_get("/flaky", retries=3)
+        self.assertTrue(json.loads(text).get("recovered"))
+        self.assertEqual(self.server.hits["/flaky"], 3)
+
+    def test_get_exhausted_retries_surface_http_error(self):
+        with patch.object(dispatch.time, "sleep"):
+            text = dispatch.dispatch_get("/boom", retries=2)
+        self.assertIn("HTTP 500", json.loads(text)["error"])
+        self.assertEqual(self.server.hits["/boom"], 2)
+
+    def test_get_non_retryable_status_returned_immediately(self):
+        text = dispatch.dispatch_get("/missing")
+        self.assertIn("HTTP 404", json.loads(text)["error"])
+        self.assertEqual(self.server.hits["/missing"], 1)
+
+    def test_post_success(self):
+        text = dispatch.dispatch_post("/echo", {"k": "v"})
+        self.assertEqual(json.loads(text)["received"], {"k": "v"})
+
+    def test_post_5xx_is_never_retried(self):
+        # Writes are non-idempotent: a 500 must surface after exactly ONE
+        # request — re-sending could double-apply the write.
+        text = dispatch.dispatch_post("/boom", {"k": "v"})
+        self.assertIn("HTTP 500", json.loads(text)["error"])
+        self.assertEqual(self.server.hits["/boom"], 1)
+
+    def test_post_sends_query_params_separately_from_body(self):
+        # The @Param(value="program") QUERY convention: program rides the
+        # URL, never the JSON body.
+        text = dispatch.dispatch_post(
+            "/echo", {"name": "x"}, query_params={"program": "D2Game.dll"}
+        )
+        data = json.loads(text)
+        self.assertIn("program=D2Game.dll", data["path"])
+        self.assertEqual(data["received"], {"name": "x"})
+
+
+@unittest.skipUnless(hasattr(socket, "AF_UNIX"), "AF_UNIX not available (Windows CPython)")
+class TestUdsRequest(unittest.TestCase):
+    """transport.uds_request against a real Unix-domain-socket HTTP server.
+
+    Runs on the POSIX CI leg — this is the transport the macOS/Linux bridge
+    actually uses in production, previously covered only by mocks.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import tempfile
+
+        cls._tmpdir = tempfile.TemporaryDirectory()
+        cls.socket_path = str(Path(cls._tmpdir.name) / "ghidra-test.sock")
+
+        class UdsHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+            address_family = socket.AF_UNIX
+
+            def server_bind(self):
+                # HTTPServer.server_bind derives server_name/port from an
+                # (ip, port) tuple; a UDS address is a plain path string.
+                socketserver.TCPServer.server_bind(self)
+                self.server_name = "uds"
+                self.server_port = 0
+
+        cls.server = UdsHTTPServer(cls.socket_path, _Handler)
+        cls.server.hits = {}
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls._tmpdir.cleanup()
+
+    def test_get_round_trip(self):
+        text, status = transport.uds_request(self.socket_path, "GET", "/ok")
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(text)["ok"])
+
+    def test_post_json_round_trip(self):
+        text, status = transport.uds_request(
+            self.socket_path, "POST", "/echo", json_data={"a": 1}
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(text)["received"], {"a": 1})
+
+    def test_missing_socket_raises(self):
+        with self.assertRaises(OSError):
+            transport.uds_request(
+                str(Path(self._tmpdir.name) / "nope.sock"), "GET", "/ok", timeout=2
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

On Windows the plugin's socket-dir fallback resolved against the JVM working
drive (`F:\tmp` when Ghidra ran from `F:`) while the bridge scanned its own
drive's `\tmp`, so `list_instances` always reported "No running Ghidra
instances" and the bridge never auto-reconnected after a Ghidra restart.

## Fix (three parts)

- **Plugin:** `ServerManager.getSocketDir()` falls back to `java.io.tmpdir`
  (honors `%TEMP%`) before literal `/tmp`, so both sides agree on an absolute path.
- **Bridge:** `get_socket_dir_candidates()` sweeps every mounted drive root for
  `<drive>:\tmp\ghidra-mcp-<user>` (compat with older JARs).
- **Bridge:** Windows CPython lacks `socket.AF_UNIX` (cpython#77589), so discovery
  enriches socket-file hits with project/programs/url over the plugin's TCP
  listener (joined by PID), and connect / auto-connect / reconnect route over
  that TCP url instead of failing the UDS handshake.

## Verification

- Full Python unit suite on **windows-latest CPython**: **480 passed, 0 failed,
  7 skipped** (skips are POSIX/AF_UNIX-only paths — the Windows half this fix
  targets runs green).
- Includes new `test_transport_network.py` (real local HTTP + Unix-socket
  servers, POST-never-retries contract) and `test_bridge_cli.py` (arg wiring +
  DNS-rebinding matrix).
- **Note:** `ServerManagerSocketDirTest.java` (plugin fallback) was **not** run
  locally (no Maven on this machine) — it will be exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
