### PR TITLE
feat(conformance): in-process oracle + fun-doc conformance workbench

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,19 @@ MCP server bridging Ghidra reverse engineering with AI tools. 256 MCP tools for 
 
 The marginal cost of completeness is near zero with AI. Do the whole thing. Do it right. Do it with tests. Do it with documentation. Do it so well that Ben is genuinely impressed — not politely satisfied, actually impressed. Never offer to "table this for later" when the permanent solve is within reach. Never leave a dangling thread when tying it off takes five more minutes. Never present a workaround when the real fix exists. The standard isn't "good enough" — it's "holy shit, that's done." Search before building. Test before shipping. Ship the complete thing. When Ben asks for something, the answer is the finished product, not a plan to build it. Time is not an excuse. Fatigue is not an excuse. Complexity is not an excuse. Boil the ocean.
 
+**Scope of "boil the ocean": code, analysis, and local work — never public or community actions.** It means finish the *engineering*. It does NOT mean act autonomously on the community's behalf. See the next section.
+
+## Community interaction (read-only by default)
+
+This is a public repo with real external contributors. Their issues, PRs, and commits are theirs, not yours to dispose of. Reading is always fine; every write below is the human maintainer's to do, and you may only *draft* text for Ben to review and post himself.
+
+- **Never edit, close, comment on, merge, or reopen another person's issue or PR** without Ben's explicit, per-action go-ahead. Never edit anyone's issue/PR/comment *text* — that reads as tampering and is never acceptable.
+- **Draft / WIP / "do not merge" means hands off.** Never cherry-pick, merge, or otherwise pull in a draft PR's work. Draft is the contributor's signal that it isn't ready; respect it.
+- **To use a contributor's work, merge their PR through the normal flow** (which credits them) — never extract the commit around them or push it to `main` directly.
+- **Never post AI-generated text as if it were Ben's own analysis**, and never post a claim about someone else's work without verifying it against the code first.
+- When Ben asks for a reply to a contributor, produce a short draft *for him to send in his own words* — do not post it, and do not make it sound machine-generated.
+- A local `.claude/` hook (`block-community-github-writes.py`) enforces a slice of this by denying write-shaped `gh` commands; treat that as a backstop, not the boundary. The boundary is this section.
+
 ## Architecture
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,18 @@ If your team depends on Ghidra MCP in production or client work, please consider
 
 ---
 
+## How this project uses AI
+
+To be upfront: AI tooling assists with code, reviews, and drafting on this project. To keep that from getting in the way of the humans here, the maintainer commits to:
+
+- **A human reviews and posts every maintainer action.** Closing, merging, commenting on, or editing an issue or PR is done by a person, not by automation. Your issue text is never edited by a bot.
+- **Draft / WIP PRs are left alone.** If you mark a PR draft, its work won't be merged or cherry-picked until you mark it ready. To have your work land, it goes through your PR — with your authorship — not by lifting the commit around you.
+- **Claims about your work get checked before they're posted.** If a summary of your PR is wrong, that's a bug — please call it out and it'll be fixed.
+
+If you ever see any of this violated, flag it. It's a standard, not a nicety.
+
+---
+
 ## Types of Contributions
 
 ### 1. Bug Reports

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -478,15 +478,29 @@ class DebugEngine:
         self._require_stopped()
         self._state = DebuggerState.RUNNING
         self._executing = True
-        # NOTE: timeout_ms is advisory. In non-standalone mode a FINITE
-        # WaitForEvent timeout faulted here (access violation), while the
-        # infinite wait that stepi() uses is proven-good. So run with an
-        # infinite wait (returns on a breakpoint) and let the caller bound it
-        # by issuing /debugger/interrupt from another connection — interrupt()
-        # is thread-safe and unblocks WaitForEvent.
+        # A FINITE WaitForEvent timeout faults (AV) in non-standalone mode, and
+        # the engine's single worker can't be interrupted from within its own
+        # blocked wait. So run the proven infinite wait and self-bound it with a
+        # timer thread that issues SetInterrupt (thread-safe, unblocks
+        # WaitForEvent) — go_wait always returns within ~timeout_ms.
+        bomb_state = {"timed_out": False}
+
+        def _bomb():
+            bomb_state["timed_out"] = True
+            try:
+                if self._protected_base is not None:
+                    self._protected_base._control.SetInterrupt(
+                        DbgEng.DEBUG_INTERRUPT_ACTIVE)
+            except Exception:
+                pass
+
+        timer = threading.Timer(max(0.05, timeout_ms / 1000.0), _bomb)
+        timer.daemon = True
+        timer.start()
         try:
             self._base.go()   # SetExecutionStatus(GO) + wait(WAIT_INFINITE)
         finally:
+            timer.cancel()
             self._state = DebuggerState.STOPPED
             self._executing = False
         pc = 0
@@ -494,7 +508,8 @@ class DebugEngine:
             pc = self._read_pc_impl()
         except Exception:
             pass
-        return {"state": "stopped", "pc": f"0x{pc:08X}"}
+        return {"state": "stopped", "timeout": bomb_state["timed_out"],
+                "pc": f"0x{pc:08X}"}
 
     def interrupt(self) -> dict:
         """Break into the debugger (interrupt execution)."""

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -236,6 +236,8 @@ class DebugEngine:
         # and it doesn't conclude a debugger is present. Off by default so
         # attach/normal debugging behave as usual.
         self._pass_exceptions = False
+        self._call_guard = False   # True during an in-process call (crash-guard)
+        self._call_fault = None     # exception code caught during a guarded call
 
         # Work queue and worker thread
         self._work_queue: queue.SimpleQueue = queue.SimpleQueue()
@@ -562,9 +564,37 @@ class DebugEngine:
         detect us. Our OWN breakpoints arrive via the separate BREAKPOINT event
         and are unaffected. Off -> NO_CHANGE (default dbgeng behaviour)."""
         first_chance = (len(args) < 2) or bool(args[1])
+        # Crash-guard: during an in-process call_function(), a fault in the called
+        # code (e.g. access violation 0xC0000005) must NOT reach the target's SEH
+        # (could crash the process). Break into the debugger so call_function can
+        # roll back the saved context. Still PASS the anti-debug INT3 flood
+        # (0x80000003) from other threads so it can't detect us.
+        if self._call_guard and first_chance:
+            code = self._exc_code(args)
+            if code == 0x80000003:
+                return DbgEng.DEBUG_STATUS_GO_NOT_HANDLED
+            self._call_fault = code
+            return DbgEng.DEBUG_STATUS_NO_CHANGE
         if self._pass_exceptions and first_chance:
             return DbgEng.DEBUG_STATUS_GO_NOT_HANDLED
         return DbgEng.DEBUG_STATUS_NO_CHANGE
+
+    @staticmethod
+    def _exc_code(args):
+        """Best-effort extract the exception code from an dbgeng exception event's
+        args (structure varies by pybag version). 0 if unknown."""
+        try:
+            rec = args[0]
+            for attr in ("ExceptionCode", "exception_code", "code"):
+                if hasattr(rec, attr):
+                    return int(getattr(rec, attr)) & 0xFFFFFFFF
+            if hasattr(rec, "ExceptionRecord"):
+                return int(rec.ExceptionRecord.ExceptionCode) & 0xFFFFFFFF
+            if isinstance(rec, dict):
+                return int(rec.get("ExceptionCode", rec.get("code", 0))) & 0xFFFFFFFF
+        except Exception:
+            pass
+        return 0
 
     def step_into(self, count: int = 1) -> dict:
         """Single-step into (trace)."""
@@ -763,9 +793,30 @@ class DebugEngine:
                 self._base.reg._set_register(name.lower(), int(val) & 0xFFFFFFFF)
             self._base.reg._set_register("esp", new_esp)
             self._base.reg._set_register("eip", int(address))
-        res = self._go_wait_impl(timeout_ms)
+        # run under the crash-guard so a fault in the called code is caught and
+        # rolled back (via the context restore below) instead of crashing the
+        # target. Register the exception handler if pass-through isn't already on.
+        exc_was_registered = self._pass_exceptions
+        if not exc_was_registered:
+            try:
+                self._base.events.exception(self._on_exception)
+            except Exception:
+                pass
+        self._call_fault = None
+        self._call_guard = True
+        try:
+            res = self._go_wait_impl(timeout_ms)
+        finally:
+            self._call_guard = False
+            if not exc_was_registered:
+                try:
+                    self._base.events.noexception()
+                except Exception:
+                    pass
         out = {k.lower(): v for k, v in self._collect_registers_impl().items()}
-        # restore the saved context (puts the target back exactly where it was)
+        faulted = (self._call_fault is not None) or (out.get("eip", 0) != int(ret_catch))
+        # restore the saved context (puts the target back exactly where it was;
+        # this is also the rollback when the call faulted or timed out)
         with self._wow64_x86_context():
             for name in ("eax", "ebx", "ecx", "edx", "esi", "edi",
                          "esp", "ebp", "eip", "eflags"):
@@ -782,6 +833,8 @@ class DebugEngine:
             "returned_to": f"0x{out.get('eip', 0):08X}",
             "ret_catch": f"0x{int(ret_catch):08X}",
             "timeout": res.get("timeout"),
+            "faulted": bool(faulted),
+            "fault_code": f"0x{(self._call_fault or 0):08X}",
         }
 
     def set_breakpoint(self, address: int,

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -761,29 +761,43 @@ class DebugEngine:
 
     def _call_function_impl(self, address, stack_args, registers, ret_catch,
                             timeout_ms):
+        # Mirrors the proven manual sequence exactly (no extra breakpoints, no
+        # eflags write, no in-handler exception juggling) -- those additions
+        # corrupted state and crashed the target. Recovery is the context
+        # restore below; crash *prevention* is the loaded-module EIP check plus
+        # calling only with valid inputs. (Catching a fault in the called code
+        # before it reaches the target's SEH needs the suspend-other-threads
+        # design -- a follow-up; until then, do not pass deliberately-bad args.)
         self._require_stopped()
         saved = {k.lower(): v for k, v in self._collect_registers_impl().items()}
         if "eip" not in saved or "esp" not in saved or saved["esp"] == 0:
             raise RuntimeError("no valid thread context (esp/eip == 0) -- target "
                                "not stopped at a real debug event")
-        if ret_catch is None:
-            ret_catch = saved["eip"]  # we're stopped here; reuse as the return-catch
-        # ensure a breakpoint exists at ret_catch (add a temp one if not)
-        have = False
+        # SAFETY: refuse to set EIP outside a loaded module (executing unmapped
+        # memory = guaranteed access violation). Best-effort; app-agnostic.
         try:
-            for bp_id in self._base.breakpoints:
-                try:
-                    if self._base._control.GetBreakpointById(bp_id).GetOffset() == ret_catch:
-                        have = True
-                        break
-                except Exception:
-                    pass
+            mods = self._get_modules_impl()
+            if mods and not any(
+                    m.runtime_base <= int(address) < m.runtime_base + m.size
+                    for m in mods):
+                raise RuntimeError(
+                    f"target 0x{int(address):08X} is not in any loaded module -- "
+                    f"refusing to call (would execute unmapped memory)")
+        except RuntimeError:
+            raise
         except Exception:
             pass
-        added_bp = None if have else self._base.breakpoints.set(expr=int(ret_catch))
+        # ret_catch defaults to the current stopped EIP, which ALREADY carries
+        # our breakpoint (that is why we are stopped). We deliberately do NOT add
+        # a breakpoint -- a second int3 at the same address can restore a stale
+        # 0xCC over the original byte on removal and crash the target later. A
+        # custom ret_catch must already have a breakpoint (else -> timeout).
+        if ret_catch is None:
+            ret_catch = saved["eip"]
+        ret_catch = int(ret_catch)
         # build the call stack: [new_esp]=ret_catch, [+4]=arg1, [+8]=arg2, ...
-        new_esp = (saved["esp"] - 4 * (len(stack_args) + 1)) & ~0x3
-        self._base.write(new_esp, int(ret_catch).to_bytes(4, "little"))
+        new_esp = saved["esp"] - 4 * (len(stack_args) + 1)
+        self._base.write(new_esp, ret_catch.to_bytes(4, "little"))
         for i, a in enumerate(stack_args):
             self._base.write(new_esp + 4 + 4 * i,
                              (int(a) & 0xFFFFFFFF).to_bytes(4, "little"))
@@ -793,48 +807,24 @@ class DebugEngine:
                 self._base.reg._set_register(name.lower(), int(val) & 0xFFFFFFFF)
             self._base.reg._set_register("esp", new_esp)
             self._base.reg._set_register("eip", int(address))
-        # run under the crash-guard so a fault in the called code is caught and
-        # rolled back (via the context restore below) instead of crashing the
-        # target. Register the exception handler if pass-through isn't already on.
-        exc_was_registered = self._pass_exceptions
-        if not exc_was_registered:
-            try:
-                self._base.events.exception(self._on_exception)
-            except Exception:
-                pass
-        self._call_fault = None
-        self._call_guard = True
-        try:
-            res = self._go_wait_impl(timeout_ms)
-        finally:
-            self._call_guard = False
-            if not exc_was_registered:
-                try:
-                    self._base.events.noexception()
-                except Exception:
-                    pass
+        res = self._go_wait_impl(timeout_ms)
         out = {k.lower(): v for k, v in self._collect_registers_impl().items()}
-        faulted = (self._call_fault is not None) or (out.get("eip", 0) != int(ret_catch))
-        # restore the saved context (puts the target back exactly where it was;
-        # this is also the rollback when the call faulted or timed out)
+        returned_to = out.get("eip", 0)
+        faulted = (returned_to != ret_catch) or bool(res.get("timeout"))
+        # restore the saved context (same register set as the proven spike --
+        # NO eflags), which also rolls the thread back on fault/timeout.
         with self._wow64_x86_context():
             for name in ("eax", "ebx", "ecx", "edx", "esi", "edi",
-                         "esp", "ebp", "eip", "eflags"):
+                         "esp", "ebp", "eip"):
                 if name in saved:
                     self._base.reg._set_register(name, int(saved[name]))
-        if added_bp is not None:
-            try:
-                self._base.breakpoints.remove(added_bp)
-            except Exception:
-                pass
         return {
             "eax": f"0x{out.get('eax', 0):08X}",
             "edx": f"0x{out.get('edx', 0):08X}",
-            "returned_to": f"0x{out.get('eip', 0):08X}",
-            "ret_catch": f"0x{int(ret_catch):08X}",
-            "timeout": res.get("timeout"),
+            "returned_to": f"0x{returned_to:08X}",
+            "ret_catch": f"0x{ret_catch:08X}",
+            "timeout": bool(res.get("timeout")),
             "faulted": bool(faulted),
-            "fault_code": f"0x{(self._call_fault or 0):08X}",
         }
 
     def set_breakpoint(self, address: int,

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -709,6 +709,81 @@ class DebugEngine:
 
     # -- Breakpoint management ---------------------------------------------
 
+    def call_function(self, address: int, stack_args=None, registers=None,
+                      ret_catch: Optional[int] = None,
+                      timeout_ms: int = 8000) -> dict:
+        """Call a function IN-PROCESS by hijacking the currently-stopped thread.
+
+        Requires the target STOPPED at a breakpoint (valid thread context). Saves
+        the full context, sets up the calling convention (`stack_args` pushed
+        after a return address; `registers` written for register args like
+        ecx/edx/eax), runs to a return-catch breakpoint, reads the result, then
+        RESTORES the saved context (also the crash safety-net). Proven on WOW64:
+        writing EIP + go_wait commits the context (only single-step is blocked).
+
+        The caller sets up any pointer-arg scratch via write_memory first and
+        passes the address in `registers`/`stack_args`. Returns
+        {eax, edx, returned_to, timeout, ret_catch}. Verify returned_to==ret_catch.
+        """
+        return self._run_on_engine(self._call_function_impl, int(address),
+                                   list(stack_args or []), dict(registers or {}),
+                                   ret_catch, int(timeout_ms))
+
+    def _call_function_impl(self, address, stack_args, registers, ret_catch,
+                            timeout_ms):
+        self._require_stopped()
+        saved = {k.lower(): v for k, v in self._collect_registers_impl().items()}
+        if "eip" not in saved or "esp" not in saved or saved["esp"] == 0:
+            raise RuntimeError("no valid thread context (esp/eip == 0) -- target "
+                               "not stopped at a real debug event")
+        if ret_catch is None:
+            ret_catch = saved["eip"]  # we're stopped here; reuse as the return-catch
+        # ensure a breakpoint exists at ret_catch (add a temp one if not)
+        have = False
+        try:
+            for bp_id in self._base.breakpoints:
+                try:
+                    if self._base._control.GetBreakpointById(bp_id).GetOffset() == ret_catch:
+                        have = True
+                        break
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        added_bp = None if have else self._base.breakpoints.set(expr=int(ret_catch))
+        # build the call stack: [new_esp]=ret_catch, [+4]=arg1, [+8]=arg2, ...
+        new_esp = (saved["esp"] - 4 * (len(stack_args) + 1)) & ~0x3
+        self._base.write(new_esp, int(ret_catch).to_bytes(4, "little"))
+        for i, a in enumerate(stack_args):
+            self._base.write(new_esp + 4 + 4 * i,
+                             (int(a) & 0xFFFFFFFF).to_bytes(4, "little"))
+        # set register args + esp + eip, then run to the return-catch
+        with self._wow64_x86_context():
+            for name, val in registers.items():
+                self._base.reg._set_register(name.lower(), int(val) & 0xFFFFFFFF)
+            self._base.reg._set_register("esp", new_esp)
+            self._base.reg._set_register("eip", int(address))
+        res = self._go_wait_impl(timeout_ms)
+        out = {k.lower(): v for k, v in self._collect_registers_impl().items()}
+        # restore the saved context (puts the target back exactly where it was)
+        with self._wow64_x86_context():
+            for name in ("eax", "ebx", "ecx", "edx", "esi", "edi",
+                         "esp", "ebp", "eip", "eflags"):
+                if name in saved:
+                    self._base.reg._set_register(name, int(saved[name]))
+        if added_bp is not None:
+            try:
+                self._base.breakpoints.remove(added_bp)
+            except Exception:
+                pass
+        return {
+            "eax": f"0x{out.get('eax', 0):08X}",
+            "edx": f"0x{out.get('edx', 0):08X}",
+            "returned_to": f"0x{out.get('eip', 0):08X}",
+            "ret_catch": f"0x{int(ret_catch):08X}",
+            "timeout": res.get("timeout"),
+        }
+
     def set_breakpoint(self, address: int,
                        bp_type: BreakpointType = BreakpointType.SOFTWARE,
                        oneshot: bool = False,

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -478,36 +478,30 @@ class DebugEngine:
         self._require_stopped()
         self._state = DebuggerState.RUNNING
         self._executing = True
-        ctrl = self._base._control
-        ctrl.SetExecutionStatus(DbgEng.DEBUG_STATUS_GO)
-        deadline = time.time() + max(0, timeout_ms) / 1000.0
+        timed_out = False
         try:
-            while time.time() < deadline:
+            # Use pybag's go(timeout) -> wait(timeout), the SAME worker path
+            # stepi() uses (proven to advance the target). Returns True on a
+            # break event, False on timeout (pybag issues SetInterrupt then);
+            # some paths raise DbgEngTimeout instead — treat that as a timeout.
+            try:
+                hit = self._base.go(int(timeout_ms))
+                timed_out = (hit is False)
+            except exception.DbgEngTimeout:
+                timed_out = True
                 try:
-                    ctrl.WaitForEvent(300)   # advances the target; raises on timeout
-                except exception.DbgEngTimeout:
-                    pass
-                try:
-                    if ctrl.GetExecutionStatus() == DbgEng.DEBUG_STATUS_BREAK:
-                        self._state = DebuggerState.STOPPED
-                        self._executing = False
-                        return {"state": "stopped", "pc": f"0x{self._read_pc_impl():08X}"}
+                    self._base._control.SetInterrupt(DbgEng.DEBUG_INTERRUPT_ACTIVE)
                 except Exception:
                     pass
-            # timed out while still running -> interrupt to regain control
-            ctrl.SetInterrupt(DbgEng.DEBUG_INTERRUPT_ACTIVE)
-            try:
-                ctrl.WaitForEvent(500)
-            except exception.DbgEngTimeout:
-                pass
+        finally:
             self._state = DebuggerState.STOPPED
             self._executing = False
-            return {"state": "stopped", "timeout": True,
-                    "pc": f"0x{self._read_pc_impl():08X}"}
+        pc = 0
+        try:
+            pc = self._read_pc_impl()
         except Exception:
-            self._state = DebuggerState.STOPPED
-            self._executing = False
-            raise
+            pass
+        return {"state": "stopped", "timeout": timed_out, "pc": f"0x{pc:08X}"}
 
     def interrupt(self) -> dict:
         """Break into the debugger (interrupt execution)."""

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -230,6 +230,12 @@ class DebugEngine:
         self._is_wow64 = False
         self._protected_base: Optional[AllDbg] = None
         self._events = EngineEventHandler()
+        # Anti-anti-debug: when enabled, pass first-chance exceptions (notably
+        # the INT3/STATUS_BREAKPOINT flood PD2 throws) to the TARGET's own SEH
+        # instead of the debugger swallowing them, so the target's handler runs
+        # and it doesn't conclude a debugger is present. Off by default so
+        # attach/normal debugging behave as usual.
+        self._pass_exceptions = False
 
         # Work queue and worker thread
         self._work_queue: queue.SimpleQueue = queue.SimpleQueue()
@@ -311,7 +317,14 @@ class DebugEngine:
 
     def _attach_impl(self, target: str) -> dict:
         if self._state not in (DebuggerState.DETACHED, DebuggerState.EXITED):
-            raise RuntimeError(f"Cannot attach in state {self._state.value}")
+            # Already attached — detach first so re-attach is robust/idempotent
+            # (fixes "Cannot attach in state stopped" and clears stale
+            # breakpoint objects that otherwise E_NOINTERFACE on removal).
+            logger.info(f"Already {self._state.value}; detaching before re-attach")
+            try:
+                self._detach_impl()
+            except Exception as e:
+                logger.warning(f"pre-attach detach failed (continuing): {e}")
 
         base = self._base
         target_name = target
@@ -520,6 +533,38 @@ class DebugEngine:
         self._state = DebuggerState.STOPPED
         self._executing = False
         return {"state": "stopped"}
+
+    # -- Anti-anti-debug: first-chance exception pass-through ----------------
+
+    def set_pass_exceptions(self, enabled: bool) -> dict:
+        """Enable/disable handing first-chance exceptions to the target's own
+        SEH instead of the debugger swallowing them. Defeats INT3-based
+        anti-debug (e.g. PD2's breakpoint-exception flood)."""
+        return self._run_on_engine(self._set_pass_exceptions_impl, bool(enabled))
+
+    def _set_pass_exceptions_impl(self, enabled: bool) -> dict:
+        self._pass_exceptions = enabled
+        try:
+            if enabled:
+                self._base.events.exception(self._on_exception)
+            else:
+                self._base.events.noexception()
+        except Exception as e:
+            logger.warning(f"exception pass-through toggle failed: {e}")
+        logger.info(f"Exception pass-through {'ENABLED' if enabled else 'disabled'}")
+        return {"pass_exceptions": self._pass_exceptions}
+
+    def _on_exception(self, *args):
+        """dbgeng EXCEPTION-event callback. args[0]=ExceptionRecord,
+        args[1]=first-chance flag. When pass-through is on, first-chance
+        exceptions (notably the INT3/STATUS_BREAKPOINT anti-debug flood) are
+        continued as NOT-handled so the target's own handler runs and it can't
+        detect us. Our OWN breakpoints arrive via the separate BREAKPOINT event
+        and are unaffected. Off -> NO_CHANGE (default dbgeng behaviour)."""
+        first_chance = (len(args) < 2) or bool(args[1])
+        if self._pass_exceptions and first_chance:
+            return DbgEng.DEBUG_STATUS_GO_NOT_HANDLED
+        return DbgEng.DEBUG_STATUS_NO_CHANGE
 
     def step_into(self, count: int = 1) -> dict:
         """Single-step into (trace)."""

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -478,21 +478,14 @@ class DebugEngine:
         self._require_stopped()
         self._state = DebuggerState.RUNNING
         self._executing = True
-        timed_out = False
+        # NOTE: timeout_ms is advisory. In non-standalone mode a FINITE
+        # WaitForEvent timeout faulted here (access violation), while the
+        # infinite wait that stepi() uses is proven-good. So run with an
+        # infinite wait (returns on a breakpoint) and let the caller bound it
+        # by issuing /debugger/interrupt from another connection — interrupt()
+        # is thread-safe and unblocks WaitForEvent.
         try:
-            # Use pybag's go(timeout) -> wait(timeout), the SAME worker path
-            # stepi() uses (proven to advance the target). Returns True on a
-            # break event, False on timeout (pybag issues SetInterrupt then);
-            # some paths raise DbgEngTimeout instead — treat that as a timeout.
-            try:
-                hit = self._base.go(int(timeout_ms))
-                timed_out = (hit is False)
-            except exception.DbgEngTimeout:
-                timed_out = True
-                try:
-                    self._base._control.SetInterrupt(DbgEng.DEBUG_INTERRUPT_ACTIVE)
-                except Exception:
-                    pass
+            self._base.go()   # SetExecutionStatus(GO) + wait(WAIT_INFINITE)
         finally:
             self._state = DebuggerState.STOPPED
             self._executing = False
@@ -501,7 +494,7 @@ class DebugEngine:
             pc = self._read_pc_impl()
         except Exception:
             pass
-        return {"state": "stopped", "timeout": timed_out, "pc": f"0x{pc:08X}"}
+        return {"state": "stopped", "pc": f"0x{pc:08X}"}
 
     def interrupt(self) -> dict:
         """Break into the debugger (interrupt execution)."""

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -463,6 +463,52 @@ class DebugEngine:
         self._run_on_engine(_impl)
         return {"state": "running"}
 
+    def go_wait(self, timeout_ms: int = 4000) -> dict:
+        """Resume execution and BLOCK until a breakpoint/event or timeout.
+
+        Unlike go_nowait (which only sets DEBUG_STATUS_GO and relies on the
+        idle DispatchCallbacks pump — that does not actually advance the
+        target), this pumps WaitForEvent on the engine thread, which is what
+        makes dbgeng run the debuggee and deliver breakpoint events. On timeout
+        it interrupts so control is regained. Returns {state, pc, timeout?}.
+        """
+        return self._run_on_engine(self._go_wait_impl, timeout_ms)
+
+    def _go_wait_impl(self, timeout_ms: int) -> dict:
+        self._require_stopped()
+        self._state = DebuggerState.RUNNING
+        self._executing = True
+        ctrl = self._base._control
+        ctrl.SetExecutionStatus(DbgEng.DEBUG_STATUS_GO)
+        deadline = time.time() + max(0, timeout_ms) / 1000.0
+        try:
+            while time.time() < deadline:
+                try:
+                    ctrl.WaitForEvent(300)   # advances the target; raises on timeout
+                except exception.DbgEngTimeout:
+                    pass
+                try:
+                    if ctrl.GetExecutionStatus() == DbgEng.DEBUG_STATUS_BREAK:
+                        self._state = DebuggerState.STOPPED
+                        self._executing = False
+                        return {"state": "stopped", "pc": f"0x{self._read_pc_impl():08X}"}
+                except Exception:
+                    pass
+            # timed out while still running -> interrupt to regain control
+            ctrl.SetInterrupt(DbgEng.DEBUG_INTERRUPT_ACTIVE)
+            try:
+                ctrl.WaitForEvent(500)
+            except exception.DbgEngTimeout:
+                pass
+            self._state = DebuggerState.STOPPED
+            self._executing = False
+            return {"state": "stopped", "timeout": True,
+                    "pc": f"0x{self._read_pc_impl():08X}"}
+        except Exception:
+            self._state = DebuggerState.STOPPED
+            self._executing = False
+            raise
+
     def interrupt(self) -> dict:
         """Break into the debugger (interrupt execution)."""
         # interrupt() can be called from any thread

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -110,6 +110,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             "/debugger/detach": self._handle_detach,
             "/debugger/go": self._handle_go,
             "/debugger/go_wait": lambda: self._handle_go_wait(body),
+            "/debugger/pass_exceptions": lambda: self._handle_pass_exceptions(body),
             "/debugger/interrupt": self._handle_interrupt,
             "/debugger/step_into": lambda: self._handle_step_into(body),
             "/debugger/step_over": lambda: self._handle_step_over(body),
@@ -347,6 +348,11 @@ class RequestHandler(BaseHTTPRequestHandler):
         timeout_ms = int(body.get("timeout_ms", 4000))
         result = ds.engine.go_wait(timeout_ms)
         self._send_json(result)
+
+    def _handle_pass_exceptions(self, body: dict):
+        ds = self._ds()
+        enabled = bool(body.get("enabled", True))
+        self._send_json(ds.engine.set_pass_exceptions(enabled))
 
     def _handle_interrupt(self):
         ds = self._ds()

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -117,6 +117,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             "/debugger/breakpoint": lambda: self._handle_set_breakpoint(body),
             "/debugger/write_memory": lambda: self._handle_write_memory(body),
             "/debugger/write_registers": lambda: self._handle_write_registers(body),
+            "/debugger/call_function": lambda: self._handle_call_function(body),
             "/debugger/sync_modules": lambda: self._handle_sync_modules(body),
             "/debugger/trace/start": lambda: self._handle_trace_start(body),
             "/debugger/trace/stop": lambda: self._handle_trace_stop(body),
@@ -243,6 +244,33 @@ class RequestHandler(BaseHTTPRequestHandler):
                 parsed[name] = int(val)
         applied = ds.engine.write_registers(parsed)
         self._send_json({"applied": {k: f"0x{v:08X}" for k, v in applied.items()}})
+
+    def _handle_call_function(self, body: dict):
+        """Call a function in-process (generic x86/WOW64 target). Body:
+        {address | (address+address_type:'ghidra'+module), stack_args:[..],
+         registers:{ecx:..,edx:..,eax:..}, ret_catch?, timeout_ms?}. Values may be
+         ints or 0x-hex strings. App-agnostic: no target-specific assumptions."""
+        def _num(v):
+            if isinstance(v, str):
+                return int(v, 16) if v.lower().startswith("0x") else int(v)
+            return int(v)
+        ds = self._ds()
+        addr = body.get("address")
+        if addr is None:
+            self._send_error(400, "Missing 'address'")
+            return
+        address = _num(addr)
+        if body.get("address_type") == "ghidra":
+            address = ds.mapper.to_runtime(address, body.get("module") or None)
+        ret_catch = body.get("ret_catch")
+        if ret_catch is not None:
+            ret_catch = _num(ret_catch)
+        registers = {k: _num(v) for k, v in (body.get("registers") or {}).items()}
+        stack_args = [_num(a) for a in (body.get("stack_args") or [])]
+        result = ds.engine.call_function(
+            address, stack_args=stack_args, registers=registers,
+            ret_catch=ret_catch, timeout_ms=int(body.get("timeout_ms", 8000)))
+        self._send_json(result)
 
     def _handle_address_map(self):
         ds = self._ds()

--- a/debugger/server.py
+++ b/debugger/server.py
@@ -109,6 +109,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             "/debugger/attach": lambda: self._handle_attach(body),
             "/debugger/detach": self._handle_detach,
             "/debugger/go": self._handle_go,
+            "/debugger/go_wait": lambda: self._handle_go_wait(body),
             "/debugger/interrupt": self._handle_interrupt,
             "/debugger/step_into": lambda: self._handle_step_into(body),
             "/debugger/step_over": lambda: self._handle_step_over(body),
@@ -339,6 +340,12 @@ class RequestHandler(BaseHTTPRequestHandler):
     def _handle_go(self):
         ds = self._ds()
         result = ds.engine.go_nowait()
+        self._send_json(result)
+
+    def _handle_go_wait(self, body: dict):
+        ds = self._ds()
+        timeout_ms = int(body.get("timeout_ms", 4000))
+        result = ds.engine.go_wait(timeout_ms)
         self._send_json(result)
 
     def _handle_interrupt(self):

--- a/fun-doc/conformance_protected.json
+++ b/fun-doc/conformance_protected.json
@@ -1,0 +1,12 @@
+{
+  "generated": "2026-07-03",
+  "note": "Functions carrying an OpenD2 conformance tag in Ghidra (ANALYZED_RUNTIME / ORACLE / PORTED / PROVEN). These are hand-verified against the live PD2-S12 process and/or ported to the OpenD2 clone; they are EXCLUDED from the auto-doc selector so a cheap worker cannot overwrite a runtime-verified plate. Keys are fun-doc function keys: '<program_path>::<address>'. Regenerate from Ghidra tags via scripts/gen_conformance_protected.py (or the in-scan ingest once landed). Pinning a function in the dashboard bypasses this protection for a deliberate re-document.",
+  "protected_keys": {
+    "/Mods/PD2-S12/D2Game.dll::6fc31a70": ["ANALYZED_RUNTIME"],
+    "/Mods/PD2-S12/D2Game.dll::6fc32380": ["ANALYZED_RUNTIME", "ORACLE"],
+    "/Mods/PD2-S12/D2Game.dll::6fcea760": ["ANALYZED_RUNTIME"],
+    "/Mods/PD2-S12/D2Common.dll::6fd510b0": ["ORACLE", "PORTED", "PROVEN"],
+    "/Mods/PD2-S12/D2Common.dll::6fd51100": ["ANALYZED_RUNTIME", "ORACLE", "PORTED", "PROVEN"],
+    "/Mods/PD2-S12/D2Common.dll::6fd51180": ["ORACLE", "PORTED", "PROVEN"]
+  }
+}

--- a/fun-doc/conformance_protected.json
+++ b/fun-doc/conformance_protected.json
@@ -5,6 +5,7 @@
     "/Mods/PD2-S12/D2Game.dll::6fc31a70": ["ANALYZED_RUNTIME"],
     "/Mods/PD2-S12/D2Game.dll::6fc32380": ["ANALYZED_RUNTIME", "ORACLE"],
     "/Mods/PD2-S12/D2Game.dll::6fcea760": ["ANALYZED_RUNTIME"],
+    "/Mods/PD2-S12/D2Game.dll::6fc970a0": ["ANALYZED_RUNTIME", "ORACLE", "PORTED", "PROVEN"],
     "/Mods/PD2-S12/D2Common.dll::6fd510b0": ["ORACLE", "PORTED", "PROVEN"],
     "/Mods/PD2-S12/D2Common.dll::6fd51100": ["ANALYZED_RUNTIME", "ORACLE", "PORTED", "PROVEN"],
     "/Mods/PD2-S12/D2Common.dll::6fd51180": ["ORACLE", "PORTED", "PROVEN"]

--- a/fun-doc/conformance_workbench.py
+++ b/fun-doc/conformance_workbench.py
@@ -1,0 +1,160 @@
+"""
+conformance_workbench.py -- implementation-coverage + side-by-side data for the
+fun-doc dashboard.
+
+Ties each PD2-S12 Ghidra function to its equivalent OpenD2 implementation so the
+dashboard can show original ASSEMBLY, decompiled PSEUDOCODE, and the live ported
+C++ side by side, and report how much of each binary is actually IMPLEMENTED
+(not merely documented).
+
+Link source of truth = the OpenD2 repo itself. Ported symbols carry a marker:
+    // @PD2S12 <Module>!<Symbol> @ 0x<ghidra_address>  (conformance: <STATE>)
+(see Shared/D2Seed.hpp). Ghidra carries the reverse @OPEND2 marker + the
+PORTED / PROVEN function tags. build_index() greps the OpenD2 tree for @PD2S12,
+so the coverage index is always in sync with the committed code.
+"""
+import os
+import re
+from pathlib import Path
+
+OPEND2_REPO = Path(os.environ.get("FUNDOC_OPEND2_REPO", r"C:\Users\benam\source\cpp\OpenD2"))
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+
+_MARKER_RE = re.compile(
+    r"@PD2S12\s+(?P<module>\w+)!(?P<symbol>\w+)\s*@\s*(?P<addr>0x[0-9a-fA-F]+)"
+    r"(?:.*?conformance:\s*(?P<state>\w+))?"
+)
+_SRC_GLOBS = (
+    "Shared/**/*.hpp", "Shared/**/*.cpp",
+    "Modcode/**/*.cpp", "Modcode/**/*.hpp",
+    "Engine/**/*.cpp", "Engine/**/*.hpp",
+)
+
+
+def _module_to_program(module):
+    return "Game.exe" if module.lower() == "game" else f"{module}.dll"
+
+
+def build_index(repo=None):
+    """Scan the OpenD2 repo for @PD2S12 markers. Returns a list of dicts:
+    {program, module, address, symbol, file, line, state}. `address` is
+    lowercase hex without the 0x prefix (matches fun-doc's key format)."""
+    repo = Path(repo or OPEND2_REPO)
+    out = []
+    seen = set()
+    for pattern in _SRC_GLOBS:
+        for path in repo.glob(pattern):
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                m = _MARKER_RE.search(line)
+                if not m:
+                    continue
+                program = _module_to_program(m.group("module"))
+                addr = m.group("addr")[2:].lower()
+                key = f"{program}::{addr}"
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append({
+                    "program": program,
+                    "module": m.group("module"),
+                    "address": addr,
+                    "symbol": m.group("symbol"),
+                    "file": str(path.relative_to(repo)).replace("\\", "/"),
+                    "line": lineno,
+                    "state": (m.group("state") or "PORTED").upper(),
+                })
+    return out
+
+
+def coverage_summary(repo=None):
+    """Per-program implementation coverage derived from the OpenD2 markers."""
+    idx = build_index(repo)
+    by_program = {}
+    for e in idx:
+        p = by_program.setdefault(e["program"], {"ported": 0, "proven": 0, "symbols": []})
+        p["ported"] += 1
+        if e["state"] == "PROVEN":
+            p["proven"] += 1
+        p["symbols"].append({"symbol": e["symbol"], "address": e["address"], "state": e["state"]})
+    return {"total_ported": len(idx), "by_program": by_program}
+
+
+def _extract_source_symbol(repo, file, symbol, hint_line=None):
+    """Extract the C/C++ definition of `symbol` from `file`: find the signature
+    line ('symbol('), then brace-match to the closing '}'. Returns
+    (code, start_line) or (None, None). `hint_line` is searched first."""
+    path = Path(repo or OPEND2_REPO) / file
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None, None
+    sig_re = re.compile(r"\b" + re.escape(symbol) + r"\s*\(")
+    order = list(range(max(0, (hint_line or 1) - 1), len(lines))) + list(range(0, len(lines)))
+    start = next((i for i in order if sig_re.search(lines[i])), None)
+    if start is None:
+        return None, None
+    depth = 0
+    began = False
+    end = start
+    for j in range(start, len(lines)):
+        for ch in lines[j]:
+            if ch == "{":
+                depth += 1
+                began = True
+            elif ch == "}":
+                depth -= 1
+        end = j
+        if began and depth <= 0:
+            break
+    return "\n".join(lines[start:end + 1]), start + 1
+
+
+def _ghidra_get(endpoint, params, timeout=8):
+    import requests
+    try:
+        r = requests.get(f"{GHIDRA_HTTP}/{endpoint.lstrip('/')}", params=params, timeout=timeout)
+        r.raise_for_status()
+        return r.text
+    except Exception as exc:  # noqa: BLE001 - surface the failure in the pane
+        return f"<ghidra fetch failed: {exc}>"
+
+
+def get_sidebyside(program, address, repo=None):
+    """Assemble the 3-pane data for one function: original ASSEMBLY + decompiled
+    PSEUDOCODE (from the live Ghidra plugin) + the linked OpenD2 implementation
+    (if any). Safe to call without a linked port (opend2=None)."""
+    repo = Path(repo or OPEND2_REPO)
+    addr = address.lower().replace("0x", "")
+    entry = next(
+        (e for e in build_index(repo) if e["address"] == addr and e["program"] == program),
+        None,
+    )
+    asm = _ghidra_get("disassemble_function", {"address": f"0x{addr}", "program": program})
+    pseudo = _ghidra_get("decompile_function", {"address": f"0x{addr}", "program": program})
+    opend2 = None
+    if entry:
+        code, resolved_line = _extract_source_symbol(repo, entry["file"], entry["symbol"], entry.get("line"))
+        opend2 = {
+            "file": entry["file"],
+            "line": resolved_line,
+            "symbol": entry["symbol"],
+            "state": entry["state"],
+            "code": code,
+        }
+    return {
+        "program": program,
+        "address": addr,
+        "assembly": asm,
+        "pseudocode": pseudo,
+        "opend2": opend2,
+        "implemented": entry is not None,
+    }
+
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(coverage_summary(), indent=2))

--- a/fun-doc/conformance_workbench.py
+++ b/fun-doc/conformance_workbench.py
@@ -35,20 +35,39 @@ def _module_to_program(module):
     return "Game.exe" if module.lower() == "game" else f"{module}.dll"
 
 
+def _find_def_after(lines, marker_line_1based, max_ahead=15):
+    """Scan forward from a @PD2S12 marker (which sits directly above its C++
+    function) for the first function-definition signature. Returns
+    (symbol, def_line_1based) or (None, None). The OpenD2 C++ symbol differs
+    from the Ghidra name (e.g. D2Seed_Advance vs SEED_GetRandomNumberAlt), so we
+    read it from the code, not the marker."""
+    ctrl = {"if", "for", "while", "switch", "return", "sizeof", "catch", "do"}
+    for i in range(marker_line_1based, min(len(lines), marker_line_1based + max_ahead)):
+        s = lines[i].strip()
+        if not s or s.startswith(("//", "/*", "*", "#")):
+            continue
+        m = re.search(r"([A-Za-z_]\w*)\s*\(", s)
+        if m and m.group(1) not in ctrl:
+            return m.group(1), i + 1
+    return None, None
+
+
 def build_index(repo=None):
     """Scan the OpenD2 repo for @PD2S12 markers. Returns a list of dicts:
-    {program, module, address, symbol, file, line, state}. `address` is
-    lowercase hex without the 0x prefix (matches fun-doc's key format)."""
+    {program, module, address, ghidra_name, symbol, file, line, state}.
+    `symbol` is the OpenD2 C++ function (read from the line below the marker);
+    `ghidra_name` is the PD2-S12 function name. `address` is lowercase hex
+    without the 0x prefix (matches fun-doc's key format)."""
     repo = Path(repo or OPEND2_REPO)
     out = []
     seen = set()
     for pattern in _SRC_GLOBS:
         for path in repo.glob(pattern):
             try:
-                text = path.read_text(encoding="utf-8", errors="replace")
+                lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
             except OSError:
                 continue
-            for lineno, line in enumerate(text.splitlines(), 1):
+            for idx, line in enumerate(lines):
                 m = _MARKER_RE.search(line)
                 if not m:
                     continue
@@ -58,13 +77,15 @@ def build_index(repo=None):
                 if key in seen:
                     continue
                 seen.add(key)
+                opend2_symbol, def_line = _find_def_after(lines, idx + 1)
                 out.append({
                     "program": program,
                     "module": m.group("module"),
                     "address": addr,
-                    "symbol": m.group("symbol"),
+                    "ghidra_name": m.group("symbol"),
+                    "symbol": opend2_symbol or m.group("symbol"),
                     "file": str(path.relative_to(repo)).replace("\\", "/"),
-                    "line": lineno,
+                    "line": def_line or (idx + 1),
                     "state": (m.group("state") or "PORTED").upper(),
                 })
     return out
@@ -79,7 +100,12 @@ def coverage_summary(repo=None):
         p["ported"] += 1
         if e["state"] == "PROVEN":
             p["proven"] += 1
-        p["symbols"].append({"symbol": e["symbol"], "address": e["address"], "state": e["state"]})
+        p["symbols"].append({
+            "symbol": e["symbol"],
+            "ghidra_name": e.get("ghidra_name"),
+            "address": e["address"],
+            "state": e["state"],
+        })
     return {"total_ported": len(idx), "by_program": by_program}
 
 

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -2913,6 +2913,29 @@ def save_priority_queue(queue):
         tmp_path.replace(PRIORITY_QUEUE_FILE)
 
 
+_CONFORMANCE_PROTECTED_PATH = Path(__file__).resolve().parent / "conformance_protected.json"
+_conformance_protected_cache = None
+
+
+def load_conformance_protected(force_reload=False):
+    """Set of fun-doc function keys ('<program>::<address>') that carry an
+    OpenD2 conformance tag in Ghidra (ANALYZED_RUNTIME / ORACLE / PORTED /
+    PROVEN). These are hand-verified against the live PD2-S12 process and/or
+    ported to the OpenD2 clone, so the auto-doc selector must NEVER pick them —
+    a cheap worker could overwrite a runtime-verified plate. Loaded from
+    conformance_protected.json (generated from Ghidra tags); cached; empty set
+    when the file is absent so this is a no-op on installs without it."""
+    global _conformance_protected_cache
+    if _conformance_protected_cache is None or force_reload:
+        try:
+            with open(_CONFORMANCE_PROTECTED_PATH, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            _conformance_protected_cache = set((data.get("protected_keys") or {}).keys())
+        except (FileNotFoundError, ValueError, OSError):
+            _conformance_protected_cache = set()
+    return _conformance_protected_cache
+
+
 def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=None):
     """Canonical work-queue selector. Used by both fun_doc CLI and web dashboard.
 
@@ -2936,6 +2959,7 @@ def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=N
         queue = load_priority_queue()
     pinned_list = list(queue.get("pinned", []))
     pinned = set(pinned_list)
+    conformance_protected = load_conformance_protected()
     cfg = queue.get("config") or DEFAULT_QUEUE_CONFIG
     good_enough = cfg.get("good_enough_score", 80)
     require_scored = (
@@ -2951,6 +2975,15 @@ def select_candidates(funcs, queue=None, active_binary=None, with_scoring_lane=N
             continue
         is_pinned = key in pinned
         if active_binary and func.get("program_name") != active_binary:
+            continue
+
+        # Conformance-protected: functions carrying an OpenD2 conformance tag
+        # in Ghidra (ANALYZED_RUNTIME / ORACLE / PORTED / PROVEN) are
+        # hand-verified against the live PD2-S12 process and/or already ported
+        # to the OpenD2 clone. NEVER auto-document them — a cheap worker could
+        # overwrite a runtime-verified plate. Pinning bypasses for a deliberate
+        # re-document. Source: conformance_protected.json (from Ghidra tags).
+        if key in conformance_protected and not is_pinned:
             continue
 
         score = func.get("score", 0)

--- a/fun-doc/templates/dashboard.html
+++ b/fun-doc/templates/dashboard.html
@@ -714,6 +714,7 @@
         <div style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
             <button class="btn active" id="tab-list" onclick="switchView('list')">List View</button>
             <button class="btn" id="tab-graph" onclick="switchView('graph')">Call Graph Layers</button>
+            <button class="btn" id="tab-conformance" onclick="switchView('conformance')">Conformance</button>
         </div>
 
         <!-- Call Graph Layers panel (hidden by default, shown when tab-graph is active) -->
@@ -726,6 +727,39 @@
             </div>
             <div class="panel-content" id="callGraphContent">
                 <div style="text-align: center; color: var(--text-muted); padding: 1rem;">Loading call graph layers...</div>
+            </div>
+        </div>
+
+        <!-- Conformance / implementation workbench (hidden by default) -->
+        <div class="panel" id="conformancePanel" style="display: none;">
+            <div class="panel-header">
+                <h2>Implementation Coverage</h2>
+                <span style="color: var(--text-muted); font-size: 0.65rem;">
+                    PD2-S12 Ghidra functions ported to OpenD2 (via <code>@PD2S12</code> links). PROVEN = conformance-tested. Click a symbol for the side-by-side view.
+                </span>
+            </div>
+            <div class="panel-content" id="conformanceContent">
+                <div style="text-align: center; color: var(--text-muted); padding: 1rem;">Loading coverage...</div>
+            </div>
+            <div class="panel-header" style="margin-top: 0.5rem;">
+                <h2>Side-by-side &mdash; Assembly | Pseudocode | OpenD2</h2>
+                <span id="sbsTitle" style="color: var(--text-muted); font-size: 0.65rem;">Select a function above.</span>
+            </div>
+            <div class="panel-content">
+                <div style="display: flex; gap: 0.5rem; align-items: stretch;">
+                    <div style="flex:1; min-width:0;">
+                        <div style="font-size:0.6rem; text-transform:uppercase; letter-spacing:0.5px; color: var(--text-muted); margin-bottom:2px;">PD2-S12 Assembly</div>
+                        <pre id="sbsAsm" style="background: var(--bg-medium); border:1px solid var(--border-dark); padding:0.5rem; font-size:0.62rem; line-height:1.3; max-height:60vh; overflow:auto; white-space:pre; margin:0; font-family: var(--font-mono);"></pre>
+                    </div>
+                    <div style="flex:1; min-width:0;">
+                        <div style="font-size:0.6rem; text-transform:uppercase; letter-spacing:0.5px; color: var(--text-muted); margin-bottom:2px;">Decompiled Pseudocode</div>
+                        <pre id="sbsPseudo" style="background: var(--bg-medium); border:1px solid var(--border-dark); padding:0.5rem; font-size:0.62rem; line-height:1.3; max-height:60vh; overflow:auto; white-space:pre; margin:0; font-family: var(--font-mono);"></pre>
+                    </div>
+                    <div style="flex:1; min-width:0;">
+                        <div style="font-size:0.6rem; text-transform:uppercase; letter-spacing:0.5px; color: var(--color-set); margin-bottom:2px;">OpenD2 (live port)</div>
+                        <pre id="sbsOpenD2" style="background: var(--bg-medium); border:1px solid var(--border-dark); padding:0.5rem; font-size:0.62rem; line-height:1.3; max-height:60vh; overflow:auto; white-space:pre; margin:0; font-family: var(--font-mono);"></pre>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -2478,11 +2512,69 @@
         function switchView(view) {
             document.getElementById('tab-list').classList.toggle('active', view === 'list');
             document.getElementById('tab-graph').classList.toggle('active', view === 'graph');
+            const cTab = document.getElementById('tab-conformance');
+            if (cTab) cTab.classList.toggle('active', view === 'conformance');
             const allFuncsPanel = document.getElementById('allFuncsPanel');
             const graphPanel = document.getElementById('callGraphPanel');
+            const confPanel = document.getElementById('conformancePanel');
             if (allFuncsPanel) allFuncsPanel.style.display = view === 'list' ? '' : 'none';
             if (graphPanel) graphPanel.style.display = view === 'graph' ? '' : 'none';
+            if (confPanel) confPanel.style.display = view === 'conformance' ? '' : 'none';
             if (view === 'graph') loadCallGraphLayers();
+            if (view === 'conformance') loadConformance();
+        }
+
+        async function loadConformance() {
+            const el = document.getElementById('conformanceContent');
+            if (!el) return;
+            try {
+                const data = await (await fetch('/api/conformance/coverage')).json();
+                const progs = data.by_program || {};
+                const names = Object.keys(progs).sort();
+                if (!names.length) {
+                    el.innerHTML = '<div style="text-align:center; color: var(--text-muted); padding:1rem;">No linked implementations yet. Add a <code>@PD2S12 Module!Symbol @ 0xADDR</code> marker in OpenD2 source to link a port.</div>';
+                    return;
+                }
+                let html = `<div style="font-size:0.65rem; color: var(--text-muted); margin-bottom:0.5rem; font-family: var(--font-mono);">${data.total_ported} function(s) ported across ${names.length} binary(ies)</div>`;
+                for (const name of names) {
+                    const p = progs[name];
+                    html += `<div style="margin-bottom:0.5rem;"><div style="font-weight:600; color: var(--accent-gold); font-size:0.7rem;">${escapeHtml(name)} &mdash; ${p.ported} ported, ${p.proven} proven</div>`;
+                    html += '<table class="data-table"><thead><tr><th>OpenD2 symbol</th><th>PD2-S12 name</th><th>Addr</th><th>State</th></tr></thead><tbody>';
+                    for (const s of p.symbols) {
+                        const color = s.state === 'PROVEN' ? 'var(--color-set)' : 'var(--text-muted)';
+                        html += `<tr class="func-row" style="cursor:pointer;" onclick="showSideBySide('${escapeHtml(name)}','${escapeHtml(s.address)}','${escapeHtml(s.symbol)}')">
+                            <td class="mono">${escapeHtml(s.symbol)}</td>
+                            <td class="mono" style="color: var(--text-muted);">${escapeHtml(s.ghidra_name||'')}</td>
+                            <td class="mono">${escapeHtml(s.address)}</td>
+                            <td class="mono" style="color:${color};">${escapeHtml(s.state)}</td>
+                        </tr>`;
+                    }
+                    html += '</tbody></table></div>';
+                }
+                el.innerHTML = html;
+            } catch (e) {
+                el.innerHTML = `<div style="color: var(--accent-red-light); padding:0.5rem;">Error loading coverage: ${e.message}</div>`;
+            }
+        }
+
+        async function showSideBySide(program, address, symbol) {
+            document.getElementById('sbsTitle').textContent = `${program} @ ${address} → ${symbol || ''}`;
+            const asmEl = document.getElementById('sbsAsm');
+            const psEl = document.getElementById('sbsPseudo');
+            const odEl = document.getElementById('sbsOpenD2');
+            asmEl.textContent = psEl.textContent = odEl.textContent = 'Loading…';
+            try {
+                const d = await (await fetch(`/api/conformance/sidebyside?program=${encodeURIComponent(program)}&address=${encodeURIComponent(address)}`)).json();
+                asmEl.textContent = d.assembly || '(none)';
+                psEl.textContent = d.pseudocode || '(none)';
+                if (d.opend2 && d.opend2.code) {
+                    odEl.textContent = `// ${d.opend2.file}:${d.opend2.line} [${d.opend2.state}]\n` + d.opend2.code;
+                } else {
+                    odEl.textContent = d.implemented ? '(linked, but source not found)' : '(not yet ported)';
+                }
+            } catch (e) {
+                asmEl.textContent = psEl.textContent = odEl.textContent = 'Error: ' + e.message;
+            }
         }
 
         async function loadCallGraphLayers() {

--- a/fun-doc/web.py
+++ b/fun-doc/web.py
@@ -3036,6 +3036,34 @@ def create_app(state_file, event_bus=None, dashboard_port=5000):
             }
         )
 
+    @app.route("/api/conformance/coverage", methods=["GET"])
+    def conformance_coverage():
+        """Implementation-coverage: which PD2-S12 functions have a linked OpenD2
+        port (and which are conformance-proven). Source of truth = the OpenD2
+        repo's @PD2S12 markers, scanned by conformance_workbench."""
+        try:
+            import conformance_workbench as cw
+
+            return jsonify(cw.coverage_summary())
+        except Exception as exc:  # noqa: BLE001 - report, don't 500 the dashboard
+            return jsonify({"error": str(exc), "total_ported": 0, "by_program": {}})
+
+    @app.route("/api/conformance/sidebyside", methods=["GET"])
+    def conformance_sidebyside():
+        """3-pane data for one function: original ASSEMBLY + decompiled
+        PSEUDOCODE (live from the Ghidra plugin) + the linked OpenD2
+        implementation. Query params: program, address."""
+        program = request.args.get("program", "")
+        address = request.args.get("address", "")
+        if not program or not address:
+            return jsonify({"error": "program and address required"}), 400
+        try:
+            import conformance_workbench as cw
+
+            return jsonify(cw.get_sidebyside(program, address))
+        except Exception as exc:  # noqa: BLE001
+            return jsonify({"error": str(exc)}), 500
+
     @app.route("/api/context/binary", methods=["POST"])
     def set_active_binary():
         data = request.json

--- a/fun-doc/workbench_selftest.py
+++ b/fun-doc/workbench_selftest.py
@@ -1,0 +1,69 @@
+"""
+Headless self-test for the conformance workbench dashboard routes.
+
+Exercises /api/conformance/* through a Flask TEST CLIENT -- no browser, no live
+server -- so the side-by-side panel's data contract can be verified as it's
+built, and MiniMax output can be spot-checked in CI-style runs.
+
+    python workbench_selftest.py
+
+Exit code 0 = all checks pass. The assembly/pseudocode panes need the Ghidra
+plugin (127.0.0.1:8089); if it's down those panes carry a "<ghidra fetch
+failed>" marker but the route still returns 200 and the OpenD2 pane is populated
+from the committed source, so the harness still validates the contract.
+"""
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault("FUNDOC_DASHBOARD", "false")
+    os.environ.setdefault("FUNDOC_OPEND2_REPO", r"C:\Users\benam\source\cpp\OpenD2")
+    from web import create_app
+
+    state_file = os.path.join(os.path.dirname(__file__), "state.json")
+    app, _socketio = create_app(state_file)
+    client = app.test_client()
+    ok = True
+
+    # 1) coverage endpoint
+    r = client.get("/api/conformance/coverage")
+    cov = r.get_json() or {}
+    d2c = (cov.get("by_program") or {}).get("D2Common.dll", {})
+    print("[coverage]   status=%s total_ported=%s  D2Common ported=%s proven=%s"
+          % (r.status_code, cov.get("total_ported"), d2c.get("ported"), d2c.get("proven")))
+    if r.status_code != 200 or (d2c.get("proven") or 0) < 3:
+        print("  FAIL: expected >=3 PROVEN functions in D2Common.dll")
+        ok = False
+
+    # 2) side-by-side for a known LINKED function (RNG advance)
+    r = client.get("/api/conformance/sidebyside",
+                   query_string={"program": "D2Common.dll", "address": "6fd51100"})
+    sbs = r.get_json() or {}
+    o = sbs.get("opend2") or {}
+    print("[sidebyside] status=%s implemented=%s opend2=%s"
+          % (r.status_code, sbs.get("implemented"), o.get("symbol")))
+    if r.status_code != 200 or not sbs.get("implemented") or not o.get("code"):
+        print("  FAIL: expected linked OpenD2 code for 6fd51100")
+        ok = False
+    else:
+        print("  OpenD2 %s:%s [%s]  src=%d chars | asm=%d chars | pseudo=%d chars"
+              % (o.get("file"), o.get("line"), o.get("state"), len(o.get("code") or ""),
+                 len(sbs.get("assembly") or ""), len(sbs.get("pseudocode") or "")))
+
+    # 3) an UNLINKED (tagged but not-yet-ported) function still returns cleanly
+    r = client.get("/api/conformance/sidebyside",
+                   query_string={"program": "D2Game.dll", "address": "6fc32380"})
+    sbs2 = r.get_json() or {}
+    print("[sidebyside] unlinked drop fn: status=%s implemented=%s (expect False)"
+          % (r.status_code, sbs2.get("implemented")))
+    if r.status_code != 200 or sbs2.get("implemented"):
+        print("  FAIL: unlinked function should report implemented=False without erroring")
+        ok = False
+
+    print("\nSELFTEST %s" % ("PASS" if ok else "FAIL"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a **conformance-tracking capability** to ghidra-mcp + fun-doc: prove a
reimplemented function matches a *specific target binary* (PD2-S12 / 1.13c)
bit-for-bit, and keep proven functions from being re-touched by auto-doc.

### Debugger — in-process oracle
- Generic `call_function` that invokes a function in the live target by
  hijacking a stopped thread (save context → set up the calling convention →
  run-to-return → read `EAX`/`EDX` → restore), with a module-range EIP sanity
  check. App-agnostic (not PD2-specific).
- Blocking `go_wait` path so the target actually runs under the debugger, plus
  first-chance **exception pass-through** to defeat `INT3` anti-debug.

### fun-doc — conformance workbench
- Auto-doc **protection** for conformance-tagged / pinned functions
  (`conformance_protected.json`) so a proven port isn't overwritten.
- Workbench backend: implementation-coverage board + assembly/pseudocode/source
  **side-by-side** view.
- Dashboard **API routes** + a **Conformance panel**; headless workbench self-test.

### First proven port
- `CalcDamageBonusByLevel` protected as the first harness-proven port.

## Verification

- Merges cleanly into `main` (no conflicts).
- The in-process `call_function` harness has been exercised live against the
  running PD2-S12 target (used this session to mint golden vectors); fun-doc
  workbench ships a headless self-test.

## Note

This branch's base includes one unrelated docs commit — `e252554 docs: add
community-interaction guardrails` — which rides along because it sits at the
root of the branch below a merge commit (dropping it would require a risky
rebase across the merge). Happy to split it into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
