### PR TITLE
fix(debugger): resolve #366/#367 WOW64 exception-filter contradiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,36 @@ Complete version history for the Ghidra MCP Server project.
 
 ### Fixed
 
+- **WOW64 exception-filter gaps found in review of #366/#367.** #366 and #367
+  shipped with no test coverage of `_on_exception`, `_our_bp_addrs`, or the
+  fast path, and their design docs assumed contradictory models of how a
+  planted breakpoint's INT3 is delivered on WOW64 (first-chance EXCEPTION vs.
+  the separate BREAKPOINT event) with no live run confirming either. Added
+  `TestOnExceptionFilter`/`TestDetachClearsBreakpointBookkeeping` in
+  `tests/unit/test_debugger_engine.py` pinning the fast path, WX86 code
+  handling, ret_catch recognition, and fault capture, so a future change
+  can't silently regress either PR's fix. Also fixed two real bugs the
+  contradiction surfaced: (1) `_on_exception`'s address match now queries
+  dbgeng's *live* breakpoint list (`_live_bp_addrs()`) instead of the
+  `_our_bp_addrs` shadow set, which went stale the moment a oneshot
+  breakpoint fired (dbgeng auto-drops the object with no
+  `remove_breakpoint()` call to clean up the shadow entry) — a later real
+  exception at the reused address would otherwise be misclassified as ours
+  and hidden from the target; (2) `detach()` now clears
+  `_our_bp_addrs`/`_bp_id_to_addr`/`_call_guard`/`_stepping`, which
+  previously survived a detach and could misclassify the next attached
+  process's exceptions. **Live-verified end to end on genuine WOW64
+  (2026-07-05)**: compiled a synthetic, disposable x86 process (confirmed
+  PE machine type 0x14C) looping on `kernel32!SleepEx`. Passive path:
+  `go_wait` reported repeated genuine hits under the merged filter even
+  without registering `events.breakpoint()` — dbgeng halts execution at a
+  recognized breakpoint independent of the interest mask, so the fast path
+  does not swallow ordinary passive-capture breakpoints. Guarded-call path:
+  with the thread stopped at that hit, `call_function` (defaulted
+  `ret_catch`) returned cleanly (`returned_to == ret_catch`, not faulted),
+  and passive capture kept working afterward with no run-control poisoning.
+  See the docstring on `_on_exception` and the `reference-debugger-sim-runs`
+  memory.
 - **fun-doc storage bootstrap race.** `_get_storage_repo()` was an unlocked
   check-then-build singleton and `db/migrate.py` recorded schema versions
   with a bare INSERT, so two threads bootstrapping the same fresh SQLite

--- a/debugger/engine.py
+++ b/debugger/engine.py
@@ -448,6 +448,13 @@ class DebugEngine:
         self._is_wow64 = False
         self._state = DebuggerState.DETACHED
         self._executing = False
+        # A detached process's breakpoint objects are gone; stale addresses
+        # here would misclassify a future (re-attached) process's real
+        # exceptions at a reused address as "ours" in _on_exception.
+        self._our_bp_addrs.clear()
+        self._bp_id_to_addr.clear()
+        self._call_guard = False
+        self._stepping = False
         logger.info(f"Detached from PID {pid}")
         return {"state": "detached", "pid": pid}
 
@@ -580,9 +587,37 @@ class DebugEngine:
         the GC thread and corrupt the dbgeng client (observed: a _compointer_base
         __del__ AV, then SetExecutionStatus -> 0x80070005 and a wedged worker).
         So we take a FAST PATH that never inspects the record unless we are
-        actually mid-call/mid-step. Breakpoints we plant (incl. call_function's
-        ret_catch) surface via the separate BREAKPOINT event, not here, so the
-        fast path does not miss them."""
+        actually mid-call/mid-step. Breakpoints we plant via set_breakpoint()
+        (used for passive capture) are recognized dbgeng breakpoint objects,
+        so a hit calls the separate BREAKPOINT event/handler, not this one —
+        this fast path never needs to protect them. That specifically matches
+        prior empirical behavior (passive breakpoint capture already worked
+        against this WOW64 target before this filter existed, when ALL
+        first-chance exceptions were passed through unconditionally), which
+        is only explainable if ordinary planted breakpoints don't route
+        through here. The ONE breakpoint this filter must protect is
+        call_function's ret_catch, planted via an artificial EIP-hijack
+        rather than normal execution — and that is covered because
+        _call_guard is True for the call's entire duration, so the mid-
+        call/mid-step branch below (not this fast path) always runs for it.
+        CONFIRMED (2026-07-05): live-verified end to end against a genuine
+        WOW64 target — a synthetic disposable process (PE machine type
+        0x14C, unrelated to any specific target application) built to loop
+        on kernel32!SleepEx. (1) Passive path:
+        attach + pass_exceptions + set_breakpoint + go_wait reported repeated
+        real hits (timeout=False, pc at the breakpoint, real WX86 exception
+        codes) even though this code never calls events.breakpoint() (so
+        DEBUG_EVENT_BREAKPOINT is absent from GetInterestMask) — dbgeng's own
+        execution-halt-at-breakpoint is independent of whether our callback
+        is subscribed to be notified; the interest mask only gates the
+        notification, not the underlying stop. (2) Guarded-call path: with
+        the thread stopped at that same hit breakpoint, call_function (no
+        explicit ret_catch, so it defaults to the current EIP — the proven
+        manual flow) returned cleanly (returned_to == ret_catch, faulted =
+        False) and passive go_wait capture continued to hit afterward with
+        no run-control poisoning. Both halves of this filter are now
+        live-confirmed on real WOW64 exception delivery, not just reasoned
+        about or tested against a native target."""
         first_chance = (len(args) < 2) or bool(args[1])
         if not first_chance:
             return DbgEng.DEBUG_STATUS_NO_CHANGE
@@ -601,7 +636,7 @@ class DebugEngine:
         if code in (0x80000003, 0x4000001F):
             addr = self._exc_address(args)
             if addr is None or addr == self._call_ret_catch \
-                    or addr in self._our_bp_addrs:
+                    or addr in self._live_bp_addrs():
                 return DbgEng.DEBUG_STATUS_NO_CHANGE
         # A genuine FAULT (e.g. AV 0xC0000005) inside a guarded call must break
         # into the debugger so call_function can roll back, not reach the SEH.
@@ -908,7 +943,7 @@ class DebugEngine:
             "ret_catch": f"0x{ret_catch:08X}",
             "timeout": bool(res.get("timeout")),
             "faulted": bool(faulted),
-            "fault_code": (f"0x{fault:08X}" if fault else None),
+            "fault_code": (f"0x{fault:08X}" if fault is not None else None),
         }
 
     def set_breakpoint(self, address: int,
@@ -953,6 +988,30 @@ class DebugEngine:
         logger.info(f"Breakpoint #{bp_id} set at 0x{address:08X} "
                     f"(type={bp_type.value}, oneshot={oneshot})")
         return bp_id
+
+    def _live_bp_addrs(self) -> set:
+        """Addresses of breakpoints dbgeng still actually has planted.
+
+        `_our_bp_addrs` is a shadow set updated on set/remove, but dbgeng
+        auto-drops a oneshot breakpoint's object the moment it fires — with
+        no corresponding remove_breakpoint() call, so the shadow set can go
+        stale and keep an address "ours" long after dbgeng forgot it. Query
+        dbgeng directly here instead of trusting the shadow set; this only
+        runs inside the already-narrow call/step-guarded window in
+        _on_exception, not the high-rate flood path, so the extra round trip
+        is cheap and safe.
+        """
+        addrs = set()
+        try:
+            for bp_id in self._base.breakpoints:
+                try:
+                    bp_obj = self._base._control.GetBreakpointById(bp_id)
+                    addrs.add(int(bp_obj.GetOffset()) & 0xFFFFFFFF)
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return addrs
 
     def remove_breakpoint(self, bp_id: int) -> None:
         """Remove a breakpoint by ID."""

--- a/tests/unit/test_debugger_engine.py
+++ b/tests/unit/test_debugger_engine.py
@@ -69,6 +69,7 @@ def import_engine_with_stubs():
     fake_core.DEBUG_BREAKPOINT_ONE_SHOT = 8
     fake_core.DEBUG_BREAKPOINT_DATA = 16
     fake_core.DEBUG_STATUS_NO_CHANGE = 0
+    fake_core.DEBUG_STATUS_GO_NOT_HANDLED = 2
 
     fake_exception = types.ModuleType("pybag.dbgeng.exception")
 
@@ -102,6 +103,13 @@ def make_engine(engine_module, base, state):
     engine._is_wow64 = False
     engine._protected_base = base
     engine._thread = threading.current_thread()
+    engine._pass_exceptions = False
+    engine._call_guard = False
+    engine._stepping = False
+    engine._call_ret_catch = None
+    engine._call_fault = None
+    engine._our_bp_addrs = set()
+    engine._bp_id_to_addr = {}
     return engine
 
 
@@ -426,3 +434,170 @@ class TestMemoryAndRegisterWrites:
         engine._write_registers_impl({"eip": 0x401000})
 
         assert engine._protected_base._control.set_calls == [0x14C, 0x8664]
+
+
+class TestOnExceptionFilter:
+    """Regression tests for the WOW64 exception-filter contradiction found in
+    review: PR #366's design assumed our own breakpoints could arrive as
+    first-chance EXCEPTION events (needing _our_bp_addrs matching here), while
+    PR #367's fast path assumes they never reach here (breakpoints surface via
+    the separate BREAKPOINT event) and skips inspection entirely outside a
+    call/step window. These tests pin down the currently-intended behavior of
+    _on_exception so a future change can't silently reintroduce either the
+    COM-record-touching-on-every-flood-event bug (#367's fix) or a swallowed
+    ret_catch/guarded-fault (#366's fix) without a test failing.
+    """
+
+    CODE_INT3 = 0x80000003
+    CODE_WX86_INT3 = 0x4000001F
+    CODE_STEP = 0x80000004
+    CODE_WX86_STEP = 0x4000001E
+    CODE_AV = 0xC0000005
+
+    @staticmethod
+    def exc(code, address=0x401000):
+        return {"ExceptionCode": code, "ExceptionAddress": address}
+
+    def test_fast_path_never_touches_record_when_not_guarding(self):
+        engine_module = import_engine_with_stubs()
+        engine = make_engine(engine_module, object(), engine_module.DebuggerState.STOPPED)
+        engine._pass_exceptions = True
+
+        # If the fast path regresses into inspecting the record on the flood
+        # path, this raises instead of silently passing. Plain functions
+        # assigned on the instance (not via the class) shadow the
+        # @staticmethod without descriptor binding, so no self is passed.
+        def _boom(args):
+            raise AssertionError("must not inspect record outside call/step")
+
+        engine._exc_code = _boom
+        engine._exc_address = _boom
+
+        result = engine._on_exception(self.exc(self.CODE_WX86_INT3), True)
+
+        assert result == engine_module.DbgEng.DEBUG_STATUS_GO_NOT_HANDLED
+
+    def test_fast_path_passes_through_when_pass_exceptions_disabled(self):
+        engine_module = import_engine_with_stubs()
+        engine = make_engine(engine_module, object(), engine_module.DebuggerState.STOPPED)
+        engine._pass_exceptions = False
+
+        result = engine._on_exception(self.exc(self.CODE_INT3), True)
+
+        assert result == engine_module.DbgEng.DEBUG_STATUS_NO_CHANGE
+
+    def test_guarded_call_recognizes_ret_catch_breakpoint(self):
+        engine_module = import_engine_with_stubs()
+        engine = make_engine(engine_module, object(), engine_module.DebuggerState.STOPPED)
+        engine._call_guard = True
+        engine._call_ret_catch = 0x501000
+        engine._pass_exceptions = True
+
+        result = engine._on_exception(self.exc(self.CODE_WX86_INT3, 0x501000), True)
+
+        assert result == engine_module.DbgEng.DEBUG_STATUS_NO_CHANGE
+
+    def test_guarded_call_still_passes_through_unrelated_flood_int3(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeBase:
+            breakpoints = []  # no live breakpoints -> not "ours"
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+        engine._call_guard = True
+        engine._call_ret_catch = 0x501000
+        engine._pass_exceptions = True
+
+        # An anti-debug INT3 at an unrelated address during the call window
+        # must still reach the target's SEH, not be swallowed as "ours".
+        result = engine._on_exception(self.exc(self.CODE_INT3, 0x999999), True)
+
+        assert result == engine_module.DbgEng.DEBUG_STATUS_GO_NOT_HANDLED
+
+    def test_guarded_call_catches_genuine_fault(self):
+        engine_module = import_engine_with_stubs()
+        engine = make_engine(engine_module, object(), engine_module.DebuggerState.STOPPED)
+        engine._call_guard = True
+        engine._call_ret_catch = 0x501000
+        engine._pass_exceptions = True
+
+        result = engine._on_exception(self.exc(self.CODE_AV, 0x401000), True)
+
+        assert result == engine_module.DbgEng.DEBUG_STATUS_NO_CHANGE
+        assert engine._call_fault == self.CODE_AV
+
+    def test_stale_shadow_set_no_longer_misclassifies_removed_oneshot_bp(self):
+        """Regression: dbgeng auto-drops a fired oneshot breakpoint's object
+        with no remove_breakpoint() call, so _our_bp_addrs alone can go stale.
+        _on_exception must reconcile against dbgeng's live breakpoint list
+        (_live_bp_addrs) rather than trust the shadow set, so a later real
+        exception at the reused address isn't wrongly swallowed as ours."""
+        engine_module = import_engine_with_stubs()
+
+        class FakeBase:
+            breakpoints = []  # dbgeng no longer has anything planted
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+        engine._call_guard = True
+        engine._call_ret_catch = 0x501000
+        engine._pass_exceptions = True
+        # Stale bookkeeping: our oneshot bp fired and dbgeng dropped it, but
+        # nothing called remove_breakpoint() to clear this shadow entry.
+        engine._our_bp_addrs = {0x401000}
+
+        result = engine._on_exception(self.exc(self.CODE_INT3, 0x401000), True)
+
+        # Must be treated as a genuine target exception (passed through),
+        # not silently absorbed because of the stale shadow-set entry.
+        assert result == engine_module.DbgEng.DEBUG_STATUS_GO_NOT_HANDLED
+
+    def test_live_bp_addrs_reconciles_against_dbgeng_not_shadow_set(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeBpObj:
+            def GetOffset(self):
+                return 0x601000
+
+        class FakeControl:
+            def GetBreakpointById(self, bp_id):
+                return FakeBpObj()
+
+        class FakeBase:
+            breakpoints = [7]
+            _control = FakeControl()
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+
+        assert engine._live_bp_addrs() == {0x601000}
+
+    def test_second_chance_exception_lets_dbgeng_handle_it(self):
+        engine_module = import_engine_with_stubs()
+        engine = make_engine(engine_module, object(), engine_module.DebuggerState.STOPPED)
+        engine._pass_exceptions = True
+
+        result = engine._on_exception(self.exc(self.CODE_INT3), False)
+
+        assert result == engine_module.DbgEng.DEBUG_STATUS_NO_CHANGE
+
+
+class TestDetachClearsBreakpointBookkeeping:
+    def test_detach_clears_shadow_bp_state_and_call_flags(self):
+        engine_module = import_engine_with_stubs()
+
+        class FakeBase:
+            def detach_proc(self):
+                pass
+
+        engine = make_engine(engine_module, FakeBase(), engine_module.DebuggerState.STOPPED)
+        engine._target_pid = 4321
+        engine._our_bp_addrs = {0x401000, 0x402000}
+        engine._bp_id_to_addr = {1: 0x401000, 2: 0x402000}
+        engine._call_guard = True
+        engine._stepping = True
+
+        engine._detach_impl()
+
+        assert engine._our_bp_addrs == set()
+        assert engine._bp_id_to_addr == {}
+        assert engine._call_guard is False
+        assert engine._stepping is False


### PR DESCRIPTION
## Summary
- #366 and #367 shipped with no test coverage of `_on_exception` and rested on contradictory models of how a planted breakpoint's INT3 is delivered on WOW64. This left it unverified whether the merged fast path would silently swallow passive-capture breakpoints.
- Live-verified end to end against a genuine WOW64 target: a synthetic, disposable x86 process (confirmed PE machine type `0x14C`, unrelated to any specific target application) built to loop on `kernel32!SleepEx`. Both the passive-capture path (`go_wait` catches repeated real hits) and the guarded-call path (`call_function` with a defaulted `ret_catch` returns cleanly, no run-control poisoning afterward) work correctly under the current filter.
- Also fixes two real bugs the contradiction surfaced: `_on_exception`'s address match now queries dbgeng's *live* breakpoint list instead of a shadow set that went stale on oneshot breakpoints; `detach()` now clears breakpoint/call-guard bookkeeping so a later re-attach can't misclassify exceptions from stale state.
- Adds `TestOnExceptionFilter`/`TestDetachClearsBreakpointBookkeeping` unit tests pinning this behavior.

This PR is scoped to the shared, application-agnostic exception filter in `debugger/engine.py`. It does not add or rely on any target-specific behavior.

## Test plan
- [x] `pytest tests/unit/test_debugger_engine.py -q` — 21 passed
- [x] `pytest tests/unit/ -q --cov-fail-under=46` — full suite passes, 53.36% coverage (floor 46%)
- [x] Live verification against a disposable, synthetic WOW64 process: passive breakpoint capture + guarded `call_function` both confirmed working with no poisoning
- [ ] CI (Ubuntu + Windows matrix, Python 3.10-3.13) — pending on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)