### PR TITLE
fun-doc: OpenD2 conformance port pipeline (document -> port -> prove)

### DIFF
--- a/fun-doc/abi_static.py
+++ b/fun-doc/abi_static.py
@@ -1,0 +1,1496 @@
+"""abi_static.py -- MECHANICAL ABI derivation from disassembly (no model, no oracle).
+
+Why this exists (2026-07-08 batch lessons, see D2MOO conformance workflow): the two
+worst port failures were the drafting model GUESSING ABI facts that the disassembly
+states outright:
+
+  * GetAnimSequenceRecord: model declared __fastcall/ECX for a function whose disasm
+    reads `[ESP+4]` and ends `RET 0x4` -- plain 1-slot __stdcall. Wrong callconv makes
+    the ORIGINAL read its arg from the wrong place -> live_prove_failed, 3 retries.
+  * DATATBLS_GetItemDataByCode: Ghidra's prototype said ONE param, but the disasm
+    ends `RET 0xC` -- THREE stack slots (two unused). Marshalling 1 arg while the
+    callee pops 3 corrupted the oracle stack -> SEH fault -> the function was wrongly
+    written off as "blocked".
+
+Both facts are 100% derivable statically:
+  RET n            -> callee cleans n bytes  -> n/4 stack slots, stdcall-family
+  [ESP+x] reads    -> which slots are actually used
+  reads-before-writes of GP registers -> register-explicit incoming args
+  `dword ptr [0x...]` absolute derefs -> data globals the reimpl needs resolved
+  CALL <addr>      -> delegates (delegate-rung / not-a-leaf detection)
+  decompile "Subroutine does not return" / _exit / CleanupAndAbort -> abort class
+    (out-of-range input KILLS the process/bridge -> vectors must stay in-envelope)
+
+derive_abi() is heuristic-but-honest: linear scan with an ESP-delta tracker; any
+construct it can't track precisely (calls, branches before stack reads) sets
+`approx=True` so callers treat used_slots as advisory while ret_imm/slots stay
+authoritative (RET n is unambiguous).
+
+Standalone: stdlib only. Self-test: python abi_static.py  (runs the 4-function
+known-answer corpus captured from live D2Common 1.13c).
+"""
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# disasm parsing
+# ---------------------------------------------------------------------------
+# Ghidra /disassemble_function lines: "6fdc19a0: MOV EAX,dword ptr [ESP + 0x4] ; comment"
+_LINE_RE = re.compile(r"^\s*([0-9a-fA-F]{6,}):\s+(\S+)\s*(.*?)\s*(?:;.*)?$")
+
+_GP32 = ("EAX", "EBX", "ECX", "EDX", "ESI", "EDI", "EBP")
+# sub-register -> parent 32-bit register
+_SUBREG = {}
+for _r in _GP32:
+    _SUBREG[_r] = _r
+for _p, _subs in (("EAX", ("AX", "AL", "AH")), ("EBX", ("BX", "BL", "BH")),
+                  ("ECX", ("CX", "CL", "CH")), ("EDX", ("DX", "DL", "DH")),
+                  ("ESI", ("SI",)), ("EDI", ("DI",)), ("EBP", ("BP",))):
+    for _s in _subs:
+        _SUBREG[_s] = _p
+
+_REG_TOKEN_RE = re.compile(r"\b(E?[ABCD]X|E?[SD]I|E?BP|[ABCD][LH])\b", re.IGNORECASE)
+_ESP_READ_RE = re.compile(r"\[\s*ESP\s*(?:\+\s*(0x[0-9a-fA-F]+|\d+))?\s*\]", re.IGNORECASE)
+_ABS_MEM_RE = re.compile(r"\[\s*(0x[0-9a-fA-F]+)\s*\]")
+_IMM_RE = re.compile(r"^(?:0x[0-9a-fA-F]+|-?\d+)$")
+
+_ABORT_DECOMPILE_RE = re.compile(
+    r"Subroutine does not return|_exit\s*\(|CleanupAndAbort|ExitProcess|\babort\s*\(",
+    re.IGNORECASE)
+
+# The D2Common 1.13c abort-idiom helpers (GetReturnAddress / CleanupAndAbort /
+# _exit). Every fatal out-of-range branch this session called exactly these three,
+# and they are NOT delegates in the delegate-rung sense -- they're unreachable
+# in-envelope. derive_abi() splits them out of `calls` so the planner doesn't
+# misfile every abort-class getter as delegate-rung. Version-specific; extend or
+# override for other targets.
+ABORT_HELPERS = {0x6fd5921c, 0x6fd59216, 0x6fd51b0d}
+
+
+def _regs_in(text: str) -> set:
+    """Parent 32-bit GP registers mentioned anywhere in an operand string."""
+    return {_SUBREG[m.group(1).upper()] for m in _REG_TOKEN_RE.finditer(text or "")}
+
+
+def parse_disasm(text: str) -> list:
+    """[(addr:int, mnemonic:str, operands:str)] from Ghidra disassembly text."""
+    out = []
+    for line in (text or "").splitlines():
+        m = _LINE_RE.match(line)
+        if m:
+            out.append((int(m.group(1), 16), m.group(2).upper(), m.group(3).strip()))
+    return out
+
+
+def detect_abort_path(decompiled_text: str) -> bool:
+    """True when the DECOMPILE shows a noreturn/abort branch. Such a function is
+    ABORT CLASS: an input that reaches the branch calls _exit/CleanupAndAbort and
+    kills the process (or the oracle bridge) UNCATCHABLY -- so prove vectors must
+    stay strictly in the valid envelope and V1 adversarial sweeps must skip it.
+    (GetAnimSequenceRecord killed the :8790 bridge 3x before this was automated;
+    contrast GetItemDataRecord whose out-of-range path RETURNS NULL -> full-range
+    vectors are safe. The decompile states which one you have.)"""
+    return bool(_ABORT_DECOMPILE_RE.search(decompiled_text or ""))
+
+
+# A dwType (or ->dwType) comparison anywhere in the body. Combined with
+# detect_abort_path, this flags a HANDLE-typed abort gated on the captured
+# object's dispatch type -- distinct from a SCALAR out-of-range abort.
+_DWTYPE_CMP_RE = re.compile(r"\bdwType\b\s*(?:==|!=|<|>|<=|>=)", re.IGNORECASE)
+
+
+def detect_handle_abort_hazard(decompiled_text: str) -> bool:
+    """True when a handle-getter's abort path is gated on the CAPTURED OBJECT's
+    dwType (e.g. `if (pUnit->dwType == 0) {...} else CleanupAndAbort();`), not a
+    numeric index. CONFIRMED LIVE CRASH (2026-07-08, STAT_GetUnitCalculatedStat):
+    the oracle's handle-prove path round-robins DISTINCT captured object types
+    (Player/Monster/Object/...) for branch-coverage diversity -- for a function
+    gated this way, that diversity mechanism itself feeds it the wrong type and
+    triggers an UNCATCHABLE abort (a real 'Halt' dialog that force-terminates the
+    game process, unlike a wild-read SEH fault). detect_abort_path() alone can't
+    distinguish this from a safe scalar-index abort class, so callers must check
+    BOTH: abort present AND a dwType comparison -> refuse automated handle-prove
+    (the fix needs a Player-only capture pin, which the C++ capture mechanism
+    doesn't support yet -- so this is a SKIP, not a clamp, until it does)."""
+    return bool(detect_abort_path(decompiled_text) and _DWTYPE_CMP_RE.search(decompiled_text or ""))
+
+
+def derive_abi(disasm_text: str) -> dict:
+    """Ground-truth ABI facts from a function's disassembly. See module docstring.
+
+    Returns {
+      ret_imm:      bytes the callee cleans (RET n), 0 for plain RET, None if no RET seen
+      slots:        stack arg slots = ret_imm // 4 (None when ret_imm is None)
+      used_slots:   sorted slot indices actually read via [ESP+x] (advisory if approx)
+      reg_args:     GP registers read before written (register-explicit incoming args)
+      callconv:     'stdcall' | 'fastcall' | 'thiscall' | 'register_explicit'
+                    | 'cdecl_or_caller_clean' | 'unknown'
+      calls:        CALL target addresses (delegates; non-empty => NOT a pure leaf)
+      data_globals: absolute `[0x...]` memory-deref operands (globals to resolve)
+      approx:       True when used_slots tracking crossed a call/branch (heuristic zone)
+      notes:        human-readable derivation notes
+    }
+    """
+    ins = parse_disasm(disasm_text)
+    notes: list = []
+    ret_imms: set = set()
+    used_offsets: set = set()
+    calls: list = []
+    data_globals: list = []
+    written: set = set()
+    reg_args: set = set()
+    depth = 0          # linear ESP delta (bytes pushed since entry)
+    approx = False
+
+    for addr, mn, ops in ins:
+        # --- absolute data derefs (any instruction) ---
+        for m in _ABS_MEM_RE.finditer(ops):
+            v = int(m.group(1), 16)
+            if v not in data_globals:
+                data_globals.append(v)
+
+        # --- stack arg reads: [ESP] / [ESP+off], adjusted by tracked push depth ---
+        for m in _ESP_READ_RE.finditer(ops):
+            off = int(m.group(1), 0) if m.group(1) else 0
+            orig = off - depth          # offset as seen at function entry
+            if orig >= 4:               # 0 = return address slot
+                used_offsets.add(orig)
+            elif depth:                 # post-push read we can't attribute cleanly
+                approx = True
+
+        # --- register reads-before-writes (incoming register args) ---
+        reads: set = set()
+        writes: set = set()
+        if mn in ("MOV", "MOVSX", "MOVZX", "LEA"):
+            parts = ops.split(",", 1)
+            if len(parts) == 2:
+                dst, src = parts[0].strip(), parts[1].strip()
+                reads |= _regs_in(src)
+                if "[" in dst:                       # memory dst: its address regs are READ
+                    reads |= _regs_in(dst)
+                else:
+                    writes |= _regs_in(dst)
+        elif mn in ("TEST", "CMP"):
+            reads |= _regs_in(ops)
+        elif mn == "PUSH":
+            reads |= _regs_in(ops)
+            depth += 4
+        elif mn == "POP":
+            writes |= _regs_in(ops)
+            depth -= 4
+        elif mn == "IMUL":
+            parts = [p.strip() for p in ops.split(",")]
+            if parts:
+                writes |= _regs_in(parts[0])
+                for p in parts[1:]:
+                    reads |= _regs_in(p)
+        elif mn in ("ADD", "SUB", "AND", "OR", "XOR", "SBB", "ADC",
+                    "SHL", "SHR", "SAR", "ROL", "ROR"):
+            parts = ops.split(",", 1)
+            if len(parts) == 2:
+                dst, src = parts[0].strip(), parts[1].strip()
+                d_esp = dst.upper() == "ESP"
+                if d_esp and mn in ("SUB", "ADD") and _IMM_RE.match(src):
+                    depth += int(src, 0) * (1 if mn == "SUB" else -1)
+                if mn == "XOR" and dst.strip().upper() == src.strip().upper():
+                    writes |= _regs_in(dst)          # xor r,r zero idiom: write-only
+                else:
+                    reads |= _regs_in(src)
+                    if "[" in dst:
+                        reads |= _regs_in(dst)
+                    else:
+                        reads |= _regs_in(dst)       # read-modify-write
+                        writes |= _regs_in(dst)
+        elif mn in ("INC", "DEC", "NEG", "NOT"):
+            reads |= _regs_in(ops)
+            writes |= _regs_in(ops)
+        elif mn == "CALL":
+            m = re.match(r"^(0x[0-9a-fA-F]+)$", ops.strip())
+            if m:
+                calls.append(int(m.group(1), 16))
+            # caller-saved clobber; args consumed by a callee-clean callee. We can't
+            # see the callee's cleanup, so RESET the linear depth (true whenever the
+            # tracked depth came from arg pushes -- the norm in these leaf/thunk fns)
+            # and flag the remainder of the scan as approximate.
+            writes |= {"EAX", "ECX", "EDX"}
+            if depth:
+                depth = 0
+                approx = True
+        elif mn.startswith("RET"):
+            m = re.match(r"^(0x[0-9a-fA-F]+|\d+)$", ops.strip()) if ops.strip() else None
+            ret_imms.add(int(m.group(1), 0) if m else 0)
+
+        reg_args |= {r for r in reads if r not in written and r not in ("EBP",)}
+        written |= writes
+
+    # --- synthesize ---
+    ret_imm = None
+    if ret_imms:
+        nz = {r for r in ret_imms if r}
+        if len(nz) > 1:
+            notes.append(f"multiple RET immediates {sorted(nz)} -- shared epilogue?")
+        ret_imm = max(nz) if nz else 0
+    slots = (ret_imm // 4) if ret_imm is not None else None
+    used_slots = sorted((o - 4) // 4 for o in used_offsets)
+    if slots is not None and used_slots and used_slots[-1] >= slots and ret_imm:
+        notes.append(f"stack read beyond RET-cleaned slots (used {used_slots}, slots {slots})")
+        approx = True
+
+    if ret_imm:
+        if not reg_args:
+            callconv = "stdcall"
+        elif reg_args == {"ECX"}:
+            callconv = "thiscall"
+        elif reg_args <= {"ECX", "EDX"}:
+            callconv = "fastcall"
+        else:
+            callconv = "register_explicit"
+    elif ret_imm == 0:
+        callconv = ("register_explicit" if reg_args
+                    else ("cdecl_or_caller_clean" if used_slots else "unknown"))
+    else:
+        callconv = "unknown"
+        notes.append("no RET instruction seen (noreturn tail?)")
+
+    if slots is not None and slots and not used_slots and not approx:
+        notes.append(f"RET 0x{ret_imm:x} cleans {slots} slot(s) but none are read -- "
+                     "declare ALL of them (unused padding params) or the caller stack corrupts")
+
+    real_calls = [c for c in calls if c not in ABORT_HELPERS]
+    helper_calls = [c for c in calls if c in ABORT_HELPERS]
+    return {
+        "ret_imm": ret_imm, "slots": slots, "used_slots": used_slots,
+        "reg_args": sorted(reg_args), "callconv": callconv,
+        "calls": real_calls, "abort_helper_calls": helper_calls,
+        "data_globals": data_globals,
+        "approx": approx, "notes": notes,
+    }
+
+
+def abi_prompt_block(abi: dict, abort_class: bool = False) -> str:
+    """A prompt section stating the DERIVED ABI as authoritative, for injection
+    into draft prompts. The model no longer gets a vote on callconv/slot count."""
+    if not abi or abi.get("slots") is None:
+        lines = ["## ABI (static derivation unavailable -- follow the plate/decompile)"]
+    else:
+        lines = ["## AUTHORITATIVE ABI (derived mechanically from the disassembly -- "
+                 "do NOT contradict this)"]
+        cc = abi["callconv"]
+        n = abi["slots"]
+        lines.append(f"- Calling convention: {cc}; the callee cleans {abi['ret_imm']} bytes "
+                     f"(RET 0x{abi['ret_imm']:x}) => declare EXACTLY {n} stack parameter(s).")
+        if abi["used_slots"] and len(abi["used_slots"]) < (n or 0):
+            unused = [i for i in range(n) if i not in abi["used_slots"]]
+            lines.append(f"- Only slot(s) {abi['used_slots']} are read; slot(s) {unused} are "
+                         f"UNUSED but MUST still be declared (e.g. `int unused{unused[0]+1}`) "
+                         f"or the stack is corrupted at return.")
+        if abi["reg_args"]:
+            lines.append(f"- Register-explicit incoming args: {', '.join(abi['reg_args'])}.")
+        if abi["calls"]:
+            lines.append(f"- Calls {len(abi['calls'])} subroutine(s) -- not a pure leaf.")
+    if abort_class:
+        lines.append("- ABORT CLASS: the out-of-range branch terminates the process "
+                     "(_exit/CleanupAndAbort). input_sets MUST stay strictly IN-RANGE: "
+                     "small non-negative indices only. NO negatives, NO INT_MIN/INT_MAX, "
+                     "NO huge values, NO 'boundary+1' probes -- any of those KILLS the game.")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# MECHANICAL GETTER TRANSLATION (no model). The hottest port class -- a shadow_leaf
+# getter -- is 2-5 instructions of a pure MOV-chain: load the pointer param, walk a
+# few [reg+off] derefs (each optionally null-guarded by a TEST/JNZ that skips an
+# abort block), and return the final read (MOV/MOVSX/MOVZX = width+sign). That maps
+# to C with ZERO model involvement, ZERO guesswork.
+#
+# WHY (2026-07-08): three reimpls diverged ~99% because the MODEL drafted from
+# Ghidra's decompile PROSE -- `pStateLinkedList[1].pStateHead` became invented
+# struct-size/index arithmetic reading a bogus fixed offset. The disasm is
+# unambiguous (`MOV EAX,[EAX+0xa8]; MOV EAX,[EAX+0xc]`). Translating it directly
+# removes the whole defect class (and the CONCAT31 u8/u32 oscillation) for the
+# functions this handles; anything with a branch / arithmetic / call / 2nd arg
+# returns None so the caller falls back to the model.
+# ---------------------------------------------------------------------------
+_MEM_OFF_RE = re.compile(
+    r"\[\s*(E?[ABCD]X|E?[SD]I|E?BP)\s*(?:\+\s*(0x[0-9a-fA-F]+|\d+))?\s*\]", re.IGNORECASE)
+
+
+def _ret_c_type(ret: str):
+    return {"u8": "unsigned char", "i8": "char", "u16": "unsigned short", "i16": "short",
+            "u32": "unsigned int", "i32": "int", "void": "void*"}.get(ret, "unsigned int")
+
+
+def translate_getter_to_c(name: str, disasm_text: str, *, callconv: str = "stdcall",
+                          ret: str = "u32") -> dict:
+    """A pure pointer-deref getter's disasm -> {ok, code, ret, chain, reason}.
+
+    Handles the LINEAR shape: `MOV EAX,[ESP+4]` (the single pointer param), a
+    sequence of `MOV/MOVSX/MOVZX EAX,[EAX+off]` (pointer walks; the LAST is the
+    returned read, its mnemonic sets width+sign), optional null-guards (`TEST
+    EAX,EAX` + a conditional to a return-0 / abort block, either JNZ-skips-abort or
+    JZ-jumps-to-null-return), a trailing chain of value transforms on the final read
+    (`AND/OR/XOR/SHL/SHR EAX, imm` -- flag/bit getters like `& 4` or `>>8 & 1`), the
+    `XOR EAX,EAX` return-0 idiom, and a final `RET n`. ANY CMP / value-compare branch
+    / IMUL/MUL/LEA/ADD/SUB on a data reg / a deref AFTER a transform (computed
+    address) / CALL to a non-abort target / 2nd stack arg / a register outside the
+    EAX chain -> ok=False with a reason (caller falls back to the model)."""
+    ins = parse_disasm(disasm_text)
+    if not ins:
+        return {"ok": False, "reason": "no disassembly"}
+
+    _COP = {"AND": "&", "OR": "|", "XOR": "^", "SHL": "<<", "SHR": ">>"}
+    param_loaded = False
+    derefs = []          # list of (offset, sign_class, width) -- pointer walks; last is the read
+    guards = []          # indices into `derefs` (or -1 for the param itself) null-guarded
+    post_ops = []        # (c_operator, imm) value transforms applied AFTER the last deref
+    type_gates = []      # (chain_depth, off, imm, width) -- `CMP [chain+off],imm; Jcc->ret0`
+    pending_guard_reg = None   # 'EAX' after a TEST EAX,EAX awaiting its conditional
+    pending_cmp_gate = None    # (off, imm, width) after a CMP [EAX+off],imm awaiting its Jcc
+    ret_imm = None
+    default_ret = 0            # value returned on the guard-fail path (0 via XOR EAX,EAX,
+                               # or a nonzero `MOV EAX,imm` -- e.g. GetItemQuality `return 2`)
+
+    for _addr, mn, ops in ins:
+        if mn == "PUSH":
+            continue                     # abort-block arg / return addr
+        if mn == "CALL":
+            m = re.match(r"^(0x[0-9a-fA-F]+)$", ops.strip())
+            tgt = int(m.group(1), 16) if m else None
+            if tgt in ABORT_HELPERS:
+                continue                 # abort idiom -- guarded, never taken
+            return {"ok": False, "reason": f"calls non-abort subroutine {ops.strip()}"}
+        if mn == "JMP":
+            continue                     # into the abort / null-return block; harmless
+        if mn.startswith("RET"):
+            m = re.match(r"^(0x[0-9a-fA-F]+|\d+)$", ops.strip()) if ops.strip() else None
+            ret_imm = int(m.group(1), 0) if m else 0
+            continue                     # multiple RETs (null path + value path) are fine
+        if mn == "TEST":
+            regs = _regs_in(ops)
+            if regs == {"EAX"}:
+                pending_guard_reg = "EAX"
+                continue
+            return {"ok": False, "reason": f"TEST on {regs} (not the EAX chain)"}
+        if mn[0] == "J" and mn != "JMP":
+            # A conditional AFTER a `TEST EAX,EAX` is a NULL-GUARD on the current
+            # pointer, whichever sense (JNZ skips the abort; JZ jumps to a return-0).
+            if pending_guard_reg == "EAX":
+                guards.append(len(derefs) - 1)
+                pending_guard_reg = None
+                continue
+            # A conditional AFTER a `CMP [chain+off],imm` is a TYPE-GATE: the getter
+            # returns the default (0) unless the field equals the immediate (the
+            # ubiquitous `if (pUnit->dwType != 4) return 0;` item-getter guard). The
+            # gate lands on the CURRENT chain pointer (len(derefs) walks applied).
+            if pending_cmp_gate is not None:
+                goff, gimm, gw = pending_cmp_gate
+                type_gates.append((len(derefs), goff, gimm, gw))
+                pending_cmp_gate = None
+                continue
+            return {"ok": False, "reason": f"conditional {mn} not a null-guard/type-gate"}
+        if mn == "CMP":
+            # Only a `CMP <mem on the EAX chain>, imm` is a translatable type-gate;
+            # a register/global compare (bound check, computed branch) still bails.
+            parts = ops.split(",", 1)
+            if len(parts) == 2:
+                lhs, rhs = parts[0].strip(), parts[1].strip()
+                mm = _MEM_OFF_RE.search(lhs)
+                if _IMM_RE.match(rhs) and mm and mm.group(1).upper() == "EAX":
+                    goff = int(mm.group(2), 0) if mm.group(2) else 0
+                    lsl = lhs.lower()
+                    gw = "d" if "dword" in lsl else ("w" if "word" in lsl
+                                                     else ("b" if "byte" in lsl else "d"))
+                    pending_cmp_gate = (goff, int(rhs, 0), gw)
+                    continue
+            return {"ok": False, "reason": "CMP not a [EAX+off],imm type-gate -- computed branch"}
+        if mn in ("ADD", "SUB"):
+            # `ADD/SUB ESP, imm` = stack cleanup (harmless); on a data reg = computed.
+            if ops.split(",", 1)[0].strip().upper() == "ESP":
+                continue
+            return {"ok": False, "reason": f"arithmetic {mn} on data reg -- computed getter"}
+        if mn in _COP:
+            parts = ops.split(",", 1)
+            dst = parts[0].strip().upper()
+            src = parts[1].strip() if len(parts) == 2 else ""
+            # a sub-register (AX/AL) write is still the EAX accumulator (low bits).
+            if _SUBREG.get(dst) != "EAX":
+                return {"ok": False, "reason": f"{mn} writes {dst}, not the EAX chain"}
+            if mn == "XOR" and _SUBREG.get(src.upper()) == "EAX":
+                continue                 # `XOR EAX,EAX` / `XOR AX,AX` = return-0 idiom (null path)
+            if _IMM_RE.match(src):       # AND/OR/XOR/SHL/SHR EAX, imm -> a value transform
+                post_ops.append((_COP[mn], int(src, 0)))
+                continue
+            return {"ok": False, "reason": f"{mn} EAX,{src} -- non-immediate transform"}
+        if mn in ("IMUL", "MUL", "LEA", "SAR", "ROL", "ROR", "NOT", "NEG"):
+            return {"ok": False, "reason": f"arithmetic {mn} -- computed getter, needs the model"}
+        if mn in ("MOV", "MOVSX", "MOVZX"):
+            parts = ops.split(",", 1)
+            if len(parts) != 2:
+                return {"ok": False, "reason": f"unparsed MOV operands: {ops}"}
+            dst, src = parts[0].strip().upper(), parts[1].strip()
+            # MOVSX/MOVZX target EAX directly; a plain `MOV AX/AL,..` writes the low
+            # bits of the EAX accumulator -- both are the return-value chain. The read
+            # WIDTH comes from the operand (`byte/word ptr`), captured below.
+            if _SUBREG.get(dst) != "EAX":
+                return {"ok": False, "reason": f"writes {dst}, not the EAX chain"}
+            esp = _ESP_READ_RE.search(src)
+            if esp:
+                off = int(esp.group(1), 0) if esp.group(1) else 0
+                if off != 4 or param_loaded:
+                    return {"ok": False, "reason": f"non-arg-0 stack read [ESP+{off}]"}
+                param_loaded = True
+                continue
+            mm = _MEM_OFF_RE.search(src)
+            if mm:
+                if post_ops:
+                    return {"ok": False, "reason": "deref AFTER a transform -- computed address"}
+                base = mm.group(1).upper()
+                if base != "EAX":
+                    return {"ok": False, "reason": f"deref base {base}, not the EAX chain"}
+                off = int(mm.group(2), 0) if mm.group(2) else 0
+                sl = src.lower()
+                width = ("d" if "dword" in sl else "w" if "word" in sl
+                         else "b" if "byte" in sl else None)
+                derefs.append((off, {"MOVSX": "sx", "MOVZX": "zx"}.get(mn, "mov"), width))
+                continue
+            # `MOV EAX, <immediate>` = the guard-fail DEFAULT return value (the non-zero
+            # analogue of `XOR EAX,EAX`; e.g. GetItemQuality's `MOV EAX,0x2` -> return 2).
+            if mn == "MOV" and _IMM_RE.match(src):
+                default_ret = int(src, 0)
+                continue
+            return {"ok": False, "reason": f"MOV from non-memory {src} -- not a deref chain"}
+        return {"ok": False, "reason": f"unhandled instruction {mn} {ops}"}
+
+    if not param_loaded or not derefs:
+        return {"ok": False, "reason": "not a [ESP+4] pointer-deref getter"}
+
+    # width/sign of the FINAL read decides the return type -- UNLESS a trailing
+    # transform is present (a mask/shift yields a full-width int, not a byte). The
+    # width is READ from the memory operand (`byte/word/dword ptr`) so a plain
+    # `MOV AX, word ptr [..]` correctly yields u16 -- CRITICAL: the oracle's RetMask
+    # compares only the low <width> bits, so a byte/word read must declare u8/u16 or
+    # the stale upper EAX bits (the high half of the intermediate pointer) get
+    # compared and a bit-exact reimpl falsely mismatches (the ITEMS word-getter bug).
+    final_off, final_sign, final_width = derefs[-1]
+    if post_ops:
+        eff_ret = ret if ret in ("u32", "i32") else "u32"
+    elif final_width == "b":
+        eff_ret = "i8" if final_sign == "sx" else "u8"
+    elif final_width == "w":
+        eff_ret = "i16" if final_sign == "sx" else "u16"
+    elif final_width == "d":
+        eff_ret = "i32" if (final_sign == "sx" or ret == "i32") else "u32"
+    elif final_sign == "zx":            # width unknown: fall back to the sign class
+        eff_ret = "u8" if "byte" in disasm_text.lower() else "u16"
+    elif final_sign == "sx":
+        eff_ret = "i8" if "byte" in disasm_text.lower() else "i16"
+    else:
+        eff_ret = ret if ret in ("u32", "i32", "void") else "u32"
+    ret_c = _ret_c_type(eff_ret)
+
+    _GATE_CT = {"b": "unsigned char", "w": "unsigned short", "d": "unsigned int"}
+
+    _dflt = f"0x{default_ret:x}" if default_ret else "0"
+
+    def _gates_at(depth):               # type-gate guards on the pointer at this depth
+        return [f"    if (*({_GATE_CT.get(gw, 'unsigned int')}*)(r + 0x{go:x}) != 0x{gi:x}u)"
+                f" return {_dflt};   // type-gate"
+                for (dd, go, gi, gw) in type_gates if dd == depth]
+
+    lines = ['#include "../provider_runtime.h"', "",
+             f"// D2MOO_REIMPL_EXPORT: {name}",
+             "// [abi_static] MECHANICALLY TRANSLATED from disassembly (no model): "
+             "pure pointer-deref getter"
+             + (" with type-gate(s)." if type_gates else ".")
+             + (f"  (guard-fail default = {_dflt})" if default_ret else ""),
+             f'extern "C" {ret_c} __stdcall {name}(void* p)', "{",
+             f"    if (p == nullptr) return {_dflt};",
+             "    char* r = (char*)p;"]
+    lines += _gates_at(0)               # gate(s) on the param pointer itself
+    for i, (off, _s, _w) in enumerate(derefs[:-1]):
+        lines.append(f"    r = *(char**)(r + 0x{off:x});")
+        if i in guards:
+            lines.append(f"    if (r == nullptr) return {_dflt};")
+        lines += _gates_at(i + 1)       # gate(s) on this chain pointer
+    expr = f"*({_ret_c_type('u32') if post_ops else ret_c}*)(r + 0x{final_off:x})"
+    for op, imm in post_ops:            # apply transforms left-to-right: ((v >> 8) & 1)
+        expr = f"({expr} {op} 0x{imm:x}u)"
+    lines.append(f"    return {expr};")
+    lines.append("}")
+    return {"ok": True, "code": "\n".join(lines) + "\n", "ret": eff_ret,
+            "chain": [off for off, _s, _w in derefs], "ret_imm": ret_imm,
+            "post_ops": post_ops, "type_gates": type_gates,
+            "reason": f"linear getter: param -> {len(derefs)} deref(s)"
+                      + (f", {len(type_gates)} type-gate(s)" if type_gates else "")
+                      + (f" + {len(post_ops)} transform(s)" if post_ops else "")}
+
+
+_RESOLVE_REV = None
+_RESOLVE_GEN = (r"C:\Users\benam\source\cpp\D2MOO\D2.Detours.patches\1.13c"
+                r"\D2Common_ResolveTable.gen.h")
+
+
+def resolve_reverse_map(path: str = None) -> dict:
+    """address(int) -> verified name, parsed from D2Common_ResolveTable.gen.h. A
+    delegate reimpl resolves its callee BY NAME (D2MOO_Resolve), so the CALL target
+    address from the disasm must map to a name the resolver knows. Cached."""
+    global _RESOLVE_REV
+    if _RESOLVE_REV is not None and path is None:
+        return _RESOLVE_REV
+    p = path or _RESOLVE_GEN
+    rev = {}
+    try:
+        text = open(p, encoding="utf-8").read()
+        for m in re.finditer(r'\{\s*"([^"]+)",\s*0x([0-9a-fA-F]+)u\s*\}', text):
+            rev[int(m.group(2), 16)] = m.group(1)
+    except OSError:
+        pass
+    if path is None:
+        _RESOLVE_REV = rev
+    return rev
+
+
+def resolvable_callees(disasm_text: str, resolve_rev: dict = None) -> list:
+    """Every `CALL 0x...` target in the disasm that maps to a RESOLVABLE D2Common name
+    (excluding the abort helpers). Returns [(addr, name), ...], de-duplicated in order.
+    Used to HINT the model: a reimpl must reach a game function via D2MOO_Resolve(name),
+    never a direct call (unresolved symbol -> the whole provider build fails)."""
+    rev = resolve_rev if resolve_rev is not None else resolve_reverse_map()
+    out, seen = [], set()
+    for _addr, mn, ops in parse_disasm(disasm_text):
+        if mn != "CALL":
+            continue
+        m = re.match(r"^(0x[0-9a-fA-F]+)$", ops.strip())
+        if not m:
+            continue
+        tgt = int(m.group(1), 16)
+        if tgt in ABORT_HELPERS or tgt in seen:
+            continue
+        nm = rev.get(tgt)
+        if nm:
+            out.append((tgt, nm))
+            seen.add(tgt)
+    return out
+
+
+def callthrough_prompt_block(callees: list) -> str:
+    """A prompt fragment telling the model to resolve+call-through the given callees
+    (list of (addr, name)) instead of calling them directly. Empty if no callees."""
+    if not callees:
+        return ""
+    names = ", ".join(n for _a, n in callees)
+    ex = callees[0][1]
+    return (
+        "\n\n## CALL-THROUGH REQUIRED -- this function CALLS other D2Common function(s): "
+        f"{names}.\n"
+        "The provider is a standalone DLL and CANNOT link those symbols -- calling one "
+        "DIRECTLY is an unresolved external that FAILS THE WHOLE BUILD. Resolve each BY "
+        "NAME via the injected resolver and call through a function pointer:\n"
+        "```cpp\n"
+        f'    typedef void* (__stdcall *{ex}_t)(unsigned int);   // match the callee ABI from the disasm\n'
+        f'    {ex}_t _f = ({ex}_t)D2MOO_Resolve("{ex}");\n'
+        "    if (_f == nullptr) return /*fallback*/ 0;\n"
+        "    void* _r = _f(arg);\n"
+        "```\n"
+        "Use the EXACT verified name(s) above. Derive each callee's calling convention / "
+        "arg count from the disasm (PUSH count, RET n, or ECX/EDX for __fastcall). "
+        "D2MOO_Resolve is declared in provider_runtime.h (already included).")
+
+
+def resolvable_globals(disasm_text: str, resolve_rev: dict = None) -> list:
+    """Every absolute `[0x...]` data-global deref in the disasm that maps to a resolvable
+    name. Returns [(addr, name), ...]. Hints the model to resolve game globals via
+    D2MOO_Resolve (a direct extern reference = unresolved external = whole-build fail)."""
+    rev = resolve_rev if resolve_rev is not None else resolve_reverse_map()
+    out, seen = [], set()
+    for _addr, _mn, ops in parse_disasm(disasm_text):
+        for m in _ABS_MEM_RE.finditer(ops):
+            a = int(m.group(1), 16)
+            if a in rev and a not in seen:
+                out.append((a, rev[a]))
+                seen.add(a)
+    return out
+
+
+def global_resolve_prompt_block(globals_: list) -> str:
+    """Prompt fragment: resolve the given game globals (list of (addr, name)) via
+    D2MOO_Resolve. Empty if none."""
+    if not globals_:
+        return ""
+    names = ", ".join(n for _a, n in globals_)
+    ex = globals_[0][1]
+    return (
+        f"\n\n## GLOBAL RESOLVE REQUIRED -- this function reads game global(s): {names}.\n"
+        "The provider is a standalone DLL and CANNOT link game globals -- referencing one "
+        "as an `extern` symbol is an unresolved external that FAILS THE WHOLE BUILD. "
+        "Resolve each BY NAME; D2MOO_Resolve returns the ADDRESS OF THE VARIABLE:\n"
+        "```cpp\n"
+        f'    void* _g = D2MOO_Resolve("{ex}");   // address of the variable\n'
+        "    if (_g == nullptr) return 0;\n"
+        f'    // a `g_p*` POINTER variable holds a table base -> deref once:\n'
+        f'    char* base = (char*)*(void**)_g;\n'
+        "```\n"
+        "Use the EXACT verified name(s) above. A `g_p<X>` name is a POINTER variable (the "
+        "disasm does `MOV reg,[global]` then derefs reg) -- resolve, then deref once. "
+        "D2MOO_Resolve is declared in provider_runtime.h (already included).\n"
+        "CRITICAL -- read every field via a RAW OFFSET CAST from the disasm, e.g. "
+        "`*(unsigned char*)(base + idx*STRIDE + 0xNN)`. Do NOT use Ghidra decompiler struct "
+        "TYPE names (`ItemTypeDataEntry*`, `->bField10`, `undefined4`, ...) -- they are "
+        "decompiler fictions NOT defined in the provider translation unit, so they FAIL "
+        "THE BUILD. Only fixed-width casts (`unsigned char/short/int`) + numeric offsets.")
+
+
+def translate_delegate_getter_to_c(name: str, disasm_text: str, *, callconv: str = "stdcall",
+                                   ret: str = "u32", resolve_rev: dict = None) -> dict:
+    """A DELEGATE getter -- `param -> [guards] -> load arg field -> CALL a resolvable
+    D2Common function -> [null guard] -> read a field off the result -> [substitute] ->
+    return` -- translated to a CALL-THROUGH reimpl that resolves the callee BY NAME
+    (D2MOO_Resolve) and calls the REAL game function. Because it calls through, the
+    callee's own data-globals are the game's real globals -- no global wiring needed.
+
+    Handles the consistent ITEMS_GetItemRecord* family (Variant A): fallback-constant
+    guards (`return 0x64`), one call to a resolvable stdcall(1) callee, a sub-dword
+    result read (width from the operand -> correct RetMask), and an optional
+    `CMP v,imm; Jcc` value-substitute (`return (v==imm) ? fallback : v`).
+
+    BAILS (ok=False, caller falls back to the model) on: ABORT-class guards (CALL to an
+    abort helper -- that's a handle-abort-hazard, not a fallback); 0 or >1 CALL; a callee
+    not in the resolve table; an ECX/EDX base; >1 arg pushed; or any shape it can't map."""
+    rev = resolve_rev if resolve_rev is not None else resolve_reverse_map()
+    ins = parse_disasm(disasm_text)
+    if not ins:
+        return {"ok": False, "reason": "no disassembly"}
+
+    param_loaded = False
+    called = None            # (name) of the resolved callee once CALL is seen
+    n_calls = 0
+    n_push = 0
+    arg_off = None           # offset of the field loaded as the callee arg
+    type_gates = []          # (off, imm, w) pre-call field gates (dwType==imm)
+    result_off = None        # offset of the field read off the call result
+    result_sign = "mov"
+    result_width = None
+    subst = None             # (imm) from a post-read `CMP v,imm; Jcc`
+    fallback = 0             # the guard/fallback return constant
+    ret_imm = None
+    pending_cmp = None       # (kind, off, imm, w): 'gate' pre-call or 'subst' post-read
+
+    for _addr, mn, ops in ins:
+        if mn == "PUSH":
+            n_push += 1
+            continue
+        if mn == "JMP" or (mn[0] == "J" and mn != "JMP" and pending_cmp is None):
+            # bare conditional after a TEST null-guard (or JMP into fallback) -- harmless
+            continue
+        if mn.startswith("RET"):
+            m = re.match(r"^(0x[0-9a-fA-F]+|\d+)$", ops.strip()) if ops.strip() else None
+            ret_imm = int(m.group(1), 0) if m else 0
+            continue
+        if mn == "TEST":
+            continue                     # null-guard sentinel (either side of the call)
+        if mn == "CMP":
+            parts = ops.split(",", 1)
+            if len(parts) != 2:
+                return {"ok": False, "reason": f"unparsed CMP {ops}"}
+            lhs, rhs = parts[0].strip(), parts[1].strip()
+            if not _IMM_RE.match(rhs):
+                return {"ok": False, "reason": f"CMP against non-imm {rhs}"}
+            mm = _MEM_OFF_RE.search(lhs)
+            if mm and mm.group(1).upper() == "EAX" and not called:
+                lsl = lhs.lower()
+                gw = "d" if "dword" in lsl else "w" if "word" in lsl else "b" if "byte" in lsl else "d"
+                pending_cmp = ("gate", int(mm.group(2), 0) if mm.group(2) else 0, int(rhs, 0), gw)
+                continue
+            if _SUBREG.get(lhs.upper()) == "EAX" and called and result_off is not None:
+                pending_cmp = ("subst", None, int(rhs, 0), None)
+                continue
+            return {"ok": False, "reason": f"CMP shape not a gate/substitute: {ops}"}
+        if mn[0] == "J" and mn != "JMP":
+            if pending_cmp and pending_cmp[0] == "gate":
+                type_gates.append((pending_cmp[1], pending_cmp[2], pending_cmp[3]))
+            elif pending_cmp and pending_cmp[0] == "subst":
+                subst = pending_cmp[2]
+            pending_cmp = None
+            continue
+        if mn == "CALL":
+            m = re.match(r"^(0x[0-9a-fA-F]+)$", ops.strip())
+            tgt = int(m.group(1), 16) if m else None
+            if tgt in ABORT_HELPERS:
+                return {"ok": False, "reason": "abort-class guard (CleanupAndAbort/_exit)"}
+            nm = rev.get(tgt)
+            if not nm:
+                return {"ok": False, "reason": f"callee 0x{tgt:x} not in resolve table"}
+            n_calls += 1
+            if n_calls > 1:
+                return {"ok": False, "reason": "more than one CALL -- not a simple delegate"}
+            called = nm
+            continue
+        if mn in ("MOV", "MOVSX", "MOVZX"):
+            parts = ops.split(",", 1)
+            if len(parts) != 2:
+                return {"ok": False, "reason": f"unparsed MOV {ops}"}
+            dst, src = parts[0].strip().upper(), parts[1].strip()
+            esp = _ESP_READ_RE.search(src)
+            if esp:
+                off = int(esp.group(1), 0) if esp.group(1) else 0
+                if off != 4 or _SUBREG.get(dst) != "EAX" or param_loaded:
+                    return {"ok": False, "reason": f"unexpected stack read {ops}"}
+                param_loaded = True
+                continue
+            mm = _MEM_OFF_RE.search(src)
+            if mm:
+                base = mm.group(1).upper()
+                if base != "EAX":
+                    return {"ok": False, "reason": f"deref base {base}, not EAX chain"}
+                off = int(mm.group(2), 0) if mm.group(2) else 0
+                if not called:
+                    if arg_off is not None:
+                        return {"ok": False, "reason": "more than one pre-call arg load"}
+                    arg_off = off               # the field passed to the callee
+                else:
+                    result_off = off            # LAST post-call read = the returned field
+                    result_sign = {"MOVSX": "sx", "MOVZX": "zx"}.get(mn, "mov")
+                    sl = src.lower()
+                    result_width = ("d" if "dword" in sl else "w" if "word" in sl
+                                    else "b" if "byte" in sl else None)
+                continue
+            # MOV reg, imm  (fallback constant on the guard path) or reg,reg (shuffle)
+            if _IMM_RE.match(src) and _SUBREG.get(dst) == "EAX":
+                fallback = int(src, 0)
+                continue
+            if _SUBREG.get(src.upper()) == "EAX" and _SUBREG.get(dst) == "EAX":
+                continue                        # EAX<->sub shuffle (e.g. MOV EAX,ECX post-read)
+            return {"ok": False, "reason": f"MOV shape unhandled: {ops}"}
+        if mn in ("ADD", "SUB") and ops.split(",", 1)[0].strip().upper() == "ESP":
+            continue                            # cdecl-arg cleanup after a foreign call
+        if mn == "XOR":
+            parts = ops.split(",", 1)
+            if (len(parts) == 2 and _SUBREG.get(parts[0].strip().upper()) == "EAX"
+                    and _SUBREG.get(parts[1].strip().upper()) == "EAX"):
+                fallback = 0                    # `XOR EAX,EAX` / `XOR AL,AL` = return-0 fallback
+                continue
+            return {"ok": False, "reason": f"XOR shape unhandled: {ops}"}
+        return {"ok": False, "reason": f"unhandled instruction {mn} {ops}"}
+
+    if not (param_loaded and called and arg_off is not None and result_off is not None):
+        return {"ok": False, "reason": "not a param->load->CALL->read delegate"}
+
+    signed = (result_sign == "sx")
+    if result_width == "b":
+        eff_ret = "i8" if signed else "u8"
+    elif result_width == "w":
+        eff_ret = "i16" if signed else "u16"
+    elif result_width == "d":
+        eff_ret = "i32" if signed else "u32"
+    else:
+        eff_ret = ret if ret in ("u32", "i32") else "u32"
+    ret_c = _ret_c_type(eff_ret)
+    read_c = _ret_c_type(eff_ret)
+    fb = f"0x{fallback:x}"
+
+    lines = ['#include "../provider_runtime.h"', "",
+             f"// D2MOO_REIMPL_EXPORT: {name}",
+             f"// [abi_static] DELEGATE call-through (no model): resolves + calls {called}.",
+             f'typedef void* (__stdcall *_callee_t)(unsigned int);',
+             f'extern "C" {ret_c} __stdcall {name}(void* p)', "{",
+             f"    if (p == nullptr) return {fb};",
+             "    char* r = (char*)p;"]
+    for (goff, gimm, gw) in type_gates:
+        gt = {"b": "unsigned char", "w": "unsigned short", "d": "unsigned int"}.get(gw, "unsigned int")
+        lines.append(f"    if (*({gt}*)(r + 0x{goff:x}) != 0x{gimm:x}u) return {fb};")
+    lines += [
+        f"    unsigned int _arg = *(unsigned int*)(r + 0x{arg_off:x});",
+        f'    _callee_t _f = (_callee_t)D2MOO_Resolve("{called}");',
+        f"    if (_f == nullptr) return {fb};",
+        "    char* _rec = (char*)_f(_arg);",
+        f"    if (_rec == nullptr) return {fb};",
+        f"    {read_c} _v = *({read_c}*)(_rec + 0x{result_off:x});"]
+    if subst is not None:
+        lines.append(f"    return (_v == 0x{subst:x}) ? ({ret_c}){fb} : _v;")
+    else:
+        lines.append("    return _v;")
+    lines.append("}")
+    return {"ok": True, "code": "\n".join(lines) + "\n", "ret": eff_ret,
+            "callee": called, "arg_off": arg_off, "result_off": result_off,
+            "type_gates": type_gates, "fallback": fallback, "subst": subst,
+            "ret_imm": ret_imm,
+            "reason": f"delegate: param -> field 0x{arg_off:x} -> {called}() "
+                      f"-> read 0x{result_off:x}" + (f" (subst {subst})" if subst is not None else "")}
+
+
+def translate_global_table_getter_to_c(name: str, disasm_text: str, *,
+                                       callconv: str = "stdcall", ret: str = "u32",
+                                       resolve_rev: dict = None) -> dict:
+    """A GLOBAL-TABLE INDEXED getter -- the dominant DATATBLS shape:
+        idx = arg; if (idx < 0 || idx >= (*g_table)->count) return FB;
+        rec = (*g_table)->records + idx*STRIDE; return rec->field;
+    disasm idiom (regs may vary):
+        MOV EAX,[ESP+4]              ; idx
+        TEST EAX,EAX; JL  fb         ; idx < 0
+        MOV  Cx,[0x<global>]         ; base = *(void**)g   (the table pointer's value)
+        CMP  EAX,[Cx+<countOff>]; JGE fb
+        MOV  Dx,[Cx+<recOff>]        ; records = *(void**)(base+recOff)
+        IMUL EAX,EAX,<stride>
+        ADD  EAX,Dx                  ; rec = records + idx*stride
+        TEST EAX,EAX; JZ  fb
+        MOV/MOVSX/MOVZX EAX,<w>[EAX+<fieldOff>]
+        RET n ; fb: XOR EAX,EAX / MOV EAX,imm; RET n
+    Emits a reimpl that resolves the global BY NAME (D2MOO_Resolve) and reads via RAW
+    casts -- deterministic, no model (the model oscillates on the resolve-deref chain).
+    The offsets/stride/width/global are all in the disasm. BAILS on any deviation."""
+    rev = resolve_rev if resolve_rev is not None else resolve_reverse_map()
+    ins = parse_disasm(disasm_text)
+    if not ins:
+        return {"ok": False, "reason": "no disassembly"}
+
+    role = {}                # reg -> 'idx' | 'base' | 'records' | 'offset' | 'rec'
+    param_loaded = False
+    global_name = None
+    count_off = records_off = stride = field_off = None
+    field_sign = "mov"
+    field_width = None
+    fallback = 0
+    ret_imm = None
+
+    def _memparts(operand):
+        m = _MEM_OFF_RE.search(operand)
+        if not m:
+            return None, None
+        return m.group(1).upper(), (int(m.group(2), 0) if m.group(2) else 0)
+
+    for _addr, mn, ops in ins:
+        if mn in ("TEST", "PUSH"):
+            continue
+        if mn == "JMP" or (mn[0] == "J" and mn != "JMP"):
+            continue                 # guards (idx<0 / idx>=count / rec==0) -> emitted below
+        if mn.startswith("RET"):
+            m = re.match(r"^(0x[0-9a-fA-F]+|\d+)$", ops.strip()) if ops.strip() else None
+            ret_imm = int(m.group(1), 0) if m else 0
+            continue
+        if mn == "CMP":
+            # idx >= count : CMP <idxreg>,[<basereg>+countOff]
+            parts = ops.split(",", 1)
+            if len(parts) == 2 and role.get(parts[0].strip().upper()) == "idx":
+                base, off = _memparts(parts[1])
+                if base and role.get(base) == "base":
+                    count_off = off
+                    continue
+            return {"ok": False, "reason": f"CMP not the bound check: {ops}"}
+        if mn == "IMUL":
+            # IMUL EAX,EAX,imm  -> idx*stride
+            p = [x.strip().upper() for x in ops.split(",")]
+            if len(p) == 3 and role.get(p[0]) == "idx" and p[1] == p[0] and _IMM_RE.match(p[2].lower()):
+                stride = int(p[2], 0)
+                role[p[0]] = "offset"
+                continue
+            return {"ok": False, "reason": f"IMUL not idx*stride: {ops}"}
+        if mn == "ADD":
+            p = [x.strip().upper() for x in ops.split(",")]
+            if p[0] == "ESP":
+                continue
+            if len(p) == 2 and role.get(p[0]) == "offset" and role.get(p[1]) == "records":
+                role[p[0]] = "rec"
+                continue
+            return {"ok": False, "reason": f"ADD not offset+records: {ops}"}
+        if mn == "XOR":
+            p = [x.strip().upper() for x in ops.split(",")]
+            if len(p) == 2 and _SUBREG.get(p[0]) == _SUBREG.get(p[1]):
+                fallback = 0
+                continue
+            return {"ok": False, "reason": f"XOR unhandled: {ops}"}
+        if mn in ("MOV", "MOVSX", "MOVZX"):
+            parts = ops.split(",", 1)
+            if len(parts) != 2:
+                return {"ok": False, "reason": f"unparsed MOV {ops}"}
+            dst, src = parts[0].strip().upper(), parts[1].strip()
+            dparent = _SUBREG.get(dst)
+            esp = _ESP_READ_RE.search(src)
+            if esp:                                   # MOV EAX,[ESP+4] -> idx param
+                off = int(esp.group(1), 0) if esp.group(1) else 0
+                if off != 4 or param_loaded or dparent != "EAX":
+                    return {"ok": False, "reason": f"unexpected stack read {ops}"}
+                param_loaded = True
+                role["EAX"] = "idx"
+                continue
+            am = _ABS_MEM_RE.search(src)
+            if am:                                    # MOV reg,[0x<global>] -> base
+                a = int(am.group(1), 16)
+                nm = rev.get(a)
+                if not nm or global_name:
+                    return {"ok": False, "reason": f"global 0x{a:x} not resolvable / 2nd global"}
+                global_name = nm
+                role[dst] = "base"
+                continue
+            base, off = _memparts(src)
+            if base:
+                if role.get(base) == "base" and mn == "MOV":     # records = base->recOff
+                    records_off = off
+                    role[dst] = "records"
+                    continue
+                if role.get(base) == "rec":                       # final field read off rec
+                    field_off = off
+                    field_sign = {"MOVSX": "sx", "MOVZX": "zx"}.get(mn, "mov")
+                    sl = src.lower()
+                    field_width = ("d" if "dword" in sl else "w" if "word" in sl
+                                   else "b" if "byte" in sl else None)
+                    role[dst] = "result"
+                    continue
+                return {"ok": False, "reason": f"deref base role {role.get(base)}: {ops}"}
+            if _IMM_RE.match(src) and dparent == "EAX":           # MOV EAX,imm fallback const
+                fallback = int(src, 0)
+                continue
+            return {"ok": False, "reason": f"MOV shape unhandled: {ops}"}
+        return {"ok": False, "reason": f"unhandled instruction {mn} {ops}"}
+
+    if not (param_loaded and global_name and count_off is not None
+            and records_off is not None and stride is not None and field_off is not None):
+        return {"ok": False, "reason": "not a global-table indexed getter "
+                f"(g={global_name} count={count_off} rec={records_off} stride={stride} field={field_off})"}
+
+    # The original ends `MOV{ZX|SX} EAX, <w>[rec+off]` -- it returns the FULL EAX,
+    # zero-/sign-EXTENDED to 32 bits. So the return type is the EXTENDED width (u32 for
+    # MOVZX, i32 for MOVSX), NOT the sub-dword read type -- else a `unsigned char` return
+    # leaves the upper EAX bits undefined and diverges from the original's clean MOVZX
+    # under a 32-bit RetMask. Read at the native width, then cast to the 32-bit result.
+    signed = (field_sign == "sx")
+    read_c = {"b": ("signed char" if signed else "unsigned char"),
+              "w": ("short" if signed else "unsigned short"),
+              "d": ("int" if signed else "unsigned int")}.get(field_width, "unsigned int")
+    if field_sign == "zx":
+        eff_ret = "u32"
+    elif field_sign == "sx":
+        eff_ret = "i32"
+    elif field_width == "d":
+        eff_ret = "u32"
+    else:                       # plain MOV sub-register read (rare) -> mask by width
+        eff_ret = {"b": "u8", "w": "u16"}.get(field_width, "u32")
+    ret_c = _ret_c_type(eff_ret)
+    fb = f"0x{fallback:x}"
+
+    lines = ['#include "../provider_runtime.h"', "",
+             f"// D2MOO_REIMPL_EXPORT: {name}",
+             f"// [abi_static] GLOBAL-TABLE getter (no model): {global_name}"
+             f"->records[idx*0x{stride:x}] + 0x{field_off:x}.",
+             f'extern "C" {ret_c} __stdcall {name}(int idx)', "{",
+             f"    if (idx < 0) return {fb};",
+             f'    void* _g = D2MOO_Resolve("{global_name}");',
+             f"    if (_g == nullptr) return {fb};",
+             "    char* base = (char*)*(void**)_g;",
+             f"    if (base == nullptr) return {fb};",
+             f"    if (idx >= *(int*)(base + 0x{count_off:x})) return {fb};",
+             f"    char* records = (char*)*(void**)(base + 0x{records_off:x});",
+             f"    char* rec = records + (int)idx * 0x{stride:x};",
+             f"    if (rec == nullptr) return {fb};",
+             f"    return ({ret_c})*({read_c}*)(rec + 0x{field_off:x});",
+             "}"]
+    return {"ok": True, "code": "\n".join(lines) + "\n", "ret": eff_ret,
+            "global": global_name, "count_off": count_off, "records_off": records_off,
+            "stride": stride, "field_off": field_off, "fallback": fallback, "ret_imm": ret_imm,
+            "reason": f"global-table getter: {global_name}->records[idx*0x{stride:x}] "
+                      f"+ 0x{field_off:x} ({eff_ret})"}
+
+
+def apply_static_abi(layout: dict, input_sets: list, abi: dict) -> tuple:
+    """Override a model-drafted register param_layout (the fun-doc 'inputs/outputs'
+    shape) with statically derived facts. Returns (layout, input_sets, notes).
+    - stdcall + N slots: every input forced to register 'stack'; missing unused
+      slots are PADDED with zero-valued params so the marshal pushes all N.
+    Only corrects what the disasm states; register_explicit layouts pass through."""
+    notes: list = []
+    if not abi or abi.get("slots") is None or not isinstance(layout, dict):
+        return layout, input_sets, notes
+    inputs = layout.get("inputs")
+    if not isinstance(inputs, list):
+        return layout, input_sets, notes
+
+    if abi["callconv"] == "stdcall":
+        for i in inputs:
+            reg = str(i.get("register", "")).upper()
+            if reg not in ("", "STACK", "STK"):
+                notes.append(f"forced input '{i.get('name')}' register {reg} -> stack "
+                             f"(disasm: RET 0x{abi['ret_imm']:x}, no register reads)")
+                i["register"] = "stack"
+        n = abi["slots"]
+        if len(inputs) < n:
+            for k in range(len(inputs), n):
+                pad = f"unused{k + 1}"
+                inputs.append({"name": pad, "register": "stack", "signed": True})
+                for s in (input_sets or []):
+                    s.setdefault(pad, 0)
+            notes.append(f"padded {n - len(inputs) + (n - n)} -> declared {n} slots "
+                         f"(RET 0x{abi['ret_imm']:x}; model declared fewer)")
+        elif len(inputs) > n:
+            notes.append(f"model declared {len(inputs)} inputs but callee cleans only "
+                         f"{n} slot(s) -- NOT trimmed (verify manually)")
+    return layout, input_sets, notes
+
+
+def clamp_abort_vectors(input_sets: list, max_index: int = 32) -> tuple:
+    """For an ABORT-CLASS function: keep only vectors whose every value lies in
+    [0, max_index); if none survive, synthesize a dense in-range sweep. The valid
+    upper bound is a LIVE global we can't read statically, so this is deliberately
+    conservative -- small indices into any populated game table are in-range."""
+    safe = [s for s in (input_sets or [])
+            if all(isinstance(v, int) and 0 <= v < max_index for v in s.values())]
+    dropped = len(input_sets or []) - len(safe)
+    if not safe:
+        names = sorted({k for s in (input_sets or []) for k in s}) or ["value"]
+        safe = [{n: i for n in names} for i in range(16)]
+    return safe, dropped
+
+
+# ---------------------------------------------------------------------------
+# self-test: known-answer corpus captured live from D2Common 1.13c (2026-07-08)
+# ---------------------------------------------------------------------------
+_CORPUS = {
+    # RET 0x4, 1 slot used, stdcall, 2 data globals, 3 helper calls (abort path)
+    "GetItemDataRecord": """
+6fdc19a0: MOV EAX,dword ptr [ESP + 0x4]
+6fdc19a4: CMP EAX,dword ptr [0x6fdefb94]
+6fdc19aa: JC 0x6fdc19b1
+6fdc19ac: XOR EAX,EAX
+6fdc19ae: RET 0x4
+6fdc19b1: MOV ECX,dword ptr [0x6fdefb98]
+6fdc19b7: TEST ECX,ECX
+6fdc19b9: JNZ 0x6fdc19da
+6fdc19bb: PUSH 0x1ef
+6fdc19c0: CALL 0x6fd5921c
+6fdc19c5: PUSH EAX
+6fdc19c6: PUSH 0x6fdda728
+6fdc19cb: CALL 0x6fd59216
+6fdc19d0: ADD ESP,0xc
+6fdc19d3: PUSH -0x1
+6fdc19d5: CALL 0x6fd51b0d
+6fdc19da: IMUL EAX,EAX,0x1a8
+6fdc19e0: ADD EAX,ECX
+6fdc19e2: RET 0x4
+""",
+    # RET 0xC, THREE slots, only slot 0 read -- the stack-corruption discovery
+    "DATATBLS_GetItemDataByCode": """
+6fd9e1d0: MOV EAX,dword ptr [ESP + 0x4]
+6fd9e1d4: TEST EAX,EAX
+6fd9e1d6: JNZ 0x6fd9e1db
+6fd9e1d8: RET 0xc
+6fd9e1db: MOV EAX,dword ptr [EAX]
+6fd9e1dd: MOVSX EAX,word ptr [EAX]
+6fd9e1e0: RET 0xc
+""",
+    # RET 0x4, 1 slot, stdcall, abort path via CALL/_exit, 2 data globals
+    "GetAnimSequenceRecord": """
+6fd8e980: MOV EAX,dword ptr [ESP + 0x4]
+6fd8e984: CMP EAX,dword ptr [0x6fdf0b98]
+6fd8e98a: JL 0x6fd8e993
+6fd8e98c: PUSH 0xdd
+6fd8e991: JMP 0x6fd8e99c
+6fd8e993: TEST EAX,EAX
+6fd8e995: JGE 0x6fd8e9b6
+6fd8e997: PUSH 0xde
+6fd8e99c: CALL 0x6fd5921c
+6fd8e9a1: PUSH EAX
+6fd8e9a2: PUSH 0x6fdda728
+6fd8e9a7: CALL 0x6fd59216
+6fd8e9ac: ADD ESP,0xc
+6fd8e9af: PUSH -0x1
+6fd8e9b1: CALL 0x6fd51b0d
+6fd8e9b6: MOV ECX,dword ptr [0x6fdf0b94]
+6fd8e9bc: IMUL EAX,EAX,0x1c0
+6fd8e9c2: ADD EAX,ECX
+6fd8e9c4: RET 0x4
+""",
+    # RET 0x8, 2 slots, slot 1 read AFTER a call (depth-reset heuristic), delegate
+    "ITEMS_LookupItemRecordByCode": """
+6fdc1960: MOV EAX,dword ptr [ESP + 0x4]
+6fdc1964: MOV ECX,dword ptr [0x6fdeff6c]
+6fdc196a: PUSH 0x0
+6fdc196c: PUSH EAX
+6fdc196d: PUSH ECX
+6fdc196e: CALL 0x6fd59240
+6fdc1973: TEST EAX,EAX
+6fdc1975: JGE 0x6fdc1986
+6fdc1977: MOV EDX,dword ptr [ESP + 0x8]
+6fdc197b: MOV dword ptr [EDX],0x0
+6fdc1981: XOR EAX,EAX
+6fdc1983: RET 0x8
+6fdc1986: MOV ECX,dword ptr [ESP + 0x8]
+6fdc198a: MOV dword ptr [ECX],EAX
+6fdc198c: IMUL EAX,EAX,0x1a8
+6fdc1992: ADD EAX,dword ptr [0x6fdefb98]
+6fdc1998: RET 0x8
+""",
+    # PURE GETTERS the translator should handle (deref chain + null guards, no branch):
+    # STAT_GetActiveSkillFieldC: deref +0xa8, read +0xc (the re-drafted 2026-07-08 fn)
+    "STAT_GetActiveSkillFieldC": """
+6fd80420: MOV EAX,dword ptr [ESP + 0x4]
+6fd80424: TEST EAX,EAX
+6fd80426: JNZ 0x6fd8042f
+6fd80428: PUSH 0x64a
+6fd8042d: JMP 0x6fd8043e
+6fd8042f: MOV EAX,dword ptr [EAX + 0xa8]
+6fd80435: TEST EAX,EAX
+6fd80437: JNZ 0x6fd80458
+6fd80439: PUSH 0x40f
+6fd8043e: CALL 0x6fd5921c
+6fd80443: PUSH EAX
+6fd80444: PUSH 0x6fdda728
+6fd80449: CALL 0x6fd59216
+6fd8044e: ADD ESP,0xc
+6fd80451: PUSH -0x1
+6fd80453: CALL 0x6fd51b0d
+6fd80458: MOV EAX,dword ptr [EAX + 0xc]
+6fd8045b: RET 0x4
+""",
+    # PATH_GetDirection: single MOVZX byte read at +0x65 -> ret u8 (CONCAT31 getter)
+    "PATH_GetDirection": """
+6fd84c00: MOV EAX,dword ptr [ESP + 0x4]
+6fd84c04: MOVZX EAX,byte ptr [EAX + 0x65]
+6fd84c08: RET 0x4
+""",
+    # PATH_GetDynamicX: single dword read at +0xc
+    "PATH_GetDynamicX": """
+6fd68210: MOV EAX,dword ptr [ESP + 0x4]
+6fd68214: MOV EAX,dword ptr [EAX + 0xc]
+6fd68217: RET 0x4
+""",
+}
+
+
+def _selftest() -> int:
+    a = derive_abi(_CORPUS["GetItemDataRecord"])
+    assert a["ret_imm"] == 4 and a["slots"] == 1 and a["used_slots"] == [0], a
+    assert a["callconv"] == "stdcall" and not a["reg_args"], a
+    assert 0x6fdefb94 in a["data_globals"] and 0x6fdefb98 in a["data_globals"], a
+    # its 3 calls are ALL the abort idiom -> zero real delegates
+    assert not a["calls"] and len(a["abort_helper_calls"]) == 3, a
+
+    a = derive_abi(_CORPUS["DATATBLS_GetItemDataByCode"])
+    assert a["ret_imm"] == 0xC and a["slots"] == 3 and a["used_slots"] == [0], a
+    assert a["callconv"] == "stdcall" and not a["calls"], a
+
+    a = derive_abi(_CORPUS["GetAnimSequenceRecord"])
+    assert a["ret_imm"] == 4 and a["slots"] == 1 and a["used_slots"] == [0], a
+    assert a["callconv"] == "stdcall", a
+    assert 0x6fdf0b94 in a["data_globals"] and 0x6fdf0b98 in a["data_globals"], a
+
+    a = derive_abi(_CORPUS["ITEMS_LookupItemRecordByCode"])
+    assert a["ret_imm"] == 8 and a["slots"] == 2, a
+    assert a["used_slots"] == [0, 1], a          # slot 1 read post-call (depth reset)
+    assert 0x6fd59240 in a["calls"], a           # the Fog bsearch delegate
+    assert a["approx"], a                        # crossed a call -> flagged heuristic
+
+    assert detect_abort_path("/* WARNING: Subroutine does not return */ _exit(-1);")
+    assert detect_abort_path("CleanupAndAbort();")
+    assert not detect_abort_path("return (ITEMS_ItemRecord *)0x0;")
+
+    # handle-abort hazard: the EXACT decompile that crashed a live batch (2026-07-08)
+    stat_calc = """
+uint STAT_GetUnitCalculatedStat(UnitAny *pUnit)
+{
+  if ((pUnit != (UnitAny *)0x0) && (pUnit->dwType == 0)) {
+    return *(uint *)&pUnit->pPlayerData->field_0x2c;
+  }
+  GetReturnAddress();
+  CleanupAndAbort();
+  _exit(-1);
+}
+"""
+    assert detect_handle_abort_hazard(stat_calc), "must catch the confirmed live-crash pattern"
+    # a scalar (index-gated) abort is NOT a handle hazard -- no dwType comparison
+    assert not detect_handle_abort_hazard(
+        "int f(int idx) { if (idx < count) return arr[idx]; CleanupAndAbort(); _exit(-1); }")
+    # a dwType READ with no abort is fine (e.g. GetPathFieldByUnitType dispatches on
+    # type but returns different VALUES per branch -- it never aborts)
+    assert not detect_handle_abort_hazard(
+        "int f(UnitAny *p) { if (p->dwType == 2) return *(int*)(p+8); return *(int*)(p+4); }")
+
+    lay = {"inputs": [{"name": "nSequenceId", "register": "ECX", "signed": True}],
+           "outputs": [{"name": "ret", "register": "EAX", "signed": False}]}
+    sets = [{"nSequenceId": 3}]
+    abi3 = derive_abi(_CORPUS["DATATBLS_GetItemDataByCode"])
+    lay2, sets2, notes = apply_static_abi(lay, sets, abi3)
+    assert lay2["inputs"][0]["register"] == "stack", lay2
+    assert len(lay2["inputs"]) == 3 and sets2[0].get("unused2") == 0, (lay2, sets2)
+
+    safe, dropped = clamp_abort_vectors(
+        [{"i": 0}, {"i": 5}, {"i": -1}, {"i": 2147483647}, {"i": 31}], 32)
+    assert dropped == 2 and len(safe) == 3, (safe, dropped)
+    safe, dropped = clamp_abort_vectors([{"i": -1}, {"i": 99999}], 32)
+    assert dropped == 2 and len(safe) == 16, (len(safe), dropped)
+
+    # --- mechanical getter translation ---
+    # STAT: param -> deref +0xa8 (guarded) -> read +0xc. The exact bug that cost the
+    # session -- the disasm translator gets it right where the model got it wrong.
+    t = translate_getter_to_c("STAT_GetActiveSkillFieldC", _CORPUS["STAT_GetActiveSkillFieldC"])
+    assert t["ok"] and t["chain"] == [0xa8, 0xc], t
+    assert "*(char**)(r + 0xa8)" in t["code"] and "if (r == nullptr) return 0;" in t["code"], t["code"]
+    assert "*(unsigned int*)(r + 0xc)" in t["code"], t["code"]
+
+    # PATH_GetDirection: MOVZX byte -> u8 return, single read at +0x65
+    t = translate_getter_to_c("PATH_GetDirection", _CORPUS["PATH_GetDirection"])
+    assert t["ok"] and t["ret"] == "u8" and t["chain"] == [0x65], t
+    assert "unsigned char" in t["code"] and "*(unsigned char*)(r + 0x65)" in t["code"], t["code"]
+
+    # PATH_GetDynamicX: single dword read at +0xc
+    t = translate_getter_to_c("PATH_GetDynamicX", _CORPUS["PATH_GetDynamicX"])
+    assert t["ok"] and t["chain"] == [0xc] and t["ret"] == "u32", t
+
+    # TRAILING BIT-MASK getters -- the class the translator used to over-defer.
+    # STAT_GetStatListFlag4: read +0x34, AND 4 (real disasm, 2026-07-08)
+    t = translate_getter_to_c("STAT_GetStatListFlag4", """
+6fd8b220: MOV EAX,dword ptr [ESP + 0x4]
+6fd8b224: MOV EAX,dword ptr [EAX + 0x34]
+6fd8b227: AND EAX,0x4
+6fd8b22a: RET 0x4
+""")
+    assert t["ok"] and t["chain"] == [0x34] and t["post_ops"] == [("&", 4)], t
+    assert "(*(unsigned int*)(r + 0x34) & 0x4u)" in t["code"], t["code"]
+
+    # STAT_IsUnitStatListFlag8Set: deref +0x5c (JZ-null-guard) -> read +0x10 -> >>8 &1,
+    # with a XOR EAX,EAX return-0 idiom on the null path (real disasm)
+    t = translate_getter_to_c("STAT_IsUnitStatListFlag8Set", """
+6fd87de0: MOV EAX,dword ptr [ESP + 0x4]
+6fd87de4: TEST EAX,EAX
+6fd87de6: JNZ 0x6fd87ded
+6fd87de8: XOR EAX,EAX
+6fd87dea: RET 0x4
+6fd87ded: MOV EAX,dword ptr [EAX + 0x5c]
+6fd87df0: TEST EAX,EAX
+6fd87df2: JZ 0x6fd87de8
+6fd87df4: MOV EAX,dword ptr [EAX + 0x10]
+6fd87df7: SHR EAX,0x8
+6fd87dfa: AND EAX,0x1
+6fd87dfd: RET 0x4
+""")
+    assert t["ok"] and t["chain"] == [0x5c, 0x10], t
+    assert t["post_ops"] == [(">>", 8), ("&", 1)], t
+    assert "*(char**)(r + 0x5c)" in t["code"] and "if (r == nullptr) return 0;" in t["code"], t["code"]
+    assert "((*(unsigned int*)(r + 0x10) >> 0x8u) & 0x1u)" in t["code"], t["code"]
+
+    # a deref AFTER a transform is a computed address -> must still DEFER
+    t = translate_getter_to_c("Computed", """
+6f000000: MOV EAX,dword ptr [ESP + 0x4]
+6f000004: MOV EAX,dword ptr [EAX + 0x8]
+6f000007: SHL EAX,0x2
+6f00000a: MOV EAX,dword ptr [EAX + 0x10]
+6f00000d: RET 0x4
+""")
+    assert not t["ok"] and "computed address" in t["reason"], t
+
+    # BRANCHY / COMPUTED getters must DEFER to the model (ok=False):
+    t = translate_getter_to_c("HaveLightResBonus", """
+6fd7fe10: MOV EAX,dword ptr [ESP + 0x4]
+6fd7fe37: MOV ECX,dword ptr [EAX]
+6fd7fe39: CMP ECX,0x2
+6fd7fe3c: JZ 0x6fd7fe5a
+6fd7fe5a: MOV EAX,dword ptr [EAX + 0x2c]
+6fd7fe5f: RET 0x4
+""")
+    assert not t["ok"], t                # type-dispatch branch -> defers to the model
+    t = translate_getter_to_c("GetItemDataRecord", _CORPUS["GetItemDataRecord"])
+    assert not t["ok"], t                # has IMUL + data-global reads -> not a pure getter
+
+    # TYPE-GATED sub-dword getters (ITEMS family, real 1.13c disasm, 2026-07-08):
+    # `CMP [pUnit],0x4; JNZ ret0` dwType gate + a sub-register `MOV AX/AL,word/byte ptr`
+    # read. The whole ITEMS_GetItem* getter family bailed the translator (CMP + AX/AL
+    # dst) -> went to the model, which declared the WRONG return WIDTH (u32 for a word
+    # read) -> the oracle's RetMask compared the stale upper-EAX pointer bits -> false
+    # mismatch. Both facts are 100% in the disasm: gate as guard, width from operand.
+    t = translate_getter_to_c("ITEMS_GetItemDataField32", """
+6fd739e0: MOV EAX,dword ptr [ESP + 0x4]
+6fd739e4: TEST EAX,EAX
+6fd739e6: JZ 0x6fd739fb
+6fd739e8: CMP dword ptr [EAX],0x4
+6fd739eb: JNZ 0x6fd739fb
+6fd739ed: MOV EAX,dword ptr [EAX + 0x14]
+6fd739f0: TEST EAX,EAX
+6fd739f2: JZ 0x6fd739fb
+6fd739f4: MOV AX,word ptr [EAX + 0x32]
+6fd739f8: RET 0x4
+6fd739fb: XOR AX,AX
+6fd739fe: RET 0x4
+""")
+    assert t["ok"] and t["ret"] == "u16" and t["chain"] == [0x14, 0x32], t
+    assert t["type_gates"] == [(0, 0, 4, "d")], t
+    assert "!= 0x4u) return 0" in t["code"] and "unsigned short" in t["code"], t
+
+    t = translate_getter_to_c("ITEMS_GetItemDataByte44", """
+6fd73c50: MOV EAX,dword ptr [ESP + 0x4]
+6fd73c54: TEST EAX,EAX
+6fd73c56: JZ 0x6fd73c6a
+6fd73c58: CMP dword ptr [EAX],0x4
+6fd73c5b: JNZ 0x6fd73c6a
+6fd73c5d: MOV EAX,dword ptr [EAX + 0x14]
+6fd73c60: TEST EAX,EAX
+6fd73c62: JZ 0x6fd73c6a
+6fd73c64: MOV AL,byte ptr [EAX + 0x44]
+6fd73c67: RET 0x4
+6fd73c6a: XOR AL,AL
+6fd73c6c: RET 0x4
+""")
+    assert t["ok"] and t["ret"] == "u8" and t["chain"] == [0x14, 0x44], t
+    assert t["type_gates"] == [(0, 0, 4, "d")] and "unsigned char" in t["code"], t
+
+    # DELEGATE call-through getter (ITEMS_GetItemRecord* Variant A, real 1.13c disasm,
+    # 2026-07-08): param -> dwType gate -> load field4 -> CALL GetItemDataRecord ->
+    # null-guard -> read u16 -> (v==1)?0x64:v. Emits a reimpl that resolves the callee
+    # BY NAME and calls the REAL game function (its globals are the game's real globals).
+    # LIVE-verified: the emitted code == the hand-written call-through that PROVEN 1/1.
+    _rev = {0x6fdc19a0: "GetItemDataRecord"}
+    t = translate_delegate_getter_to_c("ITEMS_GetItemRecordField108", """
+6fd72970: MOV EAX,dword ptr [ESP + 0x4]
+6fd72974: TEST EAX,EAX
+6fd72976: JZ 0x6fd72997
+6fd72978: CMP dword ptr [EAX],0x4
+6fd7297b: JNZ 0x6fd72997
+6fd7297d: MOV EAX,dword ptr [EAX + 0x4]
+6fd72980: PUSH EAX
+6fd72981: CALL 0x6fdc19a0
+6fd72986: TEST EAX,EAX
+6fd72988: JZ 0x6fd72997
+6fd7298a: MOV AX,word ptr [EAX + 0x108]
+6fd72991: CMP AX,0x1
+6fd72995: JNZ 0x6fd7299b
+6fd72997: MOV AX,0x64
+6fd7299b: RET 0x4
+""", resolve_rev=_rev)
+    assert t["ok"] and t["ret"] == "u16" and t["callee"] == "GetItemDataRecord", t
+    assert t["arg_off"] == 0x4 and t["result_off"] == 0x108 and t["subst"] == 1 and t["fallback"] == 0x64, t
+    assert 'D2MOO_Resolve("GetItemDataRecord")' in t["code"] and "(_v == 0x1) ?" in t["code"], t["code"]
+
+    # DELEGATE with abort-class guards (GetItemCode: CleanupAndAbort/_exit on guard fail)
+    # MUST bail -> handle-abort-hazard, not a fallback-return delegate.
+    t = translate_delegate_getter_to_c("ITEMS_GetItemCode", """
+6fd72ff0: MOV EAX,dword ptr [ESP + 0x4]
+6fd72ff4: TEST EAX,EAX
+6fd72ff6: JNZ 0x6fd72fff
+6fd72ff8: PUSH 0x798
+6fd72ffd: JMP 0x6fd73009
+6fd72fff: CMP dword ptr [EAX],0x4
+6fd73002: JZ 0x6fd73023
+6fd73004: PUSH 0x799
+6fd73009: CALL 0x6fd5921c
+6fd7300e: PUSH EAX
+6fd7300f: PUSH 0x6fdda728
+6fd73014: CALL 0x6fd59216
+6fd73019: ADD ESP,0xc
+6fd7301c: PUSH -0x1
+6fd7301e: CALL 0x6fd51b0d
+6fd73023: MOV EAX,dword ptr [EAX + 0x4]
+6fd73026: PUSH EAX
+6fd73027: CALL 0x6fdc19a0
+6fd7302c: MOV ECX,dword ptr [EAX + 0x84]
+6fd73032: TEST ECX,ECX
+6fd73034: JZ 0x6fd7303b
+6fd73036: MOV EAX,ECX
+6fd73038: RET 0x4
+6fd7303b: MOV EAX,dword ptr [EAX + 0x80]
+6fd73041: RET 0x4
+""", resolve_rev=_rev)
+    assert not t["ok"] and "abort-class" in t["reason"], t
+    # a callee NOT in the resolve table must bail (can't resolve by name)
+    t = translate_delegate_getter_to_c("X", """
+6f000000: MOV EAX,dword ptr [ESP + 0x4]
+6f000004: MOV EAX,dword ptr [EAX + 0x4]
+6f000007: PUSH EAX
+6f000008: CALL 0x6f999999
+6f00000d: MOV EAX,dword ptr [EAX + 0x8]
+6f000010: RET 0x4
+""", resolve_rev=_rev)
+    assert not t["ok"] and "not in resolve table" in t["reason"], t
+
+    # resolvable_callees + callthrough_prompt_block: the model-hint path for delegates
+    # the mechanical translator can't handle (multi-arg / fastcall callees). Must find
+    # the resolvable CALL, skip abort helpers, and emit a D2MOO_Resolve hint.
+    cs = resolvable_callees("""
+6f000000: MOV EAX,dword ptr [ESP + 0x4]
+6f000004: PUSH EAX
+6f000005: CALL 0x6fdc19a0
+6f00000a: PUSH 0x1
+6f00000c: CALL 0x6fd5921c
+6f000011: RET 0x4
+""", resolve_rev={0x6fdc19a0: "GetItemDataRecord"})
+    assert cs == [(0x6fdc19a0, "GetItemDataRecord")], cs   # abort helper 0x6fd5921c skipped
+    hint = callthrough_prompt_block(cs)
+    assert 'D2MOO_Resolve("GetItemDataRecord")' in hint and "CALL-THROUGH REQUIRED" in hint, hint
+    assert callthrough_prompt_block([]) == ""
+
+    # resolvable_globals + global_resolve_prompt_block: the global-table getter hint.
+    gs = resolvable_globals("""
+6f000000: MOV EAX,dword ptr [ESP + 0x4]
+6f000004: MOV ECX,dword ptr [0x6fde9e1c]
+6f00000a: MOVZX EAX,byte ptr [EAX + 0x10]
+6f00000e: RET 0x4
+""", resolve_rev={0x6fde9e1c: "g_pDataTables"})
+    assert gs == [(0x6fde9e1c, "g_pDataTables")], gs
+    gh = global_resolve_prompt_block(gs)
+    assert 'D2MOO_Resolve("g_pDataTables")' in gh and "GLOBAL RESOLVE REQUIRED" in gh, gh
+    assert global_resolve_prompt_block([]) == ""
+
+    # GLOBAL-TABLE INDEXED getter (the dominant DATATBLS shape, real 1.13c disasm): the
+    # model oscillates on the resolve-deref chain (proves FieldE, mismatches Field10) ->
+    # translate it MECHANICALLY: resolve the global BY NAME, deref, bound-check, index by
+    # stride, raw-cast the field. All offsets/stride/width from the disasm. 2026-07-08.
+    _rev2 = {0x6fde9e1c: "g_pDataTables"}
+    t = translate_global_table_getter_to_c("DATATBLS_GetItemTypeField10", """
+6fd72f80: MOV EAX,dword ptr [ESP + 0x4]
+6fd72f84: TEST EAX,EAX
+6fd72f86: JL 0x6fd72fa8
+6fd72f88: MOV ECX,dword ptr [0x6fde9e1c]
+6fd72f8e: CMP EAX,dword ptr [ECX + 0xbfc]
+6fd72f94: JGE 0x6fd72fa8
+6fd72f96: MOV EDX,dword ptr [ECX + 0xbf8]
+6fd72f9c: IMUL EAX,EAX,0xe4
+6fd72fa2: ADD EAX,EDX
+6fd72fa4: TEST EAX,EAX
+6fd72fa6: JNZ 0x6fd72fad
+6fd72fa8: XOR EAX,EAX
+6fd72faa: RET 0x4
+6fd72fad: MOVZX EAX,byte ptr [EAX + 0x10]
+6fd72fb1: RET 0x4
+""", resolve_rev=_rev2)
+    # the original MOVZX-es byte->EAX, so the return is the ZERO-EXTENDED full 32-bit
+    # value (u32), read at the native byte width.
+    assert t["ok"] and t["ret"] == "u32" and t["global"] == "g_pDataTables", t
+    assert t["count_off"] == 0xbfc and t["records_off"] == 0xbf8 and t["stride"] == 0xe4 and t["field_off"] == 0x10, t
+    assert 'D2MOO_Resolve("g_pDataTables")' in t["code"] and "idx * 0xe4" in t["code"], t["code"]
+    assert "(unsigned int)*(unsigned char*)(rec + 0x10)" in t["code"], t["code"]
+    # a MOVSX word variant -> i16
+    t = translate_global_table_getter_to_c("DATATBLS_GetItemTypeFieldE", """
+6fd735d0: MOV EAX,dword ptr [ESP + 0x4]
+6fd735d4: TEST EAX,EAX
+6fd735d6: JL 0x6fd735f8
+6fd735d8: MOV ECX,dword ptr [0x6fde9e1c]
+6fd735de: CMP EAX,dword ptr [ECX + 0xbfc]
+6fd735e4: JGE 0x6fd735f8
+6fd735e6: MOV EDX,dword ptr [ECX + 0xbf8]
+6fd735ec: IMUL EAX,EAX,0xe4
+6fd735f2: ADD EAX,EDX
+6fd735f4: TEST EAX,EAX
+6fd735f6: JNZ 0x6fd735fd
+6fd735f8: XOR EAX,EAX
+6fd735fa: RET 0x4
+6fd735fd: MOVSX EAX,word ptr [EAX + 0xe]
+6fd73601: RET 0x4
+""", resolve_rev=_rev2)
+    assert t["ok"] and t["ret"] == "i32" and t["field_off"] == 0xe, t
+    assert "(int)*(short*)(rec + 0xe)" in t["code"], t["code"]
+    # a global NOT in the resolve table must bail
+    t = translate_global_table_getter_to_c("X", """
+6f000000: MOV EAX,dword ptr [ESP + 0x4]
+6f000008: MOV ECX,dword ptr [0x6f111111]
+6f00000e: CMP EAX,dword ptr [ECX + 0x10]
+6f000014: JGE 0x6f000020
+6f000016: MOV EDX,dword ptr [ECX + 0xc]
+6f00001c: IMUL EAX,EAX,0x20
+6f00001f: ADD EAX,EDX
+6f000021: MOVZX EAX,byte ptr [EAX + 0x4]
+6f000025: RET 0x4
+""", resolve_rev=_rev2)
+    assert not t["ok"] and "not resolvable" in t["reason"], t
+
+    print("[ok] abi_static self-test: known-answer corpus + helpers + getter translator pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_selftest())

--- a/fun-doc/adversarial_reproof.py
+++ b/fun-doc/adversarial_reproof.py
@@ -1,0 +1,656 @@
+"""adversarial_reproof.py -- Rung V1 of the shipping-promotion ladder
+(conformance/SHIPPING_PROMOTION_PLAN.md).
+
+A CONF_LIVE reimpl is bit-exact vs the original across *the vectors the drafting
+model chose*, in one game state. Two residual risks make that not shipping-grade:
+  #1 self-consistency bias -- the SAME model wrote the reimpl AND its test
+     vectors, so it tends to test what it implemented, not what the original does;
+  #2 input-coverage gaps -- 12-15 vectors miss exact boundaries / overflows.
+
+V1 closes both by re-proving each CONF_LIVE function against an INDEPENDENT
+adversarial vector set that is derived ONLY from the original's decompile (never
+the reimpl) and is aimed at breaking it: every branch boundary the decompile
+tests, a dense sweep, and extremes (0, +-1, INT_MIN/MAX, powers of two). The
+vectors are replayed through the SAME live `/oracle` seam prove_candidate.py uses
+(the reimpl is already staged in the running provider). All-match => stamp the
+registry row `vetted: adversarial`; any mismatch REOPENS the reimpl (writes a
+permanent regression case + a needs_review flag), exactly like a shadow divergence.
+
+Two independence layers, both free of the drafting model:
+  - ALGORITHMIC floor (always): a deterministic extremes+sweep+power-of-two set.
+    Needs no model and already breaks the self-consistency bias for coverage.
+  - MODEL augmentation (default on; --no-model to skip): a separate Claude call,
+    shown ONLY the decompile + arg schema, asked for the branch-boundary values
+    it can SEE in the code. This is the risk-#1 killer the plan describes.
+
+Scope: oracle input-sweep only works for SCALAR-input functions (i32/buf args
+keyed by arg id). `handle`-input functions (the unit getters) take a live game
+object, not a vector value -- they can't be adversarially swept via the oracle
+and are reported as shadow-only (they earn evidence through V2 shadowing instead).
+
+Standalone. CLI:
+    python adversarial_reproof.py --function GetDataTableRowEntryCount
+    python adversarial_reproof.py --all            # every CONF_LIVE scalar row
+    python adversarial_reproof.py --all --no-model # algorithmic floor only
+
+Model mode needs claude_agent_sdk (fun-doc/.venv). Algorithmic-only mode is
+stdlib-only and runs under any python.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import http.client
+import json
+import os
+import time
+from pathlib import Path
+from urllib.parse import urlparse, urlencode
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+PROVEN_REGISTRY = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+VECTORS_DIR = D2MOO_REPO / "conformance" / "vectors"
+DIVERGENCE_DIR = VECTORS_DIR / "divergences"
+
+ORACLE_URL = os.environ.get("D2DBG_MCP_URL", "http://127.0.0.1:8790")
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+GHIDRA_PROGRAM = os.environ.get("GHIDRA_PROGRAM", "D2Common.dll")
+_D2COMMON_BASE = 0x6FD50000
+
+# A hard cap so a wide multi-arg cartesian can't explode the oracle call.
+MAX_VECTORS = int(os.environ.get("V1_MAX_VECTORS", "256"))
+# Model id for the adversary call. Left unset => claude_agent_sdk default.
+V1_MODEL = os.environ.get("V1_MODEL") or None
+
+
+# --------------------------------------------------------------------------- #
+# HTTP helpers
+# --------------------------------------------------------------------------- #
+class OracleDied(Exception):
+    """The oracle server thread stopped accepting connections mid-run -- almost
+    always because a vector crashed it. We abort loudly rather than bisect into
+    a corpse, and name the function/vectors that were in flight."""
+
+
+def _oracle_reachable() -> bool:
+    try:
+        return _oracle_get("/status", timeout=4).get("ok", False)
+    except OSError:
+        return False
+
+
+def _oracle_post(path: str, body: dict, timeout: int = 60) -> dict:
+    u = urlparse(ORACLE_URL)
+    try:
+        conn = http.client.HTTPConnection(u.hostname, u.port or 8790, timeout=timeout)
+        conn.request("POST", path, body=json.dumps(body).encode(),
+                     headers={"Content-Type": "application/json"})
+        raw = conn.getresponse().read().decode("utf-8", "replace")
+        conn.close()
+    except OSError as e:
+        # Connection reset/refused: the server may have died on a prior vector.
+        # Confirm with a status probe; if truly gone, this is fatal, not a per-
+        # vector fault (bisecting further would just keep failing).
+        if not _oracle_reachable():
+            raise OracleDied(f"oracle unreachable after {type(e).__name__}: {e}")
+        return {"ok": False, "error": f"conn-error(server alive): {e}"}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"ok": False, "error": f"non-JSON: {raw[:200]}"}
+
+
+def _oracle_get(path: str, timeout: int = 10) -> dict:
+    u = urlparse(ORACLE_URL)
+    conn = http.client.HTTPConnection(u.hostname, u.port or 8790, timeout=timeout)
+    try:
+        conn.request("GET", path)
+        raw = conn.getresponse().read().decode("utf-8", "replace")
+    finally:
+        conn.close()
+    return json.loads(raw)
+
+
+def _ghidra_decompile(address_hex: str, timeout: int = 60) -> str | None:
+    """GET /decompile_function?address=..&program=.. -- pseudocode text or None."""
+    u = urlparse(GHIDRA_HTTP)
+    qs = urlencode({"address": address_hex, "program": GHIDRA_PROGRAM, "timeout": timeout})
+    conn = http.client.HTTPConnection(u.hostname, u.port or 8089, timeout=timeout + 5)
+    try:
+        conn.request("GET", f"/decompile_function?{qs}")
+        raw = conn.getresponse().read().decode("utf-8", "replace")
+    except OSError as e:
+        return None
+    finally:
+        conn.close()
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw if raw and "404" not in raw else None
+    if isinstance(obj, dict):
+        if obj.get("error"):
+            return None
+        for k in ("decompiled", "decompilation", "code", "result", "pseudocode"):
+            if obj.get(k):
+                return obj[k]
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Registry + spec resolution
+# --------------------------------------------------------------------------- #
+def _load_registry() -> list[dict]:
+    if not PROVEN_REGISTRY.exists():
+        return []
+    return [json.loads(l) for l in PROVEN_REGISTRY.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _save_registry(rows: list[dict]) -> None:
+    with open(PROVEN_REGISTRY, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def _spec_by_name() -> dict[str, Path]:
+    """Index every conformance/vectors/*.spec.json by its declared `name`."""
+    out: dict[str, Path] = {}
+    for p in glob.glob(str(VECTORS_DIR / "*.spec.json")):
+        try:
+            nm = json.load(open(p, encoding="utf-8")).get("name")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if nm and nm not in out:
+            out[nm] = Path(p)
+    return out
+
+
+SCALAR_KINDS = {"i32", "u32", "int", "uint", "buf"}
+
+
+def _scalar_args(spec: dict) -> list[dict]:
+    """Args whose value is supplied by the vector (i32/buf), i.e. sweepable.
+    `buf` args are output/inout buffers seeded by an int; still vector-driven."""
+    return [a for a in spec.get("args", []) if a.get("kind") in SCALAR_KINDS]
+
+
+def _handle_args(spec: dict) -> list[dict]:
+    return [a for a in spec.get("args", []) if a.get("kind") == "handle"]
+
+
+# --------------------------------------------------------------------------- #
+# Adversarial vector generation -- SAFE BY CONSTRUCTION
+#
+# Hard lesson (2026-07-07): blindly sweeping extremes CRASHED the oracle server
+# thread on DUNGEON_GetTownLevelIdFromActNo -- it dispatches through a jump table
+# indexed by `act`, so an out-of-domain value jumps into garbage and executes it,
+# a fault SEH cannot catch (unlike a wild READ, which it catches and we quarantine).
+# The spec even documented "act 0..4 ONLY -- the original ABORTS for act>4".
+#
+# Safety principle: the EXISTING PROVEN spec vectors define the known-safe input
+# ENVELOPE. We densify adversarially WITHIN that envelope (always safe), and only
+# widen PAST it when the model -- reading the decompile -- certifies out-of-domain
+# behavior is graceful or an at-worst SEH-recoverable wild read (never abort/jump).
+# --------------------------------------------------------------------------- #
+INT_MAX = 0x7FFFFFFF
+INT_MIN = -0x80000000
+
+# out-of-domain classes the model may assign. Only these two permit widening the
+# sweep past the proven envelope; everything else stays strictly inside it.
+WIDEN_OK = {"graceful", "wild_read"}
+
+
+def _vec_value(v: dict, arg_id: str):
+    """Read an int arg's value from a spec vector, tolerating the legacy
+    mis-keying where some specs stored the value under a stray key (e.g.
+    `example_index`) instead of the arg id. Falls back to the sole numeric
+    value in the vector."""
+    if arg_id in v and isinstance(v[arg_id], (int, float)):
+        return int(v[arg_id])
+    nums = [x for x in v.values() if isinstance(x, (int, float))]
+    return int(nums[0]) if len(nums) == 1 else None
+
+
+def _spec_envelope(spec: dict, int_args: list[dict]) -> dict[str, tuple[int, int, list[int]]]:
+    """Per int-arg: (lo, hi, observed_values) from the spec's PROVEN vectors --
+    the domain a prior live oracle proof demonstrated is safe to call."""
+    env: dict[str, tuple[int, int, list[int]]] = {}
+    for a in int_args:
+        i = a["id"]
+        obs = [val for val in (_vec_value(v, i) for v in spec.get("vectors", [])) if val is not None]
+        if obs:
+            env[i] = (min(obs), max(obs), sorted(set(obs)))
+        else:
+            env[i] = (0, 0, [0])  # no proven inputs -> only 0 is known-safe
+    return env
+
+
+def _densify_in(lo: int, hi: int) -> list[int]:
+    """A deterministic break-it spread CLAMPED to [lo, hi]: the endpoints, a
+    dense sweep near lo, every value in a small range, and power-of-two / round
+    boundaries that fall inside the envelope. Never emits anything outside."""
+    if hi < lo:
+        lo, hi = hi, lo
+    vals = {lo, hi}
+    span = hi - lo
+    # full dense fill for tiny domains (the town/act case: prove every valid input)
+    if span <= 64:
+        vals.update(range(lo, hi + 1))
+    else:
+        vals.update(range(lo, lo + 33))           # dense near the low end
+        vals.update(range(hi - 32, hi + 1))        # dense near the high end
+        mid = (lo + hi) // 2
+        vals.update(range(mid - 8, mid + 9))
+    for b in range(0, 31):                          # power-of-two boundaries in range
+        for cand in (1 << b, (1 << b) - 1, (1 << b) + 1, -(1 << b)):
+            if lo <= cand <= hi:
+                vals.add(cand)
+    for cand in (0, 1, -1, 255, 256, 32767, -32768, 65535):
+        if lo <= cand <= hi:
+            vals.add(cand)
+    return sorted(vals)
+
+
+def _extremes_in(lo: int, hi: int) -> list[int]:
+    """The wild extremes -- ONLY used when the model certifies the arg is safe to
+    widen (graceful/wild_read out-of-domain). Still bounded by any model domain."""
+    cands = [INT_MAX, INT_MAX - 1, INT_MIN, INT_MIN + 1, -1, 0,
+             65536, -65536, 1 << 24, 1 << 30, -(1 << 30)]
+    return [c for c in cands if lo <= c <= hi]
+
+
+def _adversarial_prompt(name: str, spec: dict, decompile: str,
+                        env: dict[str, tuple[int, int, list[int]]]) -> str:
+    scal = _scalar_args(spec)
+    int_args = [a for a in scal if a.get("kind") != "buf"]
+    arg_desc = ", ".join(f'{a["id"]} ({a.get("kind")})' for a in int_args)
+    ids = [a["id"] for a in int_args]
+    dom = "; ".join(f'{i}: proven-safe so far in [{env[i][0]}, {env[i][1]}]' for i in ids)
+    example = json.dumps({"out_of_domain": "graceful|wild_read|abort|dispatch|unknown",
+                          "vectors": [{i: 0 for i in ids}]})
+    return (
+        "You are an ADVERSARIAL test-vector generator for a reverse-engineering "
+        "conformance harness. Below is the Ghidra decompilation of an ORIGINAL "
+        "Diablo II function. A separate developer wrote a from-scratch C++ "
+        "re-implementation; your job is to produce inputs that would EXPOSE any "
+        "behavioral difference. You have NOT seen the re-implementation -- reason "
+        "ONLY from the decompile.\n\n"
+        "SAFETY IS CRITICAL. The vectors are executed against the LIVE game "
+        "process. If an out-of-domain argument makes the original ABORT the "
+        "process or perform a COMPUTED JUMP indexed by the argument (jump table / "
+        "switch / indirect call through an arg-indexed pointer), that input will "
+        "CRASH the game and is forbidden. First CLASSIFY what the original does "
+        "for arguments OUTSIDE its valid domain:\n"
+        "  - \"abort\": calls an abort/exit/assert path (FORBIDDEN to exceed domain)\n"
+        "  - \"dispatch\": jump table / switch / arg-indexed call (FORBIDDEN)\n"
+        "  - \"wild_read\": at worst reads out-of-bounds memory, then returns "
+        "(recoverable -- you MAY probe just past the domain)\n"
+        "  - \"graceful\": bounds-checks and early-returns/clamps (SAFE to probe past)\n"
+        "  - \"unknown\": can't tell (treated as FORBIDDEN)\n\n"
+        f"Function: {name}\n"
+        f"Integer arguments (vectors are JSON objects keyed by these ids): {arg_desc}\n"
+        f"Currently proven-safe domain: {dom}\n\n"
+        "Then produce vectors. Rules:\n"
+        "  * If out_of_domain is abort/dispatch/unknown: EVERY vector must stay "
+        "within the proven-safe domain above. Densely cover it and hit every "
+        "in-domain branch boundary the decompile tests.\n"
+        "  * If wild_read/graceful: you MAY additionally emit boundary probes just "
+        "past the domain edge (domain_max+1, a few beyond) and extremes, to test "
+        "the out-of-domain handling -- but be judicious.\n\n"
+        f"Output ONLY strict JSON, this exact shape: {example}\n"
+        "20-60 vectors. No prose, no markdown fences.\n\n"
+        "----- DECOMPILE -----\n"
+        f"{decompile}\n"
+        "----- END DECOMPILE -----"
+    )
+
+
+def _extract_json_object(text: str) -> dict | None:
+    """Pull the first balanced top-level JSON object out of a model response
+    (tolerates prose or ```json fences)."""
+    if not text:
+        return None
+    s = text.strip()
+    if s.startswith("```"):
+        s = s.split("```", 2)[1] if s.count("```") >= 2 else s.strip("`")
+        if s.lstrip().startswith("json"):
+            s = s.lstrip()[4:]
+    start = s.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    for i in range(start, len(s)):
+        if s[i] == "{":
+            depth += 1
+        elif s[i] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(s[start:i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+def _model_analysis(name: str, spec: dict, decompile: str,
+                    env: dict[str, tuple[int, int, list[int]]]
+                    ) -> tuple[str, dict[str, list[int]]]:
+    """Ask the adversary model to (1) classify out-of-domain behavior and (2)
+    propose vectors. Returns (out_of_domain_class, per-arg-id extra values).
+    ('unknown', {}) on any failure -- caller then stays strictly in-envelope."""
+    try:
+        import asyncio
+        from claude_agent_sdk import query, ClaudeAgentOptions
+    except ImportError:
+        print("  [model] claude_agent_sdk unavailable -- staying in-envelope")
+        return "unknown", {}
+
+    prompt = _adversarial_prompt(name, spec, decompile, env)
+    ids = [a["id"] for a in _scalar_args(spec) if a.get("kind") != "buf"]
+
+    async def run() -> str:
+        opts = ClaudeAgentOptions(
+            model=V1_MODEL, permission_mode="bypassPermissions", max_turns=1,
+            system_prompt=("You output only strict JSON. You classify a decompiled "
+                           "function's out-of-domain behavior and propose safe "
+                           "adversarial input vectors from the decompile alone."),
+        )
+        parts: list[str] = []
+        async for msg in query(prompt=prompt, options=opts):
+            if type(msg).__name__ == "AssistantMessage":
+                for blk in getattr(msg, "content", None) or []:
+                    if type(blk).__name__ == "TextBlock":
+                        parts.append(getattr(blk, "text", ""))
+        return "".join(parts)
+
+    try:
+        raw = asyncio.run(run())
+    except Exception as e:  # noqa: BLE001
+        print(f"  [model] call failed ({e}) -- staying in-envelope")
+        return "unknown", {}
+
+    obj = _extract_json_object(raw)
+    if not isinstance(obj, dict):
+        print("  [model] no JSON object parsed -- staying in-envelope")
+        return "unknown", {}
+    ood = str(obj.get("out_of_domain", "unknown")).strip().lower()
+    per_id: dict[str, list[int]] = {i: [] for i in ids}
+    for v in obj.get("vectors", []) or []:
+        if not isinstance(v, dict):
+            continue
+        for i in ids:
+            if i in v:
+                try:
+                    per_id[i].append(int(v[i]))
+                except (TypeError, ValueError):
+                    pass
+    kept = sum(len(x) for x in per_id.values())
+    print(f"  [model] out_of_domain={ood!r}, {len(obj.get('vectors', []))} vectors, {kept} values")
+    return ood, per_id
+
+
+def build_vectors(name: str, spec: dict, decompile: str | None, use_model: bool
+                  ) -> tuple[list[dict], str]:
+    """Assemble the adversarial vector list (each a dict keyed by arg id), SAFE by
+    construction. Returns (vectors, note). buffer args pinned to 0 (outputs/seeds)."""
+    scal = _scalar_args(spec)
+    buf_ids = [a["id"] for a in scal if a.get("kind") == "buf"]
+    int_args = [a for a in scal if a.get("kind") != "buf"]
+    base_buf = {i: 0 for i in buf_ids}
+    if not int_args:
+        return [dict(base_buf)], "buffer-only"
+
+    env = _spec_envelope(spec, int_args)
+    ood, model_extra = ("unknown", {})
+    if use_model and decompile:
+        ood, model_extra = _model_analysis(name, spec, decompile, env)
+    widen = ood in WIDEN_OK
+
+    per_id: dict[str, list[int]] = {}
+    for a in int_args:
+        i = a["id"]
+        lo, hi, obs = env[i]
+        vals = set(obs) | set(_densify_in(lo, hi))     # always: in-envelope, safe
+        if widen:
+            # allow the model's out-of-domain probes + bounded extremes (model
+            # certified this arg tolerates them). Cap how far past we go.
+            wlo, whi = min(lo, INT_MIN + 1), max(hi, INT_MAX - 1)
+            vals |= {v for v in model_extra.get(i, []) if wlo <= v <= whi}
+            vals |= set(_extremes_in(wlo, whi))
+        else:
+            # in-envelope model suggestions only (never widen for abort/dispatch)
+            vals |= {v for v in model_extra.get(i, []) if lo <= v <= hi}
+        per_id[i] = sorted(vals)
+
+    ids = [a["id"] for a in int_args]
+    vectors: list[dict] = []
+    if len(ids) == 1:
+        i = ids[0]
+        for val in per_id[i]:
+            vectors.append({**base_buf, i: val})
+    else:
+        longest = max(len(per_id[x]) for x in ids)
+        for k in range(longest):
+            vectors.append({**base_buf, **{x: per_id[x][k % len(per_id[x])] for x in ids}})
+        import itertools
+        for combo in itertools.product(*[per_id[x][:8] for x in ids]):
+            vectors.append({**base_buf, **dict(zip(ids, combo))})
+
+    seen, norm = set(), []
+    for v in vectors:
+        nv = {k: (val & 0xFFFFFFFF) for k, val in v.items()}
+        key = tuple(sorted(nv.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        norm.append(nv)
+        if len(norm) >= MAX_VECTORS:
+            break
+    note = f"ood={ood}{'/widened' if widen else '/in-envelope'}"
+    return norm, note
+
+
+# --------------------------------------------------------------------------- #
+# Resilient oracle run -- isolate vectors that FAULT the original
+# --------------------------------------------------------------------------- #
+def _is_fault(res: dict) -> bool:
+    """The oracle aborts the whole batch when the ORIGINAL faults on some vector
+    (a wild read from an out-of-domain arg -- D2MOO keeps the original's bugs).
+    Detect that so we can bisect it out rather than fail the function."""
+    return (not res.get("ok")) and "exception" in str(res.get("error", "")).lower()
+
+
+def run_oracle_resilient(spec: dict, vectors: list[dict], *, _depth: int = 0
+                         ) -> tuple[list[dict], list[dict]]:
+    """Return (comparable_results, original_fault_vectors). A vector that faults
+    the ORIGINAL can't be compared (both sides would fault) -- it's quarantined,
+    not counted as a divergence. Bisects to isolate faulting vectors so the rest
+    still prove. comparable_results[i] aligns with its input via 'vector' key."""
+    if not vectors:
+        return [], []
+    probe = dict(spec)
+    probe["vectors"] = vectors
+    res = _oracle_post("/oracle", probe)
+    if res.get("ok"):
+        out = []
+        for i, r in enumerate(res.get("results", [])):
+            rr = dict(r)
+            rr["vector"] = vectors[i]
+            out.append(rr)
+        return out, []
+    if not _is_fault(res) or _depth > 24:
+        # A non-fault error (bad spec, unreachable) -- propagate as empty compare
+        # with everything marked unproven by raising to the caller via signal.
+        raise RuntimeError(res.get("error", "oracle error"))
+    if len(vectors) == 1:
+        return [], [vectors[0]]
+    mid = len(vectors) // 2
+    lc, lf = run_oracle_resilient(spec, vectors[:mid], _depth=_depth + 1)
+    rc, rf = run_oracle_resilient(spec, vectors[mid:], _depth=_depth + 1)
+    return lc + rc, lf + rf
+
+
+# --------------------------------------------------------------------------- #
+# The V1 pass
+# --------------------------------------------------------------------------- #
+def reprove(name: str, spec_path: Path, *, use_model: bool, row: dict | None) -> dict:
+    spec = json.load(open(spec_path, encoding="utf-8"))
+    handle = _handle_args(spec)
+    scal = _scalar_args(spec)
+    int_args = [a for a in scal if a.get("kind") != "buf"]
+
+    if handle and not int_args:
+        return {"name": name, "status": "skipped-shadow-only",
+                "reason": "handle-input function: no oracle-sweepable arg (earns evidence via V2 shadow)"}
+    if not int_args:
+        return {"name": name, "status": "skipped-no-scalar",
+                "reason": "no i32/buf integer argument to sweep"}
+
+    offset = spec.get("offset")
+    if offset is None and spec.get("addr") is not None:
+        offset = spec["addr"] - _D2COMMON_BASE
+    addr_hex = f"0x{_D2COMMON_BASE + offset:x}" if offset is not None else None
+
+    decompile = _ghidra_decompile(addr_hex) if (use_model and addr_hex) else None
+    if use_model and not decompile:
+        print(f"  [ghidra] no decompile for {name} @ {addr_hex} -- algorithmic floor only")
+
+    vectors, gen_note = build_vectors(name, spec, decompile, use_model)
+    try:
+        results, orig_faults = run_oracle_resilient(spec, vectors)
+    except RuntimeError as e:
+        return {"name": name, "status": "oracle-error", "reason": str(e)}
+    # OracleDied propagates to main() -- a crashed server is fatal for the run.
+
+    compared = len(results)
+    mism = [r for r in results if not r.get("match")]
+    if compared == 0:
+        # Every generated vector faulted the original -- can't prove anything.
+        return {"name": name, "status": "all-faulted", "vectors": len(vectors),
+                "original_faults": len(orig_faults),
+                "reason": "every adversarial input faults the original (undecidable via oracle)"}
+
+    if not mism:
+        return {"name": name, "status": "vetted", "vectors": compared,
+                "original_faults": len(orig_faults), "used_model": bool(decompile)}
+
+    # Divergence: capture a permanent regression case, exactly like a shadow div.
+    fails = [{"vector": r.get("vector"), "ret": r.get("ret"), "bufs": r.get("bufs")}
+             for r in mism]
+    DIVERGENCE_DIR.mkdir(parents=True, exist_ok=True)
+    dpath = DIVERGENCE_DIR / f"{name}.adversarial.json"
+    dpath.write_text(json.dumps(
+        {"name": name, "spec": str(spec_path.name), "mismatches": len(mism),
+         "compared": compared, "original_faults": len(orig_faults),
+         "failing": fails[:64]}, indent=2), encoding="utf-8")
+    return {"name": name, "status": "DIVERGED", "vectors": compared,
+            "mismatches": len(mism), "original_faults": len(orig_faults),
+            "regression_case": str(dpath), "used_model": bool(decompile)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="V1 adversarial re-proof of CONF_LIVE reimpls.")
+    ap.add_argument("--function", help="single function name (registry `name`)")
+    ap.add_argument("--all", action="store_true", help="every CONF_LIVE row with a scalar arg")
+    ap.add_argument("--no-model", dest="model", action="store_false", default=True,
+                    help="algorithmic floor only (no adversary model call)")
+    ap.add_argument("--dry-run", action="store_true", help="don't write registry markers")
+    args = ap.parse_args()
+
+    st = _oracle_get("/status")
+    if not st.get("ok"):
+        print(f"[fatal] D2Debugger not reachable at {ORACLE_URL}")
+        return 2
+    print(f"[status] bridge={st['bridge']} dispatchers={st['dispatchers']} "
+          f"provider={st['provider']!r}  model={'on' if args.model else 'off'}")
+
+    specs = _spec_by_name()
+    rows = _load_registry()
+    by_name = {r["name"]: r for r in rows}
+
+    if args.function:
+        targets = [args.function]
+    elif args.all:
+        targets = [r["name"] for r in rows if r.get("conf") == "CONF_LIVE"]
+    else:
+        print("[fatal] pass --function NAME or --all")
+        return 2
+
+    results = []
+    for nm in targets:
+        if nm not in specs:
+            print(f"[skip] {nm}: no conformance/vectors/*.spec.json declares this name")
+            results.append({"name": nm, "status": "no-spec"})
+            continue
+        # ABORT-CLASS HARD SKIP (2026-07-08): a registry row (or its spec) flagged
+        # abort_class has a FATAL out-of-range path -- _exit/CleanupAndAbort, an
+        # uncatchable kill, not a recoverable wild read. The model-envelope logic
+        # below is a soft guard; for these functions no widening is acceptable at
+        # all, and even dense in-envelope sweeps add nothing beyond the original
+        # proof (their envelope IS the proof set). Static registry flag beats a
+        # model judgment call. (GetAnimSequenceRecord killed the bridge 3x.)
+        row = by_name.get(nm) or {}
+        spec_flag = False
+        try:
+            spec_flag = bool(json.loads(specs[nm].read_text(encoding="utf-8")).get("abort_class"))
+        except Exception:
+            pass
+        if row.get("abort_class") or spec_flag:
+            print(f"[skip] {nm}: ABORT CLASS (fatal out-of-range path) -- V1 sweep "
+                  f"forbidden; evidence rung is V2 shadow instead")
+            results.append({"name": nm, "status": "abort-class-skip"})
+            continue
+        print(f"[v1] {nm}")
+        try:
+            out = reprove(nm, specs[nm], use_model=args.model, row=by_name.get(nm))
+        except OracleDied as e:
+            print(f"  !! ORACLE DIED while proving {nm}: {e}")
+            print(f"  !! A generated vector crashed the oracle server thread. "
+                  f"The game may still run but :8790 is down -- restart to restore. "
+                  f"Suspect function: {nm}")
+            if not args.dry_run:
+                _save_registry(rows)
+            print(f"\n[aborted] oracle died on {nm}; {len(results)} functions completed first")
+            return 3
+        results.append(out)
+        tag = out["status"]
+        if tag == "vetted":
+            fault_note = (f", {out['original_faults']} inputs quarantined (fault the original)"
+                          if out.get("original_faults") else "")
+            print(f"  VETTED: {out['vectors']} adversarial vectors compared, 0 divergence"
+                  f"{fault_note}"
+                  f"{' (model+algo)' if out.get('used_model') else ' (algo-only)'}")
+            r = by_name.get(nm)
+            if r is not None and not args.dry_run:
+                r["vetted"] = "adversarial"
+                r["vetted_date"] = time.strftime("%Y-%m-%d")
+                r["vetted_vectors"] = out["vectors"]
+                r["vetted_model"] = bool(out.get("used_model"))
+                if out.get("original_faults"):
+                    r["vetted_quarantined"] = out["original_faults"]
+                r.pop("needs_review", None)
+        elif tag == "DIVERGED":
+            print(f"  !! DIVERGED: {out['mismatches']}/{out['vectors']} mismatch -- "
+                  f"REOPENS reimpl. regression case: {out['regression_case']}")
+            r = by_name.get(nm)
+            if r is not None and not args.dry_run:
+                r["vetted"] = "adversarial-FAILED"
+                r["needs_review"] = True
+                r["vetted_date"] = time.strftime("%Y-%m-%d")
+        else:
+            print(f"  {tag}: {out.get('reason', '')}")
+
+    if not args.dry_run:
+        _save_registry(rows)
+
+    vetted = sum(1 for r in results if r["status"] == "vetted")
+    diverged = [r["name"] for r in results if r["status"] == "DIVERGED"]
+    skipped = sum(1 for r in results if r["status"].startswith("skipped"))
+    print(f"\n[summary] {vetted} vetted, {len(diverged)} DIVERGED, {skipped} shadow-only/skipped, "
+          f"{len(results)} total")
+    if diverged:
+        print(f"[summary] REOPENED (adversarial divergence): {', '.join(diverged)}")
+    return 1 if diverged else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/batch_assess.py
+++ b/fun-doc/batch_assess.py
@@ -1,0 +1,119 @@
+"""batch_assess.py -- run a backlog of functions through the WHOLE prove_doc workflow
+(live-prove -> gate -> canonical-name -> DOC rung) and emit a performance scorecard.
+
+This is the batch harness for assessing the unified pipeline at scale: it loops
+prove_doc() over conformance/profiler/hot_backlog.json, CHECKPOINTS after every function
+(so a mid-batch game/oracle crash loses nothing), and prints a scorecard partitioning
+outcomes by result + how far each function got through the pipeline stages.
+
+    python batch_assess.py                 # run the whole backlog
+    python batch_assess.py --count 4       # first N only (smaller wave)
+    python batch_assess.py --scorecard     # re-print scorecard from the last run, no proving
+
+Honest by construction: failures are DATA (they show where the pipeline stops), not hidden.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+D2MOO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+BACKLOG = D2MOO / "conformance" / "profiler" / "hot_backlog.json"
+OUT = D2MOO / "conformance" / "profiler" / f"batch_assess_results.json"
+
+
+def _stage_reached(summary: dict) -> str:
+    """Coarse 'how far did it get' bucket from the stages present."""
+    st = summary.get("stages", {})
+    if summary.get("result", "").startswith("EXCEPTION"):
+        return "exception"
+    if st.get("prove") not in ("proven_live_pending_review", "(skipped -- gate-only re-run)"):
+        return "prove_failed"
+    if "canonical_name" in st:
+        cn = st["canonical_name"]
+        if isinstance(cn, dict) and cn.get("applied"):
+            return "canonical_named"
+    if "gate" in st:
+        return "gated"
+    return "proven_only"
+
+
+def run(count: int | None) -> list:
+    os.environ.setdefault("FUNDOC_LIVE_PROVE", "1")
+    os.environ.setdefault("FUNDOC_DOC_TAGS", "1")      # stamp the DOC_ maturity rung
+    import prove_doc as pd
+    rows = json.loads(BACKLOG.read_text(encoding="utf-8")).get("backlog", [])
+    if count:
+        rows = rows[:count]
+    results = []
+    for i, r in enumerate(rows):
+        name, addr = r["name"], r["address"]
+        print(f"\n===== [{i+1}/{len(rows)}] {name} {addr} ({r.get('hits','?')} hits) =====",
+              flush=True)
+        t0 = datetime.now()
+        try:
+            s = pd.prove_doc(addr, name)
+        except Exception as e:
+            s = {"name": name, "address": addr, "result": f"EXCEPTION: {e}",
+                 "trace": traceback.format_exc()[-600:], "stages": {}}
+        s["_secs"] = round((datetime.now() - t0).total_seconds(), 1)
+        s["_hits"] = r.get("hits")
+        s["_reached"] = _stage_reached(s)
+        results.append(s)
+        OUT.write_text(json.dumps(results, indent=2, default=str), encoding="utf-8")   # checkpoint
+        print(f"  -> {s.get('result')}  [{s['_reached']}]  ({s['_secs']}s)", flush=True)
+    return results
+
+
+def scorecard(results: list) -> None:
+    n = len(results)
+    reached = collections.Counter(s.get("_reached") for s in results)
+    total_s = sum(s.get("_secs", 0) for s in results)
+    print("\n" + "=" * 72)
+    print(f"BATCH SCORECARD -- {n} functions, {total_s/60:.1f} min total "
+          f"({total_s/max(n,1):.0f}s avg)")
+    print("=" * 72)
+    print("\nHOW FAR THROUGH THE PIPELINE:")
+    order = ["canonical_named", "proven_only", "gated", "prove_failed", "exception"]
+    for k in order:
+        if reached.get(k):
+            print(f"  {k:<18} {reached[k]}")
+    for k, v in reached.items():
+        if k not in order:
+            print(f"  {k:<18} {v}")
+    proven = [s for s in results if s.get("_reached") not in ("prove_failed", "exception")]
+    named = [s for s in results if s.get("_reached") == "canonical_named"]
+    print(f"\nPROVED (whole workflow ran): {len(proven)}/{n}")
+    print(f"CANONICAL-NAMED live:        {len(named)}/{n}")
+    print("\nPER-FUNCTION:")
+    for s in results:
+        cn = s.get("stages", {}).get("canonical_name", {})
+        nm = (f"  -> {cn['to']}" if isinstance(cn, dict) and cn.get("applied")
+              else (f"  (name: {cn.get('unresolved','')[:40]})" if isinstance(cn, dict)
+                    and cn.get("unresolved") else ""))
+        print(f"  {s['name']:<34} {s.get('_reached',''):<16} {str(s.get('result',''))[:46]}{nm}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--count", type=int, default=None)
+    ap.add_argument("--scorecard", action="store_true",
+                    help="re-print scorecard from the last results file, no proving")
+    args = ap.parse_args()
+    if args.scorecard:
+        results = json.loads(OUT.read_text(encoding="utf-8"))
+    else:
+        results = run(args.count)
+    scorecard(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/battletest_promoter.py
+++ b/fun-doc/battletest_promoter.py
@@ -1,0 +1,200 @@
+"""battletest_promoter.py -- the promotion half of the continuous port loop's
+"shadow to verify" step (sibling to shadow_promote.py, which STAGES a function
+as a shadow dispatcher; this module watches the ALREADY-STAGED-AND-DEPLOYED
+dispatchers and promotes CONF_LIVE -> CONF_BATTLETESTED once real gameplay has
+produced enough zero-divergence evidence).
+
+This automates, exactly, the manual procedure run by hand 2026-07-07 (see
+conformance/D2COMMON_FULL_SHADOW_PLAN.md and proven_functions.jsonl history):
+poll D2Debugger's /dispatchers, and for any dispatcher in shadow mode with
+zero divergences and hits over a volume bar, flip its Ghidra CONF_ tag and
+registry row from CONF_LIVE to CONF_BATTLETESTED.
+
+Standalone (imports nothing from fun_doc). Two ways to use it:
+  - CLI: `python battletest_promoter.py` (one poll+promote pass) or
+         `python battletest_promoter.py --loop --interval 60` (continuous).
+  - Library: `poll_and_promote()` from fun_doc's continuous port-worker loop
+    (best-effort, non-fatal -- see maybe_promote's docstring).
+"""
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import time
+import urllib.parse
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+PROVEN_REGISTRY = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+ORACLE_URL = os.environ.get("D2DBG_MCP_URL", "http://127.0.0.1:8790")
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+
+_D2COMMON_BASE = 0x6FD50000
+BATTLE_MIN_HITS = int(os.environ.get("FUNDOC_BATTLETEST_MIN_HITS", "1000"))
+
+CONF_TAGS = ["CONF_DRAFT", "CONF_VECTORS", "CONF_LIVE", "CONF_BATTLETESTED"]
+
+
+def _http_get_json(base_url: str, path: str, timeout: int = 8) -> dict:
+    u = urllib.parse.urlparse(base_url)
+    conn = http.client.HTTPConnection(u.hostname, u.port, timeout=timeout)
+    try:
+        conn.request("GET", path)
+        raw = conn.getresponse().read().decode("utf-8", "replace")
+    finally:
+        conn.close()
+    return json.loads(raw)
+
+
+def _ghidra_post(path: str, data: dict) -> dict:
+    u = urllib.parse.urlparse(GHIDRA_HTTP)
+    conn = http.client.HTTPConnection(u.hostname, u.port or 8089, timeout=15)
+    try:
+        conn.request("POST", path, body=json.dumps(data),
+                      headers={"Content-Type": "application/json"})
+        raw = conn.getresponse().read().decode("utf-8", "replace")
+    except OSError as e:
+        return {"error": f"ghidra unreachable: {e}"}
+    finally:
+        conn.close()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"error": raw[:200]}
+
+
+def _set_battletested(address_hex: str, program: str = "D2Common.dll") -> dict:
+    others = ",".join(t for t in CONF_TAGS if t != "CONF_BATTLETESTED")
+    _ghidra_post("/remove_function_tag", {"function": address_hex, "tags": others, "program": program})
+    return _ghidra_post("/add_function_tag",
+                         {"function": address_hex, "tags": "CONF_BATTLETESTED", "program": program})
+
+
+def _load_registry() -> list:
+    if not PROVEN_REGISTRY.exists():
+        return []
+    return [json.loads(l) for l in PROVEN_REGISTRY.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _save_registry(rows: list) -> None:
+    PROVEN_REGISTRY.parent.mkdir(parents=True, exist_ok=True)
+    with open(PROVEN_REGISTRY, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def poll_and_promote(*, min_hits: int = BATTLE_MIN_HITS, program: str = "D2Common.dll") -> dict:
+    """One pass: read live dispatcher hit/divergence counters, refresh the
+    registry's shadow_hits/shadow_divergences on every dispatcher-active row,
+    and promote any CONF_LIVE row that has crossed the zero-divergence volume
+    bar. Best-effort -- returns {"ok": False, "error": ...} on any connectivity
+    problem rather than raising (this is meant to run unattended)."""
+    try:
+        disp = _http_get_json(ORACLE_URL, "/dispatchers")
+    except OSError as e:
+        return {"ok": False, "error": f"D2Debugger unreachable: {e}"}
+    if not disp.get("ok"):
+        return {"ok": False, "error": disp.get("error", "bad /dispatchers response")}
+
+    rows = _load_registry()
+    by_key = {(r["name"], r["address"]): r for r in rows}
+    promoted = []
+    for d in disp.get("dispatchers", []):
+        addr_hex = f"0x{_D2COMMON_BASE + d['offset']:x}"
+        key = (d["name"], addr_hex)
+        r = by_key.get(key)
+        if r is None:
+            continue  # not a fun-doc/hand-tracked function; nothing to update
+        hits, divs = d.get("hits", 0), d.get("divergences", 0)
+        r["shadow_hits"] = hits
+        r["shadow_divergences"] = divs
+        r["shadow_mode"] = d.get("modeName")
+        # WINDOWED rate since the last epoch. A hot-reloaded fix (verify_shadow_fix /
+        # --set-epoch) records the counters at fix time as shadow_epoch_*; we then
+        # judge the DELTA, so a fixed function promotes on its own without a game
+        # restart to clear the pre-fix (poisoned) cumulative divergences. Default
+        # epoch 0/0 == lifetime totals (unchanged behavior for never-reset rows).
+        eh = r.get("shadow_epoch_hits", 0)
+        ed = r.get("shadow_epoch_divergences", 0)
+        dhits, ddivs = hits - eh, divs - ed
+        is_shadow = d.get("modeName") == "shadow"
+        if (is_shadow and ddivs == 0 and dhits >= min_hits and not r.get("weak_proof")
+                and r.get("conf") != "CONF_BATTLETESTED"):
+            tag_result = _set_battletested(addr_hex, program=program)
+            if tag_result.get("status") == "success" or "already_present" in str(tag_result):
+                r["conf"] = "CONF_BATTLETESTED"
+                r["battletested_date"] = time.strftime("%Y-%m-%d")
+                if eh or ed:
+                    r["battletested_windowed"] = f"{dhits} clean hits since epoch (post-fix)"
+                promoted.append({"name": d["name"], "hits": dhits})
+
+    _save_registry(rows)
+    return {"ok": True, "promoted": promoted, "dispatchers_seen": len(disp.get("dispatchers", []))}
+
+
+def set_shadow_epoch(name: str, *, program: str = "D2Common.dll") -> dict:
+    """Record the CURRENT live (hits, divergences) as this function's epoch baseline
+    in the registry, so poll_and_promote judges only NEW calls. Call right after a
+    hot-reloaded reimpl fix -- the pre-fix cumulative divergences are poisoned; the
+    epoch draws a clean line so a correct fix promotes without a game restart."""
+    try:
+        disp = _http_get_json(ORACLE_URL, "/dispatchers")
+    except OSError as e:
+        return {"ok": False, "error": f"D2Debugger unreachable: {e}"}
+    cur = None
+    for d in disp.get("dispatchers", []):
+        if d["name"] == name:
+            cur = d
+            break
+    if cur is None:
+        return {"ok": False, "error": f"{name} is not a live dispatcher"}
+    rows = _load_registry()
+    hit = False
+    for r in rows:
+        if r.get("name") == name:
+            r["shadow_epoch_hits"] = cur.get("hits", 0)
+            r["shadow_epoch_divergences"] = cur.get("divergences", 0)
+            r["shadow_epoch_date"] = time.strftime("%Y-%m-%d")
+            hit = True
+    if not hit:
+        return {"ok": False, "error": f"{name} not in registry"}
+    _save_registry(rows)
+    return {"ok": True, "name": name, "epoch_hits": cur.get("hits", 0),
+            "epoch_divergences": cur.get("divergences", 0)}
+
+
+def loop(interval: int = 60, *, stop_flag=None) -> None:
+    """Continuous polling loop. `stop_flag` (optional) is anything with
+    .is_set() -- lets a caller (e.g. fun-doc's WorkerManager) interrupt it the
+    same way the existing functions-mode worker loop does."""
+    while True:
+        if stop_flag is not None and stop_flag.is_set():
+            return
+        result = poll_and_promote()
+        if result.get("promoted"):
+            print(f"[battletest_promoter] promoted: {result['promoted']}")
+        elif not result.get("ok"):
+            print(f"[battletest_promoter] {result.get('error')}")
+        for _ in range(interval):
+            if stop_flag is not None and stop_flag.is_set():
+                return
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--loop", action="store_true", help="poll continuously instead of once")
+    ap.add_argument("--interval", type=int, default=60, help="seconds between polls in --loop mode")
+    ap.add_argument("--min-hits", type=int, default=BATTLE_MIN_HITS)
+    ap.add_argument("--set-epoch", metavar="NAME",
+                    help="record NAME's current shadow counters as its epoch baseline "
+                         "(after a hot-reloaded fix -- promote on NEW clean calls, no restart)")
+    args = ap.parse_args()
+    if args.set_epoch:
+        print(json.dumps(set_shadow_epoch(args.set_epoch), indent=2))
+    elif args.loop:
+        loop(args.interval)
+    else:
+        print(json.dumps(poll_and_promote(min_hits=args.min_hits), indent=2))

--- a/fun-doc/bench_d2common.py
+++ b/fun-doc/bench_d2common.py
@@ -1,0 +1,326 @@
+"""bench_d2common.py -- non-destructive documentation benchmark on the REAL binary.
+
+The fresh, pristine /testing/D2Common.dll (auto-analysis only: FUN_/Ordinal names,
+undefined types, no plates) is byte-identical to our annotated /Mods/PD2-S12 copy, so
+they map by ADDRESS. We run the MODEL doc-generation BLIND on the fresh copy and score
+its output against the annotated copy (the answer key) -- WITHOUT touching our real work
+(golden_bench had to strip-in-place; this uses a separate program).
+
+Why the MODEL stages, not the translators: fresh and annotated share identical bytes, so
+the DETERMINISTIC translators produce identical output on both -> circular/trivial. The
+non-trivial thing to measure on real codegen is the model's NAME/PLATE/prototype recovery.
+
+Axes (user-ratified rubric; INDEPENDENT judge for prose to avoid circularity):
+  * prototype : return-width + param-count match (mechanical)
+  * name      : does the generated name mean the same as the annotated name? (judge)
+  * plate     : is the generated plate semantically accurate vs the annotated plate? (judge)
+Authority tier: 'proven' functions have oracle-verified behavior (their prototype axis is
+authoritative truth); 'documented' functions are a regression signal vs our best docs.
+
+Two-phase (each phase sets its own scope-guard folder via env at process start):
+  1) python bench_d2common.py --extract --names A,B,C   (PD2 scope; reads answer key)
+  2) python bench_d2common.py --score                   (/testing scope; generates+scores)
+  python bench_d2common.py --selftest
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+ANNOTATED = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+FRESH = "/testing/D2Common.dll"
+REGISTRY = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+CANDIDATES = D2MOO_REPO / "conformance" / "reimpl_provider" / "candidates"
+OUT_DIR = D2MOO_REPO / "conformance" / "benchmark"
+ANSWER_JSON = OUT_DIR / "d2common_answer.json"
+SCORE_JSON = OUT_DIR / "d2common_score.json"
+
+_RW = {"u8": 1, "i8": 1, "u16": 2, "i16": 2, "u32": 4, "i32": 4}
+_TYPE_W = {"byte": 1, "uchar": 1, "unsigned char": 1, "char": 1, "signed char": 1,
+           "undefined1": 1, "bool": 1, "uint8_t": 1, "int8_t": 1, "u8": 1, "i8": 1,
+           "ushort": 2, "short": 2, "unsigned short": 2, "signed short": 2, "word": 2,
+           "undefined2": 2, "uint16_t": 2, "int16_t": 2, "wchar_t": 2, "u16": 2, "i16": 2,
+           "uint": 4, "int": 4, "unsigned int": 4, "signed int": 4, "dword": 4,
+           "undefined4": 4, "long": 4, "unsigned long": 4, "uint32_t": 4, "int32_t": 4,
+           "u32": 4, "i32": 4, "undefined": 4, "float": 4, "size_t": 4, "hresult": 4,
+           "bool32": 4}
+
+
+# ---------------------------------------------------------------------------
+# pure logic (offline-testable)
+# ---------------------------------------------------------------------------
+
+def _ret_type(prototype: str, name: str) -> str:
+    """Return-type token from a prototype string."""
+    head = prototype.split(name)[0] if name in prototype else prototype.split("(")[0]
+    return " ".join(head.replace("*", " * ").split()).strip().lower()
+
+
+def _ret_width(ret_token: str) -> int | None:
+    t = ret_token.replace(" *", "*").strip()
+    if t.endswith("*"):
+        return 4
+    return _TYPE_W.get(t.replace("unsigned ", "unsigned "), _TYPE_W.get(t))
+
+
+def _param_count(prototype: str) -> int:
+    m = re.search(r"\(([^)]*)\)", prototype)
+    if not m:
+        return -1
+    inner = m.group(1).strip()
+    if not inner or inner.lower() == "void":
+        return 0
+    return len([p for p in inner.split(",") if p.strip()])
+
+
+def score_prototype(gen_proto: str, gen_name: str, truth: dict) -> dict:
+    """Mechanical: return-width + param-count. Truth width prefers the PROVEN reimpl
+    (oracle-verified) over the annotated prototype when available."""
+    tw = truth.get("proven_ret_width") or _ret_width(_ret_type(truth["prototype"], truth["name"]))
+    gw = _ret_width(_ret_type(gen_proto, gen_name))
+    ret_ok = (gw is not None and gw == tw)
+    tp = truth.get("proven_param_count")
+    if tp is None:
+        tp = _param_count(truth["prototype"])
+    gp = _param_count(gen_proto)
+    param_ok = (gp == tp)
+    return {"ret_width_ok": ret_ok, "param_count_ok": param_ok,
+            "score": round((ret_ok + param_ok) / 2, 3),
+            "truth_ret_width": tw, "got_ret_width": gw,
+            "truth_params": tp, "got_params": gp}
+
+
+def aggregate(results: dict) -> dict:
+    if not results:
+        return {"n": 0}
+    axes = ("prototype", "name", "plate")
+    agg = {a: round(sum(r["axes"][a] for r in results.values()) / len(results), 3) for a in axes}
+    overall = round(sum(r["score"] for r in results.values()) / len(results), 3)
+    proven = [r for r in results.values() if r.get("tier") == "proven"]
+    return {"n": len(results), "overall": overall, "axes": agg,
+            "proven_n": len(proven),
+            "proven_prototype": round(sum(r["axes"]["prototype"] for r in proven) / len(proven), 3)
+            if proven else None}
+
+
+# ---------------------------------------------------------------------------
+# phase 1: extract the answer key (run under PD2 scope)
+# ---------------------------------------------------------------------------
+
+def _registry() -> list:
+    return [json.loads(l) for l in REGISTRY.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _proven_facts(name: str) -> dict:
+    """Oracle-verified facts from the proven candidate (authoritative behavior)."""
+    cand = CANDIDATES / f"{name}.cpp"
+    if not cand.exists():
+        return {}
+    try:
+        import prove_doc
+        f = prove_doc.parse_reimpl_facts(cand.read_text(encoding="utf-8"))
+        # semantic ret width from the field read (not the harness u32)
+        reads = f.get("field_reads") or []
+        maxd = max((r.get("depth", 0) for r in reads), default=0)
+        finals = [r for r in reads if r.get("depth", 0) == maxd]
+        rw = finals[0]["width"] if finals else None
+        return {"proven_ret_width": rw, "proven_param_count": f.get("params")}
+    except Exception:
+        return {}
+
+
+def extract(names: list, program: str = None) -> dict:
+    import fun_doc
+    prog = program or ANNOTATED
+    reg = {r["name"]: r for r in _registry()}
+    proven_names = set(reg)
+    key = {}
+    for name in names:
+        row = reg.get(name)
+        addr = row["address"] if row else None
+        if not addr:
+            print(f"[extract] {name}: not in registry -- skip")
+            continue
+        dec = str(fun_doc.ghidra_get("/decompile_function",
+                                     params={"address": addr, "program": prog}))
+        m = re.search(r"^\s*([\w\s\*]+?\s\*?\s*" + re.escape(name) + r"\s*\([^)]*\))",
+                      dec.replace("\r", ""), re.MULTILINE)
+        proto = m.group(1).strip() if m else None
+        plate = fun_doc.ghidra_get("/get_plate_comment", params={"address": addr, "program": prog})
+        plate_txt = plate.get("comment") if isinstance(plate, dict) else str(plate)
+        entry = {"name": name, "address": addr, "prototype": proto or f"undefined {name}()",
+                 "plate": plate_txt or "", "tier": "proven" if name in proven_names else "documented",
+                 **_proven_facts(name)}
+        key[name] = entry
+        print(f"[extract] {name} @{addr} tier={entry['tier']} proven_ret_w={entry.get('proven_ret_width')}")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    ANSWER_JSON.write_text(json.dumps(key, indent=2), encoding="utf-8")
+    print(f"[extract] wrote {len(key)} answer-key entries -> {ANSWER_JSON}")
+    return key
+
+
+# ---------------------------------------------------------------------------
+# phase 2: generate BLIND on the fresh copy + score (run under /testing scope)
+# ---------------------------------------------------------------------------
+
+_GEN_PROMPT = """You are documenting an UNKNOWN function from a freshly analyzed binary.
+You have ONLY the decompiler output below (no name, no types, no comments -- a blind
+Ghidra auto-analysis). Recover what the function does.
+
+## Decompiled (blind)
+```c
+{decompiled}
+```
+## Disassembly (ground truth for widths/offsets)
+```
+{disasm}
+```
+
+Produce documentation as STRICT JSON only:
+{{"name": "<CamelCase semantic function name reflecting behavior>",
+  "prototype": "<full C prototype with your recovered return type + params>",
+  "plate": "<concise doc: 1-line summary, algorithm steps, params, returns, special cases>"}}"""
+
+_JUDGE_PROMPT = """Compare GENERATED reverse-engineering documentation against the
+REFERENCE (known-good) documentation for the same function. Score how well the generated
+version captures the SAME meaning. Be strict but fair: different wording that conveys the
+same behavior scores high; missing or wrong behavior scores low.
+
+## REFERENCE name: {ref_name}
+## GENERATED name: {gen_name}
+
+## REFERENCE plate
+{ref_plate}
+
+## GENERATED plate
+{gen_plate}
+
+Output STRICT JSON only:
+{{"name_match": <0.0-1.0, do the two names denote the same function/behavior>,
+  "plate_accuracy": <0.0-1.0, does the generated plate accurately capture the reference behavior>,
+  "reason": "<one sentence>"}}"""
+
+
+def generate(addr: str, program: str, provider=None, model=None) -> dict:
+    import fun_doc
+    dec = str(fun_doc.ghidra_get("/decompile_function", params={"address": addr, "program": program}))
+    dis = str(fun_doc.ghidra_get("/disassemble_function", params={"address": addr, "program": program}))
+    prompt = _GEN_PROMPT.format(decompiled=dec[:4000], disasm=dis[:3000])
+    prov = provider or fun_doc.AI_PROVIDER
+    mdl = model
+    if mdl is None:
+        try:
+            mdl = fun_doc.get_configured_model(prov, "FULL")
+        except Exception:
+            mdl = None
+    for _ in range(3):
+        text, _m = fun_doc.invoke_claude(prompt, model=mdl, max_turns=2, provider=prov, complexity_tier=None)
+        obj = fun_doc._extract_first_json(text or "")
+        if isinstance(obj, dict) and obj.get("prototype"):
+            return obj
+        prompt += "\n\nREMINDER: reply with ONLY the strict JSON object."
+    return {}
+
+
+def judge(ref_name: str, ref_plate: str, gen_name: str, gen_plate: str, provider=None, model=None) -> dict:
+    import fun_doc
+    prompt = _JUDGE_PROMPT.format(ref_name=ref_name, gen_name=gen_name,
+                                  ref_plate=(ref_plate or "")[:3000], gen_plate=(gen_plate or "")[:3000])
+    prov = provider or fun_doc.AI_PROVIDER
+    mdl = model
+    if mdl is None:
+        try:
+            mdl = fun_doc.get_configured_model(prov, "FULL")
+        except Exception:
+            mdl = None
+    for _ in range(3):
+        text, _m = fun_doc.invoke_claude(prompt, model=mdl, max_turns=2, provider=prov, complexity_tier=None)
+        obj = fun_doc._extract_first_json(text or "")
+        if isinstance(obj, dict) and "name_match" in obj:
+            return obj
+        prompt += "\n\nREMINDER: reply with ONLY the strict JSON object."
+    return {"name_match": 0.0, "plate_accuracy": 0.0, "reason": "judge failed to return JSON"}
+
+
+def score(program: str = FRESH, provider=None, model=None) -> dict:
+    key = json.loads(ANSWER_JSON.read_text(encoding="utf-8"))
+    results = {}
+    for name, truth in key.items():
+        addr = truth["address"]
+        gen = generate(addr, program, provider=provider, model=model)
+        if not gen:
+            results[name] = {"tier": truth["tier"], "score": 0.0,
+                             "axes": {"prototype": 0.0, "name": 0.0, "plate": 0.0},
+                             "error": "generation failed"}
+            print(f"  {name:<32} GEN-FAIL")
+            continue
+        proto = score_prototype(gen.get("prototype", ""), gen.get("name", ""), truth)
+        j = judge(truth["name"], truth["plate"], gen.get("name", ""), gen.get("plate", ""),
+                  provider=provider, model=model)
+        axes = {"prototype": proto["score"],
+                "name": float(j.get("name_match", 0.0)),
+                "plate": float(j.get("plate_accuracy", 0.0))}
+        results[name] = {"tier": truth["tier"], "score": round(sum(axes.values()) / 3, 3),
+                         "axes": axes, "generated_name": gen.get("name"),
+                         "generated_prototype": gen.get("prototype"),
+                         "prototype_detail": proto, "judge_reason": j.get("reason")}
+        print(f"  {name:<32} [{truth['tier']:<10}] proto={proto['score']} "
+              f"name={axes['name']} plate={axes['plate']} -> {results[name]['score']}  "
+              f"(gen name: {gen.get('name')})")
+    out = {"program": program, **aggregate(results), "functions": results}
+    SCORE_JSON.write_text(json.dumps(out, indent=2, default=str), encoding="utf-8")
+    return out
+
+
+def _selftest() -> int:
+    assert _ret_width(_ret_type("unsigned short f(void *p)", "f")) == 2
+    assert _ret_width(_ret_type("byte DATATBLS_X(int i)", "DATATBLS_X")) == 1
+    assert _ret_width(_ret_type("MonsterRec * f(int i)", "f")) == 4
+    assert _param_count("int f(int a, int b, int c)") == 3
+    assert _param_count("int f(void)") == 0
+    truth = {"name": "GetLife", "prototype": "unsigned short GetLife(void *p)",
+             "proven_ret_width": 2, "proven_param_count": 1}
+    s = score_prototype("ushort MyGetLife(void* u)", "MyGetLife", truth)
+    assert s["score"] == 1.0, s
+    s2 = score_prototype("int Wrong(void* u, int x)", "Wrong", truth)
+    assert s2["ret_width_ok"] is False and s2["param_count_ok"] is False and s2["score"] == 0.0, s2
+    agg = aggregate({"a": {"tier": "proven", "score": 0.8, "axes": {"prototype": 1.0, "name": 0.7, "plate": 0.7}},
+                     "b": {"tier": "documented", "score": 0.6, "axes": {"prototype": 0.5, "name": 0.6, "plate": 0.7}}})
+    assert agg["n"] == 2 and agg["proven_n"] == 1 and agg["proven_prototype"] == 1.0, agg
+    print("[ok] bench_d2common self-test: prototype/param/aggregate logic pass")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--extract", action="store_true")
+    ap.add_argument("--score", action="store_true")
+    ap.add_argument("--names", help="comma-separated function names (for --extract)")
+    ap.add_argument("--program", default=None)
+    ap.add_argument("--provider", default=os.environ.get("AI_PROVIDER"))
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    # Set the scope-guard folder IN PYTHON (a Bash `VAR=/testing` gets MSYS path-mangled
+    # to C:/Program Files/Git/testing). Set BEFORE any fun_doc import (read at module load).
+    if args.extract:
+        os.environ["FUN_DOC_PROJECT_FOLDER"] = str(Path(ANNOTATED).parent).replace("\\", "/")
+        names = [n.strip() for n in (args.names or "").split(",") if n.strip()]
+        extract(names, program=args.program)
+        return 0
+    if args.score:
+        os.environ["FUN_DOC_PROJECT_FOLDER"] = str(Path(args.program or FRESH).parent).replace("\\", "/")
+        out = score(program=args.program or FRESH, provider=args.provider, model=args.model)
+        print(json.dumps({k: v for k, v in out.items() if k != "functions"}, indent=2, default=str))
+        return 0
+    ap.error("pick --extract / --score / --selftest")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/bench_score.py
+++ b/fun-doc/bench_score.py
@@ -1,0 +1,163 @@
+"""bench_score.py -- score the documentation pipeline against the benchmark DLL.
+
+The benchmark DLL is compiled from KNOWN ground truth (conformance/benchmark/), loaded
+fresh into Ghidra (Ordinal/FUN_ only), and fed BLIND to the pipeline. This scores what
+the REAL production tooling recovers from that fresh binary against answer_key.json --
+an objective "how true is the documentation" number, because we authored the answer.
+
+Phase-1 axes (MECHANICAL, objective from disasm -- no model, no game):
+  * ret_width   : did we recover the true return width?
+  * field_reads : did we recover the exact (offset,width) fields the fn accesses?
+  * gate        : did we recover the type-gate (offset+immediate)?
+Recovery uses the ACTUAL abi_static translators (production code), so a bail is an
+honest finding (e.g. a compiler idiom the translator doesn't yet handle), not hidden.
+
+The prose/name axes (plate accuracy, semantic-name recovery) need doc-gen + an
+independent judge -- Phase 2.
+
+Usage:
+    python bench_score.py --program bench_core.dll
+    python bench_score.py --selftest
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+# the benchmark program lives OUTSIDE the PD2 scope guard -- re-scope to the benchmark
+# folder BEFORE fun_doc imports (it reads the scope at module load).
+os.environ["FUN_DOC_PROJECT_FOLDER"] = "/benchmark"
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+BENCH_DIR = D2MOO_REPO / "conformance" / "benchmark"
+ANSWER_KEY = BENCH_DIR / "answer_key" / "bench_core.answer.json"
+
+# ordinal -> fresh-Ghidra address (from the .def RVAs + 0x10000000 image base).
+ORD_ADDR = {10001: "0x100010c0", 10042: "0x100010a0", 10108: "0x10001080",
+            10205: "0x10001050", 10333: "0x10001030"}
+# the benchmark's own global (g_pMonsterTable) -- there is no resolve table, so give
+# the translators a benchmark resolve map keyed by the address the disasm derefs.
+BENCH_GLOBALS = {0x10015948: "g_pMonsterTable"}
+
+
+def _facts_from_translators(name: str, disasm: str, abi_static) -> dict:
+    """Run the production translators on a fresh-binary disasm; return the recovered
+    facts + which translator matched (or the bail reason)."""
+    rev = BENCH_GLOBALS
+    # try flat/gated getter, then global-table, then delegate -- as the pipeline routes.
+    t = abi_static.translate_getter_to_c(name, disasm)
+    if t.get("ok"):
+        reads = [{"off": o, "width": {"u8": 1, "i8": 1, "u16": 2, "i16": 2,
+                                      "u32": 4, "i32": 4}.get(t["ret"], 4)}
+                 for o in (t.get("chain") or [])]
+        # the LAST chain entry is the value read (its width = ret); earlier are ptr walks (4).
+        for r in reads[:-1]:
+            r["width"] = 4
+        gates = [{"off": g[1], "imm": g[2]} for g in (t.get("type_gates") or [])]
+        return {"matched": "flat_getter", "ret": t["ret"], "reads": reads, "gates": gates}
+    gt = abi_static.translate_global_table_getter_to_c(name, disasm, resolve_rev=rev)
+    if gt.get("ok"):
+        reads = [{"off": gt["count_off"], "width": 4}, {"off": gt["records_off"], "width": 4},
+                 {"off": gt["field_off"], "width": {"u8": 1, "u16": 2, "u32": 4,
+                                                    "i8": 1, "i16": 2, "i32": 4}.get(gt["ret"], 4)}]
+        return {"matched": "global_table", "ret": gt["ret"], "reads": reads, "gates": [],
+                "global": gt["global"], "stride": gt["stride"]}
+    dl = abi_static.translate_delegate_getter_to_c(name, disasm, resolve_rev=rev)
+    if dl.get("ok"):
+        w = {"u8": 1, "u16": 2, "u32": 4, "i8": 1, "i16": 2, "i32": 4}.get(dl["ret"], 4)
+        return {"matched": "delegate", "ret": dl["ret"],
+                "reads": [{"off": dl["result_off"], "width": w}],
+                "gates": [{"off": g[0], "imm": g[1]} for g in (dl.get("type_gates") or [])]}
+    return {"matched": None,
+            "bail": {"flat": t.get("reason"), "global_table": gt.get("reason"),
+                     "delegate": dl.get("reason")}}
+
+
+def score_function(ak: dict, recovered: dict) -> dict:
+    """Score one function's recovered facts against its answer-key truth."""
+    truth_ret_w = ak["ret"]["width"]
+    rw = {"u8": 1, "i8": 1, "u16": 2, "i16": 2, "u32": 4, "i32": 4}
+    got_ret_w = rw.get(recovered.get("ret"), None)
+    ret_ok = (got_ret_w == truth_ret_w)
+
+    # field-read recovery: fraction of TRUE (offset,width) field reads recovered.
+    truth_reads = {(r["off"], r["width"]) for r in ak.get("reads", [])}
+    got_reads = {(r["off"], r["width"]) for r in recovered.get("reads", [])}
+    if truth_reads:
+        field_recall = len(truth_reads & got_reads) / len(truth_reads)
+    else:
+        field_recall = 1.0 if not got_reads else 0.0   # pure-computed: no reads is correct
+
+    # gate recovery
+    truth_gates = {(g.get("off"), g.get("imm")) for g in ak.get("gates", []) if "imm" in g}
+    got_gates = {(g["off"], g["imm"]) for g in recovered.get("gates", [])}
+    gate_ok = (truth_gates == got_gates) if truth_gates else (not got_gates)
+
+    axes = {"ret_width": 1.0 if ret_ok else 0.0,
+            "field_reads": round(field_recall, 3),
+            "gate": 1.0 if gate_ok else 0.0}
+    score = round(sum(axes.values()) / len(axes), 3)
+    return {"matched": recovered.get("matched"), "score": score, "axes": axes,
+            "truth_reads": sorted(truth_reads), "got_reads": sorted(got_reads),
+            "bail": recovered.get("bail")}
+
+
+def run(program: str) -> dict:
+    import fun_doc, abi_static
+    ak = json.loads(ANSWER_KEY.read_text(encoding="utf-8"))
+    fns = {f["name"]: f for f in ak["functions"]}
+    results = {}
+    for name, meta in fns.items():
+        ordn = meta.get("export_ordinal")
+        if ordn not in ORD_ADDR:
+            continue   # un-exported (bench_LookupMonster) -> Phase 2 (needs FUN_ discovery)
+        addr = ORD_ADDR[ordn]
+        disasm = str(fun_doc.ghidra_get("/disassemble_function",
+                                        params={"address": addr, "program": program}))
+        recovered = _facts_from_translators(name, disasm, abi_static)
+        results[name] = {"address": addr, "shape": meta["shape"],
+                         **score_function(meta, recovered)}
+    scored = [r["score"] for r in results.values()]
+    agg = round(sum(scored) / len(scored), 3) if scored else 0.0
+    return {"program": program, "aggregate_mechanical_score": agg,
+            "n": len(results), "functions": results}
+
+
+def _selftest() -> int:
+    ak = {"ret": {"width": 2}, "reads": [{"off": 0x8, "width": 4}, {"off": 0x4, "width": 2}],
+          "gates": [{"off": 0, "imm": 2}]}
+    rec = {"matched": "flat_getter", "ret": "u16",
+           "reads": [{"off": 0x8, "width": 4}, {"off": 0x4, "width": 2}],
+           "gates": [{"off": 0, "imm": 2}]}
+    s = score_function(ak, rec)
+    assert s["score"] == 1.0 and s["axes"] == {"ret_width": 1.0, "field_reads": 1.0, "gate": 1.0}, s
+    # a miss: wrong field width recovered
+    rec2 = {"matched": "flat_getter", "ret": "u32",
+            "reads": [{"off": 0x8, "width": 4}, {"off": 0x4, "width": 4}], "gates": []}
+    s2 = score_function(ak, rec2)
+    assert s2["axes"]["ret_width"] == 0.0 and s2["axes"]["field_reads"] == 0.5 and s2["axes"]["gate"] == 0.0, s2
+    # pure computed: no reads, none recovered -> field axis perfect
+    s3 = score_function({"ret": {"width": 4}, "reads": [], "gates": []},
+                        {"matched": None, "ret": "i32", "reads": [], "gates": []})
+    assert s3["axes"]["field_reads"] == 1.0, s3
+    print("[ok] bench_score self-test: scoring axes pass")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--program", default="bench_core.dll")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    print(json.dumps(run(args.program), indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/d2moo_names.py
+++ b/fun-doc/d2moo_names.py
@@ -1,0 +1,461 @@
+"""d2moo_names.py -- authoritative field/struct names from the D2MOO reimplementation.
+
+The D2MOO source (source/D2Common/include/**) carries community-canonical struct
+definitions built from 20+ years of D2 reverse engineering -- every field NAMED at its
+offset (`uint8_t nThrowable;  //0x10`). We proved our reimpls bit-exact against these
+functions but never imported the NAMES; that is why getters ended up as `GetItemTypeField10`
+(transcription) instead of `GetItemTypeThrowable` (understanding).
+
+This module parses those headers into {struct: {offset: field}} + a size index, so a
+proven getter -- whose STRUCT is identified by stride==struct-size and whose OFFSET comes
+from the proof -- can be named from the REAL field. Offset names become a flagged last
+resort only where D2MOO itself has no field.
+
+Usage:
+    python d2moo_names.py --selftest
+    python d2moo_names.py --lookup D2ItemTypesTxt:0x10      # -> nThrowable
+    python d2moo_names.py --size 0xe4                       # structs of that size
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+INCLUDE_DIRS = [D2MOO_REPO / "source" / "D2Common" / "include",
+                D2MOO_REPO / "source" / "D2CommonDefinitions" / "include"]
+
+_SCALAR_W = {
+    "char": 1, "int8_t": 1, "uint8_t": 1, "byte": 1, "BYTE": 1, "bool": 1, "BOOLEAN": 1,
+    "int16_t": 2, "uint16_t": 2, "short": 2, "WORD": 2, "wchar_t": 2, "unsigned short": 2,
+    "int": 4, "int32_t": 4, "uint32_t": 4, "DWORD": 4, "long": 4, "unsigned long": 4,
+    "float": 4, "BOOL": 4, "unsigned int": 4, "uint": 4, "HANDLE": 4, "LPVOID": 4,
+    "int64_t": 8, "uint64_t": 8, "double": 8, "__int64": 8,
+}
+_FIELD_RE = re.compile(
+    r"^\s*((?:const\s+|struct\s+|union\s+|unsigned\s+|signed\s+)*[\w:]+)\s*(\**)\s*"
+    r"(\w+)\s*((?:\[\s*\w+\s*\])*)\s*;\s*//\s*0x([0-9a-fA-F]+)")
+_STRUCT_HEAD_RE = re.compile(r"\b(struct|union)\s+([A-Za-z_]\w*)\s*(?:final\s*)?\{")
+_UNION_HEAD_RE = re.compile(r"\b(?:union|struct)\s*//\s*0x([0-9a-fA-F]+)")
+_MEMBER_RE = re.compile(r"^\s*((?:struct\s+|const\s+)*[\w:]+)\s*(\*+)\s*(\w+)\s*;")
+# D2 unit type -> the type-specific data-struct member name fragment (dwType gate value).
+_UNITTYPE_MEMBER = {0: "Player", 1: "Monster", 2: "Object", 3: "Missile", 4: "Item", 5: "Tile"}
+
+_CACHE = None
+
+
+def _width(type_tok: str, ptr: str, array: str, structs: dict) -> int:
+    if ptr:
+        return 4
+    base = 1
+    if type_tok in _SCALAR_W:
+        base = _SCALAR_W[type_tok]
+    elif type_tok in structs:                 # nested struct value
+        base = structs[type_tok]["size"] or 4
+    else:
+        base = 4                              # enum / unknown scalar -> 4
+    for m in re.finditer(r"\[\s*(\w+)\s*\]", array or ""):
+        n = m.group(1)
+        base *= int(n, 0) if re.fullmatch(r"(0x)?[0-9a-fA-F]+", n) else 1
+    return base
+
+
+def _parse_file(text: str, structs: dict):
+    """Brace-match each top-level struct/union; collect offset-annotated field lines."""
+    i = 0
+    while True:
+        m = _STRUCT_HEAD_RE.search(text, i)
+        if not m:
+            break
+        name = m.group(2)
+        depth, j = 1, m.end()
+        start = m.end()
+        while j < len(text) and depth:
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+            j += 1
+        body = text[start:j - 1]
+        fields = {}
+        for line in body.splitlines():
+            fm = _FIELD_RE.match(line)
+            if not fm:
+                continue
+            type_tok = fm.group(1).replace("struct ", "").replace("union ", "").strip()
+            ptr, fname, array, off = fm.group(2), fm.group(3), fm.group(4), int(fm.group(5), 16)
+            fields.setdefault(off, {"name": fname, "type": (type_tok + (ptr or "")).strip(),
+                                    "width": _width(type_tok, ptr, array, structs),
+                                    "array": bool(array), "is_ptr": bool(ptr)})
+        # anonymous offset-annotated UNIONS (`union //0x14 { D2ItemDataStrc* pItemData; ... }`)
+        # -- the type-specific data pointer at a unit offset; members keyed for chain-follow.
+        for um in _UNION_HEAD_RE.finditer(body):
+            uoff = int(um.group(1), 16)
+            bo = body.find("{", um.end())
+            if bo < 0:
+                continue
+            d2, k = 1, bo + 1
+            while k < len(body) and d2:
+                d2 += 1 if body[k] == "{" else -1 if body[k] == "}" else 0
+                k += 1
+            members = []
+            for line in body[bo + 1:k - 1].splitlines():
+                mm = _MEMBER_RE.match(line)
+                if mm and mm.group(2):        # pointer members only (the data-struct ptrs)
+                    members.append({"name": mm.group(3), "type": (mm.group(1) + mm.group(2)).strip()})
+            if members:
+                fields.setdefault(uoff, {"name": members[0]["name"], "type": members[0]["type"],
+                                         "width": 4, "kind": "union", "members": members, "is_ptr": True})
+        if fields:
+            size = max(off + f["width"] for off, f in fields.items())
+            # keep the LARGEST definition if a name repeats across headers
+            if name not in structs or size >= structs[name]["size"]:
+                structs[name] = {"size": size, "fields": fields}
+        i = j
+    return structs
+
+
+def load(include_dirs=None) -> dict:
+    """{struct_name: {'size': int, 'fields': {offset: {name,type,width,...}}}}. Cached."""
+    global _CACHE
+    if _CACHE is not None and include_dirs is None:
+        return _CACHE
+    structs = {}
+    for d in (include_dirs or INCLUDE_DIRS):
+        for p in Path(d).rglob("*.h"):
+            try:
+                _parse_file(p.read_text(encoding="utf-8", errors="replace"), structs)
+            except OSError:
+                pass
+    if include_dirs is None:
+        _CACHE = structs
+    return structs
+
+
+def by_size(size: int, structs=None) -> list:
+    """Struct names whose total size equals `size` (the stride==size bridge)."""
+    s = structs if structs is not None else load()
+    return sorted(n for n, d in s.items() if d["size"] == size)
+
+
+def field_at(struct: str, off: int, structs=None) -> dict | None:
+    s = structs if structs is not None else load()
+    d = s.get(struct)
+    return d["fields"].get(off) if d else None
+
+
+_HUNGARIAN = re.compile(r"^(dw|n|w|b|sz|p|f|h|a|wsz|q|u|i|l|g)(?=[A-Z0-9])")
+
+
+def resolve_unit_chain(gate_imm: int, union_off: int, read_off: int,
+                       unit_struct: str = "D2UnitStrc", structs=None) -> dict | None:
+    """A 2-level UNIT getter: pUnit gated on dwType==gate_imm, deref the type-data pointer
+    at `union_off` (the D2UnitStrc union), read a field at `read_off` in that sub-struct.
+    dwType selects the union member (4=Item -> pItemData -> D2ItemDataStrc)."""
+    s = structs if structs is not None else load()
+    u = (s.get(unit_struct) or {}).get("fields", {}).get(union_off)
+    if not u or u.get("kind") != "union":
+        return None
+    frag = _UNITTYPE_MEMBER.get(gate_imm)
+    member = next((m for m in u["members"] if frag and frag.lower() in m["name"].lower()), None)
+    if not member:
+        return {"ok": False, "reason": f"no union member for dwType=={gate_imm} at {unit_struct}+0x{union_off:x}"}
+    sub = re.sub(r"\s*\*+$", "", member["type"])
+    f = field_at(sub, read_off, s)
+    if not f:
+        return {"ok": False, "struct": sub, "read_off": read_off,
+                "reason": f"D2MOO {sub} has no field at +0x{read_off:x}"}
+    return {"ok": True, "struct": sub, "member": member["name"], "field": f["name"],
+            "field_type": f["type"], "field_width": f["width"], "read_off": read_off,
+            "reason": f"{unit_struct}.{member['name']}(dwType {gate_imm})->{sub}+0x{read_off:x} = {f['name']} ({f['type']})"}
+
+
+def unit_union_member_names(unit_struct: str = "D2UnitStrc", structs=None) -> list:
+    """All member identifier names of the D2UnitStrc type-data union (pPlayerData,
+    pMonsterData, pItemData, ...). Used to correct a stale union-member reference in a
+    plate body to the one this getter actually uses."""
+    s = structs if structs is not None else load()
+    names = []
+    for fld in (s.get(unit_struct) or {}).get("fields", {}).values():
+        if fld.get("kind") == "union":
+            names += [m["name"] for m in fld["members"] if m.get("name")]
+    return names
+
+
+def semantic_suffix(field_name: str) -> str:
+    """Strip a Hungarian prefix -> a PascalCase name suffix (nThrowable -> Throwable)."""
+    base = _HUNGARIAN.sub("", field_name)
+    return base[:1].upper() + base[1:] if base else field_name
+
+
+def derive_getter_name(current_name: str, struct: str, off: int, structs=None) -> dict:
+    """Propose a real function name from the field at (struct, off). Returns
+    {ok, field, proposed_name, reason} -- ok=False means D2MOO has no field there
+    (offset name stays, flagged)."""
+    f = field_at(struct, off, structs)
+    if not f:
+        return {"ok": False, "reason": f"no D2MOO field at {struct}+0x{off:x} -- offset name is honest here"}
+    suffix = semantic_suffix(f["name"])
+    # replace a trailing Field<hex>/Byte<hex>/Short<hex>/Dword<hex>/0x.. token with the real suffix
+    stem = re.sub(r"(Field|Byte|Short|Dword|Word|Flag|Get)?0?x?[0-9A-Fa-f]{1,4}$", "", current_name)
+    stem = re.sub(r"(Field|Byte|Short|Dword|Word)$", "", stem).rstrip("_")
+    proposed = f"{stem}{suffix}" if stem and not stem.endswith(suffix) else f"{stem}_{suffix}"
+    return {"ok": True, "field": f["name"], "field_type": f["type"], "field_width": f["width"],
+            "proposed_name": proposed,
+            "reason": f"{struct}+0x{off:x} = {f['name']} ({f['type']})"}
+
+
+_OFFSET_NAME_RE = re.compile(
+    r"(Field|Byte|Short|Dword|Word|Flag|Bit|Struct)_?(0x)?[0-9A-Fa-f]{1,4}(Set|Bit\d+)?$"
+    r"|0x[0-9A-Fa-f]{1,4}\w*$")
+# single-level getters: subsystem/name -> the PARAM struct type (the getter reads a field
+# directly off its pointer param). Ordered; first match wins.
+_PARAM_STRUCT = [
+    (re.compile(r"GetSkillNode|GetSkill(?!s)"), "D2SkillStrc"),
+    (re.compile(r"StatList"), "D2StatListStrc"),
+    (re.compile(r"GetInventory|Inventory"), "D2InventoryStrc"),
+    (re.compile(r"GetRoom|Room"), "D2RoomStrc"),
+]
+# subsystem/name-pattern -> canonical D2MOO record struct (disambiguates same-offset fields).
+_NAME_STRUCT = [
+    (re.compile(r"GetItemType|ItemTypesTxt|ItemTypeProperty"), "D2ItemTypesTxt"),
+    (re.compile(r"GetItemRecord|ItemsTxt|GetItemData.*Record|GetUltraOrBase|GetItemRecordCode"), "D2ItemsTxt"),
+    (re.compile(r"GetMissileRecord|MissilesTxt|GetMissileData"), "D2MissilesTxt"),
+    (re.compile(r"GetMonStats|MonStatsTxt|GetMonsterData"), "D2MonStatsTxt"),
+    (re.compile(r"GetSkill.*Record|SkillsTxt|GetSkillsTxt"), "D2SkillsTxt"),
+    (re.compile(r"GetLevelRecord|LevelsTxt|GetLevelData"), "D2LevelsTxt"),
+    (re.compile(r"GetOverlayRecord|OverlayTxt"), "D2OverlayTxt"),
+]
+
+
+def is_offset_name(name: str) -> bool:
+    """True if the function name ends in an offset-derived token (Field10/Byte44/Short0x10)."""
+    return bool(_OFFSET_NAME_RE.search(name))
+
+
+def _extract_from_candidate(cpp: str) -> dict:
+    """stride, records-ptr offset, final-read offset+width, callee from a proven candidate."""
+    out = {"stride": None, "read_off": None, "read_w": None, "callee": None, "records_off": None,
+           "gate_off": None, "gate_imm": None, "union_off": None}
+    m = re.search(r"idx\s*\*\s*0x([0-9a-fA-F]+)", cpp) or re.search(r"\*\s*0x([0-9a-fA-F]+)\s*;", cpp)
+    if m:
+        out["stride"] = int(m.group(1), 16)
+    # the records pointer of a global-table getter: `*(void**)(base + 0xRECOFF)` -- this
+    # offset into the DataTables header NAMES the table authoritatively (stride can collide).
+    rm = re.search(r"\*\s*\(\s*void\s*\*\s*\*\s*\)\s*\(\s*base\s*\+\s*0x([0-9a-fA-F]+)\s*\)", cpp)
+    if rm:
+        out["records_off"] = int(rm.group(1), 16)
+    for c in re.finditer(r'D2MOO_Resolve\("([^"]+)"\)', cpp):
+        if not c.group(1).startswith(("g_", "_g_")):
+            out["callee"] = c.group(1)
+    # BASE: mechanical uses `r + 0x`; model-drafted uses `(char*)pUnit + 0x` / `pItemData + 0x`.
+    _B = r"(?:\(\s*char\s*\*\s*\)\s*)?\w+"
+    # 2-level UNIT getter: dwType gate + the type-data pointer deref (union offset). The gate
+    # reads a uint at the param+off and compares != imm (dwType).
+    # dwType gate: `*(uint*)(pUnit + 0x0) != 4` OR `*(uint*)pUnit != 4` (offset omitted = 0);
+    # imm may be decimal or hex.
+    gm = re.search(r"\*\s*\(\s*(?:unsigned\s+int|int|uint)\s*\*\s*\)\s*\(?\s*" + _B
+                   + r"(?:\s*\+\s*0x([0-9a-fA-F]+))?\s*\)?\s*!=\s*(0x[0-9a-fA-F]+|\d+)", cpp)
+    if gm:
+        out["gate_off"] = int(gm.group(1), 16) if gm.group(1) else 0
+        out["gate_imm"] = int(gm.group(2), 0)
+    # the type-data pointer deref: `VAR = *(void**|char**)((char*)pUnit + 0x14)` (NOT the
+    # DataTables `base` deref, which is the records path).
+    pl = re.search(r"=\s*\*\s*\(\s*(?:char|void)\s*\*\s*\*\s*\)\s*\(\s*" + _B + r"\s*\+\s*0x([0-9a-fA-F]+)\s*\)", cpp)
+    if pl and out["records_off"] is None and out["stride"] is None:
+        out["union_off"] = int(pl.group(1), 16)
+    out["masked"] = bool(re.search(r"return[^;]*(&|>>|<<)\s*0x", cpp))
+    out["single_level"] = (out["union_off"] is None and out["stride"] is None
+                           and out["records_off"] is None and out["callee"] is None)
+    # the DEEPEST scalar field read = the returned field (the gate's uint read at the param
+    # is earlier in source order, so `reads[-1]` is the real field).
+    reads = []
+    for r in re.finditer(r"\*\s*\(\s*(unsigned\s+char|signed\s+char|char|unsigned\s+short|short|"
+                         r"unsigned\s+int|int)\s*\*\s*\)\s*\(\s*" + _B + r"\s*\+\s*0x([0-9a-fA-F]+)\s*\)", cpp):
+        w = {"char": 1, "short": 2, "int": 4}[r.group(1).split()[-1]]
+        reads.append((int(r.group(2), 16), w))
+    if reads:
+        out["read_off"], out["read_w"] = reads[-1]
+    return out
+
+
+def _domain(struct: str) -> str:
+    """D2ItemTypesTxt -> ItemType, D2OverlayTxt -> Overlay, D2ItemsTxt -> Item (short,
+    for building a function name)."""
+    core = re.sub(r"^D2", "", struct)
+    core = re.sub(r"(Txt|Strc|Rec|Record)$", "", core)
+    if core.endswith("s") and not core.endswith("ss"):
+        core = core[:-1]                      # ItemTypes -> ItemType, Items -> Item
+    return core
+
+
+def canonicalize(name: str, cpp: str, structs=None) -> dict:
+    """Resolve a proven getter's REAL name from D2MOO. Struct identity is taken from the
+    DataTables HEADER field (records-ptr offset -> the named table pointer) when available
+    -- AUTHORITATIVE, and it also catches a WRONG subsystem guess (a 'Missile' getter that
+    actually reads the Overlay table). Falls back to stride==size, then name pattern.
+    Returns {ok, struct, field, proposed_name, corrected_subsystem, reason}."""
+    s = structs if structs is not None else load()
+    ex = _extract_from_candidate(cpp)
+    off = ex["read_off"]
+    if off is None:
+        return {"ok": False, "reason": "no field read found in candidate"}
+    # 2-LEVEL UNIT getter: resolve through the D2UnitStrc union (dwType -> data struct).
+    if ex["union_off"] is not None and ex["gate_imm"] is not None:
+        uc = resolve_unit_chain(ex["gate_imm"], ex["union_off"], off, structs=s)
+        if uc and uc.get("ok"):
+            prefix = name.split("_")[0] + "_" if "_" in name else ""
+            domain = _domain(uc["struct"])
+            proposed = f"{prefix}Get{domain}{semantic_suffix(uc['field'])}"
+            old_core = re.sub(r"^\w+_Get", "", name)
+            return {"ok": True, "struct": uc["struct"], "field": uc["field"],
+                    "field_type": uc["field_type"], "field_width": uc.get("field_width"),
+                    "read_off": off, "proposed_name": proposed, "member": uc.get("member"),
+                    "corrected_subsystem": domain.lower() not in old_core.lower(),
+                    "how": "unit-union chain", "reason": uc["reason"]}
+        if uc and not uc.get("ok"):
+            return {"ok": False, "read_off": off, "reason": uc["reason"]}
+
+    # SINGLE-LEVEL getter on a NAMED PARAM struct (STAT/SKILLS/...): read a field directly
+    # off the param pointer. SAFETY: if the getter MASKS the value (a flag) but the D2MOO
+    # field there is a POINTER, the layouts disagree (version drift) -> FLAG, never guess.
+    if ex.get("single_level"):
+        for rx, st in _PARAM_STRUCT:
+            if rx.search(name) and st in s:
+                f = field_at(st, off, s)
+                if not f:
+                    return {"ok": False, "struct": st, "read_off": off,
+                            "reason": f"D2MOO {st} has no field at +0x{off:x}"}
+                if ex.get("masked") and f.get("is_ptr"):
+                    return {"ok": False, "struct": st, "read_off": off,
+                            "reason": f"SUSPECT: {st}+0x{off:x} = {f['name']} is a POINTER but the "
+                            f"getter masks it as a flag -- likely a 1.13c-vs-D2MOO layout drift; VERIFY"}
+                prefix = name.split("_")[0] + "_" if "_" in name else ""
+                domain = _domain(st)
+                proposed = f"{prefix}Get{domain}{semantic_suffix(f['name'])}"
+                old_core = re.sub(r"^\w+_Get", "", name)
+                return {"ok": True, "struct": st, "field": f["name"], "field_type": f["type"],
+                        "field_width": f["width"], "read_off": off, "proposed_name": proposed,
+                        "corrected_subsystem": domain.lower() not in old_core.lower(),
+                        "how": "param struct", "reason": f"{st}+0x{off:x} = {f['name']} ({f['type']})"}
+
+    struct, how = None, None
+    dt = s.get("D2DataTablesStrc")
+    if ex["records_off"] is not None and dt:
+        hdr = dt["fields"].get(ex["records_off"])
+        if hdr and hdr.get("is_ptr"):
+            struct = re.sub(r"\s*\*$", "", hdr["type"])   # D2OverlayTxt* -> D2OverlayTxt
+            how = f"DataTables header +0x{ex['records_off']:x} = {hdr['name']}"
+    if not struct and ex["stride"]:
+        matches = by_size(ex["stride"], s)
+        txt = [m for m in matches if m.endswith("Txt")]
+        struct = (txt or matches or [None])[0]
+        how = f"stride 0x{ex['stride']:x} == sizeof({struct})" if struct else None
+    if not struct:
+        for rx, st in _NAME_STRUCT:
+            if rx.search(name) and st in s:
+                struct, how = st, "name pattern"
+                break
+    if not struct:
+        return {"ok": False, "reason": f"struct not identified (stride={ex['stride']}, "
+                f"records_off={ex['records_off']}, callee={ex['callee']})", "read_off": off}
+    f = field_at(struct, off, s)
+    if not f:
+        return {"ok": False, "struct": struct, "read_off": off,
+                "reason": f"D2MOO {struct} has no field at +0x{off:x} -- offset name is honest here"}
+    prefix = name.split("_")[0] + "_" if "_" in name else ""
+    domain = _domain(struct)
+    suffix = semantic_suffix(f["name"])
+    proposed = f"{prefix}Get{domain}{suffix}"
+    # did the OLD name claim a different domain than the true table? (Missile vs Overlay)
+    old_core = re.sub(r"^\w+_Get", "", name)
+    corrected = domain.lower() not in old_core.lower() and not is_offset_name(domain)
+    return {"ok": True, "struct": struct, "field": f["name"], "field_type": f["type"],
+            "field_width": f["width"], "read_off": off, "proposed_name": proposed,
+            "corrected_subsystem": corrected, "how": how,
+            "reason": f"{struct}+0x{off:x} = {f['name']} ({f['type']}) [{how}]"}
+
+
+def _selftest() -> int:
+    structs = load()
+    assert structs, "no structs parsed"
+    it = structs.get("D2ItemTypesTxt")
+    assert it, "D2ItemTypesTxt not found"
+    # the money shot: offset 0x10 is nThrowable, struct size is the 0xe4 stride.
+    assert it["size"] == 0xE4, hex(it["size"])
+    assert it["fields"][0x10]["name"] == "nThrowable", it["fields"][0x10]
+    assert it["fields"][0x0C]["name"] == "wShoots" and it["fields"][0x0C]["width"] == 2, it["fields"][0x0C]
+    assert "D2ItemTypesTxt" in by_size(0xE4), by_size(0xE4)
+    assert semantic_suffix("nThrowable") == "Throwable"
+    assert semantic_suffix("wShoots") == "Shoots"
+    assert semantic_suffix("dwFlags") == "Flags"
+    d = derive_getter_name("DATATBLS_GetItemTypeField10", "D2ItemTypesTxt", 0x10)
+    assert d["ok"] and d["field"] == "nThrowable" and "Throwable" in d["proposed_name"], d
+    d2 = derive_getter_name("X", "D2ItemTypesTxt", 0x999)
+    assert not d2["ok"], d2
+    # is_offset_name + canonicalize from a candidate cpp
+    assert is_offset_name("DATATBLS_GetItemTypeField10")
+    assert is_offset_name("ITEMS_GetItemRecordField104")
+    assert not is_offset_name("DATATBLS_GetItemTypeThrowable")
+    gt_cpp = ('extern "C" unsigned char __stdcall DATATBLS_GetItemTypeField10(int idx){\n'
+              '  char* records = (char*)*(void**)(base + 0xbf8);\n'
+              '  char* rec = records + (int)idx * 0xe4;\n'
+              '  return (unsigned int)*(unsigned char*)(rec + 0x10); }')
+    c = canonicalize("DATATBLS_GetItemTypeField10", gt_cpp, structs)
+    assert c["ok"] and c["struct"] == "D2ItemTypesTxt" and c["field"] == "nThrowable", c
+    dl_cpp = ('extern "C" unsigned char __stdcall ITEMS_GetItemRecordField104(void* p){\n'
+              '  _callee_t _f = (_callee_t)D2MOO_Resolve("GetItemDataRecord");\n'
+              '  return *(unsigned char*)(_rec + 0x104); }')
+    c2 = canonicalize("ITEMS_GetItemRecordField104", dl_cpp, structs)
+    assert c2["ok"] and c2["struct"] == "D2ItemsTxt" and c2["field"] == "nRangeAdder", c2
+    # UNION parse + 2-level unit-getter chain: D2UnitStrc union@0x14, dwType==4 -> pItemData
+    u = structs["D2UnitStrc"]["fields"].get(0x14)
+    assert u and u.get("kind") == "union" and any("Item" in m["name"] for m in u["members"]), u
+    uc = resolve_unit_chain(4, 0x14, 0x32, structs=structs)
+    assert uc["ok"] and uc["struct"] == "D2ItemDataStrc" and uc["field"] == "wRarePrefix", uc
+    gated_cpp = ('extern "C" unsigned short __stdcall ITEMS_GetItemDataField32(void* p){\n'
+                 '  char* r = (char*)p;\n'
+                 '  if (*(unsigned int*)(r + 0x0) != 0x4u) return 0;\n'
+                 '  r = *(char**)(r + 0x14);\n'
+                 '  return *(unsigned short*)(r + 0x32); }')
+    c3 = canonicalize("ITEMS_GetItemDataField32", gated_cpp, structs)
+    assert c3["ok"] and c3["struct"] == "D2ItemDataStrc" and c3["field"] == "wRarePrefix", c3
+    assert "RarePrefix" in c3["proposed_name"], c3
+    # single-level param-struct getter: SKILLS reads D2SkillStrc.nQuantity (clean)
+    sk_cpp = ('extern "C" unsigned int __stdcall SKILLS_GetSkillNodeField0x30(void* p){\n'
+              '  char* r = (char*)p; return *(unsigned int*)(r + 0x30); }')
+    c4 = canonicalize("SKILLS_GetSkillNodeField0x30", sk_cpp, structs)
+    assert c4["ok"] and c4["struct"] == "D2SkillStrc" and c4["field"] == "nQuantity", c4
+    # SAFETY: STAT flag getter masks a POINTER field -> layout drift -> must FLAG, not rename
+    fl_cpp = ('extern "C" unsigned int __stdcall STAT_GetStatListFlag4(void* p){\n'
+              '  char* r = (char*)p; return (*(unsigned int*)(r + 0x34) & 0x4u); }')
+    c5 = canonicalize("STAT_GetStatListFlag4", fl_cpp, structs)
+    assert not c5["ok"] and "SUSPECT" in c5["reason"], c5
+    print(f"[ok] d2moo_names self-test: parsed {len(structs)} structs; "
+          f"D2ItemTypesTxt+0x10 = nThrowable; GetItemTypeField10 -> {d['proposed_name']}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lookup", help="Struct:0xOFF -> field")
+    ap.add_argument("--size", help="0xNN -> struct names of that size")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    if args.lookup:
+        struct, off = args.lookup.split(":")
+        f = field_at(struct.strip(), int(off, 16))
+        print(f"{args.lookup} -> {f}")
+        return 0
+    if args.size:
+        print(f"size {args.size}: {by_size(int(args.size, 16))}")
+        return 0
+    ap.error("pick --lookup / --size / --selftest")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/db/migrations/0005_port_pipeline.sql
+++ b/fun-doc/db/migrations/0005_port_pipeline.sql
@@ -1,0 +1,21 @@
+-- fun-doc migration 0005: OpenD2 conformance port pipeline (Postgres).
+--
+-- Adds the columns needed to track Stage 2/3 ("port" + "prove") of the
+-- document -> port -> prove pipeline described in
+-- OpenD2/docs/EMULATION_CONFORMANCE_PLAN.md Sec 14. Populated only for
+-- functions the new PORT worker mode has touched.
+--
+-- port_status values: none | drafted | vectors_minted | harness_failed
+--                    | proven_pending_review | integrated
+-- port_last_result: the most recent harness outcome (a short human-readable
+--   PASS/FAIL summary), for surfacing in the dashboard without re-running
+--   the harness.
+
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS port_status VARCHAR;
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS port_attempts INTEGER DEFAULT 0;
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS port_draft_path VARCHAR;
+ALTER TABLE fun_doc.functions_workflow
+    ADD COLUMN IF NOT EXISTS port_last_result VARCHAR;

--- a/fun-doc/db/migrations/0005_port_pipeline.sqlite.sql
+++ b/fun-doc/db/migrations/0005_port_pipeline.sqlite.sql
@@ -1,0 +1,8 @@
+-- fun-doc migration 0005: OpenD2 conformance port pipeline (SQLite).
+-- See 0005_port_pipeline.sql for rationale. db/migrate.py handles
+-- IF-NOT-EXISTS via PRAGMA table_info inspection.
+
+ALTER TABLE functions_workflow ADD COLUMN port_status VARCHAR;
+ALTER TABLE functions_workflow ADD COLUMN port_attempts INTEGER DEFAULT 0;
+ALTER TABLE functions_workflow ADD COLUMN port_draft_path VARCHAR;
+ALTER TABLE functions_workflow ADD COLUMN port_last_result VARCHAR;

--- a/fun-doc/fast_path.py
+++ b/fun-doc/fast_path.py
@@ -1,0 +1,292 @@
+"""fast_path.py -- batch getter-proving engine (the validated fast path, automated).
+
+Turns the manual loop (decompile -> recognize pattern -> draft reimpl -> build ->
+prove -> document) into a repeatable batch tool. It ROUTES each candidate to the
+right MECHANICAL translator + DISCRIMINATING prover that already exist in fun-doc,
+then auto-documents the winners.
+
+Routing (first match wins), all using the live oracle with SYNTHETIC discriminating
+objects (no gameplay, no real handle, no shadow rebuild for these classes):
+
+  flat getter          abi_static.translate_getter_to_c        -> run_synth_prove
+    (1 ptr param, fixed-offset read, optional dwType gate; the synth object's
+     unique-per-offset bytes make a wrong offset MISMATCH)
+  2-level getter       (chain len 2: ptr@O1 -> deref -> field@O2) -> run_synth2_prove
+    (the class that used to stateful_skip -> hand-shadowed; synth2 nests a
+     discriminating object so it proves statically-live, no game needed)
+  delegate call-through abi_static.translate_delegate_getter_to_c -> run_delegate_prove
+  global-table indexed  abi_static.translate_global_table_getter_to_c -> prove_spec sweep
+
+On a STRONG (allMatch + discriminating) proof: register CONF_LIVE + canonical-name
+(d2moo_names) + stamp a plate + tag. Non-discriminating / non-matching -> reported,
+NOT promoted (never overclaim).
+
+    python fast_path.py --addrs 0x6fd73b40,0x6fd72920 [--program /Mods/PD2-S12/D2Common.dll]
+    python fast_path.py --selftest      # routing dry-run on the translators, no oracle
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+PROGRAM = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+D2COMMON_BASE = 0x6FD50000
+
+
+def _addr_hex(a) -> str:
+    if isinstance(a, str):
+        a = int(a, 16) if a.lower().startswith("0x") else int(a, 16)
+    return f"0x{a:x}"
+
+
+def classify_and_draft(name: str, decompile: str, disasm: str):
+    """Route to a (class, reimpl_code, prover_kwargs) via the mechanical translators.
+    Returns dict {cls, code, ret, prover, kwargs} or {cls:'unsupported', reason}."""
+    import abi_static
+    # 1) flat getter (single fixed-offset read, optional dwType gate)
+    flat = abi_static.translate_getter_to_c(name, disasm)
+    if flat.get("ok") and len(flat.get("chain", [1])) <= 1:
+        return {"cls": "flat", "code": flat["code"], "ret": flat.get("ret", "u32"),
+                "prover": "synth", "gates": flat.get("type_gates") or flat.get("gates")}
+    # 2) delegate call-through
+    dele = abi_static.translate_delegate_getter_to_c(name, disasm)
+    if dele.get("ok"):
+        return {"cls": "delegate", "code": dele["code"], "ret": dele.get("ret", "u32"),
+                "prover": "delegate", "arg_off": dele.get("arg_off", 4),
+                "type_gates": dele.get("type_gates")}
+    # 3) global-table indexed getter
+    try:
+        import d2moo_names
+        rev = d2moo_names.resolve_reverse_map() if hasattr(d2moo_names, "resolve_reverse_map") else None
+    except Exception:
+        rev = None
+    gt = abi_static.translate_global_table_getter_to_c(name, disasm, resolve_rev=rev)
+    if gt.get("ok"):
+        return {"cls": "global_table", "code": gt["code"], "ret": gt.get("ret", "u32"),
+                "prover": "prove_spec"}
+    # 4) 2-level getter (the synth2 class) -- flat translator reports a 2-deep chain
+    if flat.get("chain") and len(flat["chain"]) == 2:
+        return {"cls": "two_level", "code": flat["code"], "ret": flat.get("ret", "u32"),
+                "prover": "synth2", "gates": flat.get("type_gates") or flat.get("gates")}
+    return {"cls": "unsupported",
+            "reason": flat.get("reason") or dele.get("reason") or gt.get("reason") or "no translator matched"}
+
+
+def _draft_one(addr, program: str = PROGRAM) -> dict:
+    """Decompile+disasm -> route -> write the candidate (NO build/prove). For batch mode:
+    draft all, build the provider ONCE, then prove each with build=False."""
+    import fun_doc
+    import port_live_prove as plp
+    ah = _addr_hex(addr)
+    dec = fun_doc.ghidra_get("/decompile_function", params={"address": ah, "program": program})
+    dis = fun_doc.ghidra_get("/disassemble_function", params={"address": ah, "program": program})
+    if not dec or fun_doc._is_error_response(dec) or not dis or fun_doc._is_error_response(dis):
+        return {"addr": ah, "result": "fetch_failed"}
+    name = _name_of(dec) or f"FUN_{ah[2:]}"
+    route = classify_and_draft(name, str(dec), str(dis))
+    if route["cls"] == "unsupported":
+        return {"addr": ah, "name": name, "result": "unsupported", "reason": route["reason"]}
+    plp.write_candidate(route["code"], name)   # stage so ONE build compiles them all
+    return {"addr": ah, "name": name, "route": route, "result": "drafted"}
+
+
+def prove_one(addr, program: str = PROGRAM, *, build: bool = True) -> dict:
+    """Full loop for ONE function: decompile+disasm -> route -> prove -> (doc)."""
+    import fun_doc
+    import port_live_prove as plp
+    ah = _addr_hex(addr)
+    dec = fun_doc.ghidra_get("/decompile_function", params={"address": ah, "program": program})
+    dis = fun_doc.ghidra_get("/disassemble_function", params={"address": ah, "program": program})
+    if not dec or fun_doc._is_error_response(dec) or not dis or fun_doc._is_error_response(dis):
+        return {"addr": ah, "result": "fetch_failed"}
+    name = _name_of(dec) or f"FUN_{ah[2:]}"
+    route = classify_and_draft(name, str(dec), str(dis))
+    if route["cls"] == "unsupported":
+        return {"addr": ah, "name": name, "result": "unsupported", "reason": route["reason"]}
+    return _prove_routed(addr, ah, name, route, program, build=build)
+
+
+def _prove_routed(addr, ah, name, route, program, *, build=True) -> dict:
+    import port_live_prove as plp
+    if route["prover"] == "synth":
+        res = plp.run_synth_prove(route["code"], name, addr, ret=route["ret"], gates=route.get("gates"), build=build)
+    elif route["prover"] == "synth2":
+        res = plp.run_synth2_prove(route["code"], name, addr, ret=route["ret"], gates=route.get("gates"), build=build)
+    elif route["prover"] == "delegate":
+        res = plp.run_delegate_prove(route["code"], name, addr, ret=route["ret"],
+                                     arg_off=route.get("arg_off", 4), type_gates=route.get("type_gates"), build=build)
+    else:  # global_table -> prove via a discriminating index sweep through prove_spec
+        res = _prove_global_table(route["code"], name, addr, route["ret"], build=build)
+
+    out = {"addr": ah, "name": name, "cls": route["cls"], "prover": route["prover"],
+           "ok": bool(res.get("ok")), "allMatch": res.get("allMatch"),
+           "discriminating": res.get("discriminating", res.get("proof_kind") in ("synth", "synth2")),
+           "result": "PROVEN" if res.get("ok") else res.get("failure_stage", "failed")}
+    if out["ok"]:
+        out["doc"] = _document(addr, name, route, res, program)
+    return out
+
+
+def _prove_global_table(code, name, addr, ret, *, build=True) -> dict:
+    """Build + prove a global-table (scalar-index) getter via the live oracle (_invoke_prove)
+    with a spread index sweep; STRONG only if allMatch AND the original VARIES across indices
+    (>=3 distinct) -- else non-discriminating (a wrong offset would match a uniform field too).
+    Requires the game IN-GAME (tables load on game entry), like the delegate prover."""
+    import json
+    import port_live_prove as plp
+    rr = ret if ret in ("u8", "i8", "u16", "i16", "u32", "i32") else "u32"
+    plp.write_candidate(code, name)
+    if build:
+        b = plp.build_provider_attributed(name)
+        if not b.get("ok"):
+            return {"ok": False, "failure_stage": b.get("stage")}
+    idxs = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 120, 160, 200, 300, 450, -1]
+    spec = {"name": name, "addr": plp._int(addr), "callconv": "stdcall", "ret": rr,
+            "args": [{"id": "i", "kind": "i32"}], "compare": ["ret"],
+            "vectors": [{"i": i} for i in idxs]}
+    plp.VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    sp = plp.VECTORS_DIR / f"{name}.spec.json"
+    sp.write_text(json.dumps(spec) + "\n", encoding="utf-8")
+    r = plp._invoke_prove(sp, build=False)
+    ov = (r.get("oracle") or {}).get("results") or []
+    orig = set(row["ret"]["o"] for row in ov if isinstance(row.get("ret"), dict) and "o" in row["ret"])
+    r["discriminating"] = bool(r.get("ok") and len(orig) >= 3)
+    if r.get("ok") and not r["discriminating"]:
+        r["ok"] = False
+        r["failure_stage"] = f"non_discriminating (distinct={len(orig)})"
+    if r.get("ok"):
+        r["writeback"] = plp.record_proof(name, addr, spec, r)
+    return r
+
+
+def _document(addr, name, route, res, program) -> str:
+    """Canonical-name + plate + CONF_LIVE tag + registry, on a strong proof."""
+    try:
+        import fun_doc
+        import d2moo_names
+        ah = _addr_hex(addr)
+        final = name
+        if d2moo_names.is_offset_name(name):
+            c = d2moo_names.canonicalize(name, route["code"])
+            if c.get("ok"):
+                fun_doc.ghidra_post("/rename_function_by_address",
+                                    data={"function_address": ah, "new_name": c["proposed_name"]},
+                                    params={"program": Path(program).name})
+                final = c["proposed_name"]
+        note = (f"[FAST-PATH PROVEN] {route['cls']} getter, discriminating "
+                f"{route['prover']} proof (allMatch). CONF_LIVE.")
+        fun_doc.ghidra_post("/set_plate_comment", data={"address": ah, "comment": note},
+                            params={"program": program})
+        fun_doc.ghidra_post("/add_function_tag",
+                            data={"function": ah, "tags": "CONF_LIVE"},
+                            params={"program": Path(program).name})
+        return f"documented -> {final}"
+    except Exception as e:
+        return f"doc_error: {e}"
+
+
+_NAME_STOP = {"NULL", "if", "while", "for", "return", "switch", "sizeof", "CONCAT22",
+              "CONCAT31", "CONCAT13", "SUB84", "void", "int", "uint", "char", "byte",
+              "short", "ushort", "bool", "undefined", "code", "float", "double"}
+
+
+def _name_of(dec) -> str:
+    """The real function name from the decompile signature: the first identifier-before-'('
+    that isn't a C keyword / decompiler pseudo-op / NULL guard (which the naive regex grabbed,
+    drafting a junk 'NULL.cpp' that poisoned the batch build until the sibling-heal removed it)."""
+    for m in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_]+)\s*\(", str(dec)):
+        nm = m.group(1)
+        if nm not in _NAME_STOP and ("_" in nm or re.match(r"[A-Z][a-z]", nm)):
+            return nm
+    return ""
+
+
+def run(addrs, program: str = PROGRAM) -> list:
+    """BATCH: draft (route + stage candidate) all -> build the provider ONCE -> prove each
+    (build=False) + document. One rebuild for the whole batch instead of one per function."""
+    import port_live_prove as plp
+    drafts = []
+    for a in addrs:
+        d = _draft_one(a, program)
+        drafts.append(d)
+        tag = f"{d['route']['cls']}/{d['route']['prover']}" if d.get("route") else d["result"]
+        print(f"  draft {a}: {tag}", flush=True)
+    staged = [d for d in drafts if d["result"] == "drafted"]
+    if staged:
+        print(f"\n[build] one provider build for {len(staged)} staged candidate(s)...", flush=True)
+        b = plp.build_provider_attributed(staged[0]["name"])
+        if not b.get("ok"):
+            print(f"[build] FAILED: {b.get('stage')} -- {str(b.get('detail'))[:200]}", flush=True)
+            for d in staged:
+                d["result"] = "build_failed"
+            return drafts
+    results = []
+    for d in drafts:
+        if d["result"] != "drafted":
+            results.append({"addr": d["addr"], "name": d.get("name"), "cls": "-",
+                            "result": d["result"], "reason": d.get("reason")})
+            continue
+        r = _prove_routed(int(d["addr"], 16), d["addr"], d["name"], d["route"], program, build=False)
+        results.append(r)
+        print(f"  [{r.get('cls','?')}/{r.get('prover','?')}] {d['name']}: {r['result']}"
+              f"{'  ' + str(r.get('doc','')) if r.get('doc') else ''}", flush=True)
+    return results
+
+
+def scorecard(results):
+    import collections
+    c = collections.Counter(r["result"] for r in results)
+    proven = [r for r in results if r["result"] == "PROVEN"]
+    print("\n" + "=" * 64)
+    print(f"FAST-PATH SCORECARD -- {len(results)} candidates")
+    for k, v in c.most_common():
+        print(f"  {k:<22} {v}")
+    print(f"\nPROVEN (CONF_LIVE, discriminating): {len(proven)}")
+    for r in proven:
+        print(f"  {r['name']:<38} {r['cls']}/{r['prover']}  {r.get('doc','')}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--addrs", help="comma-separated function addresses (0x...)")
+    ap.add_argument("--program", default=PROGRAM)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    if not args.addrs:
+        ap.error("--addrs required (or --selftest)")
+    addrs = [a.strip() for a in args.addrs.split(",") if a.strip()]
+    results = run(addrs, args.program)
+    scorecard(results)
+    Path("fast_path_results.json").write_text(json.dumps(results, indent=2, default=str), encoding="utf-8")
+    return 0
+
+
+def _selftest() -> int:
+    # Routing dry-run: feed canned disasm to classify_and_draft (no oracle/Ghidra).
+    # A genuinely FLAT gated getter (read +0x40, null-guard, XOR return-0 default).
+    flat = ("6fd70000: MOV EAX,dword ptr [ESP + 0x4]\n6fd70004: TEST EAX,EAX\n"
+            "6fd70006: JZ 0x6fd70012\n6fd70008: MOV EAX,dword ptr [EAX + 0x40]\n"
+            "6fd7000c: RET 0x4\n6fd70012: XOR EAX,EAX\n6fd70014: RET 0x4\n")
+    r = classify_and_draft("SomeFlagGetter", "", flat)
+    print(f"[selftest] flat getter routed -> cls={r['cls']} prover={r.get('prover')}")
+    assert r["cls"] == "flat" and r["prover"] == "synth", r
+    # 2-level getter with a NON-ZERO default return (GetItemQuality's `MOV EAX,0x2`) now
+    # routes to synth2 (abi_static learned the nonzero-default idiom, 2026-07-09).
+    gq = ("6fd73b40: MOV EAX,dword ptr [ESP + 0x4]\n6fd73b44: TEST EAX,EAX\n6fd73b46: JZ 0x6fd73b59\n"
+          "6fd73b48: CMP dword ptr [EAX],0x4\n6fd73b4b: JNZ 0x6fd73b59\n"
+          "6fd73b4d: MOV EAX,dword ptr [EAX + 0x14]\n6fd73b50: TEST EAX,EAX\n6fd73b52: JZ 0x6fd73b59\n"
+          "6fd73b54: MOV EAX,dword ptr [EAX]\n6fd73b56: RET 0x4\n6fd73b59: MOV EAX,0x2\n6fd73b5e: RET 0x4\n")
+    r2 = classify_and_draft("ITEMS_GetItemQuality", "", gq)
+    print(f"[selftest] GetItemQuality (2-level, nonzero default) -> cls={r2['cls']} prover={r2.get('prover')}")
+    assert r2["cls"] == "two_level" and r2["prover"] == "synth2", r2
+    print("[ok] fast_path routing self-test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -1064,6 +1064,12 @@ _STATE_DIRECT_FIELDS = (
     "name_source",
     "name_source_binary",
     "name_confidence",
+    # OpenD2 conformance port pipeline (document -> port -> prove). Populated
+    # only for functions the PORT worker has touched; NULL/none otherwise.
+    "port_status",
+    "port_attempts",
+    "port_draft_path",
+    "port_last_result",
 )
 
 
@@ -10049,6 +10055,1758 @@ def run_globals_worker_pass(
                 "count_reached" if processed >= count else "exhausted"
             )
     summary["processed"] = processed
+    return summary
+
+
+# ==========================================================================
+# OpenD2 conformance PORT pipeline (document -> port -> prove).
+# Live-proves a reimpl draft against the D2MOO oracle; see port_pipeline.py
+# / port_live_prove.py / prove_doc.py for the drivers.
+# ==========================================================================
+
+def process_global_leaf_live(program, address, func_name, decompiled, *,
+                             provider, model=None, max_turns=15, worker_id=None,
+                             max_fix_attempts=3, static_abi=None, abort_class=False):
+    """LIVE-prove path for a 'global_leaf' function (reads named game globals ->
+    not statically provable, but provable against the RUNNING game via the D2MOO
+    resolver). Drafts a resolver-based reimpl (D2MOO_Resolve for globals), then
+    proves it against the live D2Debugger oracle. No OpenD2 static harness.
+
+    Returns:
+      "proven_live_pending_review" -- proved bit-exact live; staged in D2MOO's
+                                      candidates/, CONF_LIVE tagged, registered.
+      "live_prove_failed"          -- reimpl drafted but did not prove.
+      "malformed_response"         -- no parseable blocks after retries.
+      "unsupported_abi"            -- register layout outside the oracle marshaller.
+      "blocked"                    -- quota pause.
+    """
+    import port_pipeline as pp
+    try:
+        import port_live_prove as plp
+    except Exception as e:
+        update_function_state(f"{program}::{address}", {
+            "port_status": "error", "port_last_result": f"live module import: {e}"})
+        return "error"
+
+    run_id = str(uuid.uuid4())[:8]
+    started_at = datetime.now()
+    key = f"{program}::{address}"
+
+    def _log(result, **extra):
+        _append_run_log({
+            "run_id": run_id, "timestamp": started_at.isoformat(),
+            "worker_id": worker_id, "mode": "port_live",
+            "program": program, "address": address, "name": func_name,
+            "provider": provider, "model": model, "result": result, **extra,
+        })
+
+    if not model:
+        try:
+            model = get_configured_model(provider, "FULL")
+        except Exception:
+            model = None
+
+    bus_emit("port_drafted", {
+        "key": key, "name": func_name, "address": address,
+        "program": Path(program).name, "program_path": program, "status": "drafting (live)",
+    })
+
+    prompt = plp.build_live_draft_prompt(func_name, address, decompiled)
+    try:
+        import abi_static
+        if static_abi or abort_class:
+            # authoritative ABI facts from the disassembly + abort-class safety rule
+            prompt += "\n\n" + abi_static.abi_prompt_block(static_abi, abort_class)
+        # GLOBAL-RESOLVE + CALL-THROUGH hints: a global_leaf reimpl MUST reach game
+        # globals (and any callee) via D2MOO_Resolve, never a direct extern/call (the
+        # #1 build_candidate failure for this class -- the model drafts `_g_pDataTables`
+        # or `GetX(id)` directly -> unresolved external -> build fails). Inject the exact
+        # verified names + the resolve pattern from the disasm. 2026-07-08.
+        _dis = ghidra_get("/disassemble_function",
+                          params={"address": f"0x{address}", "program": program})
+        if _dis and not _is_error_response(_dis):
+            _globs = abi_static.resolvable_globals(str(_dis))
+            if _globs:
+                prompt += abi_static.global_resolve_prompt_block(_globs)
+                _log("global_resolve_hint_injected", globals=[n for _a, n in _globs])
+            _callees = abi_static.resolvable_callees(str(_dis))
+            if _callees:
+                prompt += abi_static.callthrough_prompt_block(_callees)
+    except Exception:
+        pass
+    reimpl = layout = input_sets = None
+    attempts = 0
+
+    # GLOBAL-TABLE SHORT-CIRCUIT: the dominant DATATBLS getter shape
+    # (`g_table->records[idx*stride]->field`) translates MECHANICALLY from the disasm
+    # -- resolve the global BY NAME, deref, bound-check, index, raw-cast. The MODEL
+    # oscillates on the resolve-deref chain (proves one, mismatches its twin); the
+    # translation is deterministic + bit-exact. Prove with index vectors, no model.
+    try:
+        import abi_static
+        _dis = ghidra_get("/disassemble_function",
+                          params={"address": f"0x{address}", "program": program})
+        if _dis and not _is_error_response(_dis):
+            gt = abi_static.translate_global_table_getter_to_c(func_name, str(_dis))
+            if gt.get("ok"):
+                reimpl = gt["code"]
+                layout = {"inputs": [{"name": "idx", "signed": True}],
+                          "outputs": [{"name": "ret", "register": "EAX",
+                                       "signed": gt["ret"].startswith("i")}]}
+                input_sets = [{"idx": i} for i in
+                              (0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144)]
+                attempts = 1
+                _log("global_table_translated", global_=gt.get("global"),
+                     stride=gt.get("stride"), field_off=gt.get("field_off"), ret=gt.get("ret"))
+    except Exception as e:
+        _log("global_table_skip", error=str(e))
+
+    if not reimpl:
+        while attempts < max(1, max_fix_attempts):
+            attempts += 1
+            text, meta = invoke_claude(prompt, model=model, max_turns=max_turns,
+                                       provider=provider, complexity_tier=None)
+            if (meta or {}).get("quota_paused"):
+                update_function_state(key, {"port_status": "blocked",
+                                            "port_last_result": "quota_paused"})
+                _log("blocked", reason="quota_paused")
+                return "blocked"
+            reimpl, layout, input_sets = plp.parse_live_response(text or "")
+            if reimpl:
+                break
+            _log("malformed_response_retry", attempt=attempts)
+
+    if not reimpl:
+        update_function_state(key, {"port_status": "malformed_response",
+                                    "port_attempts": attempts,
+                                    "port_last_result": "no parseable live-draft blocks"})
+        _log("malformed_response", attempts=attempts)
+        return "malformed_response"
+
+    # OVERRIDE the drafted layout with the statically derived ABI: the disasm's
+    # RET n / register facts beat any model guess (a guessed ECX/fastcall on a
+    # stack-arg getter burned 3 prove rounds before this). Also pads unused slots
+    # so the marshal pushes exactly what the callee cleans.
+    try:
+        import abi_static
+        layout, input_sets, abi_notes = abi_static.apply_static_abi(
+            layout, input_sets, static_abi)
+        if abi_notes:
+            _log("static_abi_override", notes=abi_notes)
+    except Exception:
+        pass
+
+    # Rung V1 vetting (SHIPPING_PROMOTION_PLAN.md): fold in INDEPENDENT adversarial
+    # vectors. A separate model call that sees ONLY the decompile (never the reimpl)
+    # generates hard boundary/sweep/extreme inputs; merging them into the proof set
+    # means the reimpl must pass cases its own author may have dodged (kills the
+    # "the model tested what it implemented" self-consistency bias). Any divergence
+    # flows through the same fix-retry loop below. Best-effort + on by default for
+    # the live path; FUNDOC_ADVERSARIAL_VET=0 to disable.
+    input_names = [i.get("name") for i in (layout.get("inputs") or []) if i.get("name")]
+    if abort_class:
+        # ABORT CLASS: the out-of-range branch is FATAL (_exit/CleanupAndAbort) --
+        # adversarial widening would kill the game/bridge (it did, 3x, on
+        # GetAnimSequenceRecord). Skip the vet and CLAMP vectors to the safe envelope.
+        _log("adversarial_vet_skipped", reason="abort_class")
+    elif input_names and os.environ.get("FUNDOC_ADVERSARIAL_VET", "1") == "1":
+        try:
+            adv_prompt = plp.build_adversarial_vectors_prompt(func_name, decompiled, input_names)
+            atext, _ = invoke_claude(adv_prompt, model=model, max_turns=max_turns,
+                                     provider=provider, complexity_tier=None)
+            adv_inputs = plp.parse_adversarial_vectors(atext, input_names)
+            if adv_inputs:
+                seen, merged = set(), []
+                for s in list(input_sets) + adv_inputs:
+                    k = tuple(sorted((str(kk), str(vv)) for kk, vv in s.items()))
+                    if k in seen:
+                        continue
+                    seen.add(k)
+                    merged.append(s)
+                input_sets = merged[:80]  # bound oracle time
+                _log("adversarial_vectors_added", added=len(adv_inputs), total=len(input_sets))
+        except Exception as e:
+            _log("adversarial_vectors_skip", error=str(e))
+
+    # Prove, with a bounded fix-retry loop: a first-attempt reimpl that drafts
+    # cleanly but proves FALSE (e.g. a pointer-vs-base deref slip) gets the live
+    # oracle's divergence fed back so the model can self-correct -- the live
+    # analogue of the static path's harness fix-loop.
+    if abort_class:
+        try:
+            import abi_static
+            input_sets, dropped = abi_static.clamp_abort_vectors(input_sets)
+            _log("abort_vectors_clamped", dropped=dropped, kept=len(input_sets))
+        except Exception:
+            pass
+
+    live = None
+    prove_attempts = 0
+    while prove_attempts < max(1, max_fix_attempts):
+        prove_attempts += 1
+        try:
+            live = plp.run_live_prove(reimpl, func_name, address, layout, input_sets,
+                                      abort_class=abort_class)
+        except plp.UnsupportedLiveABI as e:
+            plp.remove_candidate(func_name)
+            update_function_state(key, {"port_status": "unsupported_abi",
+                                        "port_last_result": str(e)})
+            _log("unsupported_abi", reason=str(e))
+            return "unsupported_abi"
+        except Exception as e:
+            plp.remove_candidate(func_name)
+            update_function_state(key, {"port_status": "error", "port_last_result": str(e)})
+            _log("error", error=str(e))
+            return "error"
+        if live.get("ok") or prove_attempts >= max(1, max_fix_attempts):
+            break
+        # diverged -> feed the oracle output back and re-draft once more
+        fix_prompt = plp.build_live_fix_prompt(func_name, decompiled, reimpl, live.get("output", ""))
+        text, meta = invoke_claude(fix_prompt, model=model, max_turns=max_turns,
+                                   provider=provider, complexity_tier=None)
+        if (meta or {}).get("quota_paused"):
+            break
+        new_reimpl, new_layout, new_inputs = plp.parse_live_response(text or "")
+        if not new_reimpl:
+            break  # malformed fix -> stop, report the last real prove result
+        reimpl, layout, input_sets = new_reimpl, new_layout, new_inputs
+        try:  # the fix draft gets the same ABI override + abort clamp as the first
+            import abi_static
+            layout, input_sets, _n = abi_static.apply_static_abi(layout, input_sets, static_abi)
+            if abort_class:
+                input_sets, _d = abi_static.clamp_abort_vectors(input_sets)
+        except Exception:
+            pass
+        _log("live_prove_fix_retry", attempt=prove_attempts)
+
+    if live.get("ok"):
+        update_function_state(key, {
+            "port_status": "proven_live_pending_review", "port_attempts": attempts,
+            "port_live_status": "proven_live",
+            "port_last_result": f"live {live.get('passed')}/{live.get('total')}"})
+        bus_emit("port_live_prove_result", {
+            "key": key, "name": func_name, "ok": True,
+            "passed": live.get("passed"), "total": live.get("total")})
+        _log("proven_live_pending_review", passed=live.get("passed"),
+             total=live.get("total"))
+        return "proven_live_pending_review"
+
+    # Failed to prove -> REMOVE the candidate. A failed reimpl is often also a
+    # non-compiling one (undefined type, etc.), and one broken candidates/*.cpp
+    # poisons the single provider DLL build for EVERY other function. Nothing of
+    # value is staged; its content survives in the run log.
+    plp.remove_candidate(func_name)
+    fstage = live.get("failure_stage") or "prove"
+    fdetail = live.get("failure_detail") or ""
+    update_function_state(key, {
+        "port_status": "live_prove_failed", "port_attempts": attempts,
+        "port_failure_stage": fstage,
+        "port_last_result": (fdetail or live.get("output") or live.get("error") or "")[-500:]})
+    _log("live_prove_failed", failure_stage=fstage, failure_detail=fdetail[:500],
+         output=(live.get("output") or "")[-2000:], error=live.get("error"))
+    return f"live_prove_failed[{fstage}]"
+
+
+# ---------------------------------------------------------------------------
+# POST-PROOF NAME AUDIT (write-back discipline, CONFORMANCE_TAXONOMY.md
+# "Renaming: ground-truth-to-ground-truth, else FLAG"). A proof grounds a
+# function's BEHAVIOR + ABI, NOT its name -- so after a proof we check the name
+# and apply the guidance CONSERVATIVELY: auto-rename ONLY a generic auto-name
+# (FUN_/Ordinal_/...); a REAL name that contradicts the proven behavior is FLAGGED
+# for human review, never overwritten with a model guess (annotate-don't-overwrite).
+# ---------------------------------------------------------------------------
+_AUTO_NAME_RE = re.compile(r"^(FUN_|Ordinal_|SUB_|LAB_|UNK_|DAT_)", re.IGNORECASE)
+
+
+def _is_auto_name(name):
+    """A generic decompiler/exporter auto-name with no semantic basis -- free to
+    replace with a behavior-derived name (evidence rank bottom, per the taxonomy)."""
+    return bool(_AUTO_NAME_RE.match(name or ""))
+
+
+def _reconcile_registry_name(address, new_name, old_name):
+    """After an auto-rename, keep proven_functions.jsonl in sync (Ghidra just became
+    the truth for this address -- the known 'adopt-ghidra' direction). Updates the row
+    by address, keeps ghidra_prev_name. Best-effort. The standalone
+    conformance/tools/check_consistency.py handles the ambiguous / downstream cases."""
+    try:
+        reg = (Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+               / "conformance" / "proven_functions.jsonl")
+        if not reg.exists():
+            return
+        addr_norm = ("0x" + str(address).lower().lstrip("0x"))
+        out, changed = [], False
+        for line in reg.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                out.append(line)
+                continue
+            if str(row.get("address", "")).lower() == addr_norm and row.get("name") == old_name:
+                row["ghidra_prev_name"] = row.get("ghidra_prev_name", old_name)
+                row["name"] = new_name
+                changed = True
+            out.append(json.dumps(row))
+        if changed:
+            reg.write_text("\n".join(out) + "\n", encoding="utf-8")
+    except Exception:  # noqa: BLE001 -- registry sync must never break a proof
+        pass
+
+
+def _extract_first_json(text):
+    """First balanced top-level JSON object out of a model reply (tolerates fences/prose)."""
+    if not text:
+        return None
+    s = text.strip()
+    m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", s, re.DOTALL)
+    if m:
+        s = m.group(1)
+    start = s.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    for i in range(start, len(s)):
+        if s[i] == "{":
+            depth += 1
+        elif s[i] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(s[start:i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+def build_name_audit_prompt(func_name, decompiled):
+    return (
+        "You are auditing a Ghidra function NAME against its now-PROVEN behavior. A bit-exact "
+        "conformance proof just confirmed what this function DOES (its return value + the exact "
+        "fields it reads). Decide whether the current name is accurate, under a STRICT evidence rule.\n\n"
+        f"Current name: {func_name}\n\n"
+        "Decompiled (proven) behavior:\n```\n" + str(decompiled) + "\n```\n\n"
+        "RULES:\n"
+        "- A proof grounds BEHAVIOR, not the name. Propose a rename ONLY when you have GROUND-TRUTH "
+        "evidence for a better name: a string constant the function references, a clearly-named callee "
+        "it invokes, or UNAMBIGUOUS domain behavior. A plausible-but-unverified guess is NOT grounds.\n"
+        "- Exactly one verdict:\n"
+        "  * \"keep\": the current name accurately describes the proven behavior.\n"
+        "  * \"rename\": the current name is CONTRADICTED by the proven behavior (it implies behavior the "
+        "function does NOT have), OR is a generic auto-name (FUN_/Ordinal_/SUB_/LAB_), AND you can derive "
+        "a clear, convention-fitting name FROM THE PROVEN BEHAVIOR. Put it in proposed_name. This need NOT "
+        "be the final canonical name -- an accurate behavior-derived name beats a contradicted one.\n"
+        "  * \"flag\": the name is wrong/misleading but you CANNOT derive an adequate replacement from the "
+        "behavior alone (too generic to name, or the correct name needs external evidence -- a referenced "
+        "string, an xref, or the D2MOO canonical name).\n"
+        "- Naming convention: SUBSYSTEM_ActionThing (e.g. UNIT_GetMode, DATATBLS_GetSkillsTxtRecord).\n\n"
+        "Output ONLY strict JSON, no prose: "
+        "{\"verdict\":\"keep|rename|flag\",\"proposed_name\":\"<name or empty>\",\"reason\":\"<one sentence>\"}"
+    )
+
+
+def _ghidra_audit_flag(program_name, address, text, marker="[AUDIT"):
+    """Prepend an idempotent [AUDIT] note to the plate. `marker` is the per-concern
+    phrase whose presence means 'already flagged this concern' -- distinct markers
+    (name vs type) let both coexist without one suppressing the other. Best-effort."""
+    try:
+        cur = ghidra_get("/get_plate_comment",
+                         params={"address": f"0x{address}", "program": program_name})
+        existing = cur.get("comment") if isinstance(cur, dict) else (cur or "")
+        if marker in (existing or ""):
+            return "already-flagged"
+        body = text + ("\n\n" + existing if existing else "")
+        ghidra_post("/set_plate_comment",
+                    data={"address": f"0x{address}", "comment": body, "program": program_name})
+        return "flagged"
+    except Exception as e:  # noqa: BLE001
+        return f"error:{e}"
+
+
+def _post_proof_name_audit(program_name, address, func_name, decompiled, *, provider, model, log):
+    """After a proof grounds BEHAVIOR, check the Ghidra NAME and apply the write-back
+    guidance CONSERVATIVELY. Auto-rename ONLY a generic auto-name; a contradicting REAL
+    name is FLAGGED, never overwritten with a model guess. Opt out: FUNDOC_NAME_AUDIT=0.
+    Best-effort -- never affects the proof result."""
+    if os.environ.get("FUNDOC_NAME_AUDIT", "1") != "1":
+        return
+    try:
+        text, meta = invoke_claude(build_name_audit_prompt(func_name, decompiled),
+                                   model=model, max_turns=2, provider=provider, complexity_tier=None)
+        obj = _extract_first_json(text or "")
+        if not isinstance(obj, dict):
+            log("name_audit_skip", reason="no JSON verdict")
+            return
+        verdict = str(obj.get("verdict", "")).lower().strip()
+        proposed = str(obj.get("proposed_name") or "").strip()
+        reason = str(obj.get("reason") or "").strip()
+        if verdict == "keep":
+            log("name_audit_keep", name=func_name)
+            return
+        if verdict == "rename" and proposed and proposed != func_name:
+            # The proof CONTRADICTS the current name and yields a better, convention-
+            # fitting name -> overwrite the weaker guess (the existing name is itself
+            # an unvalidated decompiler-era guess; a proof-grounded name outranks it).
+            # RECOVERABLE + refinable: the old name is preserved in a trail note (keyed
+            # by ADDRESS, survives the rename), so a wrong call is revertible and a
+            # later canonical (string/xref/D2MOO) can still refine it. Auto-names take
+            # the same path -- they just always qualify.
+            r = ghidra_post("/rename_function_by_address",
+                            data={"function_address": f"0x{address}", "new_name": proposed},
+                            params={"program": program_name})
+            renamed = not (isinstance(r, dict) and r.get("error"))
+            if renamed:
+                _reconcile_registry_name(address, proposed, func_name)  # registry follows (known dir)
+                trail = (f"[RENAMED {datetime.now().date().isoformat()}] {func_name} -> {proposed} "
+                         f"(proof-derived: the prior name was contradicted by the proven behavior -- "
+                         f"{reason}). Not necessarily canonical -- verify vs a string/xref/D2MOO name; "
+                         f"regenerate the resolve/profiler snapshots if this fn is name-resolved.")
+                _ghidra_audit_flag(program_name, address, trail, marker=f"{func_name} -> {proposed}")
+                ghidra_post("/save_program", data={"program": program_name})
+            log("name_audit_rename", old=func_name, new=proposed, applied=renamed,
+                auto=_is_auto_name(func_name))
+            return
+        # verdict == flag, OR a rename with no derivable name ->
+        # annotate: wrong but no proof-derivable replacement (needs external evidence).
+        note = (f"[AUDIT {datetime.now().date().isoformat()}] Post-proof name check: {reason} "
+                + (f"Suggested (UNVERIFIED, needs ground truth): {proposed}. " if proposed else "")
+                + "Behavior is proven (CONF_LIVE) but the name was NOT auto-changed -- verify against "
+                + "a referenced string / xref / D2MOO canonical name before renaming.")
+        st = _ghidra_audit_flag(program_name, address, note, marker="Post-proof name check")
+        if st == "flagged":
+            ghidra_post("/save_program", data={"program": program_name})
+        log("name_audit_flag", name=func_name, proposed=proposed, status=st, reason=reason)
+    except Exception as e:  # noqa: BLE001  -- a doc audit must never break a proof
+        log("name_audit_error", error=str(e))
+
+
+def build_type_audit_prompt(func_name, decompiled, reimpl_cpp):
+    return (
+        "You are auditing a Ghidra function's PARAMETER TYPES against its now-PROVEN behavior. A "
+        "bit-exact conformance proof just confirmed exactly how this function reads its arguments "
+        "(the offsets, widths, and dereference depth had to be right to match). Report ONLY parameter-"
+        "type corrections the PROVEN behavior grounds -- nothing speculative.\n\n"
+        f"Function: {func_name}\n\n"
+        "Ghidra decompile (declared param types + proven body usage):\n```\n" + str(decompiled) + "\n```\n\n"
+        "The proven reimplementation (uses void* + raw offset casts):\n```cpp\n" + str(reimpl_cpp) + "\n```\n\n"
+        "The reimpl's declared calling convention + return type are also PROVEN (they had to match).\n"
+        "RULES (a proof grounds ABI + widths + pointer depth, NOT semantic names or exact struct "
+        "type identity):\n"
+        "- \"fix\": ANY of -- a parameter dereferenced MORE pointer levels than its declared type "
+        "(declared `T*` but body does `**(T**)p` -> `T**`); a read WIDTH contradicting the declared scalar "
+        "type; a RETURN type/width/signedness contradicting the proven return (e.g. a 1-byte return "
+        "declared `int`, or a pointer return declared `int`); or a CALLING CONVENTION differing from the "
+        "proven one. Provide the FULL corrected C prototype (and corrected_callconv if the convention is "
+        "wrong). Unambiguous, proof-backed ground truth.\n"
+        "- \"flag\": a scalar-typed pointer (int*/short*) is used purely as a STRUCT base (indexed at "
+        "offsets / `->`) so it is really a struct pointer, but you cannot name the EXACT struct with ground "
+        "truth. Describe it; do NOT invent a struct type name.\n"
+        "- \"ok\": the declared prototype (params, return, convention) is consistent with the proven usage.\n"
+        "- NEVER rename variables or parameters here, and NEVER invent a struct type name for \"fix\".\n\n"
+        "Output ONLY strict JSON: {\"verdict\":\"ok|fix|flag\",\"corrected_prototype\":\"<full prototype or "
+        "empty>\",\"corrected_callconv\":\"<stdcall|fastcall|cdecl|thiscall or empty>\",\"reason\":\"<one sentence>\"}"
+    )
+
+
+def _post_proof_type_audit(program_name, address, func_name, decompiled, reimpl_cpp, *,
+                           provider, model, log):
+    """After a proof grounds field OFFSETS + WIDTHS + pointer DEPTH, check the Ghidra
+    PARAMETER TYPES. Auto-CORRECT only the unambiguous proof-backed case (a param
+    dereferenced deeper than its declared pointer level, e.g. short* -> short**);
+    FLAG struct-ness where the exact type is uncertain. Never touches local-variable
+    names/types (the doc workflow owns those). Opt out FUNDOC_TYPE_AUDIT=0. Best-effort."""
+    if os.environ.get("FUNDOC_TYPE_AUDIT", "1") != "1":
+        return
+    try:
+        text, meta = invoke_claude(build_type_audit_prompt(func_name, decompiled, reimpl_cpp),
+                                   model=model, max_turns=2, provider=provider, complexity_tier=None)
+        obj = _extract_first_json(text or "")
+        if not isinstance(obj, dict):
+            log("type_audit_skip", reason="no JSON verdict")
+            return
+        verdict = str(obj.get("verdict", "")).lower().strip()
+        proto = str(obj.get("corrected_prototype") or "").strip()
+        callconv = str(obj.get("corrected_callconv") or "").strip().lower()
+        reason = str(obj.get("reason") or "").strip()
+        if verdict == "ok":
+            log("type_audit_ok", name=func_name)
+            return
+        if verdict == "fix" and proto and "(" in proto and ")" in proto:
+            # Proof-backed ABI correction (pointer level / width / return / convention).
+            # Ghidra rejects a malformed prototype, so this is bounded; ground truth.
+            data = {"function_address": f"0x{address}", "prototype": proto}
+            if callconv in ("stdcall", "fastcall", "cdecl", "thiscall"):
+                data["calling_convention"] = f"__{callconv}"
+            r = ghidra_post("/set_function_prototype", data=data,
+                            params={"program": program_name})
+            ok = not (isinstance(r, dict) and r.get("error"))
+            if ok:
+                ghidra_post("/save_program", data={"program": program_name})
+            log("type_audit_fix", name=func_name, prototype=proto, applied=ok, reason=reason)
+            return
+        # flag (or a "fix" we won't auto-apply) -> annotate for review.
+        note = (f"[AUDIT {datetime.now().date().isoformat()}] Post-proof type check: {reason} "
+                + (f"Suggested prototype (verify): {proto}. " if proto else "")
+                + "Behavior/offsets proven (CONF_LIVE); parameter type NOT auto-changed -- confirm the "
+                + "exact struct/type before applying.")
+        st = _ghidra_audit_flag(program_name, address, note, marker="Post-proof type check")
+        if st == "flagged":
+            ghidra_post("/save_program", data={"program": program_name})
+        log("type_audit_flag", name=func_name, status=st, reason=reason)
+    except Exception as e:  # noqa: BLE001 -- must never break a proof
+        log("type_audit_error", error=str(e))
+
+
+# ---------------------------------------------------------------------------
+# STRUCT-FIELD LEDGER (the compounding asset). Every proof confirms offset->width
+# ->role of the game struct its pointer arg points to. That knowledge otherwise
+# evaporates into a void* reimpl; here it ACCUMULATES into a per-struct ledger, so
+# proving many unit getters reconstructs D2UnitStrc etc. with proof-backed fields.
+# Ledger only (not auto-applied to Ghidra structs) -- safe, conflict-detecting; a
+# separate gated step can later apply conflict-free high-confidence fields.
+# ---------------------------------------------------------------------------
+_STRUCT_LEDGER_PATH = os.path.join(
+    os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"),
+    "conformance", "struct_field_ledger.json")
+
+
+def build_struct_field_prompt(func_name, decompiled):
+    return (
+        "A conformance proof just confirmed EXACTLY how this function reads the game-object struct "
+        "its pointer argument points to. Extract the struct FIELDS the PROVEN behavior reads -- "
+        "GROUND TRUTH ONLY, nothing speculative.\n\n"
+        f"Function: {func_name}\n\n"
+        "Decompile (proven):\n```\n" + str(decompiled) + "\n```\n\n"
+        "Report the fields of the struct the PRIMARY pointer argument points to that this function "
+        "ACTUALLY reads. For each field: byte OFFSET (hex), WIDTH in bytes (1/2/4/8), KIND "
+        "(int|uint|byte|short|ptr|enum), and a short ROLE. Include a field ONLY if the proven code "
+        "reads it; invent nothing.\n"
+        "Give the struct a STABLE key: the DECLARED pointer type if it is a named struct (e.g. "
+        "UnitAny, D2StatListStrc); if declared as a bare scalar pointer (int*/short*), use your best "
+        "domain name (e.g. 'UnitAny' when it dispatches on unit-type at +0x0).\n\n"
+        "Output ONLY strict JSON: "
+        "{\"struct_key\":\"<name>\",\"fields\":[{\"offset\":\"0xNN\",\"width\":N,\"kind\":\"...\",\"role\":\"...\"}]}"
+    )
+
+
+def _accumulate_struct_fields(program_name, address, func_name, decompiled, *, provider, model, log):
+    """Extract the proof-confirmed struct fields and MERGE into the struct-field
+    ledger (conformance/struct_field_ledger.json), keyed by struct. Confirms
+    matching fields (adds the source), records CONFLICTS (same offset, different
+    width/kind). Opt out FUNDOC_STRUCT_LEDGER=0. Best-effort -- never breaks a proof."""
+    if os.environ.get("FUNDOC_STRUCT_LEDGER", "1") != "1":
+        return
+    try:
+        text, meta = invoke_claude(build_struct_field_prompt(func_name, decompiled),
+                                   model=model, max_turns=2, provider=provider, complexity_tier=None)
+        obj = _extract_first_json(text or "")
+        if not isinstance(obj, dict):
+            log("struct_ledger_skip", reason="no JSON")
+            return
+        struct_key = str(obj.get("struct_key") or "").strip()
+        fields = obj.get("fields")
+        if not struct_key or not isinstance(fields, list) or not fields:
+            log("struct_ledger_skip", reason="no struct_key/fields")
+            return
+        led = {}
+        if os.path.exists(_STRUCT_LEDGER_PATH):
+            try:
+                led = json.load(open(_STRUCT_LEDGER_PATH, encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                led = {}
+        structs = led.setdefault("structs", {})
+        s = structs.setdefault(struct_key, {"fields": {}, "conflicts": []})
+        src = f"{func_name}@0x{address}"
+        added = confirmed = conflicts = 0
+        for f in fields:
+            if not isinstance(f, dict):
+                continue
+            off = str(f.get("offset", "")).lower().strip()
+            if not off.startswith("0x"):
+                continue
+            width = int(f.get("width") or 0)
+            kind = str(f.get("kind") or "").lower().strip()
+            role = str(f.get("role") or "").strip()
+            cur = s["fields"].get(off)
+            # A proof grounds WIDTH + pointer-ness; the finer KIND (enum vs uint) is
+            # interpretive, so only WIDTH or ptr-vs-scalar disagreement is a real
+            # conflict. On agreement, keep the MORE SPECIFIC kind (enum/byte/short/ptr
+            # over generic int/uint).
+            generic = {"int", "uint", ""}
+            if cur is None:
+                s["fields"][off] = {"width": width, "kind": kind, "role": role, "sources": [src]}
+                added += 1
+            elif cur.get("width") == width and (cur.get("kind") == "ptr") == (kind == "ptr"):
+                if src not in cur["sources"]:
+                    cur["sources"].append(src)
+                if cur.get("kind") in generic and kind not in generic:
+                    cur["kind"] = kind      # upgrade to the more specific interpretation
+                confirmed += 1
+            else:
+                s["conflicts"].append({"offset": off,
+                                       "have": {"width": cur.get("width"), "kind": cur.get("kind")},
+                                       "new": {"width": width, "kind": kind}, "source": src})
+                conflicts += 1
+        # keep fields sorted by numeric offset for readability
+        s["fields"] = dict(sorted(s["fields"].items(), key=lambda kv: int(kv[0], 16)))
+        os.makedirs(os.path.dirname(_STRUCT_LEDGER_PATH), exist_ok=True)
+        with open(_STRUCT_LEDGER_PATH, "w", encoding="utf-8") as fp:
+            json.dump(led, fp, indent=2)
+        log("struct_ledger", struct=struct_key, added=added, confirmed=confirmed, conflicts=conflicts)
+    except Exception as e:  # noqa: BLE001
+        log("struct_ledger_error", error=str(e))
+
+
+# ---------------------------------------------------------------------------
+# ENUM / CONSTANT LEDGER (the compounding companion to the struct-field ledger).
+# Every proof confirms the magic constants a function dispatches on; those form
+# enums (unit-type 0-6, stat-list guard 0x1020304, skill ids). Accumulate them
+# cross-function so the meaning of each constant is proof-confirmed by many callers.
+# ---------------------------------------------------------------------------
+_ENUM_LEDGER_PATH = os.path.join(
+    os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"),
+    "conformance", "enum_ledger.json")
+
+
+def build_enum_prompt(func_name, decompiled):
+    return (
+        "A conformance proof just confirmed this function's behavior, including the MAGIC CONSTANTS it "
+        "compares against / dispatches on. Extract the enumerated constants -- GROUND TRUTH from the "
+        "proven code only.\n\n"
+        f"Function: {func_name}\n\n"
+        "Decompile (proven):\n```\n" + str(decompiled) + "\n```\n\n"
+        "Identify ENUM families: a set of small integer constants a single field is compared against that "
+        "clearly form an enumeration (e.g. a unit-type field compared to 0,1,2,4,5 -> a UnitType enum). "
+        "Give each family a stable NAME, the FIELD it discriminates (byte offset if determinable), and the "
+        "{value,label} pairs the proven code establishes. Also list standalone magic CONSTANTS (e.g. a "
+        "validity guard 0x1020304) with their role. Include ONLY what the proven code uses; invent nothing, "
+        "and do NOT guess labels you cannot justify from the code (use \"?\" if unknown).\n\n"
+        "Output ONLY strict JSON: {\"enums\":[{\"name\":\"UnitType\",\"field\":\"+0x00 dwType\",\"values\":"
+        "[{\"value\":0,\"label\":\"Player\"}]}],\"constants\":[{\"value\":\"0x1020304\",\"role\":\"...\"}]}"
+    )
+
+
+def _accumulate_enums(program_name, address, func_name, decompiled, *, provider, model, log):
+    """Extract proof-confirmed enum families + magic constants and MERGE into the
+    enum ledger (conformance/enum_ledger.json). Cross-confirms values across
+    functions; conflicts on same value/different label. Opt out FUNDOC_ENUM_LEDGER=0."""
+    if os.environ.get("FUNDOC_ENUM_LEDGER", "1") != "1":
+        return
+    try:
+        text, meta = invoke_claude(build_enum_prompt(func_name, decompiled),
+                                   model=model, max_turns=2, provider=provider, complexity_tier=None)
+        obj = _extract_first_json(text or "")
+        if not isinstance(obj, dict):
+            log("enum_ledger_skip", reason="no JSON")
+            return
+        led = {}
+        if os.path.exists(_ENUM_LEDGER_PATH):
+            try:
+                led = json.load(open(_ENUM_LEDGER_PATH, encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                led = {}
+        enums = led.setdefault("enums", {})
+        consts = led.setdefault("constants", {})
+        src = f"{func_name}@0x{address}"
+        added = confirmed = conflicts = 0
+        for e in obj.get("enums") or []:
+            if not isinstance(e, dict):
+                continue
+            name = str(e.get("name") or "").strip()
+            if not name:
+                continue
+            fam = enums.setdefault(name, {"field": str(e.get("field") or ""), "values": {}, "conflicts": []})
+            for v in e.get("values") or []:
+                if not isinstance(v, dict) or "value" not in v:
+                    continue
+                key = str(v.get("value"))
+                label = str(v.get("label") or "?").strip()
+                cur = fam["values"].get(key)
+                if cur is None:
+                    fam["values"][key] = {"label": label, "sources": [src]}
+                    added += 1
+                elif cur["label"] == label or label == "?" or cur["label"] == "?":
+                    if label != "?" and cur["label"] == "?":
+                        cur["label"] = label      # upgrade unknown -> known
+                    if src not in cur["sources"]:
+                        cur["sources"].append(src)
+                    confirmed += 1
+                else:
+                    fam["conflicts"].append({"value": key, "have": cur["label"], "new": label, "source": src})
+                    conflicts += 1
+        for c in obj.get("constants") or []:
+            if not isinstance(c, dict) or "value" not in c:
+                continue
+            key = str(c.get("value"))
+            role = str(c.get("role") or "").strip()
+            cc = consts.setdefault(key, {"role": role, "sources": []})
+            if src not in cc["sources"]:
+                cc["sources"].append(src)
+        os.makedirs(os.path.dirname(_ENUM_LEDGER_PATH), exist_ok=True)
+        with open(_ENUM_LEDGER_PATH, "w", encoding="utf-8") as fp:
+            json.dump(led, fp, indent=2)
+        log("enum_ledger", added=added, confirmed=confirmed, conflicts=conflicts)
+    except Exception as e:  # noqa: BLE001
+        log("enum_ledger_error", error=str(e))
+
+
+# ---------------------------------------------------------------------------
+# PROOF BRANCH COVERAGE. A proof that passed 8/8 on 8 live objects LOOKS strong,
+# but if all 8 were the same unit type it only exercised ONE branch. The oracle now
+# reports each captured object's dispatch field (dwType at +0) per vector; here we
+# check whether the observed values actually exercised the function's branches, and
+# FLAG uncovered paths (an all-pass proof that skipped a branch is oversold).
+# ---------------------------------------------------------------------------
+def build_coverage_prompt(func_name, decompiled, dispatch_values):
+    seen = sorted(set(v for v in dispatch_values if v is not None))
+    return (
+        "A conformance proof ran this function against several LIVE game objects and passed on all of "
+        "them. Assess BRANCH COVERAGE: did the proof actually exercise all the function's distinct "
+        "branches, or only some?\n\n"
+        f"Function: {func_name}\n\n"
+        "Decompile:\n```\n" + str(decompiled) + "\n```\n\n"
+        f"The proof ran on live objects whose DISPATCH FIELD (typically dwType at +0x00) took these "
+        f"distinct values: {seen} (raw per-vector: {dispatch_values}).\n\n"
+        "Identify the function's distinct BRANCHES keyed on that dispatch field. For each, state whether "
+        "the observed values EXERCISED it. Report branches NOT covered -- an uncovered branch means the "
+        "all-pass result did NOT actually test that path. Sub-conditions the dispatch field alone cannot "
+        "resolve (e.g. a NULL-sub-struct check) -> put in 'unknown'.\n\n"
+        "Output ONLY strict JSON: {\"covered\":[\"...\"],\"uncovered\":[\"...\"],\"unknown\":[\"...\"],"
+        "\"summary\":\"<one sentence>\"}"
+    )
+
+
+def _post_proof_coverage(program_name, address, func_name, decompiled, dispatch_values,
+                         *, provider, model, log):
+    """Check whether the proof's live objects exercised every branch; FLAG uncovered
+    paths so an all-pass proof isn't mistaken for full coverage. Opt out
+    FUNDOC_COVERAGE_AUDIT=0. Best-effort."""
+    if os.environ.get("FUNDOC_COVERAGE_AUDIT", "1") != "1" or not dispatch_values:
+        return
+    try:
+        text, meta = invoke_claude(build_coverage_prompt(func_name, decompiled, dispatch_values),
+                                   model=model, max_turns=2, provider=provider, complexity_tier=None)
+        obj = _extract_first_json(text or "")
+        if not isinstance(obj, dict):
+            log("coverage_skip", reason="no JSON")
+            return
+        uncovered = obj.get("uncovered") or []
+        summary = str(obj.get("summary") or "").strip()
+        seen = sorted(set(v for v in dispatch_values if v is not None))
+        if uncovered:
+            note = (f"[AUDIT {datetime.now().date().isoformat()}] Post-proof coverage: {summary} "
+                    f"UNCOVERED branch(es): {'; '.join(str(u) for u in uncovered)}. Dispatch values seen: "
+                    f"{seen}. The all-pass proof did NOT exercise these paths -- capture objects that hit "
+                    f"them (e.g. other unit types) to strengthen it.")
+            st = _ghidra_audit_flag(program_name, address, note, marker="Post-proof coverage")
+            if st == "flagged":
+                ghidra_post("/save_program", data={"program": program_name})
+            log("coverage_flag", uncovered=len(uncovered), seen=seen, status=st)
+        else:
+            log("coverage_full", seen=seen)
+    except Exception as e:  # noqa: BLE001
+        log("coverage_error", error=str(e))
+
+
+# ---------------------------------------------------------------------------
+# PLATE ACCURACY. The name audit checks the NAME; this checks the plate's
+# ALGORITHM PROSE against the proven behavior -- catching a stale/wrong description
+# (e.g. "returns X" when the proof shows Y). Flags a FACTUAL contradiction with the
+# correction; does NOT auto-rewrite prose (annotate-don't-overwrite -- a human edits
+# the sentence, but the falsehood is now marked so it can't silently survive).
+# ---------------------------------------------------------------------------
+def build_plate_audit_prompt(func_name, plate, decompiled):
+    return (
+        "A conformance proof just confirmed this function's exact behavior. Check whether the existing "
+        "Ghidra PLATE COMMENT's description of what the function DOES still matches the proven behavior. "
+        "IGNORE [AUDIT]/[CONFORMANCE] meta-notes and status tags -- assess only the ALGORITHM/behavior prose.\n\n"
+        f"Function: {func_name}\n\n"
+        "Current plate comment:\n```\n" + str(plate) + "\n```\n\n"
+        "Proven behavior (decompile):\n```\n" + str(decompiled) + "\n```\n\n"
+        "Report ONLY a FACTUAL discrepancy the proof establishes -- a statement in the plate that "
+        "CONTRADICTS the proven behavior (wrong return, wrong offset, wrong condition/dispatch). Do NOT "
+        "flag stylistic differences, missing detail, or plausible-but-unconfirmed prose.\n"
+        "Verdict: \"accurate\" (no contradiction) or \"discrepancy\" (a specific false statement).\n"
+        "If discrepancy, ALSO return corrected_plate: the COMPLETE plate comment with ONLY the false "
+        "statement(s) fixed and EVERYTHING ELSE preserved VERBATIM -- all other prose, AND every "
+        "[AUDIT]/[CONFORMANCE] meta-note line, unchanged and in the same order. Change the minimum.\n\n"
+        "Output ONLY strict JSON: {\"verdict\":\"accurate|discrepancy\",\"plate_says\":\"<the wrong claim>\","
+        "\"proven\":\"<what actually happens>\",\"correction\":\"<one corrected sentence>\","
+        "\"corrected_plate\":\"<full corrected plate, or empty>\"}"
+    )
+
+
+def _post_proof_plate_audit(program_name, address, func_name, decompiled, *, provider, model, log):
+    """Check the plate's algorithm prose against the proven behavior; FLAG a factual
+    contradiction (with the correction) so a falsehood can't silently survive. Does
+    not auto-rewrite prose. Opt out FUNDOC_PLATE_AUDIT=0. Best-effort."""
+    if os.environ.get("FUNDOC_PLATE_AUDIT", "1") != "1":
+        return
+    try:
+        cur = ghidra_get("/get_plate_comment",
+                         params={"address": f"0x{address}", "program": program_name})
+        plate = cur.get("comment") if isinstance(cur, dict) else (cur or "")
+        if not plate:
+            return
+        text, meta = invoke_claude(build_plate_audit_prompt(func_name, plate, decompiled),
+                                   model=model, max_turns=2, provider=provider, complexity_tier=None)
+        obj = _extract_first_json(text or "")
+        if not isinstance(obj, dict):
+            log("plate_audit_skip", reason="no JSON")
+            return
+        if str(obj.get("verdict", "")).lower().strip() != "discrepancy":
+            log("plate_audit_ok", name=func_name)
+            return
+        says = str(obj.get("plate_says") or "").strip()
+        proven = str(obj.get("proven") or "").strip()
+        correction = str(obj.get("correction") or "").strip()
+        corrected = str(obj.get("corrected_plate") or "").strip()
+        # The proof gives us the CORRECT behavioral statement, so a surgical fix beats
+        # leaving the falsehood in place. Guard against collateral damage: the rewrite
+        # must PRESERVE every [AUDIT]/[CONFORMANCE] meta-note and not be truncated --
+        # else fall back to a flag. (The trail note keeps the old wrong claim, so the
+        # edit is traceable/revertible.)
+        def _mk(s):
+            return (s or "").count("[AUDIT") + (s or "").count("[CONFORMANCE")
+        if corrected and _mk(corrected) >= _mk(plate) and len(corrected) >= int(0.6 * len(plate)):
+            trail = (f"[CORRECTED {datetime.now().date().isoformat()}] proof-backed plate fix -- was: "
+                     f"\"{says}\"; now: {correction}\n\n")
+            ghidra_post("/set_plate_comment",
+                        data={"address": f"0x{address}", "comment": trail + corrected,
+                              "program": program_name})
+            ghidra_post("/save_program", data={"program": program_name})
+            log("plate_audit_correct", name=func_name, fix=correction[:80])
+            return
+        # Couldn't safely rewrite (missing/unsafe corrected_plate) -> flag with the fix.
+        note = (f"[AUDIT {datetime.now().date().isoformat()}] Post-proof plate check: the plate states "
+                f"\"{says}\" but the PROVEN behavior is: {proven}. Correction: {correction} "
+                f"(behavior proven CONF_LIVE; prose not auto-edited this pass -- fix the wrong statement).")
+        st = _ghidra_audit_flag(program_name, address, note, marker="Post-proof plate check")
+        if st == "flagged":
+            ghidra_post("/save_program", data={"program": program_name})
+        log("plate_audit_flag", name=func_name, status=st)
+    except Exception as e:  # noqa: BLE001
+        log("plate_audit_error", error=str(e))
+
+
+_TYPE_DISPATCH_RE = re.compile(r"\bdwType\b|\bswitch\b|\bfor\b|\bwhile\b|\bcase\b")
+
+
+def _is_trivial_getter(reimpl, decompiled):
+    """A pure field getter -- one/few fixed-offset reads, no type-dispatch, loop, or
+    enum-ish switch. Such a function has NOTHING for the enum ledger and at most one
+    field for the struct ledger, so those two LLM-backed audits are pure waste on it
+    (2026-07-08: a mechanically-translated `return p->pGfxInfo` still spent 6 audit
+    calls / 58K tokens). Mechanically-translated reimpls are trivial by construction."""
+    if "MECHANICALLY TRANSLATED" in (reimpl or ""):
+        return True
+    if _TYPE_DISPATCH_RE.search(decompiled or ""):
+        return False
+    b = reimpl or ""
+    return b.count("return") <= 2 and "for" not in b and "while" not in b
+
+
+def _run_post_proof_audits(program, address, func_name, decompiled, reimpl, live, *,
+                           provider, model, log):
+    """Post-proof write-back suite, GATED on proof strength + triviality (2026-07-08).
+
+    A DEGENERATE proof (weak_proof: the original returned an identical value on every
+    vector) proved NOTHING -- a wrong offset would have matched too. Running the
+    confident name/type/plate MUTATION audits on it writes decompile-derived guesses
+    into the shared RE database while LABELING them 'proof-derived' (observed: a rename
+    rode on an all-zeros proof). So on a weak proof we DEFER the whole suite -- the
+    weak_proof flag already asks for a diverse re-prove; the audits run for real then.
+
+    On a strong proof we run the full suite, but SKIP the struct + enum ledgers for a
+    trivial getter (nothing to accumulate) -- cutting ~2 of the ~6 audit LLM calls."""
+    if live.get("weak_proof"):
+        log("post_proof_audits_deferred", reason="weak_proof (degenerate capture): a rename/"
+            "retype/plate-rewrite off this proof would be decompile-guessing labeled as proven; "
+            "re-prove against diverse objects first")
+        return
+    prog_name = Path(program).name
+    _post_proof_name_audit(prog_name, address, func_name, decompiled,
+                           provider=provider, model=model, log=log)
+    _post_proof_type_audit(prog_name, address, func_name, decompiled, reimpl,
+                           provider=provider, model=model, log=log)
+    if _is_trivial_getter(reimpl, decompiled):
+        log("ledgers_skipped_trivial", detail="pure field getter: no struct/enum knowledge to accumulate")
+    else:
+        _accumulate_struct_fields(prog_name, address, func_name, decompiled,
+                                  provider=provider, model=model, log=log)
+        _accumulate_enums(prog_name, address, func_name, decompiled,
+                          provider=provider, model=model, log=log)
+    _post_proof_coverage(prog_name, address, func_name, decompiled,
+                         live.get("dispatch_values"), provider=provider, model=model, log=log)
+    _post_proof_plate_audit(prog_name, address, func_name, decompiled,
+                            provider=provider, model=model, log=log)
+
+
+def process_handle_leaf_live(program, address, func_name, decompiled, *,
+                             provider, model=None, max_turns=15, worker_id=None,
+                             max_fix_attempts=3, static_abi=None, abort_class=False):
+    """LIVE-prove path for a 'shadow_leaf' function -- a getter that takes a POINTER
+    to a live game object (unit/record/struct) + optional scalars. Not statically
+    emulable, but provable via the oracle HANDLE path: a real captured live object
+    is passed to BOTH the original and the reimpl and the results compared (the
+    UNIT_GetMode mechanism, generalized). Drafts a void*-handle reimpl, then proves.
+
+    Returns proven_live_pending_review | live_prove_failed | malformed_response |
+    unsupported_abi | blocked | error -- same vocabulary as process_global_leaf_live.
+    """
+    import port_live_prove as plp
+
+    run_id = str(uuid.uuid4())[:8]
+    started_at = datetime.now()
+    key = f"{program}::{address}"
+
+    def _log(result, **extra):
+        _append_run_log({
+            "run_id": run_id, "timestamp": started_at.isoformat(),
+            "worker_id": worker_id, "mode": "port_handle",
+            "program": program, "address": address, "name": func_name,
+            "provider": provider, "model": model, "result": result, **extra,
+        })
+
+    if not model:
+        try:
+            model = get_configured_model(provider, "FULL")
+        except Exception:
+            model = None
+
+    prompt = plp.build_handle_draft_prompt(func_name, address, decompiled)
+    try:
+        import abi_static
+        if static_abi or abort_class:
+            prompt += "\n\n" + abi_static.abi_prompt_block(static_abi, abort_class)
+    except Exception:
+        pass
+
+    def _apply_handle_abi(lay):
+        """Force the handle layout's callconv/slot-count from the disassembly.
+        Handle layout shape: {handle_arg, scalar_args, callconv, ret}. The handle
+        occupies slot 0; RET n says how many TOTAL slots the callee cleans, so any
+        remainder beyond declared scalars is padded (the RET 0xC / 3-slot
+        DATATBLS_GetItemDataByCode discovery -- an under-declared slot count
+        corrupts the caller's stack and SEH-faults the oracle)."""
+        pads = []
+        if not (static_abi and static_abi.get("slots")) or not isinstance(lay, dict):
+            return lay, pads
+        cc = static_abi["callconv"]
+        if cc == "stdcall" and str(lay.get("callconv", "")).lower() != "stdcall":
+            _log("static_abi_override", note=f"callconv {lay.get('callconv')} -> stdcall (RET n, no reg reads)")
+            lay["callconv"] = "stdcall"
+        scal = list(lay.get("scalar_args") or [])
+        want = static_abi["slots"] - 1 - len(scal)     # slot 0 = the handle
+        if cc == "stdcall" and want > 0:
+            pads = [f"unused{len(scal) + 1 + k}" for k in range(want)]
+            lay["scalar_args"] = scal + pads
+            _log("static_abi_override",
+                 note=f"padded {want} unused slot(s) {pads} (RET 0x{static_abi['ret_imm']:x})")
+        return lay, pads
+
+    # MECHANICAL SHORT-CIRCUIT (abi_static.translate_getter_to_c): a pure pointer-
+    # deref getter is 2-5 MOV instructions -> translate the DISASM straight to C, no
+    # model, no guesswork. This is exactly the class that diverged ~99% when drafted
+    # from the decompile PROSE (2026-07-08: `pStateLinkedList[1].pStateHead` became
+    # invented struct math). If the disasm isn't a linear getter (branch/arith/call),
+    # fall through to the model -- and INJECT the disasm so the model drafts from
+    # ground truth rather than the misleading struct[i].field prose.
+    reimpl = layout = input_sets = None
+    attempts = 0
+    mech = None
+    try:
+        import abi_static
+        disasm = ghidra_get("/disassemble_function",
+                            params={"address": f"0x{address}", "program": program})
+        if disasm and not _is_error_response(disasm):
+            mech = abi_static.translate_getter_to_c(func_name, str(disasm))
+            if not mech.get("ok"):
+                prompt += ("\n\n## GROUND-TRUTH DISASSEMBLY -- translate THIS, not the decompile "
+                           "prose (Ghidra renders a single pointer walk as `struct[i].field`, which "
+                           "misleads into bogus struct-size/index math):\n```\n" + str(disasm) + "\n```")
+                # If the function calls a resolvable D2Common fn, the model must reach it
+                # via D2MOO_Resolve (a direct call = unresolved external = whole-build fail,
+                # observed live: the model drafted GetItemDataRecord(id) directly). Inject
+                # the call-through pattern so a model-drafted delegate can actually build.
+                _callees = abi_static.resolvable_callees(str(disasm))
+                if _callees:
+                    prompt += abi_static.callthrough_prompt_block(_callees)
+                    _log("callthrough_hint_injected", callees=[n for _a, n in _callees])
+                _log("mech_translate_defer", reason=mech.get("reason"))
+    except Exception as e:  # translation is an aid, never a blocker
+        _log("mech_translate_skip", error=str(e))
+
+    # DELEGATE SHORT-CIRCUIT: when the flat translator defers, the getter may still be
+    # a mechanical DELEGATE -- `param -> [gate] -> load field -> CALL a resolvable
+    # D2Common fn -> read result field -> return`. translate_delegate_getter_to_c emits
+    # a CALL-THROUGH reimpl (resolves the callee BY NAME, calls the REAL game fn, so its
+    # globals are the game's real globals). Proven IN-GAME via a discriminating multi-
+    # index synth (run_delegate_prove). Abort-class delegates keep the handle path (a
+    # handle-abort-hazard). 2026-07-08.
+    if not (mech and mech.get("ok")) and not abort_class:
+        try:
+            if disasm and not _is_error_response(disasm):
+                deleg = abi_static.translate_delegate_getter_to_c(func_name, str(disasm))
+                if deleg.get("ok"):
+                    _log("delegate_translated", callee=deleg.get("callee"),
+                         arg_off=deleg.get("arg_off"), result_off=deleg.get("result_off"))
+                    try:
+                        live = plp.run_delegate_prove(
+                            deleg["code"], func_name, address, ret=deleg["ret"],
+                            arg_off=deleg["arg_off"], type_gates=deleg.get("type_gates"))
+                    except Exception as e:
+                        plp.remove_candidate(func_name)
+                        update_function_state(key, {"port_status": "error", "port_last_result": str(e)})
+                        _log("error", error=str(e))
+                        return "error"
+                    _log("delegate_proved" if live.get("ok") else "delegate_failed",
+                         passed=live.get("passed"), total=live.get("total"),
+                         distinct=live.get("orig_distinct"), reason=live.get("failure_stage"))
+                    if live.get("ok"):
+                        update_function_state(key, {
+                            "port_status": "proven_live_pending_review", "port_attempts": 1,
+                            "port_live_status": "proven_delegate",
+                            "port_last_result": f"delegate {live.get('passed')}/{live.get('total')} "
+                                                f"(call-through {deleg.get('callee')}, discriminating)"})
+                        _run_post_proof_audits(program, address, func_name, decompiled,
+                                               deleg["code"], live, provider=provider,
+                                               model=model, log=_log)
+                        return "proven_live_pending_review"
+                    # weak/uniform or mismatch -> fall through to the model handle path
+                    plp.remove_candidate(func_name)
+        except Exception as e:
+            _log("delegate_translate_skip", error=str(e))
+
+    if mech and mech.get("ok"):
+        reimpl = mech["code"]
+        layout = {"handle_arg": "p", "scalar_args": [], "callconv": "stdcall", "ret": mech["ret"]}
+        input_sets = [{}]
+        attempts = 1
+        _log("mech_translated", chain=mech.get("chain"), ret=mech.get("ret"),
+             detail=mech.get("reason"))
+    else:
+        while attempts < max(1, max_fix_attempts):
+            attempts += 1
+            text, meta = invoke_claude(prompt, model=model, max_turns=max_turns,
+                                       provider=provider, complexity_tier=None)
+            if (meta or {}).get("quota_paused"):
+                update_function_state(key, {"port_status": "blocked", "port_last_result": "quota_paused"})
+                _log("blocked", reason="quota_paused")
+                return "blocked"
+            reimpl, layout, input_sets = plp.parse_handle_response(text or "")
+            if reimpl:
+                layout, _pads = _apply_handle_abi(layout)
+                break
+            _log("malformed_response_retry", attempt=attempts)
+
+    if not reimpl:
+        update_function_state(key, {"port_status": "malformed_response", "port_attempts": attempts,
+                                    "port_last_result": "no parseable handle-draft blocks"})
+        _log("malformed_response", attempts=attempts)
+        return "malformed_response"
+
+    # FLAT getter (single fixed-offset read, no sub-pointer deref) -> prove via the
+    # oracle's SYNTHETIC DISCRIMINATING object instead of a live capture. A live idle-
+    # town capture is all-zeros for most fields -> a wrong offset matches by luck ->
+    # weak_proof. The synth object makes every offset return a UNIQUE value, so the
+    # proof actually discriminates the offset -> a STRONG proof for exactly the flat-
+    # getter class the translator emits. Gated on (a) chain length 1 -- a synth byte is
+    # not a valid pointer, so a sub-deref getter would fault; and (b) NOT abort_class --
+    # the synth pattern is arbitrary and could trip a fatal precondition check (dwType/
+    # bounds), so abort-class getters keep the handle path where the game's own VALIDATED
+    # captured objects satisfy the precondition. 2026-07-08.
+    # Gated non-abort (the arbitrary pattern could trip a fatal precondition check).
+    # chain 1 (flat read) -> synth (flat discriminating buffer); chain 2 (read a
+    # pointer at O1, deref, read field at O2) -> synth2 (primary-of-pointers -> a
+    # discriminating secondary, so a wrong FIELD offset mismatches). Both kill the
+    # town-capture weak_proof for the mechanically-translated getter.
+    _chain = len(mech.get("chain") or []) if (mech and mech.get("ok")) else 0
+    _synth_kind = None if abort_class else {1: "synth", 2: "synth2"}.get(_chain)
+    if _synth_kind:
+        try:
+            _runner = plp.run_synth_prove if _synth_kind == "synth" else plp.run_synth2_prove
+            # pass any disasm-derived type-gates (e.g. `dwType==4`) so the oracle patches
+            # the synth object to SATISFY the precondition -> the getter takes its success
+            # path and reads the discriminating field (else both sides bail -> degenerate).
+            live = _runner(reimpl, func_name, address, ret=mech["ret"],
+                           gates=mech.get("type_gates"))
+        except Exception as e:
+            plp.remove_candidate(func_name)
+            update_function_state(key, {"port_status": "error", "port_last_result": str(e)})
+            _log("error", error=str(e))
+            return "error"
+        _log(f"{_synth_kind}_proved" if live.get("ok") else f"{_synth_kind}_failed",
+             passed=live.get("passed"), total=live.get("total"))
+        if live.get("ok"):
+            update_function_state(key, {
+                "port_status": "proven_live_pending_review", "port_attempts": 1,
+                "port_live_status": f"proven_{_synth_kind}",
+                "port_last_result": f"{_synth_kind} {live.get('passed')}/{live.get('total')} (discriminating)"})
+            _run_post_proof_audits(program, address, func_name, decompiled, reimpl, live,
+                                   provider=provider, model=model, log=_log)
+            return "proven_live_pending_review"
+        # synth mismatch => the MECHANICAL translation is wrong (rare) -> re-draft via
+        # the model as a fallback rather than trusting a bad translation.
+        _log(f"{_synth_kind}_mismatch_fallback", detail=(live.get("output") or "")[-300:])
+        reimpl = layout = input_sets = None
+        prompt += ("\n\n## The mechanical translation did NOT match the original on a discriminating "
+                   "synthetic object -- re-derive the offset(s) carefully from the disassembly above.")
+        for _a in range(max(1, max_fix_attempts)):
+            text, meta = invoke_claude(prompt, model=model, max_turns=max_turns,
+                                       provider=provider, complexity_tier=None)
+            if (meta or {}).get("quota_paused"):
+                update_function_state(key, {"port_status": "blocked", "port_last_result": "quota_paused"})
+                return "blocked"
+            reimpl, layout, input_sets = plp.parse_handle_response(text or "")
+            if reimpl:
+                layout, _pads = _apply_handle_abi(layout)
+                break
+        if not reimpl:
+            update_function_state(key, {"port_status": "malformed_response",
+                                        "port_last_result": "synth fallback: no parseable draft"})
+            return "malformed_response"
+
+    live = None
+    prove_attempts = 0
+    best = plp.BestDraft()          # keep the highest-scoring draft across retries
+    hiccups = 0
+    while prove_attempts < max(1, max_fix_attempts):
+        prove_attempts += 1
+        try:
+            live = plp.run_handle_prove(reimpl, func_name, address, layout, input_sets)
+        except Exception as e:  # bad spec / oracle down -> clean up, report
+            plp.remove_candidate(func_name)
+            update_function_state(key, {"port_status": "error", "port_last_result": str(e)})
+            _log("error", error=str(e))
+            return "error"
+        best.offer(reimpl, layout, input_sets, live)
+        if live.get("ok") or prove_attempts >= max(1, max_fix_attempts):
+            break
+        fix_prompt = plp.build_handle_fix_prompt(func_name, decompiled, reimpl, live.get("output", ""))
+        text, meta = invoke_claude(fix_prompt, model=model, max_turns=max_turns,
+                                   provider=provider, complexity_tier=None)
+        outcome = plp.provider_outcome(text, meta)
+        if outcome == "quota":
+            break
+        if outcome == "hiccup":
+            # PROVIDER misbehaved (timeout/empty) -- NOT a bad reimpl. Retry the fix
+            # without consuming a prove attempt, keeping the current best draft.
+            hiccups += 1
+            prove_attempts -= 1
+            _log("provider_hiccup_retry", attempt=prove_attempts, hiccups=hiccups)
+            if hiccups <= max(1, max_fix_attempts):
+                continue
+            break
+        new_reimpl, new_layout, new_inputs = plp.parse_handle_response(text or "")
+        if not new_reimpl:
+            break
+        new_layout, _pads = _apply_handle_abi(new_layout)   # fix drafts too
+        reimpl, layout, input_sets = new_reimpl, new_layout, new_inputs
+        _log("handle_prove_fix_retry", attempt=prove_attempts)
+
+    # Never let a provider hiccup or a worse re-draft lose an earlier better attempt.
+    if not live.get("ok") and best.have() and best.score > ((1 if live.get("ok") else 0),
+                                                             live.get("passed") or 0):
+        reimpl, layout, input_sets, live = best.reimpl, best.layout, best.input_sets, best.result
+
+    if live.get("ok"):
+        update_function_state(key, {
+            "port_status": "proven_live_pending_review", "port_attempts": attempts,
+            "port_live_status": "proven_live",
+            "port_last_result": f"handle-live {live.get('passed')}/{live.get('total')}"})
+        _log("proven_live_pending_review", passed=live.get("passed"), total=live.get("total"))
+        # Write proof-discovered facts back to Ghidra -- GATED on proof strength +
+        # triviality (see _run_post_proof_audits): a degenerate proof defers the suite,
+        # a trivial getter skips the struct/enum ledgers.
+        _run_post_proof_audits(program, address, func_name, decompiled, reimpl, live,
+                               provider=provider, model=model, log=_log)
+        return "proven_live_pending_review"
+
+    plp.remove_candidate(func_name)
+    fstage = live.get("failure_stage") or "prove"
+    fdetail = live.get("failure_detail") or ""
+    if hiccups:
+        # the provider misbehaved during the fix loop -> the retries were degraded,
+        # not necessarily the reimpl. Surface it so a flaky provider isn't read as a
+        # wrong function.
+        fstage = "provider_degraded"
+        fdetail = (f"{hiccups} provider hiccup(s) during the fix loop -- retries were degraded; "
+                   f"re-run when the provider is healthy. Last prove: {fdetail}")
+    update_function_state(key, {
+        "port_status": "live_prove_failed", "port_attempts": attempts,
+        "port_failure_stage": fstage,
+        "port_last_result": (fdetail or live.get("output") or live.get("error") or "")[-500:]})
+    _log("live_prove_failed", failure_stage=fstage, failure_detail=fdetail[:500],
+         output=(live.get("output") or "")[-2000:], error=live.get("error"))
+    return f"live_prove_failed[{fstage}]"
+
+
+def _writeback_shadow_leaf_note(program_name, address):
+    """WRITE-BACK a shadow_leaf finding to Ghidra as a plate-comment note (the
+    source-of-truth principle: a mis-typed live-struct pointer discovered while
+    porting belongs in the RE database). Marker-guarded so it's idempotent;
+    additive so it never clobbers existing docs; best-effort so it never fails a
+    port. Where a specific type correction is unambiguous (e.g. a double-deref
+    `**(T**)p` proves the param is `T**` not `T*`), fix the prototype by hand /
+    via set_function_prototype -- this note flags every case for that review."""
+    marker = "shadow_leaf (live-pointer getter)"  # present in both manual + auto notes
+    try:
+        cur = ghidra_get("/get_plate_comment",
+                         params={"address": f"0x{address}", "program": program_name})
+        existing = ""
+        if isinstance(cur, dict):
+            existing = cur.get("comment") or ""
+        elif isinstance(cur, str):
+            existing = cur
+        if marker in existing:
+            return  # already noted -- idempotent
+        # NB: keep the '*' '/' adjacency OUT of this text -- a literal `*/` inside a
+        # Ghidra plate comment prematurely closes the /* */ block, corrupting the
+        # decompile's comment-strip + signature parse (found the hard way, PATH_
+        # GetUnitPathModeByte mis-classified after an earlier note said 'int*/short*').
+        note = (f"[CONFORMANCE] {marker}: a scalar-typed pointer param "
+                f"(Ghidra int* or short*) is used as a live-STRUCT base -- indexed at a "
+                f"nonzero offset or double-dereferenced -- NOT a scalar in/out value. "
+                f"Not statically emulable; SHADOW-provable against the running game. "
+                f"If a double-deref proves an extra pointer level, correct the prototype.")
+        body = note + ("\n\n" + existing if existing else "")
+        ghidra_post("/set_plate_comment",
+                    {"address": f"0x{address}", "comment": body, "program": program_name})
+    except Exception:
+        pass
+
+
+def process_port_candidate(program, address, func_name, *, provider, model=None,
+                            max_turns=15, worker_id=None, max_fix_attempts=3):
+    """Stage 2/3 worker for ONE function: classify -> draft -> mint vectors
+    -> prove (bounded retry on harness failure). `address` is bare hex (no
+    0x prefix), matching fun_doc's function-state key convention.
+
+    Returns one of:
+        "proven_pending_review" -- harness passed; staged in OpenD2's
+                                    Tools/d2conform/_generated_candidates/,
+                                    NOT auto-merged into Shared/, NOT
+                                    committed -- a human reviews and
+                                    promotes it.
+        "harness_failed"        -- exhausted retries, still failing.
+        "stateful_skip"         -- classify_function said "stateful" (out
+                                    of Phase 1 scope -- needs the live-trace
+                                    oracle via the manual d2-port-function
+                                    skill instead). No LLM call made.
+        "unknown_skip"          -- decompile fetch failed.
+        "malformed_response"    -- provider never returned parseable blocks.
+        "no_vectors"            -- /emulate_function couldn't mint any
+                                    vectors from the model's proposed layout.
+        "blocked"               -- quota pause / provider error.
+
+    Always appends one row to runs.jsonl with mode="port". Persists
+    port_status/port_attempts/port_draft_path/port_last_result via
+    update_function_state.
+    """
+    import port_pipeline as pp
+
+    run_id = str(uuid.uuid4())[:8]
+    started_at = datetime.now()
+    key = f"{program}::{address}"
+    prog_name = Path(program).name
+
+    def _log(result, **extra):
+        _append_run_log({
+            "run_id": run_id, "timestamp": started_at.isoformat(),
+            "worker_id": worker_id, "mode": "port",
+            "program": program, "address": address, "name": func_name,
+            "provider": provider, "model": model, "result": result,
+            **extra,
+        })
+
+    decompiled = ghidra_get(
+        "/decompile_function", params={"address": f"0x{address}", "program": program}
+    )
+    if not decompiled or _is_error_response(decompiled):
+        update_function_state(key, {"port_status": "unknown_skip",
+                                     "port_last_result": "decompile fetch failed"})
+        _log("unknown_skip")
+        return "unknown_skip"
+
+    # MECHANICAL ABI + SAFETY facts (abi_static, 2026-07-08): RET n / [ESP+x] /
+    # register reads state the callconv + slot count outright -- the model no
+    # longer gets a vote on them (a guessed fastcall and an under-declared RET 0xC
+    # both burned proofs before this). detect_abort_path flags functions whose
+    # out-of-range branch KILLS the process -> vectors must stay in-envelope.
+    static_abi = None
+    try:
+        import abi_static
+        disasm = ghidra_get("/disassemble_function",
+                            params={"address": f"0x{address}", "program": program})
+        if disasm and not _is_error_response(disasm):
+            static_abi = abi_static.derive_abi(str(disasm))
+            _log("static_abi", abi={k: v for k, v in static_abi.items() if k != "notes"},
+                 notes=static_abi.get("notes"))
+    except Exception as e:  # derivation is an aid, never a blocker
+        _log("static_abi_skip", error=str(e))
+    abort_class = False
+    try:
+        import abi_static
+        abort_class = abi_static.detect_abort_path(str(decompiled))
+        if abort_class:
+            _log("abort_class_detected")
+    except Exception:
+        pass
+
+    classification = pp.classify_function(decompiled)
+    if classification == "stateful":
+        # DELEGATE pre-check: "stateful" often just means "calls a subroutine". If that
+        # call is to a RESOLVABLE D2Common fn and the shape is a mechanical call-through
+        # delegate (param -> [gate] -> load field -> CALL -> read result), route it to
+        # the live handle-leaf path -- its delegate short-circuit proves it via call-
+        # through (resolve + call the REAL fn). Needs the live oracle (in-game). 2026-07-08.
+        if os.environ.get("FUNDOC_LIVE_PROVE") == "1" and not abort_class:
+            try:
+                import abi_static
+                _dis = ghidra_get("/disassemble_function",
+                                  params={"address": f"0x{address}", "program": program})
+                if (_dis and not _is_error_response(_dis)
+                        and abi_static.translate_delegate_getter_to_c(func_name, str(_dis)).get("ok")):
+                    _log("delegate_route", classification=classification)
+                    return process_handle_leaf_live(
+                        program, address, func_name, decompiled,
+                        provider=provider, model=model, worker_id=worker_id,
+                        max_fix_attempts=max_fix_attempts,
+                        static_abi=static_abi, abort_class=abort_class)
+            except Exception as e:
+                _log("delegate_route_skip", error=str(e))
+        # Struct-pointer params / deep pointer chains / unnamed DAT_ globals --
+        # need a live captured game object, out of the automatable scope for now
+        # (leave to the manual d2-port-function skill).
+        update_function_state(key, {"port_status": "stateful_skip"})
+        _log("stateful_skip", classification=classification)
+        return "stateful_skip"
+    if classification == "global_leaf":
+        # Reads NAMED globals -> not statically provable, but provable LIVE against
+        # the running game via the D2MOO resolver. Needs the live oracle
+        # (FUNDOC_LIVE_PROVE=1); without it these can't be proven at all -> skip.
+        if os.environ.get("FUNDOC_LIVE_PROVE") != "1":
+            update_function_state(key, {
+                "port_status": "stateful_skip",
+                "port_last_result": "global_leaf: needs FUNDOC_LIVE_PROVE=1 (live oracle)"})
+            _log("stateful_skip", classification=classification, reason="live_prove_disabled")
+            return "stateful_skip"
+        return process_global_leaf_live(
+            program, address, func_name, decompiled,
+            provider=provider, model=model, worker_id=worker_id,
+            max_fix_attempts=max_fix_attempts,
+            static_abi=static_abi, abort_class=abort_class)
+
+    if classification == "shadow_leaf":
+        # A trivial LIVE-POINTER getter (scalar-typed pointer used as a struct
+        # base, e.g. GetPathFieldByUnitType `pUnit[0xc]`). Not statically emulable
+        # (the static harness would only waste an LLM+build cycle -> no_vectors),
+        # but SHADOW-provable: the game passes the real pointer, original+reimpl
+        # both read it and compare, and these getters are hot + NON-inlined so they
+        # battletest fast. Record to the shadow backlog for staging as a shadow
+        # dispatcher (the auto-draft+stage path is the next build); don't burn the
+        # static harness here.
+        try:
+            repo = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+            bl = repo / "conformance" / "profiler" / "shadow_leaf_backlog.jsonl"
+            bl.parent.mkdir(parents=True, exist_ok=True)
+            with open(bl, "a", encoding="utf-8") as f:
+                f.write(json.dumps({"program": program, "address": address,
+                                    "name": func_name}) + "\n")
+        except OSError:
+            pass
+        # WRITE-BACK to Ghidra (source-of-truth principle): the discovery that a
+        # scalar-typed pointer is really a live-struct pointer must live in the RE
+        # database, not just our classifier. Prepend a marker-guarded (idempotent)
+        # note to the plate comment. Best-effort -- never fails the port.
+        _writeback_shadow_leaf_note(prog_name, address)
+        # HANDLE ABORT HAZARD (2026-07-08, CONFIRMED LIVE CRASH -- STAT_GetUnitCalculatedStat):
+        # a handle-getter whose abort path is gated on the CAPTURED OBJECT's dwType
+        # (not a numeric index) is UNSAFE to auto-prove -- the oracle round-robins
+        # DISTINCT captured object types for branch-coverage diversity, and for THIS
+        # class that diversity itself feeds the wrong type into an uncatchable abort
+        # (_exit -- a real "Halt" dialog, not an SEH-recoverable fault; it force-
+        # terminated the game process). No numeric clamp can fix this (the hazard is
+        # the object's TYPE, not a value); refuse until the capture mechanism supports
+        # pinning to a single known-safe object type.
+        try:
+            import abi_static
+            if abi_static.detect_handle_abort_hazard(decompiled):
+                update_function_state(key, {
+                    "port_status": "handle_abort_hazard_skip",
+                    "port_last_result": "type-gated fatal abort on the captured object's dwType -- "
+                                        "unsafe for round-robin handle-prove capture; see plate comment"})
+                _log("handle_abort_hazard_skip", classification=classification)
+                return "handle_abort_hazard_skip"
+        except Exception:
+            pass
+        # With the live oracle, PROVE it now via the handle path (a real captured
+        # live object passed to both original + reimpl -- the UNIT_GetMode
+        # mechanism). Without it, just leave it queued in the shadow backlog.
+        if os.environ.get("FUNDOC_LIVE_PROVE") == "1":
+            return process_handle_leaf_live(
+                program, address, func_name, decompiled,
+                provider=provider, model=model, worker_id=worker_id,
+                max_fix_attempts=max_fix_attempts,
+                static_abi=static_abi, abort_class=abort_class)
+        update_function_state(key, {
+            "port_status": "shadow_leaf_pending",
+            "port_last_result": "live-pointer getter: shadow-provable; recorded to shadow_leaf_backlog"})
+        _log("shadow_leaf_pending", classification=classification)
+        return "shadow_leaf_pending"
+
+    if not model:
+        try:
+            model = get_configured_model(provider, "FULL")
+        except Exception:
+            model = None
+
+    bus_emit("port_drafted", {
+        "key": key, "name": func_name, "address": address,
+        "program": prog_name, "program_path": program, "status": "drafting",
+    })
+
+    # Found by hand 2026-07-07: an unparseable initial draft was often FLAKY,
+    # not systemic -- re-running the identical prompt against the identical
+    # provider immediately produced a clean, well-formed response. The harness
+    # fix-loop below already retries on compile/vector failures; the initial
+    # draft had NO retry at all, so a single bad roll of the dice ended the
+    # candidate permanently. Bounded retry here for the same reason.
+    prompt = pp.build_port_prompt(func_name, address, program, decompiled)
+    header = dispatch = spec = None
+    draft_attempts = 0
+    max_draft_attempts = max(1, max_fix_attempts)
+    while draft_attempts < max_draft_attempts:
+        draft_attempts += 1
+        text, meta = invoke_claude(
+            prompt, model=model, max_turns=max_turns, provider=provider, complexity_tier=None
+        )
+        if (meta or {}).get("quota_paused"):
+            update_function_state(key, {"port_status": "blocked", "port_last_result": "quota_paused"})
+            _log("blocked", reason="quota_paused")
+            return "blocked"
+        header, dispatch, spec = pp.parse_port_response_full(text or "")
+        if header:
+            break
+        _log("malformed_response_retry", attempt=draft_attempts, output=(text or "")[-500:])
+
+    if not header:
+        update_function_state(key, {
+            "port_status": "malformed_response", "port_attempts": draft_attempts,
+            "port_last_result": f"no parseable code blocks after {draft_attempts} attempt(s)",
+        })
+        _log("malformed_response", attempts=draft_attempts)
+        return "malformed_response"
+
+    module = Path(program).stem
+    symbol = spec["fn"]
+    vectors, mint_errors = pp.mint_vectors(
+        program, address, spec["fn"], spec["param_layout"], spec["input_sets"]
+    )
+    if not vectors:
+        update_function_state(key, {
+            "port_status": "no_vectors",
+            "port_last_result": "; ".join(mint_errors[:3]) or "no vectors minted",
+        })
+        _log("no_vectors", errors=mint_errors[:10])
+        return "no_vectors"
+
+    bus_emit("port_vectors_minted", {
+        "key": key, "name": func_name, "count": len(vectors), "errors": len(mint_errors),
+    })
+
+    system_name = pp.pascal_to_snake_case(symbol)
+    pp.write_pending_vectors(system_name, vectors)
+
+    draft_paths = pp.write_draft(module, symbol, header, dispatch, vectors)
+    harness = pp.run_harness()
+    attempts = 1
+
+    while not harness["ok"] and attempts < max_fix_attempts:
+        fix_prompt = pp.build_port_fix_prompt(
+            func_name, address, program, decompiled, header, dispatch, harness["output"]
+        )
+        text, meta = invoke_claude(
+            fix_prompt, model=model, max_turns=max_turns, provider=provider, complexity_tier=None
+        )
+        if (meta or {}).get("quota_paused"):
+            update_function_state(key, {
+                "port_status": "blocked", "port_attempts": attempts,
+                "port_last_result": "quota_paused mid-retry",
+            })
+            _log("blocked", reason="quota_paused_retry", attempts=attempts)
+            return "blocked"
+
+        new_header, new_dispatch = pp.parse_port_response(text or "")
+        if not new_header:
+            break  # malformed fix response -- stop retrying, report the last real harness result
+        header, dispatch = new_header, new_dispatch
+        draft_paths = pp.write_draft(module, symbol, header, dispatch, vectors)
+        harness = pp.run_harness(configure=False)
+        attempts += 1
+
+    bus_emit("port_harness_result", {
+        "key": key, "name": func_name, "ok": harness["ok"],
+        "passed": harness["passed"], "total": harness["total"], "attempts": attempts,
+    })
+
+    # WS-6b: OPT-IN live proof against the running game (D2MOO's D2Debugger
+    # oracle on :8790, GRADUATED_CONFORMANCE_PIPELINE_PLAN.md). This is strictly
+    # STRONGER than the static /emulate_function harness (real function, real
+    # process) but ADDITIVE and NON-FATAL: it never downgrades a statically
+    # proven candidate -- it only stamps `port_live_status` (proven_live /
+    # live_prove_failed / unsupported_abi / error / skipped). Gated by
+    # FUNDOC_LIVE_PROVE=1 so existing OpenD2 static runs are unaffected.
+    live_status = "skipped"
+    oracle_spec = None
+    if harness["ok"] and os.environ.get("FUNDOC_LIVE_PROVE") == "1":
+        plp = None
+        try:
+            import port_live_prove as plp
+        except Exception as e:  # module/env not available -- never fail the candidate
+            _log("live_prove_skip", reason=f"import failed: {e}")
+        if plp is not None:
+            try:
+                live = plp.run_live_prove(
+                    header, symbol, address, spec["param_layout"], spec["input_sets"]
+                )
+                oracle_spec = live.get("spec")  # for shadow_promote.py below (WS-6c)
+                live_status = "proven_live" if live["ok"] else "live_prove_failed"
+                bus_emit("port_live_prove_result", {
+                    "key": key, "name": func_name, "ok": live["ok"],
+                    "passed": live.get("passed"), "total": live.get("total"),
+                })
+                _log("live_prove", ok=live["ok"], passed=live.get("passed"),
+                     total=live.get("total"), output=(live.get("output") or "")[-1000:])
+            except plp.UnsupportedLiveABI as e:
+                live_status = "unsupported_abi"
+                _log("live_prove_skip", reason=str(e))
+            except Exception as e:
+                live_status = "error"
+                _log("live_prove_error", error=str(e))
+
+    # WS-6c: OPT-IN shadow-dispatcher promotion (D2COMMON_FULL_SHADOW_PLAN.md).
+    # A function that just passed CONF_LIVE (the one-shot oracle proof above) can
+    # be staged as a live SHADOW DISPATCHER -- compared against EVERY real call
+    # the game makes, at volume, on the path to CONF_BATTLETESTED (closed out by
+    # battletest_promoter.py watching the shadow counters separately). Additive
+    # and non-fatal, same contract as the live-prove gate above: never downgrades
+    # or fails the candidate. Gated by FUNDOC_SHADOW_PROMOTE=1 so it never runs
+    # unless explicitly enabled. Only STAGES (manifest + regenerated header) --
+    # building D2Common.dll and restarting the game is a separate, explicit,
+    # batched step so this loop can never kill the user's running game.
+    shadow_status = "skipped"
+    if (live_status == "proven_live" and oracle_spec is not None
+            and os.environ.get("FUNDOC_SHADOW_PROMOTE") == "1"):
+        try:
+            import shadow_promote as sp
+            promo = sp.maybe_promote(func_name, address, oracle_spec, decompiled)
+            shadow_status = "staged" if promo.get("promoted") else f"deferred: {promo.get('reason')}"
+            bus_emit("shadow_promote_result", {
+                "key": key, "name": func_name, "promoted": promo.get("promoted"),
+                "reason": promo.get("reason"),
+            })
+            _log("shadow_promote", **promo)
+        except Exception as e:  # never fail the candidate over a promotion bug
+            shadow_status = f"error: {e}"
+            _log("shadow_promote_error", error=str(e))
+
+    if harness["ok"]:
+        update_function_state(key, {
+            "port_status": "proven_pending_review", "port_attempts": attempts,
+            "port_draft_path": draft_paths["header_path"],
+            "port_last_result": f"{harness['passed']}/{harness['total']} passed",
+            "port_live_status": live_status,
+            "port_shadow_status": shadow_status,
+        })
+        bus_emit("port_proven_pending_review", {
+            "key": key, "name": func_name, "header_path": draft_paths["header_path"],
+        })
+        _log("proven_pending_review", attempts=attempts,
+             passed=harness["passed"], total=harness["total"])
+        return "proven_pending_review"
+
+    update_function_state(key, {
+        "port_status": "harness_failed", "port_attempts": attempts,
+        "port_draft_path": draft_paths["header_path"],
+        "port_last_result": (harness["output"] or "")[-500:],
+    })
+    _log("harness_failed", attempts=attempts, output=(harness["output"] or "")[-2000:])
+    return "harness_failed"
+
+
+def run_port_worker_pass(*, worker_id, active_binary, provider, model, count,
+                          stop_flag, conformance_protected=None,
+                          on_progress=None, on_started=None,
+                          continuous=False, poll_interval=30, battletest_poll=None):
+    """Orchestrate a PORT worker run: processes Stage-2/3 candidates on
+    `active_binary`. Unlike the globals worker, PORT does NOT rotate across
+    binaries -- EMULATION_CONFORMANCE_PLAN.md Sec 15 is explicit that porting
+    proceeds one binary at a time (D2Common first), so a drained/empty binary
+    just ends the run rather than picking a new target (unless `continuous`).
+    Returns a summary dict for the caller to log/emit.
+
+    `stop_flag` is a threading.Event the WorkerManager sets to interrupt.
+    `on_progress` is invoked after each candidate with
+        (program, address, result, processed, count).
+    `on_started` is invoked before each candidate with (program, address, name).
+
+    `continuous` (default False, matching the existing one-shot behavior
+    exactly): when True, mirrors the functions-mode worker's continuous loop
+    (`while not stop_flag.is_set() and (continuous or processed < count)`) --
+    `count` is ignored as a stop condition and the pass keeps re-selecting
+    candidates (freshly, via `load_state()`, so newly-available/newly-promoted
+    functions are picked up) until `stop_flag` is set. When the candidate pool
+    is momentarily empty, it sleeps in 1s increments (stop_flag-responsive) up
+    to `poll_interval` seconds before re-checking, rather than busy-looping.
+    This is "the workers pick up a function... shadow the original... move to
+    the next" loop -- see D2COMMON_FULL_SHADOW_PLAN.md and shadow_promote.py.
+
+    `battletest_poll` (default: mirrors `continuous`): best-effort, non-fatal
+    call to battletest_promoter.poll_and_promote() once per outer iteration --
+    the "shadow the original function to verify it" half of the loop that
+    watches ALREADY-STAGED shadow dispatchers for real-gameplay zero-divergence
+    evidence and promotes CONF_LIVE -> CONF_BATTLETESTED. Independent of
+    FUNDOC_SHADOW_PROMOTE (which only STAGES new dispatchers); this just polls
+    counters on ones already deployed, so it's safe to enable even before a
+    human has built+deployed a shadow-dispatcher batch (it simply finds
+    nothing to promote yet).
+    """
+    import port_pipeline as pp
+
+    if battletest_poll is None:
+        battletest_poll = continuous
+
+    summary = {"processed": 0, "totals": {}, "stopped_reason": None}
+    if conformance_protected is None:
+        conformance_protected = load_conformance_protected()
+
+    def _poll_battletest():
+        if not battletest_poll:
+            return
+        try:
+            import battletest_promoter as btp
+            result = btp.poll_and_promote()
+            if result.get("promoted"):
+                bus_emit("battletest_promoted", {"promoted": result["promoted"]})
+                _log("battletest_promoted", **result)
+        except Exception as e:  # never fail the worker pass over this
+            _log("battletest_promote_error", error=str(e))
+
+    def _process_one(cand, processed):
+        func = cand["func"]
+        program = cand["program"]
+        address = func.get("address")
+        func_name = func.get("name") or f"FUN_{address}"
+
+        if on_started:
+            try:
+                on_started(program, address, func_name)
+            except Exception:
+                pass
+
+        # Found by hand 2026-07-07: an unexpected exception deep in one
+        # candidate's pipeline (e.g. a malformed model response tripping a
+        # type-coercion bug) propagated all the way out of run_port_worker_pass
+        # and killed the ENTIRE batch/continuous loop, not just that candidate.
+        # A worker that's meant to process many functions unattended must not
+        # let one bad function take the rest down with it.
+        try:
+            result = process_port_candidate(
+                program, address, func_name, provider=provider, model=model, worker_id=worker_id
+            )
+        except Exception as e:
+            key = f"{program}::{address}"
+            update_function_state(key, {
+                "port_status": "error", "port_last_result": f"{type(e).__name__}: {e}",
+            })
+            _append_run_log({
+                "timestamp": datetime.now().isoformat(), "mode": "port",
+                "program": program, "address": address, "name": func_name,
+                "worker_id": worker_id, "result": "error", "error": f"{type(e).__name__}: {e}",
+            })
+            result = "error"
+        summary["totals"][result] = summary["totals"].get(result, 0) + 1
+        if result != "stateful_skip":
+            processed += 1
+        if on_progress:
+            try:
+                on_progress(program, address, result, processed, count)
+            except Exception:
+                pass
+        return result, processed
+
+    processed = 0
+
+    if not continuous:
+        # Existing bounded behavior, UNCHANGED (zero risk to current callers).
+        state = load_state()
+        # Over-fetch: some candidates skip as "stateful" without counting
+        # toward `count`, so a tight limit could starve the loop before it
+        # finds enough real (leaf) work.
+        candidates = pp.select_port_candidates(
+            state["functions"], conformance_protected, active_binary=active_binary,
+            limit=max(count, 1) * 5,
+        )
+        if not candidates:
+            summary["stopped_reason"] = "no_eligible_candidates"
+            return summary
+
+        for cand in candidates:
+            if stop_flag.is_set():
+                summary["stopped_reason"] = "user_stop"
+                break
+            if processed >= count:
+                summary["stopped_reason"] = "count_reached"
+                break
+            result, processed = _process_one(cand, processed)
+            if result == "blocked":
+                summary["stopped_reason"] = "blocked"
+                break
+
+        summary["processed"] = processed
+        if summary["stopped_reason"] is None:
+            summary["stopped_reason"] = "count_reached" if processed >= count else "exhausted"
+        return summary
+
+    # Continuous mode: re-select candidates each time the pool is drained;
+    # sleep (stop_flag-responsive) rather than exit when nothing is eligible
+    # right now (e.g. everything already staged, waiting on a shadow batch).
+    while not stop_flag.is_set():
+        state = load_state()
+        candidates = pp.select_port_candidates(
+            state["functions"], conformance_protected, active_binary=active_binary,
+            limit=50,
+        )
+        if not candidates:
+            _poll_battletest()
+            for _ in range(poll_interval):
+                if stop_flag.is_set():
+                    break
+                time.sleep(1)
+            continue
+
+        drained_this_round = True
+        for cand in candidates:
+            if stop_flag.is_set():
+                summary["stopped_reason"] = "user_stop"
+                break
+            result, processed = _process_one(cand, processed)
+            if result == "blocked":
+                summary["stopped_reason"] = "blocked"
+                drained_this_round = False
+                break
+        _poll_battletest()
+        if summary["stopped_reason"] in ("user_stop", "blocked"):
+            break
+        if not drained_this_round:
+            break
+
+    summary["processed"] = processed
+    if summary["stopped_reason"] is None:
+        summary["stopped_reason"] = "stop_flag"
     return summary
 
 

--- a/fun-doc/golden_bench.py
+++ b/fun-doc/golden_bench.py
@@ -1,0 +1,237 @@
+"""golden_bench.py -- the GOLDEN-SET documentation benchmark.
+
+User's insight (2026-07-08): to evaluate the prove-to-document pipeline, CLEAR all
+documentation off a function and regenerate it from the ground up. Repeat on a fixed
+golden set after every pipeline change -> a measurable quality benchmark instead of
+anecdotes.
+
+Per function:
+  1. SNAPSHOT  -- name, prototype, plate, DOC_/CONF_ tags -> golden_snapshots/<name>.json
+                  (the safety net AND the reference to compare against)
+  2. STRIP     -- plate -> stub, DOC_*/CONF_* tags removed, prototype -> generic
+                  (name is KEPT: renaming would break resolve-table/ordinal tooling;
+                  the pipeline's name-audit still judges the name against behavior)
+  3. REGENERATE -- prove_doc.prove_doc(): classify -> draft equivalent -> prove
+                  discriminating -> consistency gate -> ledger -> DOC rung
+  4. REPORT    -- what came back vs the snapshot: doc rung earned, prototype match,
+                  plate regenerated?, proof kind. The diff is the SCORE.
+
+Usage:
+    python golden_bench.py --run --address 0x6fd84ab0 --name DATATBLS_GetMissileParamShort0x10
+    python golden_bench.py --restore --name X          # put the snapshot back
+    python golden_bench.py --selftest
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+PROGRAM_PATH = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+SNAP_DIR = D2MOO_REPO / "conformance" / "golden_snapshots"
+STRIP_STUB = "[GOLDEN-BENCH] documentation intentionally cleared for a ground-up regeneration run."
+_ALL_TAGS = ["DOC_DRAFT", "DOC_REVIEWED", "DOC_VERIFIED",
+             "CONF_DRAFT", "CONF_VECTORS", "CONF_LIVE", "CONF_BATTLETESTED", "CONF_REGRESSION"]
+
+
+def _prog_name(program: str) -> str:
+    return Path(program).name
+
+
+def snapshot(address: str, name: str, *, program: str = PROGRAM_PATH) -> dict:
+    """Capture everything we are about to destroy. Written BEFORE any strip."""
+    import fun_doc
+    addr = address if str(address).startswith("0x") else f"0x{address}"
+    plate = fun_doc.ghidra_get("/get_plate_comment",
+                               params={"address": addr, "program": program})
+    dec = str(fun_doc.ghidra_get("/decompile_function",
+                                 params={"address": addr, "program": program}))
+    m = re.search(r"^\s*([\w\s\*]+?\s\*?\s*" + re.escape(name) + r"\s*\([^)]*\))",
+                  dec.replace("\r", ""), re.MULTILINE)
+    tags = fun_doc.ghidra_get("/get_function_tags",
+                              params={"function": addr, "program": program})
+    snap = {"name": name, "address": addr, "program": program,
+            "date": datetime.datetime.now().isoformat(timespec="seconds"),
+            "plate": plate, "prototype": (m.group(1).strip() if m else None),
+            "tags": tags}
+    SNAP_DIR.mkdir(parents=True, exist_ok=True)
+    p = SNAP_DIR / f"{name}.json"
+    p.write_text(json.dumps(snap, indent=2, default=str), encoding="utf-8")
+    return {"path": str(p), **snap}
+
+
+def strip(address: str, name: str, *, program: str = PROGRAM_PATH) -> dict:
+    """Ground-zero the documentation. REFUSES to run without a snapshot on disk."""
+    import fun_doc
+    if not (SNAP_DIR / f"{name}.json").exists():
+        raise RuntimeError(f"no snapshot for {name} -- snapshot() first (safety net)")
+    addr = address if str(address).startswith("0x") else f"0x{address}"
+    prog = _prog_name(program)
+    out = {}
+    out["plate"] = fun_doc.ghidra_post("/set_plate_comment",
+                                       data={"address": addr, "comment": STRIP_STUB},
+                                       params={"program": program})
+    out["tags"] = fun_doc.ghidra_post("/remove_function_tag",
+                                      data={"function": addr, "tags": ",".join(_ALL_TAGS),
+                                            "program": prog})
+    # generic prototype: the pipeline must re-derive width/params from the proof
+    out["prototype"] = fun_doc.ghidra_post("/set_function_prototype",
+                                           data={"function_address": addr,
+                                                 "prototype": f"int {name}(int param_1)"},
+                                           params={"program": prog})
+    fun_doc.ghidra_post("/save_program", data={"program": prog})
+    return out
+
+
+def restore(name: str, *, program: str = PROGRAM_PATH) -> dict:
+    """Put the snapshot back (plate + prototype; tags restored as-were)."""
+    import fun_doc
+    snap = json.loads((SNAP_DIR / f"{name}.json").read_text(encoding="utf-8"))
+    addr = snap["address"]
+    prog = _prog_name(program)
+    out = {}
+    plate = snap.get("plate")
+    plate_text = ""
+    if isinstance(plate, dict):
+        plate_text = plate.get("comment") or ""
+    elif isinstance(plate, str):
+        try:
+            plate_text = json.loads(plate).get("comment", "")
+        except Exception:
+            plate_text = plate
+    if plate_text:
+        out["plate"] = fun_doc.ghidra_post("/set_plate_comment",
+                                           data={"address": addr, "comment": plate_text},
+                                           params={"program": program})
+    if snap.get("prototype"):
+        out["prototype"] = fun_doc.ghidra_post("/set_function_prototype",
+                                               data={"function_address": addr,
+                                                     "prototype": snap["prototype"]},
+                                               params={"program": prog})
+    fun_doc.ghidra_post("/save_program", data={"program": prog})
+    return out
+
+
+def report(address: str, name: str, snap: dict, run_summary: dict, *,
+           program: str = PROGRAM_PATH) -> dict:
+    """The benchmark score: what the pipeline regenerated vs what was there."""
+    import fun_doc
+    addr = address if str(address).startswith("0x") else f"0x{address}"
+    plate_after = str(fun_doc.ghidra_get("/get_plate_comment",
+                                         params={"address": addr, "program": program}))
+    dec = str(fun_doc.ghidra_get("/decompile_function",
+                                 params={"address": addr, "program": program}))
+    m = re.search(r"^\s*([\w\s\*]+?\s\*?\s*" + re.escape(name) + r"\s*\([^)]*\))",
+                  dec.replace("\r", ""), re.MULTILINE)
+    proto_after = m.group(1).strip() if m else None
+    regenerated = STRIP_STUB not in plate_after and len(plate_after) > 120
+    return {
+        "function": name,
+        "doc_rung_earned": run_summary.get("result"),
+        "proof": run_summary.get("stages", {}).get("prove"),
+        "discriminating": run_summary.get("stages", {}).get("discriminating"),
+        "gate": {k: run_summary.get("stages", {}).get("gate", {}).get(k)
+                 for k in ("mechanical_applied", "semantic_flags")},
+        "plate_regenerated": regenerated,
+        "prototype_before_strip": snap.get("prototype"),
+        "prototype_after": proto_after,
+        "prototype_recovered_semantics": bool(
+            proto_after and snap.get("prototype")
+            and _norm_ret(proto_after.split(name)[0]) == _norm_ret(snap["prototype"].split(name)[0])),
+    }
+
+
+_TYPE_SYNONYMS = {"uchar": "byte", "unsigned char": "byte", "u8": "byte",
+                  "ushort": "word", "unsigned short": "word", "u16": "word",
+                  "uint": "dword", "unsigned int": "dword", "u32": "dword",
+                  "undefined1": "byte", "undefined2": "word", "undefined4": "dword"}
+
+
+def _norm_ret(ret_text: str) -> str:
+    """Normalize a return-type spelling for SEMANTIC comparison -- byte==uchar==
+    unsigned char etc. (the naive textual compare scored a correct regeneration
+    as a miss: snapshot `byte f(...)` vs regenerated `uchar f(...)`)."""
+    t = " ".join(ret_text.strip().split()).lower()
+    return _TYPE_SYNONYMS.get(t, t)
+
+
+def run(address: str, name: str, *, program: str = PROGRAM_PATH,
+        provider=None, model=None, struct_hint=None) -> dict:
+    """snapshot -> strip -> prove_doc -> report. The full benchmark cycle."""
+    import prove_doc as pd
+    snap = snapshot(address, name, program=program)
+    print(f"[bench] snapshot -> {snap['path']}")
+    strip(address, name, program=program)
+    print(f"[bench] stripped: plate/tags/prototype cleared")
+    summary = pd.prove_doc(address, name, program=program, provider=provider,
+                           model=model, struct_hint=struct_hint)
+    # UNPROVEN -> the pipeline cannot regenerate docs for this one (abort-class /
+    # stateful / prove failure). RESTORE the snapshot rather than leaving the
+    # function stripped -- the bench must never destroy docs it can't rebuild.
+    if str(summary.get("result", "")).startswith("not proven"):
+        restore(name, program=program)
+        summary["stages"]["bench_restore"] = "snapshot restored (unproven -- docs kept)"
+        print(f"[bench] UNPROVEN -> snapshot restored")
+    rep = report(address, name, snap, summary, program=program)
+    out = SNAP_DIR / f"{name}.report.json"
+    out.write_text(json.dumps({"summary": summary, "report": rep},
+                              indent=2, default=str), encoding="utf-8")
+    print(f"[bench] report -> {out}")
+    return rep
+
+
+def _selftest() -> int:
+    # report scoring logic on canned data (no Ghidra)
+    fake_snap = {"prototype": "ushort DATATBLS_GetMissileParamShort0x10(void *p)"}
+    fake_run = {"result": "DOC_VERIFIED",
+                "stages": {"prove": "proven_live_pending_review",
+                           "discriminating": "True (synth)",
+                           "gate": {"mechanical_applied": [], "semantic_flags": []}}}
+    # (report() needs Ghidra; here we only sanity-check the pure comparisons)
+    a = "ushort F(void *p)".split("F")[0].strip()
+    b = "ushort  F(void *pOther)".split("F")[0].strip()
+    assert a == b == "ushort"
+    assert fake_run["stages"]["gate"]["semantic_flags"] == []
+    assert fake_snap["prototype"].startswith("ushort")
+    print("[ok] golden_bench self-test: comparison logic pass")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--run", action="store_true", help="full cycle: snapshot/strip/regen/report")
+    ap.add_argument("--restore", action="store_true", help="restore a snapshot")
+    ap.add_argument("--address")
+    ap.add_argument("--name")
+    ap.add_argument("--program", default=PROGRAM_PATH)
+    ap.add_argument("--provider", default=os.environ.get("AI_PROVIDER"))
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--struct-hint", default=None)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    if args.restore:
+        if not args.name:
+            ap.error("--restore needs --name")
+        print(json.dumps(restore(args.name, program=args.program), indent=2, default=str))
+        return 0
+    if args.run:
+        if not (args.address and args.name):
+            ap.error("--run needs --address and --name")
+        os.environ.setdefault("FUNDOC_LIVE_PROVE", "1")
+        rep = run(args.address, args.name, program=args.program,
+                  provider=args.provider, model=args.model, struct_hint=args.struct_hint)
+        print(json.dumps(rep, indent=2, default=str))
+        return 0
+    ap.error("pick --run / --restore / --selftest")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/ledger_apply.py
+++ b/fun-doc/ledger_apply.py
@@ -1,0 +1,236 @@
+"""ledger_apply.py -- apply the shared struct-field ledger to Ghidra structs.
+
+Each prove_doc run appends PROVEN (struct, offset, width, signed) field facts to
+conformance/doc_ledger/<struct>.jsonl. This pass rolls a struct's ledger up and
+reconciles it against the CURRENT Ghidra struct layout, so one proof improves the
+doc for EVERY function that uses the struct (the compounding lever).
+
+Reconciliation policy (mirrors the consistency gate -- proof-backed mechanical vs
+semantic):
+  * TYPE/WIDTH is proof-backed -> AUTO-APPLY. A byte read proven at +0x32 means the
+    field there is 1 byte; if Ghidra has it wider/mistyped, correct it (only when
+    the proof is CONSISTENT -- all reads at that offset agree on width/sign; a
+    CONFLICT between proofs is flagged, never guessed).
+  * NAME is semantic -> NEVER auto-named from an offset alone (field_0x32 stays until
+    a human/xref confirms meaning). We only ensure a proof-backed TYPE and leave a
+    review note where a good name is derivable. This is deliberately conservative:
+    a wrong struct-field name propagates to every user of the struct.
+
+Idempotent: re-running only changes fields whose Ghidra type still disagrees with
+the (consistent) proven width. Dry-run by default in --plan.
+
+Usage:
+    python ledger_apply.py --plan                     # show what WOULD change, all structs
+    python ledger_apply.py --struct ItemData          # apply one struct's ledger
+    python ledger_apply.py --struct ItemData --map UnitAny  # ledger key -> real Ghidra struct
+    python ledger_apply.py --selftest
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+PROGRAM_PATH = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+LEDGER_DIR = D2MOO_REPO / "conformance" / "doc_ledger"
+
+_WIDTH_TYPE = {(1, False): "byte", (1, True): "char",
+               (2, False): "ushort", (2, True): "short",
+               (4, False): "uint", (4, True): "int"}
+_GHIDRA_WIDTH = {"byte": 1, "uchar": 1, "undefined1": 1, "bool": 1, "char": 1,
+                 "sbyte": 1, "ushort": 2, "short": 2, "word": 2, "undefined2": 2,
+                 "wchar_t": 2, "uint": 4, "int": 4, "dword": 4, "undefined4": 4,
+                 "long": 4, "ulong": 4, "float": 4, "LPVOID": 4, "void *": 4}
+
+
+# ---------------------------------------------------------------------------
+# pure logic (offline-testable)
+# ---------------------------------------------------------------------------
+
+def consolidate(rows: list) -> dict:
+    """Ledger rows for ONE struct -> {offset: decision}. A decision is either a
+    CONSISTENT proven field (all reads agree on width+sign) or a CONFLICT (proofs
+    disagree -> flag, never apply). Only FINAL-depth reads (final=True) are trusted
+    for the named struct; side-bucket files are consumed separately by their key."""
+    by_off = defaultdict(list)
+    for r in rows:
+        by_off[r["off"]].append(r)
+    out = {}
+    for off, rs in sorted(by_off.items()):
+        widths = {(r["width"], bool(r.get("signed", False))) for r in rs}
+        fns = sorted({r.get("from_fn", "?") for r in rs})
+        if len(widths) == 1:
+            w, s = next(iter(widths))
+            out[off] = {"status": "consistent", "width": w, "signed": s,
+                        "type": _WIDTH_TYPE[(w, s)], "proofs": len(rs), "fns": fns}
+        else:
+            out[off] = {"status": "conflict", "widths": sorted(widths),
+                        "proofs": len(rs), "fns": fns}
+    return out
+
+
+def _parse_layout(text: str) -> dict:
+    """/get_struct_layout text -> {offset: {'type':.., 'name':.., 'size':..}}."""
+    out = {}
+    for m in re.finditer(r"^\s*(\d+)\s*\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|\s*(\S.*?)\s*$",
+                         text, re.MULTILINE):
+        out[int(m.group(1))] = {"size": int(m.group(2)),
+                                "type": m.group(3).strip(), "name": m.group(4).strip()}
+    return out
+
+
+def reconcile(proven: dict, layout: dict) -> list:
+    """Per offset, decide the action vs the current Ghidra struct layout.
+    Actions: retype (proof width != ghidra width, proof consistent), ok (match),
+    conflict (proofs disagree -> skip), absent (offset not a struct field ->
+    likely nested/union; flag, don't force)."""
+    actions = []
+    for off, dec in sorted(proven.items()):
+        if dec["status"] == "conflict":
+            actions.append({"off": off, "action": "conflict", **dec})
+            continue
+        cur = layout.get(off)
+        if not cur:
+            actions.append({"off": off, "action": "absent", "want_type": dec["type"],
+                            "width": dec["width"], "fns": dec["fns"]})
+            continue
+        cur_w = _GHIDRA_WIDTH.get(cur["type"].replace(" *", " *").strip(),
+                                  cur.get("size"))
+        if cur_w == dec["width"]:
+            actions.append({"off": off, "action": "ok", "type": cur["type"],
+                            "name": cur["name"]})
+        else:
+            actions.append({"off": off, "action": "retype", "from": cur["type"],
+                            "from_width": cur_w, "want_type": dec["type"],
+                            "width": dec["width"], "name": cur["name"], "fns": dec["fns"]})
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# apply (needs Ghidra)
+# ---------------------------------------------------------------------------
+
+def _ledger_rows(struct_key: str) -> list:
+    p = LEDGER_DIR / f"{struct_key}.jsonl"
+    if not p.exists():
+        return []
+    return [json.loads(l) for l in p.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def apply_struct(struct_key: str, ghidra_struct: str = None, *, program: str = PROGRAM_PATH,
+                 dry_run: bool = True, log=print) -> dict:
+    """Reconcile one ledger struct against Ghidra; apply proof-backed retypes."""
+    import fun_doc
+    gstruct = ghidra_struct or struct_key
+    rows = _ledger_rows(struct_key)
+    if not rows:
+        return {"struct": struct_key, "error": "no ledger rows"}
+    proven = consolidate(rows)
+    layout_raw = str(fun_doc.ghidra_get("/get_struct_layout",
+                                        params={"struct_name": gstruct, "program": program}))
+    if "error" in layout_raw[:60].lower() or "not found" in layout_raw.lower():
+        return {"struct": struct_key, "ghidra_struct": gstruct,
+                "error": f"struct not found in Ghidra: {layout_raw[:80]}",
+                "reconcile": reconcile(proven, {})}
+    layout = _parse_layout(layout_raw)
+    actions = reconcile(proven, layout)
+    applied = []
+    if not dry_run:
+        prog = Path(program).name
+        for a in actions:
+            if a["action"] != "retype":
+                continue
+            r = fun_doc.ghidra_post("/modify_struct_field",
+                                    data={"struct_name": gstruct,
+                                          "field_name": a.get("name") or "",
+                                          "new_type": a["want_type"]},
+                                    params={"program": prog})
+            ok = not (isinstance(r, dict) and r.get("error"))
+            applied.append({"off": a["off"], "to": a["want_type"], "ok": ok})
+        if applied:
+            fun_doc.ghidra_post("/save_program", data={"program": prog})
+    return {"struct": struct_key, "ghidra_struct": gstruct,
+            "actions": actions, "applied": applied, "dry_run": dry_run}
+
+
+def all_struct_keys() -> list:
+    if not LEDGER_DIR.exists():
+        return []
+    # skip the __lvlN side-buckets for the top-level view (they're shallower structs)
+    return sorted(p.stem for p in LEDGER_DIR.glob("*.jsonl") if "__lvl" not in p.stem)
+
+
+# ---------------------------------------------------------------------------
+# self-test (offline)
+# ---------------------------------------------------------------------------
+
+def _selftest() -> int:
+    rows = [
+        {"off": 0x32, "width": 2, "signed": False, "from_fn": "GetField32"},
+        {"off": 0x32, "width": 2, "signed": False, "from_fn": "GetField32b"},
+        {"off": 0x44, "width": 1, "signed": False, "from_fn": "GetByte44"},
+        {"off": 0x50, "width": 2, "signed": False, "from_fn": "A"},
+        {"off": 0x50, "width": 4, "signed": False, "from_fn": "B"},   # CONFLICT
+    ]
+    c = consolidate(rows)
+    assert c[0x32]["status"] == "consistent" and c[0x32]["type"] == "ushort" and c[0x32]["proofs"] == 2
+    assert c[0x44]["type"] == "byte"
+    assert c[0x50]["status"] == "conflict", c[0x50]
+
+    layout = _parse_layout(
+        "Offset | Size | Type | Name\n"
+        "-------|------|------|-----\n"
+        "    50 |    2 | ushort | wField32\n"
+        "    68 |    4 | uint   | dwField44\n")   # 0x44=68: ghidra has uint, proof says byte
+    assert layout[50]["name"] == "wField32" and layout[68]["type"] == "uint"
+
+    acts = {a["off"]: a for a in reconcile(c, layout)}
+    assert acts[0x32]["action"] == "ok"                 # matches (2==2)
+    assert acts[0x44]["action"] == "retype" and acts[0x44]["want_type"] == "byte"  # 4->1
+    assert acts[0x50]["action"] == "conflict"           # never auto-applied
+    # an offset Ghidra doesn't have as a field:
+    assert reconcile({0x99: c[0x44] if False else
+                      {"status": "consistent", "width": 1, "signed": False,
+                       "type": "byte", "proofs": 1, "fns": ["X"]}}, layout)[0][
+        "action"] == "absent"
+    print("[ok] ledger_apply self-test: consolidate + layout-parse + reconcile pass")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--plan", action="store_true", help="dry-run reconcile, all structs")
+    ap.add_argument("--struct", help="ledger struct key to apply")
+    ap.add_argument("--map", dest="ghidra_struct", help="real Ghidra struct name if != key")
+    ap.add_argument("--program", default=PROGRAM_PATH)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    if args.plan:
+        for key in all_struct_keys():
+            res = apply_struct(key, program=args.program, dry_run=True)
+            acts = res.get("actions", [])
+            n = {k: sum(1 for a in acts if a["action"] == k)
+                 for k in ("retype", "ok", "conflict", "absent")}
+            print(f"[{key}] {res.get('error', '')} retype={n['retype']} ok={n['ok']} "
+                  f"conflict={n['conflict']} absent={n['absent']}")
+            for a in acts:
+                if a["action"] in ("retype", "conflict"):
+                    print(f"    +0x{a['off']:x} {a['action']}: {json.dumps({k:v for k,v in a.items() if k not in ('off','action','fns')})}")
+        return 0
+    if args.struct:
+        res = apply_struct(args.struct, ghidra_struct=args.ghidra_struct,
+                           program=args.program, dry_run=False)
+        print(json.dumps(res, indent=2, default=str))
+        return 0
+    ap.error("pick --plan / --struct / --selftest")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/port_live_prove.py
+++ b/fun-doc/port_live_prove.py
@@ -1,0 +1,1224 @@
+"""port_live_prove.py -- WS-6b of D2MOO's GRADUATED_CONFORMANCE_PIPELINE_PLAN.md.
+
+The LIVE proving gate for the port pipeline, a sibling to port_pipeline.py's
+static `run_harness` (which proves an OpenD2 draft against Ghidra-emulated
+vectors, no game process). This module instead proves a **D2MOO** reimpl against
+the **live running Project Diablo 2** via D2Debugger's direct-call oracle
+(the D2Debugger MCP HTTP surface on 127.0.0.1:8790, GRADUATED plan WS-5).
+
+Why live matters: `/emulate_function` is static (pure/leaf only). The live
+oracle calls the REAL function in the REAL process, so it also covers functions
+whose behavior depends on real globals/state -- strictly stronger.
+
+Contract: run_live_prove(...) returns the SAME shape as port_pipeline.run_harness
+-- {ok, passed, total, output, stage, error} -- so fun_doc.process_port_candidate
+can gate on it and feed failures back through the existing bounded-retry loop
+with no change to that machinery.
+
+Design note (register-layout -> convention-ABI): fun-doc models a function's ABI
+by REGISTER (param_layout inputs/outputs on ECX/EDX/EAX...), because that is what
+Ghidra's /emulate_function speaks. The D2MOO oracle models it by CALLING
+CONVENTION + positional 32-bit slots. translate_layout_to_spec() bridges the two
+for the standard patterns (stack=stdcall, ECX=thiscall/fastcall-1, ECX+EDX=
+fastcall); non-standard register ABIs (seed in ESI, etc.) are reported as
+unsupported-for-live so the caller falls back to the static harness.
+
+Standalone (imports nothing from fun_doc), like port_pipeline.py.
+"""
+from __future__ import annotations
+
+import datetime
+import http.client
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+
+# --- D2MOO side (the reimpl provider + prover live in the D2MOO repo) ---
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+CANDIDATES_DIR = D2MOO_REPO / "conformance" / "reimpl_provider" / "candidates"
+VECTORS_DIR = D2MOO_REPO / "conformance" / "vectors"
+PROVE_SCRIPT = D2MOO_REPO / "conformance" / "tools" / "prove_candidate.py"
+PROVEN_REGISTRY = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+RESOLVE_TABLE = D2MOO_REPO / "D2.Detours.patches" / "1.13c" / "D2Common_ResolveTable.gen.h"
+LIVE_EXAMPLE = CANDIDATES_DIR / "datatable_rowcount.cpp"  # proven resolver-based reimpl
+ORACLE_URL = os.environ.get("D2DBG_MCP_URL", "http://127.0.0.1:8790")
+# Ghidra plugin REST server (same one port_pipeline.py uses) -- source of truth
+# for the RE. Every proof writes back here (writeback-source-of-truth principle).
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+
+_D2COMMON_BASE = 0x6FD50000
+
+
+class UnsupportedLiveABI(Exception):
+    """The function's register layout is outside the oracle's v1 (32-bit-slot,
+    standard-convention) marshaller -- the caller should fall back to the static
+    harness rather than treat this as a proof failure."""
+
+
+def _int(v) -> int:
+    if not isinstance(v, str):
+        return int(v)
+    try:
+        return int(v, 0)          # "0x1a4" / "123"
+    except ValueError:
+        return int(v, 16)         # bare hex "6fd51250" (fun_doc's address convention)
+
+
+def translate_layout_to_spec(name: str, address, param_layout: dict) -> dict:
+    """fun-doc register `param_layout` -> D2MOO oracle spec (callconv/args/
+    ret/compare + the original's absolute `addr`). Raises UnsupportedLiveABI for
+    register ABIs the v1 marshaller can't express."""
+    inputs = param_layout.get("inputs", [])
+    outputs = param_layout.get("outputs", [])
+    regs = [str(i.get("register", "")).upper() for i in inputs]
+
+    # Classify the calling convention from the input register pattern.
+    STACK = {"", "STACK", "STK"}
+    GP = {"EAX", "EBX", "ECX", "EDX", "ESI", "EDI"}
+    unknown = [r for r in regs if r not in STACK and r not in GP]
+    if unknown:
+        raise UnsupportedLiveABI(f"{name}: unknown register(s) {unknown}")
+    has_stack = any(r in STACK for r in regs)
+    has_reg = any(r in GP for r in regs)
+
+    orig_regs = None
+    if not has_reg:
+        callconv = "stdcall"                       # D2 default for stack args
+    elif regs[:2] == ["ECX", "EDX"] and all(r in STACK for r in regs[2:]):
+        callconv = "fastcall"
+    elif regs[:1] == ["ECX"] and all(r in STACK for r in regs[1:]):
+        callconv = "fastcall"                      # ecx-only == thiscall shape; marshals the same
+    elif not has_stack:
+        # Register-only but NON-standard placement (e.g. arg in EAX/ESI). The
+        # oracle calls the ORIGINAL register-explicit via orig_regs; the reimpl
+        # is a normal __fastcall we write, so `callconv` is the reimpl's.
+        callconv = "fastcall"
+        orig_regs = {str(i["register"]).upper(): i["name"] for i in inputs}
+    else:
+        raise UnsupportedLiveABI(
+            f"{name}: non-standard registers {regs} mixed with stack args -- "
+            f"register-explicit path is register-only (no stack args) in v1")
+
+    # Outputs: the oracle captures the EAX return only (v1). EDX (int64 hi) or
+    # memory write-sets are not yet compared live.
+    out_regs = [str(o.get("register", "")).upper() for o in outputs]
+    if any(r not in {"EAX", ""} for r in out_regs):
+        raise UnsupportedLiveABI(
+            f"{name}: output registers {out_regs} beyond EAX not comparable live yet")
+    signed = any(o.get("signed") for o in outputs if str(o.get("register", "")).upper() == "EAX")
+
+    args = [{"id": i["name"], "kind": "i32"} for i in inputs]
+    spec = {
+        "name": name,
+        "addr": _int(address),
+        "callconv": callconv,
+        "ret": ("i32" if signed else "u32") if outputs else "void",
+        "args": args,
+        "compare": ["ret"] if outputs else [],
+    }
+    if orig_regs:
+        spec["orig_regs"] = orig_regs
+    return spec
+
+
+def _fail(stage: str, msg: str, output: str = "") -> dict:
+    return {"ok": False, "passed": 0, "total": 0, "stage": stage, "error": msg, "output": output,
+            "failure_stage": stage, "failure_detail": msg}
+
+
+# ---------------------------------------------------------------------------
+# FAILURE TAXONOMY (2026-07-08). A bare "live_prove_failed" used to conflate five
+# unrelated causes -- candidate compile error, compile-cascade from a SIBLING
+# candidate, wrong-callconv marshal fault, oracle/bridge death, and a genuine
+# mismatch -- and each cost a manual reconstruction to tell apart. Every prove
+# result now carries failure_stage + failure_detail:
+#   build_candidate        -- THIS candidate does not compile (detail = its errors)
+#   build_provider_cascade -- a SIBLING candidate broke the shared provider build
+#                             (self-healed when possible; see build_provider_attributed)
+#   oracle_unreachable     -- :8790 was down before we started
+#   oracle_died_during     -- :8790 was alive, this function's vectors killed it
+#   marshal_fault          -- SEH-caught fault inside the oracle (bad ABI/pointer)
+#   mismatch               -- real divergence: orig != reimpl on >=1 vector
+#   prove_timeout / prove  -- prover subprocess timeout / unclassified
+# ---------------------------------------------------------------------------
+def check_oracle_alive(timeout: float = 3.0) -> bool:
+    """GET /status on the oracle; False on any failure. Cheap; call after a failed
+    prove to distinguish 'this function killed the bridge' from 'it diverged'."""
+    u = urllib.parse.urlparse(ORACLE_URL)
+    try:
+        conn = http.client.HTTPConnection(u.hostname, u.port or 8790, timeout=timeout)
+        conn.request("GET", "/status")
+        ok = conn.getresponse().status == 200
+        conn.close()
+        return ok
+    except OSError:
+        return False
+
+
+_CANDIDATE_ERR_RE = re.compile(r"candidates[\\/](\w+)\.cpp\((\d+)[,)]")
+_MSVC_ERR_LINE_RE = re.compile(r"error [A-Z]+\d+.*")
+
+
+def _classify_prove_failure(out: str) -> tuple:
+    """(failure_stage, detail) from prover output. Call check_oracle_alive
+    separately to upgrade to oracle_died_during."""
+    o = out or ""
+    if "not reachable" in o or "refused" in o.lower() or "ConnectionRefused" in o:
+        return "oracle_unreachable", "D2Debugger :8790 unreachable"
+    if "handler-exception" in o:
+        return "marshal_fault", ("SEH fault inside the oracle handler -- usually a wrong "
+                                 "callconv/slot-count (check RET n) or a bad pointer arg")
+    if "error C" in o or "fatal error" in o:
+        errs = "; ".join(m.group(0) for m in _MSVC_ERR_LINE_RE.finditer(o))[:400]
+        return "build_provider", errs or "compile error in provider build"
+    if "DIVERGED" in o or "MISMATCH" in o.upper():
+        return "mismatch", "original != reimpl on >=1 vector (see output)"
+    return "prove", (o.strip().splitlines() or ["no output"])[-1][:200]
+
+
+def build_provider_attributed(current_name: str, *, config: str = "Release",
+                              max_heal: int = 4) -> dict:
+    """Build + stage the reimpl provider with FAILURE ATTRIBUTION and SELF-HEALING.
+
+    All candidates/*.cpp compile into ONE provider DLL, so one broken candidate
+    poisons the build for every other function and the failure lands on whichever
+    function happened to be proving (the compile-cascade class: a CORRECT
+    GetUnitPathCoordY was failed 3x by sibling/type issues before this existed).
+
+    This wrapper parses MSBuild errors for `candidates\\<name>.cpp`:
+      * offender == current_name -> {ok:False, stage:'build_candidate', detail:errors}
+        (the caller's own draft is broken -- feed detail to the fix loop)
+      * offender is a SIBLING    -> remove the stale broken sibling (a failed
+        candidate has no staged value; its content lives in run logs), log it,
+        and REBUILD -- healing the cascade instead of misattributing it.
+    Returns {ok, stage, detail, healed:[names]}."""
+    healed: list = []
+    build_dir = str(D2MOO_REPO / "build-1.13c")
+    for _round in range(max_heal + 1):
+        # reconfigure first: CONFIGURE_DEPENDS re-globs candidates + regens the .def
+        subprocess.run(["cmake", "-S", str(D2MOO_REPO), "-B", build_dir],
+                       capture_output=True, text=True)
+        proc = subprocess.run(
+            ["cmake", "--build", build_dir, "--config", config,
+             "--target", "D2MOO_ReimplProvider"],
+            capture_output=True, text=True)
+        out = proc.stdout + proc.stderr
+        if proc.returncode == 0:
+            built = os.path.join(build_dir, "source", "D2Debugger", config,
+                                 "D2MOO_ReimplProvider.dll")
+            if not os.path.exists(built):
+                for dirpath, _, files in os.walk(build_dir):
+                    if ("D2MOO_ReimplProvider.dll" in files
+                            and os.sep + "patch" + os.sep not in dirpath):
+                        built = os.path.join(dirpath, "D2MOO_ReimplProvider.dll")
+                        break
+            import shutil
+            shutil.copyfile(built, os.path.join(build_dir, "patch", "D2MOO_ReimplProvider.dll"))
+            return {"ok": True, "stage": "build", "detail": "", "healed": healed}
+
+        offenders = sorted({m.group(1) for m in _CANDIDATE_ERR_RE.finditer(out)})
+        errs = "; ".join(m.group(0) for m in _MSVC_ERR_LINE_RE.finditer(out))[:500]
+        if current_name in offenders:
+            return {"ok": False, "stage": "build_candidate",
+                    "detail": errs or "candidate compile error", "healed": healed}
+        siblings = [n for n in offenders if n != current_name]
+        if not siblings:
+            return {"ok": False, "stage": "build_provider",
+                    "detail": errs or out[-500:], "healed": healed}
+        for n in siblings:
+            print(f"[build-heal] removing broken sibling candidate {n}.cpp "
+                  f"(it was poisoning the shared provider build)")
+            remove_candidate(n)
+            healed.append(n)
+    return {"ok": False, "stage": "build_provider",
+            "detail": f"still failing after healing {healed}", "healed": healed}
+
+
+# ---------------------------------------------------------------------------
+# LIVE-path drafting: a resolver-based D2MOO reimpl for a "global_leaf" function
+# (reads named game globals -> not statically provable, but provable LIVE because
+# the running game has the globals populated). classify_function tags these
+# "global_leaf"; process_port_candidate routes them here instead of the static
+# OpenD2 harness. The reimpl reads globals BY NAME via D2MOO_Resolve (the injected
+# verified-address resolver), exactly like the proven datatable_rowcount.cpp.
+# ---------------------------------------------------------------------------
+_GLOBAL_NAME_RE = re.compile(r'"(g_[A-Za-z_]\w*)"')
+
+
+def resolvable_globals() -> list:
+    """The g_* global names D2MOO_Resolve knows (from the generated resolve
+    table). A live reimpl may only reference these; anything else must be added
+    to conformance/tools/gen_resolve_table.py first."""
+    try:
+        text = RESOLVE_TABLE.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return sorted(set(_GLOBAL_NAME_RE.findall(text)))
+
+
+def build_live_draft_prompt(func_name: str, address, decompiled_text: str) -> str:
+    globals_list = resolvable_globals()
+    try:
+        example = LIVE_EXAMPLE.read_text(encoding="utf-8")
+    except OSError:
+        example = "(example unavailable)"
+    addr = f"0x{_int(address):x}"
+    parts = []
+    parts.append(
+        "OUTPUT CONTRACT (a machine parses your reply; a human never sees it): reply with "
+        "EXACTLY TWO fenced blocks and nothing that matters outside them -- BLOCK 1 ```cpp (the "
+        "reimpl), BLOCK 2 ```json (the register layout + input_sets). Tag them literally ```cpp "
+        "and ```json. No third block, no split code blocks, no trailing prose.")
+    parts.append("")
+    parts.append("## Task: reimplement a Diablo II function for LIVE conformance proving")
+    parts.append(
+        "You are writing a D2MOO 'reimpl provider' version of this Ghidra-analyzed PD2-S12 function. "
+        "It will be PROVEN by calling BOTH the ORIGINAL (in the live running game) and YOUR reimpl "
+        "with identical inputs and comparing results -- so it must reproduce the decompiled algorithm "
+        "EXACTLY (every offset, magic constant, integer width, and edge case).")
+    parts.append(
+        "This function reads GLOBAL game state, so it cannot be proven statically. Your reimpl must "
+        "read the SAME global from the running game via the injected resolver D2MOO_Resolve -- NOT a "
+        "hardcoded address, NOT an extern.")
+    parts.append("")
+    parts.append(f"Function: {func_name} at {addr}   (D2Common.dll)")
+    parts.append("")
+    parts.append("## Decompiled source (the spec -- includes the plate comment)")
+    parts.append("```")
+    parts.append(str(decompiled_text))
+    parts.append("```")
+    parts.append("")
+    parts.append("## REQUIRED reimpl shape")
+    parts.append(
+        "- `#include \"../provider_runtime.h\"` and a `// D2MOO_REIMPL_EXPORT: " + func_name + "` marker.\n"
+        "- `extern \"C\"` with the right calling convention (see below) + integer widths.\n"
+        "- TYPES: use ONLY plain C types the provider already has. Return `void*` for ANY pointer "
+        "return (a record/struct pointer, an array element pointer, etc.) -- do NOT name a Ghidra struct "
+        "type like `SomeTxtRecord*` / `MonStatsTxtRec*`: those are NOT defined in the provider and will "
+        "not compile (`error C2143`). Use `int`/`unsigned int`/`char`/`short`/`void*` and nothing else.\n"
+        "- Resolve each global by NAME. Ghidra's `_g_Foo` resolves as `\"g_Foo\"` (drop a leading "
+        "underscore). D2MOO_Resolve ALWAYS returns the ADDRESS OF THE SYMBOL (i.e. &g_Foo).\n"
+        "- MECHANICAL RULE for using a resolved global -- do EXACTLY this, do not improvise extra "
+        "dereferences:\n"
+        "    STEP 1: compute a base pointer ONCE at the top of the function.\n"
+        "       * If the symbol is a POINTER VARIABLE (name starts `g_p`, or Ghidra types it `T*`): the "
+        "decompile's bare `_g_pFoo` is the pointer's VALUE, so deref the resolved address ONCE:\n"
+        "           `char* base = (char*)*(void**)D2MOO_Resolve(\"g_pFoo\");`\n"
+        "       * Otherwise (data/array/struct base: `g_dw`, `g_an`, `g_<Struct>`): use the return directly:\n"
+        "           `char* base = (char*)D2MOO_Resolve(\"g_dwFoo\");`\n"
+        "    STEP 2: translate the decompile LITERALLY, replacing every `_g_Foo` with `base` and keeping "
+        "each cast/offset EXACTLY as written. `*(int *)(_g_pFoo + 0xNN)` -> `*(int*)(base + 0xNN)`; "
+        "`*(int *)(_g_pFoo + 0xMM)` -> `*(int*)(base + 0xMM)`. Add NO dereference beyond the single one in "
+        "STEP 1, and remove none. Guard null: if the resolve (or the deref) is null, return an obvious "
+        "wrong-value sentinel.\n"
+        "  (Tell for getting STEP 1 wrong: the proof matches on out-of-range/negative inputs but FAILS on "
+        "valid ones.)\n"
+        "- If D2MOO_Resolve returns null (resolver missing), return an obvious wrong-value sentinel so a "
+        "misconfig fails loudly rather than matching by accident.\n"
+        "- The decompile's FATAL/abort branch (e.g. `if (_g_pFoo == 0) { GetReturnAddress(); "
+        "CleanupAndAbort(); _exit(-1); }`) calls helpers that are NOT defined in the provider and will "
+        "NOT compile (error C3861). NEVER emit `GetReturnAddress`/`CleanupAndAbort`/`_exit`/`FID_conflict:*` "
+        "or ANY function the decompile names -- for such a not-initialized/abort branch just `return 0;` "
+        "(the oracle exercises valid in-range inputs, so that branch only has to compile).\n"
+        "- Read-only: never mutate global state. No STL. Plain C-ish C++.\n"
+        "- NEVER call a compiler-internal helper (__alldiv/__aulldiv/__allmul/...) by name -- write the "
+        "plain operator on the correct fixed-width type and let the compiler emit it.\n"
+        "- CALLING CONVENTION: DEFAULT to `__stdcall` with EVERY arg on the STACK -- that is the norm for "
+        "these D2Common data-table getters (arg read from `[ESP+n]`, callee-cleaned `RET n`). Set the "
+        "param_layout input `register` to `\"stack\"`, NOT `\"ECX\"`/`\"EAX\"`. Only declare `__fastcall` / a "
+        "register input if the PLATE COMMENT EXPLICITLY says an arg is passed in a register (e.g. 'nIndex in "
+        "ECX', 'seed in ESI'). A bare `func(int x)` signature with no such note is `__stdcall` on the stack "
+        "-- do NOT infer ECX/fastcall from the signature alone (a wrong guess makes the original read its "
+        "arg from the wrong place and the proof fails). The prover marshals the original's real (possibly "
+        "non-standard) register ABI for you -- you only need your reimpl's declared convention to match this rule.")
+    parts.append("")
+    parts.append("Resolvable global names (use ONLY these; if you need one not listed, put a `// NEEDS "
+                 "GLOBAL: <name>` comment and it will be skipped until added):")
+    parts.append(", ".join(globals_list) or "(none found)")
+    parts.append("")
+    parts.append("## Example -- a PROVEN reimpl of exactly this resolver-based shape")
+    parts.append("```cpp")
+    parts.append(example)
+    parts.append("```")
+    parts.append("")
+    parts.append("## Output")
+    parts.append("BLOCK 1 -- ```cpp: the complete reimpl (include + marker + function, all in one block).")
+    parts.append(
+        "BLOCK 2 -- ```json: the register layout + input_sets. Read the plate comment's register mapping "
+        "(implicit EAX/ECX/ESI/EDX + any stack args). Shape:")
+    parts.append("```json")
+    parts.append(json.dumps({
+        "fn": func_name,
+        "param_layout": {
+            "inputs": [{"name": "example_index", "register": "EAX", "signed": True}],
+            "outputs": [{"name": "ret", "register": "EAX", "signed": False}],
+        },
+        "input_sets": [{"example_index": 0}, {"example_index": 1}, {"example_index": -1}],
+    }, indent=2))
+    parts.append("```")
+    parts.append(
+        "input_sets: cover 0, 1, a few valid indices, out-of-range (returns null/0), and negatives -- "
+        "at least 10-15 cases. The return is often a POINTER (an absolute game address); the oracle "
+        "compares it as a 32-bit value, and orig vs reimpl agree because both read the same live global.")
+    return "\n".join(parts)
+
+
+def build_handle_draft_prompt(func_name: str, address, decompiled_text: str) -> str:
+    """Draft prompt for a LIVE-POINTER GETTER (classify_function 'shadow_leaf'):
+    the function takes a pointer to a heap-allocated live game object (unit/record/
+    struct) + optional scalar args, and reads fields. Proven by calling BOTH the
+    original and the reimpl with the SAME captured live pointer (oracle arg kind
+    'handle') and comparing -- so no resolver, no static emulation; the pointer is
+    passed in, not looked up."""
+    addr = f"0x{_int(address):x}"
+    p = []
+    p.append("OUTPUT CONTRACT (a machine parses your reply): reply with EXACTLY TWO fenced blocks -- "
+             "BLOCK 1 ```cpp (the reimpl), BLOCK 2 ```json (param_layout + input_sets). Tag them "
+             "literally ```cpp and ```json. Nothing else that matters outside them.")
+    p.append("")
+    p.append("## Task: reimplement a Diablo II LIVE-POINTER getter for handle conformance proving")
+    p.append(
+        "This function takes a POINTER to a live game object the running game allocated on the heap "
+        "(a unit / record / struct -- Ghidra often types it as a bare int*/short*). It will be PROVEN "
+        "by calling BOTH the ORIGINAL and YOUR reimpl with the SAME captured live pointer and comparing "
+        "the result, so reproduce the decompiled field reads EXACTLY -- every offset, cast, width, branch.")
+    p.append("")
+    p.append(f"Function: {func_name} at {addr}   (D2Common.dll)")
+    p.append("")
+    p.append("## Decompiled source (the spec)")
+    p.append("```")
+    p.append(str(decompiled_text))
+    p.append("```")
+    p.append("")
+    p.append("## REQUIRED reimpl shape")
+    p.append(
+        "- `#include \"../provider_runtime.h\"` and a `// D2MOO_REIMPL_EXPORT: " + func_name + "` marker.\n"
+        "- `extern \"C\"` with the SAME calling convention as the original: a SINGLE pointer arg passed on "
+        "the stack -> `__stdcall`; a pointer passed in ECX -> `__fastcall`.\n"
+        "- TYPES: use ONLY plain C types -- `int`/`unsigned int`/`short`/`unsigned short`/`char`/"
+        "`unsigned char`/`void*`. Do NOT use `uint`/`ushort`/`byte`/`undefined4` (Ghidra spellings) or "
+        "`DWORD`/`WORD`/`BYTE` (Win32 spellings) even though the decompile shows them -- rewrite each as "
+        "its plain-C equivalent (`uint`->`unsigned int`, `DWORD`->`unsigned int`, `byte`->`unsigned char`).\n"
+        "- Take the live object pointer as `void*` -- do NOT name a Ghidra struct type (UnitAny*, Room*, "
+        "etc.); those are not defined in the provider and won't compile. Read fields by casting + offset, "
+        "EXACTLY as the decompile does. Translate literally: `pUnit[0xc]` (an int* index) -> "
+        "`((int*)p)[0xc]`; `*(int *)(pUnit + 0x40)` -> `*(int*)((char*)p + 0x40)`; `**(short **)p` -> "
+        "`*(*(short**)p)`. Preserve every offset, cast, and integer width; add/remove NO dereference.\n"
+        "- NULL-guard the pointer with a plain `if (p == nullptr) return 0;`. The decompile may show the "
+        "null path calling helpers like `GetReturnAddress()`, `CleanupAndAbort()`, `_exit(-1)`, "
+        "`FID_conflict:*`, or `__report_*` -- those are NOT defined in the provider and will NOT compile "
+        "(error C3861). NEVER emit them: the oracle never passes null, so the null branch only has to "
+        "compile -- just `return 0;`. Likewise call NO function the decompile names unless it is a plain "
+        "arithmetic operator you can inline.\n"
+        "- Additional SCALAR args (indices/ids) come AFTER the pointer in declared order, as plain "
+        "int/unsigned int.\n"
+        "- Read-only; never mutate. No STL. Never call a compiler-internal helper (__alldiv/...) by name.")
+    p.append("")
+    p.append("## Output")
+    p.append("BLOCK 1 -- ```cpp: the complete reimpl (include + marker + function).")
+    p.append("BLOCK 2 -- ```json:")
+    p.append("```json")
+    p.append(json.dumps({
+        "fn": func_name,
+        "param_layout": {
+            "handle_arg": "pUnit",
+            "scalar_args": [],
+            "callconv": "stdcall",
+            "ret": "i32",
+        },
+        "input_sets": [{}],
+    }, indent=2))
+    p.append("```")
+    p.append(
+        "param_layout.handle_arg = the live-pointer param name; scalar_args = names of any additional int "
+        "args in order; callconv = stdcall (ptr on stack) or fastcall (ptr in ecx); ret = i32|u32|void|u8. "
+        "IMPORTANT: if the original returns a BYTE (a CONCAT31 decompiler artifact -- the upper 3 bytes are "
+        "pointer-derived garbage, only the low byte is meaningful), set ret=\"u8\" and return JUST the byte; "
+        "the oracle masks to the low 8 bits so it matches. "
+        "input_sets: one dict per proof case keyed by scalar_args (cover 0/1/-1/boundaries); if the ONLY "
+        "input is the live pointer, use [{}] -- the oracle supplies the captured object.")
+    return "\n".join(p)
+
+
+def build_handle_fix_prompt(func_name: str, decompiled_text: str, prior_reimpl: str,
+                            prove_output: str) -> str:
+    p = []
+    p.append("OUTPUT CONTRACT: reply with EXACTLY TWO fenced blocks -- BLOCK 1 ```cpp (corrected reimpl), "
+             "BLOCK 2 ```json (SAME param_layout + input_sets). Nothing else.")
+    p.append("")
+    p.append(f"## Your reimpl of {func_name} did not prove against the live captured object. Fix it.")
+    p.append("The oracle called BOTH the original and your reimpl with the SAME live pointer and compared:")
+    p.append("```")
+    p.append((prove_output or "(no output)")[-2500:])
+    p.append("```")
+    p.append("Re-check every offset/cast/width against the decompile; a single wrong offset or an extra/"
+             "missing dereference flips the result.")
+    p.append("## Decompiled source (the spec)")
+    p.append("```")
+    p.append(str(decompiled_text))
+    p.append("```")
+    p.append("## Your previous reimpl")
+    p.append("```cpp")
+    p.append(prior_reimpl)
+    p.append("```")
+    p.append("Output the corrected ```cpp + the ```json layout. Keep the include and the "
+             "// D2MOO_REIMPL_EXPORT marker.")
+    return "\n".join(p)
+
+
+_HEX_LITERAL_RE = re.compile(r'(?<![\w"])0[xX][0-9a-fA-F]+')
+
+
+def _is_provider_reimpl(cpp: str) -> bool:
+    """A PROVIDER candidate must define an `extern "C"` exported function -- that is
+    what the generated .def exports and what the DLL must resolve. Reject an OpenD2
+    STATIC-HARNESS draft (`namespace D2Lib { inline T fn(){...} }`), which has NO
+    extern-C symbol: written as a provider candidate it makes the .def export a symbol
+    the DLL never defines -> LNK2001 -> the WHOLE provider build fails for every
+    function (found 2026-07-08: SKILLS_GetSkillNodeRecord poisoned the build). Treating
+    such a draft as malformed here keeps it out of the provider dir entirely."""
+    c = cpp or ""
+    return 'extern "C"' in c and "namespace D2Lib" not in c
+
+
+def _json_loads_lenient(s: str):
+    """json.loads, but first rewrite bare hex integer literals (0x7FFFFFFF) to
+    decimal. The model habitually puts hex in input_sets (0x80000000, 0x7FFFFFFF)
+    even though JSON has no hex literals, which makes json.loads reject the WHOLE
+    block -> a correct reimpl gets scored malformed_response (found 2026-07-08:
+    GetAnimSequenceRecord drew hex in all 3 attempts). The lookbehind avoids
+    touching hex inside quoted strings/identifiers. Raises JSONDecodeError like
+    json.loads on anything still malformed."""
+    return json.loads(_HEX_LITERAL_RE.sub(lambda m: str(int(m.group(0), 16)), s or ""))
+
+
+def parse_handle_response(text: str):
+    """(reimpl_cpp, param_layout, input_sets) from a build_handle_draft_prompt reply.
+    (None,None,None) on any failure. param_layout must have handle_arg + callconv."""
+    import port_pipeline as pp
+    blocks = pp._fenced_blocks(text or "")
+    cpp = [c for lang, c in blocks if lang in pp._CPP_LANGS]
+    js = [c for lang, c in blocks if lang in pp._JSON_LANGS]
+    if not cpp or not js:
+        return None, None, None
+    try:
+        spec = _json_loads_lenient(js[0])
+    except json.JSONDecodeError:
+        return None, None, None
+    layout = spec.get("param_layout")
+    input_sets = spec.get("input_sets")
+    if not isinstance(layout, dict) or not layout.get("handle_arg"):
+        return None, None, None
+    if not isinstance(input_sets, list) or not input_sets:
+        input_sets = [{}]
+    if not _is_provider_reimpl(cpp[0]):   # reject OpenD2/non-extern-C drafts (build poison)
+        return None, None, None
+    reimpl = cpp[0].strip() + "\n"
+    if 'provider_runtime.h' not in reimpl:
+        reimpl = '#include "../provider_runtime.h"\n' + reimpl
+    return reimpl, layout, input_sets
+
+
+def build_handle_spec(name: str, address, param_layout: dict) -> dict:
+    """fun-doc handle param_layout -> oracle spec: arg0 = the captured live object
+    (kind 'handle'), followed by scalar args (kind 'i32') the vectors fill."""
+    cc = str(param_layout.get("callconv", "stdcall")).lower()
+    if cc not in ("stdcall", "fastcall", "cdecl", "thiscall"):
+        cc = "stdcall"
+    ret = str(param_layout.get("ret", "i32")).lower()
+    if ret not in ("i32", "u32", "void", "u8", "i8"):   # u8/i8: byte getters (CONCAT31 artifact)
+        ret = "i32"
+    args = [{"id": param_layout["handle_arg"], "kind": "handle"}]
+    for s in param_layout.get("scalar_args", []) or []:
+        args.append({"id": str(s), "kind": "i32"})
+    return {
+        "name": name, "addr": _int(address), "callconv": cc, "ret": ret,
+        "args": args, "compare": [] if ret == "void" else ["ret"],
+        "onGameThread": True,  # the object is live game state -- call on the game thread
+    }
+
+
+_GATE_W = {"b": 1, "w": 2, "d": 4}
+
+
+def _gate_spec(gates):
+    """abi_static type_gates [(depth,off,imm,w_char)] -> oracle spec [{depth,off,imm,w}]."""
+    return [{"depth": d, "off": o, "imm": i, "w": _GATE_W.get(w, 4)}
+            for (d, o, i, w) in (gates or [])]
+
+
+def run_synth_prove(reimpl_cpp: str, name: str, address, *, ret: str = "u32",
+                    struct_size: int = 256, gates=None, build: bool = True) -> dict:
+    """Prove a FLAT getter (a single fixed-offset read, no sub-pointer deref) via the
+    oracle's SYNTHETIC DISCRIMINATING object (arg kind 'synth', 2026-07-08). The oracle
+    passes both the original and the reimpl a scratch buffer whose every byte is unique
+    to its offset, so a getter reading a fixed field returns a value UNIQUE to that
+    offset -- a wrong-offset reimpl MISMATCHES the original. This kills the degenerate
+    all-zeros false positive that idle-town live captures produce (a weak_proof), giving
+    a STRONG proof for exactly the flat-getter class the mechanical translator emits.
+
+    CALLER MUST ensure the getter is FLAT -- a synth byte is not a valid pointer, so a
+    sub-deref getter would fault. (chain length 1 from abi_static.translate_getter_to_c.)"""
+    parg = {"id": "p", "kind": "synth", "bytes": struct_size}
+    gspec = _gate_spec(gates)
+    if gspec:
+        parg["gates"] = gspec
+    spec = {"name": name, "addr": _int(address), "callconv": "stdcall",
+            "ret": ret if ret in ("u8", "i8", "u16", "i16", "u32", "i32") else "u32",
+            "args": [parg],
+            "compare": ["ret"],
+            "vectors": [{}]}
+    write_candidate(reimpl_cpp, name)
+    VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    spec_path = VECTORS_DIR / f"{name}.spec.json"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    if build:
+        b = build_provider_attributed(name)
+        if not b["ok"]:
+            res = _fail(b["stage"], b["detail"])
+            res["spec"] = spec
+            return res
+    res = _invoke_prove(spec_path, build=False)
+    res["spec"] = spec
+    res["proof_kind"] = "synth"          # a discriminating proof -- never weak
+    if res.get("ok"):
+        res["writeback"] = record_proof(name, address, spec, res)
+    return res
+
+
+def run_synth2_prove(reimpl_cpp: str, name: str, address, *, ret: str = "u32",
+                     gates=None, build: bool = True) -> dict:
+    """Prove a 2-LEVEL getter (read a pointer at O1, deref, read the field at O2 --
+    no third level) via the oracle's NESTED discriminating object (arg kind
+    'synth2', 2026-07-08). The primary buffer is an array of pointers all pointing at
+    a shared secondary buffer whose byte[o]=(o*13+0x37) is unique per offset, so the
+    getter returns pattern(O2) and a wrong FIELD offset MISMATCHES the original. This
+    lifts the degenerate-town-capture weak_proof for the 2-level getter class -- the
+    majority of struct getters -- which flat synth can't reach.
+
+    CALLER MUST ensure the getter is exactly 2-level (chain length 2 from
+    abi_static.translate_getter_to_c); a 3rd deref would read the pattern as a
+    pointer and fault."""
+    parg = {"id": "p", "kind": "synth2", "bytes": 256}
+    gspec = _gate_spec(gates)
+    if gspec:
+        parg["gates"] = gspec
+    spec = {"name": name, "addr": _int(address), "callconv": "stdcall",
+            "ret": ret if ret in ("u8", "i8", "u16", "i16", "u32", "i32") else "u32",
+            "args": [parg],
+            "compare": ["ret"], "vectors": [{}]}
+    write_candidate(reimpl_cpp, name)
+    VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    spec_path = VECTORS_DIR / f"{name}.spec.json"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    if build:
+        b = build_provider_attributed(name)
+        if not b["ok"]:
+            res = _fail(b["stage"], b["detail"])
+            res["spec"] = spec
+            return res
+    res = _invoke_prove(spec_path, build=False)
+    res["spec"] = spec
+    res["proof_kind"] = "synth2"        # discriminates the field offset -- never weak
+    if res.get("ok"):
+        res["writeback"] = record_proof(name, address, spec, res)
+    return res
+
+
+_DELEGATE_INDICES = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
+
+
+def run_delegate_prove(reimpl_cpp: str, name: str, address, *, ret: str = "u32",
+                       arg_off: int, type_gates=None, indices=None,
+                       build: bool = True) -> dict:
+    """Prove a DELEGATE call-through getter (abi_static.translate_delegate_getter_to_c):
+    it resolves + calls a REAL D2Common function, so the callee's data-globals must be
+    LOADED -> this only works IN-GAME (at the title screen the callee's tables are NULL
+    and every vector degenerates). Strategy: a MULTI-INDEX gated synth -- patch the
+    dwType gate(s) + the callee's arg field to each of several record INDICES, so the
+    real callee returns a real (different) record per index. STRONG iff the reimpl
+    matches the original on EVERY index AND the original's value VARIES across indices
+    (a UNIFORM original = the read field is constant -> a wrong offset would match too ->
+    can't discriminate -> weak_proof, not strong). This variance check is the delegate
+    analogue of _degenerate_capture_note (single-vector synth can't see it)."""
+    idxs = indices or _DELEGATE_INDICES
+    base_gates = _gate_spec([(0, g[0], g[1], g[2]) for g in (type_gates or [])])
+    rr = ret if ret in ("u8", "i8", "u16", "i16", "u32", "i32") else "u32"
+    write_candidate(reimpl_cpp, name)
+    VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    if build:
+        b = build_provider_attributed(name)
+        if not b["ok"]:
+            r = _fail(b["stage"], b["detail"]); r["proof_kind"] = "delegate"; return r
+
+    npass = 0
+    orig_vals = set()
+    last = None
+    for i in idxs:
+        parg = {"id": "p", "kind": "synth", "bytes": 256,
+                "gates": base_gates + [{"depth": 0, "off": arg_off, "imm": i, "w": 4}]}
+        spec = {"name": name, "addr": _int(address), "callconv": "stdcall", "ret": rr,
+                "args": [parg], "compare": ["ret"], "vectors": [{}]}
+        sp = VECTORS_DIR / f"{name}.spec.json"
+        sp.write_text(json.dumps(spec) + "\n", encoding="utf-8")
+        r = _invoke_prove(sp, build=False)
+        last = r
+        if r.get("ok"):
+            npass += 1
+        ov = (r.get("oracle") or {}).get("results") or []
+        for row in ov:
+            rr_ = row.get("ret")
+            if isinstance(rr_, dict) and "o" in rr_:
+                orig_vals.add(rr_["o"])
+        # oracle death mid-sweep -> stop (don't burn the rest against a dead bridge)
+        if r.get("failure_stage") == "oracle_died_during":
+            break
+
+    res = {"passed": npass, "total": len(idxs), "stage": "prove",
+           "output": (last or {}).get("output", ""), "spec": spec,
+           "proof_kind": "delegate_call_through", "orig_distinct": len(orig_vals)}
+    if npass == len(idxs) and len(orig_vals) > 1:
+        res["ok"] = True
+        res["writeback"] = record_proof(name, address, spec, res)
+        res["note"] = f"delegate call-through; discriminating multi-index ({npass}/{len(idxs)}, orig varies)"
+    elif npass == len(idxs) and len(orig_vals) <= 1:
+        res["ok"] = False
+        res["failure_stage"] = "weak_uniform"
+        res["failure_detail"] = ("delegate matched all indices but the ORIGINAL returned a "
+                                 "single value on every index (uniform field) -> non-discriminating")
+    else:
+        res["ok"] = False
+        res["failure_stage"] = (last or {}).get("failure_stage", "mismatch")
+        res["failure_detail"] = f"delegate matched only {npass}/{len(idxs)} indices"
+    return res
+
+
+def run_handle_prove(reimpl_cpp: str, name: str, address, param_layout: dict,
+                     input_sets: list, *, build: bool = True) -> dict:
+    """Prove a live-pointer getter against the running game via the oracle handle
+    path (a real captured object is passed to both original and reimpl). Same
+    {ok,passed,total,output,...} shape as run_live_prove."""
+    spec = build_handle_spec(name, address, param_layout)
+    # scalar-arg vectors only; the handle arg is filled by the oracle from capture.
+    # For a HANDLE-ONLY getter, emit N empty vectors: the oracle snapshots
+    # D2Capture_LastUnit() once PER vector, and the game thread advances the captured
+    # object between iterations, so N vectors prove against up to N DISTINCT live
+    # objects (guards the "matched by luck on one object" risk) and confirm
+    # determinism. With scalar args, sweep those instead.
+    HANDLE_ONLY_VECTORS = 8
+    scalar_ids = [a["id"] for a in spec["args"] if a["kind"] == "i32"]
+    spec["vectors"] = ([{k: case.get(k, 0) for k in scalar_ids} for case in input_sets]
+                       if scalar_ids else [{} for _ in range(HANDLE_ONLY_VECTORS)])
+    write_candidate(reimpl_cpp, name)
+    VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    spec_path = VECTORS_DIR / f"{name}.spec.json"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    if build:
+        # attributed + self-healing build: a broken SIBLING candidate is healed
+        # instead of failing THIS (possibly correct) reimpl; our own compile
+        # errors come back as build_candidate with the real compiler message.
+        b = build_provider_attributed(name)
+        if not b["ok"]:
+            res = _fail(b["stage"], b["detail"])
+            res["spec"] = spec
+            return res
+    res = _invoke_prove(spec_path, build=False)
+    res["spec"] = spec
+    # Surface the per-vector dispatch-field probe (dwType of each captured object)
+    # for the post-proof BRANCH-COVERAGE analysis.
+    oracle = res.get("oracle")
+    if oracle and isinstance(oracle.get("results"), list):
+        res["dispatch_values"] = [r["probe"][0] for r in oracle["results"]
+                                  if isinstance(r.get("probe"), list) and r["probe"]]
+    res["weak_proof"] = _degenerate_capture_note(oracle)
+    if res.get("ok"):
+        res["writeback"] = record_proof(name, address, spec, res, weak_proof=res["weak_proof"])
+    return res
+
+
+def _degenerate_capture_note(oracle) -> str | None:
+    """A handle proof is DEGENERATE if the ORIGINAL returned the SAME value on every
+    vector -- then a wrong-offset reimpl matches by luck (all-zeros) and earns a
+    FALSE CONF_LIVE. Exactly how STAT_GetActiveSkillFieldC / SKILLS_GetActiveSkillAnimData
+    passed 8/8 on idle-town captures yet diverged ~99% under shadow (2026-07-08). If
+    every original return is identical (esp. 0), flag it so the row can't silently
+    promote/freeze until DIVERSE objects (dispatch values) are seen. Returns a note
+    or None."""
+    if not oracle or not isinstance(oracle.get("results"), list):
+        return None
+    results = oracle["results"]
+    orig_rets = [r["ret"]["o"] for r in results
+                 if isinstance(r.get("ret"), dict) and "o" in r["ret"]]
+    if len(orig_rets) < 2:
+        return None
+    distinct = set(orig_rets)
+    # distinct captured objects seen (probe dispatch field), if available
+    probes = {r["probe"][0] for r in results if isinstance(r.get("probe"), list) and r["probe"]}
+    if len(distinct) == 1:
+        v = next(iter(distinct))
+        objs = f", only {len(probes)} distinct object(s)" if probes else ""
+        return (f"DEGENERATE CAPTURE: the original returned the SAME value ({v}) on all "
+                f"{len(orig_rets)} vectors{objs} -- a wrong-offset reimpl matches by luck. "
+                f"This CONF_LIVE proof is WEAK; re-prove against DIVERSE objects (or trust "
+                f"shadow/V2) before promoting or freezing.")
+    return None
+
+
+def provider_outcome(text, meta) -> str:
+    """Classify an invoke_claude (text, meta) result so the retry loop can tell a
+    PROVIDER hiccup from a MODEL/reimpl problem -- they need opposite handling:
+      'quota'       -> paused; stop.
+      'hiccup'      -> the PROVIDER misbehaved (empty/None text, or a timeout/error
+                       marker in meta). This is NOT a bad reimpl -- retry the SAME
+                       prompt without consuming the fix budget, and DON'T discard the
+                       last good draft (2026-07-08: a minimax 300s hard-timeout mid-
+                       retry stranded PATH_GetDirection on a wrong u32 attempt after
+                       the correct u8 was already found).
+      'got_text'    -> the provider returned content; parse it normally.
+    """
+    if (meta or {}).get("quota_paused"):
+        return "quota"
+    m = meta or {}
+    if m.get("timeout") or m.get("hard_timeout") or m.get("error") or m.get("stalled"):
+        return "hiccup"
+    if not (text or "").strip():
+        return "hiccup"
+    return "got_text"
+
+
+class BestDraft:
+    """Accumulator that keeps the highest-scoring parseable draft across retries, so
+    a later provider hiccup or a worse re-draft never loses earlier progress. Score =
+    proven (ok) > more vectors passed > first seen."""
+    __slots__ = ("reimpl", "layout", "input_sets", "score", "result")
+
+    def __init__(self):
+        self.reimpl = self.layout = self.input_sets = self.result = None
+        self.score = (-1, -1)
+
+    def offer(self, reimpl, layout, input_sets, result) -> None:
+        if reimpl is None:
+            return
+        ok = 1 if (result or {}).get("ok") else 0
+        passed = (result or {}).get("passed") or 0
+        s = (ok, passed)
+        if s > self.score:
+            self.reimpl, self.layout, self.input_sets = reimpl, layout, input_sets
+            self.result, self.score = result, s
+
+    def have(self) -> bool:
+        return self.reimpl is not None
+
+
+def build_adversarial_vectors_prompt(func_name: str, decompiled_text: str,
+                                     input_names: list) -> str:
+    """QA/adversary prompt: generate a hard input-set purely from the DECOMPILED
+    ORIGINAL (never shown the reimpl), to catch a subtly-wrong reimplementation
+    the author's own vectors would miss. Rung V1 of SHIPPING_PROMOTION_PLAN.md."""
+    parts = []
+    parts.append("OUTPUT CONTRACT: reply with EXACTLY ONE ```json block and nothing else: "
+                 '{"input_sets": [ {..}, {..} ]}.')
+    parts.append("")
+    parts.append(f"## You are QA. Try to BREAK a reimplementation of {func_name} with adversarial inputs.")
+    parts.append(
+        "Below is the DECOMPILED ORIGINAL. You will NOT see the reimplementation -- derive inputs purely "
+        "from what the ORIGINAL does, to maximize the chance of exposing a subtly-wrong reimpl. Cover: "
+        "EVERY branch boundary the code compares against and +/-1 around it; a DENSE sweep of the valid "
+        "input range; and the extremes 0, 1, -1, INT_MIN (-2147483648), INT_MAX (2147483647), and powers "
+        "of two. Aim for 30-50 input_sets.")
+    parts.append("")
+    parts.append("## Decompiled original (the spec)")
+    parts.append("```")
+    parts.append(str(decompiled_text))
+    parts.append("```")
+    parts.append("Input field names -- use EXACTLY these keys in every input_set: " + ", ".join(input_names))
+    parts.append("```json")
+    parts.append(json.dumps({"input_sets": [
+        {n: 0 for n in input_names}, {n: 1 for n in input_names}, {n: -1 for n in input_names},
+    ]}, indent=2))
+    parts.append("```")
+    return "\n".join(parts)
+
+
+def parse_adversarial_vectors(text: str, input_names: list) -> list:
+    """Extract input_sets from a build_adversarial_vectors_prompt reply. Returns []
+    on any failure (vetting is best-effort -- a bad adversary reply just means no
+    extra coverage that round, never a broken proof)."""
+    import port_pipeline as pp
+    blocks = pp._fenced_blocks(text or "")
+    js = [c for lang, c in blocks if lang in pp._JSON_LANGS]
+    if not js:
+        return []
+    try:
+        obj = json.loads(js[0])
+    except json.JSONDecodeError:
+        return []
+    sets = obj.get("input_sets") if isinstance(obj, dict) else obj
+    if not isinstance(sets, list):
+        return []
+    out = []
+    for s in sets:
+        if isinstance(s, dict) and all(n in s for n in input_names):
+            out.append({n: s[n] for n in input_names})
+    return out
+
+
+def build_live_fix_prompt(func_name: str, decompiled_text: str, prior_reimpl: str,
+                          prove_output: str) -> str:
+    parts = []
+    parts.append(
+        "OUTPUT CONTRACT: reply with EXACTLY TWO fenced blocks -- BLOCK 1 ```cpp (the corrected "
+        "reimpl), BLOCK 2 ```json (the SAME register layout + input_sets as before). Nothing else.")
+    parts.append("")
+    parts.append(f"## Your reimpl of {func_name} did not prove against the live game. Fix it.")
+    parts.append(
+        "The oracle called BOTH the original (in the running game) and your reimpl with each input and "
+        "compared. Read the result carefully:")
+    parts.append("```")
+    parts.append((prove_output or "(no output)")[-2500:])
+    parts.append("```")
+    parts.append(
+        "IMPORTANT diagnostic: if it MATCHES on out-of-range/negative inputs (the null path) but FAILS "
+        "on valid in-range ones, you dereferenced a resolved global one level too FEW or too MANY -- "
+        "re-check the pointer-vs-base STEP 1 rule (a `g_p*` pointer variable needs "
+        "`base = *(void**)D2MOO_Resolve(\"g_p...\")`).")
+    parts.append("")
+    parts.append("## Decompiled source (the spec)")
+    parts.append("```")
+    parts.append(str(decompiled_text))
+    parts.append("```")
+    parts.append("## Your previous reimpl")
+    parts.append("```cpp")
+    parts.append(prior_reimpl)
+    parts.append("```")
+    parts.append(
+        "Output the corrected ```cpp reimpl and the ```json layout+input_sets. Keep the include and the "
+        "// D2MOO_REIMPL_EXPORT marker.")
+    return "\n".join(parts)
+
+
+def parse_live_response(text: str):
+    """Extract (reimpl_cpp, param_layout, input_sets) from a build_live_draft_prompt
+    reply (1 cpp block + 1 json block). Returns (None, None, None) on any failure."""
+    import port_pipeline as pp  # reuse the tolerant fenced-block splitter
+    blocks = pp._fenced_blocks(text or "")
+    cpp = [c for lang, c in blocks if lang in pp._CPP_LANGS]
+    js = [c for lang, c in blocks if lang in pp._JSON_LANGS]
+    if not cpp or not js:
+        return None, None, None
+    try:
+        spec = _json_loads_lenient(js[0])
+    except json.JSONDecodeError:
+        return None, None, None
+    layout = spec.get("param_layout")
+    input_sets = spec.get("input_sets")
+    if not isinstance(layout, dict) or not isinstance(input_sets, list) or not input_sets:
+        return None, None, None
+    if "inputs" not in layout or "outputs" not in layout:
+        return None, None, None
+    if not _is_provider_reimpl(cpp[0]):   # reject OpenD2/non-extern-C drafts (build poison)
+        return None, None, None
+    reimpl = cpp[0].strip() + "\n"
+    if 'provider_runtime.h' not in reimpl:  # ensure the resolver header is present
+        reimpl = '#include "../provider_runtime.h"\n' + reimpl
+    return reimpl, layout, input_sets
+
+
+def remove_candidate(name: str) -> None:
+    """Delete a candidate's .cpp + spec. CRITICAL for the automated loop: a
+    candidate that fails to PROVE is also often a candidate that fails to COMPILE
+    (e.g. an undefined Ghidra type name), and every candidates/*.cpp is compiled
+    into the ONE provider DLL -- so one broken file poisons the build for EVERY
+    other function (found by hand 2026-07-07: a --count 20 batch cascaded into
+    all-failures after one bad reimpl landed). A failed reimpl has no value staged,
+    so remove it; its content is preserved in the run log if needed. Best-effort."""
+    for p in (CANDIDATES_DIR / f"{name}.cpp",
+              VECTORS_DIR / f"{name}.spec.json",
+              VECTORS_DIR / f"{name}.adversarial.spec.json"):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+
+def write_candidate(reimpl_cpp: str, name: str) -> Path:
+    """Drop a drafted D2MOO reimpl into the provider's candidates/ dir. Ensures
+    the `// D2MOO_REIMPL_EXPORT: <name>` marker the provider build reads is
+    present. Canonical one-file-per-function name avoids duplicate symbols."""
+    # Last line of defense against build poison: refuse a non-extern-C draft LOUDLY
+    # here rather than let it silently break the whole provider .def at the next build.
+    if not _is_provider_reimpl(reimpl_cpp):
+        raise ValueError(
+            f"write_candidate({name}): content is not a provider reimpl (needs an "
+            f'`extern "C"` export, not an OpenD2 `namespace D2Lib` draft) -- refusing to '
+            f"write build poison into the provider candidates dir")
+    CANDIDATES_DIR.mkdir(parents=True, exist_ok=True)
+    body = reimpl_cpp
+    if "D2MOO_REIMPL_EXPORT:" not in body:
+        body = f"// D2MOO_REIMPL_EXPORT: {name}\n{body}"
+    path = CANDIDATES_DIR / f"{name}.cpp"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _invoke_prove(spec_path: Path, *, build: bool, timeout: int = 900) -> dict:
+    """Run prove_candidate.py --spec and map its result to run_harness's shape."""
+    if not PROVE_SCRIPT.exists():
+        return _fail("config", f"prover not found: {PROVE_SCRIPT}")
+    # --json emits the raw per-vector oracle result (incl. the coverage "probe"),
+    # which we parse back out for branch-coverage analysis without a second call.
+    cmd = [sys.executable, str(PROVE_SCRIPT), "--spec", str(spec_path), "--url", ORACLE_URL, "--json"]
+    if build:
+        cmd.append("--build")
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return _fail("prove", f"prove_candidate.py timed out after {timeout}s")
+    out = proc.stdout + proc.stderr
+    m = re.search(r"(\d+)/(\d+) match", out)
+    passed, total = (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+    res = {
+        "ok": proc.returncode == 0,
+        "passed": passed,
+        "total": total,
+        "stage": "prove",
+        "error": "" if proc.returncode == 0 else f"prover exit {proc.returncode}",
+        "output": out.strip(),
+        "oracle": _extract_oracle_json(out),
+    }
+    if not res["ok"]:
+        stage, detail = _classify_prove_failure(out)
+        # upgrade: the bridge was alive when we started (prove ran) but is dead
+        # now -> THIS function's vectors killed it. Name the killer.
+        if stage in ("marshal_fault", "prove", "mismatch") and not check_oracle_alive():
+            stage = "oracle_died_during"
+            detail = (f"the oracle bridge died while proving this function "
+                      f"(likely an abort-class out-of-range vector or an ABI fault); {detail}")
+        res["failure_stage"], res["failure_detail"] = stage, detail
+    return res
+
+
+def _extract_oracle_json(out: str):
+    """Pull the raw oracle result object (the one with a 'results' array) out of
+    prove_candidate.py --json stdout. Returns the dict or None."""
+    i = 0
+    while True:
+        start = out.find("{", i)
+        if start < 0:
+            return None
+        depth = 0
+        for j in range(start, len(out)):
+            if out[j] == "{":
+                depth += 1
+            elif out[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        obj = json.loads(out[start:j + 1])
+                        if isinstance(obj, dict) and "results" in obj:
+                            return obj
+                    except json.JSONDecodeError:
+                        pass
+                    i = start + 1
+                    break
+        else:
+            return None
+
+
+def _ghidra_post(path: str, data: dict) -> dict:
+    """POST a JSON body to the Ghidra plugin REST server (source of truth).
+    Best-effort -- write-back must NEVER fail a proof."""
+    u = urllib.parse.urlparse(GHIDRA_HTTP)
+    conn = http.client.HTTPConnection(u.hostname, u.port or 8089, timeout=15)
+    try:
+        conn.request("POST", path, body=json.dumps(data),
+                     headers={"Content-Type": "application/json"})
+        raw = conn.getresponse().read().decode("utf-8", "replace")
+    except OSError as e:
+        return {"error": f"ghidra unreachable: {e}"}
+    finally:
+        conn.close()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"error": raw[:200]}
+
+
+# Conformance-proof tag ladder (CONF_ axis), rungs low->high. Mutually exclusive:
+# promoting to one rung removes the others. See the conformance taxonomy in
+# conformance/CONFORMANCE_TAXONOMY.md.
+CONF_TAGS = ["CONF_DRAFT", "CONF_VECTORS", "CONF_LIVE", "CONF_BATTLETESTED"]
+# Orthogonal documentation-maturity ladder (DOC_ axis). Set by the documentation
+# workflow (not proving). Also mutually exclusive.
+DOC_TAGS = ["DOC_DRAFT", "DOC_REVIEWED", "DOC_VERIFIED"]
+
+
+def _set_rung(address, level: str, ladder, program: str = "D2Common.dll") -> dict:
+    """Set ONE rung on a mutually-exclusive Ghidra tag ladder: remove the other
+    rungs, add this one. Additive to OTHER axes and to decompiler comments.
+    Best-effort; never raises. Shared by the DOC_ and CONF_ write-backs."""
+    if level not in ladder:
+        return {"status": f"bad level {level!r} (want one of {ladder})"}
+    addr = f"0x{address:x}" if isinstance(address, int) else str(address)
+    others = ",".join(t for t in ladder if t != level)
+    _ghidra_post("/remove_function_tag", {"function": addr, "tags": others, "program": program})
+    tag = _ghidra_post("/add_function_tag", {"function": addr, "tags": level, "program": program})
+    return {"level": level, "status": "ok" if tag.get("status") == "success" else tag.get("error", tag)}
+
+
+def set_doc_level(address, doc_level: str, *, program: str = "D2Common.dll") -> dict:
+    """WRITE-BACK the DOC_ documentation-maturity rung in Ghidra (source of truth),
+    mutually exclusive. Call from fun-doc's documentation stages:
+      first-pass model doc            -> DOC_DRAFT
+      passed review/score >= threshold-> DOC_REVIEWED  (ABI confirmed from disasm)
+      fully ground-truthed            -> DOC_VERIFIED
+    Orthogonal to CONF_* and non-destructive to decompiler comments."""
+    return _set_rung(address, doc_level, DOC_TAGS, program)
+
+
+def record_proof(name: str, address, spec: dict, result: dict, *,
+                 program: str = "D2Common.dll", conf_level: str = "CONF_LIVE",
+                 abort_class: bool = False, weak_proof: str = None) -> dict:
+    """WRITE-BACK (see the writeback-source-of-truth principle). On a successful
+    live proof: (1) set the CONF_ rung in Ghidra -- the RE source of truth,
+    queryable via search_functions_by_tag -- REMOVING the other (mutually
+    exclusive) CONF_ rungs first, and (2) append a machine-readable row to
+    conformance/proven_functions.jsonl. Additive to the DOC_ axis and decompiler
+    comments (never clobbered). Best-effort; never raises.
+
+    conf_level defaults to CONF_LIVE (the live-oracle proof). A future battle-test
+    promoter passes CONF_BATTLETESTED (earned by zero shadow divergences in real
+    gameplay)."""
+    status = {"ghidra_tag": None, "registry": None}
+    a = spec.get("addr", address)
+    addr = f"0x{a:x}" if isinstance(a, int) else str(a)
+
+    # Mutual exclusivity handled by the shared ladder helper.
+    r = _set_rung(addr, conf_level, CONF_TAGS, program)
+    status["ghidra_tag"] = f"{conf_level}={r['status']}"
+
+    try:
+        row = {
+            "name": name, "address": addr, "program": program,
+            "conf": conf_level,
+            "callconv": spec.get("callconv"), "ret": spec.get("ret"),
+            "orig_regs": spec.get("orig_regs"),
+            "vectors": len(spec.get("vectors", [])),
+            "passed": result.get("passed"), "total": result.get("total"),
+            "date": datetime.date.today().isoformat(),
+        }
+        if abort_class or spec.get("abort_class"):
+            # out-of-range input is FATAL: V1 adversarial (and any fuzzing tool
+            # reading this registry) must stay in-envelope or skip entirely.
+            row["abort_class"] = True
+        if weak_proof:
+            # DEGENERATE capture -> this CONF_LIVE proof matched by luck; must not
+            # silently promote/freeze. shadow_promote + freeze tooling should honor this.
+            row["weak_proof"] = weak_proof
+        # proof provenance (synth / synth2 / delegate_call_through) + delegate metadata,
+        # so the registry row is self-describing (a delegate row names its callee).
+        for _k in ("proof_kind", "callee", "note"):
+            if result.get(_k) is not None:
+                row[_k] = result[_k]
+        PROVEN_REGISTRY.parent.mkdir(parents=True, exist_ok=True)
+        with open(PROVEN_REGISTRY, "a", encoding="utf-8") as f:
+            f.write(json.dumps(row) + "\n")
+        status["registry"] = str(PROVEN_REGISTRY)
+    except OSError as e:
+        status["registry"] = f"error: {e}"
+    return status
+
+
+def run_live_prove(reimpl_cpp: str, name: str, address, param_layout: dict,
+                   input_sets: list, *, build: bool = True,
+                   abort_class: bool = False) -> dict:
+    """Prove a D2MOO reimpl of `name` against the live game. Writes the reimpl
+    into the provider, translates fun-doc's layout+cases into an oracle spec,
+    and runs the prover. Returns run_harness's {ok,passed,total,output,...}.
+    Raises UnsupportedLiveABI (caller falls back to static) for exotic ABIs.
+
+    abort_class=True stamps the spec with a safety/envelope annotation (the
+    function's out-of-range path is FATAL -- see abi_static.detect_abort_path)
+    and flags the registry row so V1 adversarial sweeps skip it."""
+    spec = translate_layout_to_spec(name, address, param_layout)
+    spec["vectors"] = [dict(case) for case in input_sets]  # {name:val} == oracle vector
+    if abort_class:
+        spec["safety"] = ("ABORT CLASS: the original's out-of-range path is fatal "
+                          "(_exit/CleanupAndAbort kills the process/bridge). Vectors are "
+                          "strictly in-envelope; do NOT fuzz out-of-range (no V1 widening).")
+        spec["abort_class"] = True
+
+    write_candidate(reimpl_cpp, name)
+    VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    spec_path = VECTORS_DIR / f"{name}.spec.json"
+    spec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    if build:
+        b = build_provider_attributed(name)   # attributed + self-healing (see docstring)
+        if not b["ok"]:
+            res = _fail(b["stage"], b["detail"])
+            res["spec"] = spec
+            return res
+    res = _invoke_prove(spec_path, build=False)
+    res["spec"] = spec  # additive: lets a caller (e.g. shadow_promote.py) classify
+                        # the ABI shape without recomputing translate_layout_to_spec
+    if res.get("ok"):
+        # Write-back to the source of truth on every successful proof.
+        res["writeback"] = record_proof(name, address, spec, res,
+                                        abort_class=abort_class)
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Self-test: unit-check the ABI translator, then LIVE-prove against a running
+# game using the already-built town-level capstone spec (no rebuild, no write --
+# exercises the subprocess+parse contract end to end). Run: python port_live_prove.py
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # 1) translator unit checks (no side effects)
+    fast = translate_layout_to_spec("RNG_Foo", "0x6fd80000", {
+        "inputs": [{"name": "seedLo", "register": "ECX", "signed": False},
+                   {"name": "seedHi", "register": "EDX", "signed": False}],
+        "outputs": [{"name": "ret", "register": "EAX", "signed": False}],
+    })
+    assert fast["callconv"] == "fastcall" and [a["id"] for a in fast["args"]] == ["seedLo", "seedHi"], fast
+    assert fast["compare"] == ["ret"] and fast["addr"] == 0x6FD80000, fast
+
+    stackspec = translate_layout_to_spec("DUNGEON_GetTownLevelIdFromActNo", "0x6fd8b1e0", {
+        "inputs": [{"name": "act", "register": "STACK", "signed": False}],
+        "outputs": [{"name": "ret", "register": "EAX", "signed": True}],
+    })
+    assert stackspec["callconv"] == "stdcall" and stackspec["ret"] == "i32", stackspec
+
+    # register-explicit: non-standard reg placement (RNG's max-in-EAX) -> orig_regs
+    rng = translate_layout_to_spec("SEED_GetRandomNumber", "0x6fd510b0", {
+        "inputs": [{"name": "seed", "register": "ECX"}, {"name": "max", "register": "EAX"}],
+        "outputs": [{"name": "ret", "register": "EAX", "signed": False}],
+    })
+    assert rng.get("orig_regs") == {"ECX": "seed", "EAX": "max"}, rng
+    assert rng["callconv"] == "fastcall", rng
+
+    # mixed NON-standard register + stack arg -> still unsupported (regs path is register-only)
+    try:
+        translate_layout_to_spec("Weird", "0x1", {
+            "inputs": [{"name": "a", "register": "ESI"}, {"name": "b", "register": "STACK"}],
+            "outputs": []})
+        raise SystemExit("FAIL: expected UnsupportedLiveABI for reg+stack mix")
+    except UnsupportedLiveABI:
+        pass
+    print("[ok] translate_layout_to_spec unit checks passed")
+
+    # 2) live integration: prove the already-built town capstone via its spec.
+    town_spec = VECTORS_DIR / "town_levelid.spec.json"
+    if not town_spec.exists():
+        raise SystemExit(f"[skip] {town_spec} missing")
+    res = _invoke_prove(town_spec, build=False)
+    print(f"[live] {res['stage']}: ok={res['ok']} passed={res['passed']}/{res['total']}")
+    if not res["ok"]:
+        print(res["output"])
+        raise SystemExit("FAIL: live prove of town capstone did not pass")
+    print("[ok] live prove contract works (town capstone proven via port_live_prove)")

--- a/fun-doc/port_pipeline.py
+++ b/fun-doc/port_pipeline.py
@@ -1,0 +1,1186 @@
+"""
+port_pipeline.py -- Stage 2/3 ("port" + "prove") of the OpenD2 conformance
+pipeline described in OpenD2/docs/EMULATION_CONFORMANCE_PLAN.md Sec 14.
+
+Stage 1 (document) is fun_doc's existing auto-doc worker. This module adds
+the two stages that were, until now, entirely manual: drafting an OpenD2 C++
+port and proving it against golden vectors minted from the original binary.
+
+Scope (Phase 1, deliberately narrow): only PURE/LEAF functions provable via
+the static `/emulate_function` oracle -- no live game process, no debugger,
+no WOW64 dependency. Stateful functions (pointer/global-state args) are
+classified and skipped, left to the existing manual `d2-port-function` /
+`d2-conformance-harness` Claude Code skills in the OpenD2 repo. See the
+CMake hazard note on GENERATED_CANDIDATES_DIR below before touching that
+constant.
+
+This module is standalone (like its sibling conformance_workbench.py) -- it
+does not import fun_doc, so fun_doc/web.py import it, never the reverse.
+Callers pass in whatever fun_doc state (conformance_protected set, funcs
+dict) it needs rather than this module loading its own copies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+OPEND2_REPO = Path(os.environ.get("FUNDOC_OPEND2_REPO", r"C:\Users\benam\source\cpp\OpenD2"))
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+
+D2CONFORM_DIR = OPEND2_REPO / "Tools" / "d2conform"
+PENDING_VECTORS_DIR = D2CONFORM_DIR / "vectors" / "_pending"
+
+
+def pascal_to_snake_case(symbol):
+    """Convert a D2 symbol to a vector-file-safe snake_case name. D2 symbols
+    mix ALL_CAPS module prefixes with CamelCase (e.g.
+    "COMMON_ScaledMultiplyDivide") -- inserting "_" before EVERY capital
+    mangles an acronym run into "c_o_m_m_o_n__scaled_multiply_divide"
+    (confirmed live). Only insert at a lowercase/digit -> uppercase
+    boundary (a real camelCase hump); an existing ALL-CAPS run or
+    underscore is left untouched."""
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", symbol).lower()
+
+# CMake hazard (see CMakeLists.txt:22 GLOB_RECURSE SHARED_SRC, folded into
+# ENGINE_SRC/D2COMMON_SRC/D2SERVER_SRC): anything under Shared/ compiles into
+# the production game/D2Common/D2Server binaries. Generated, unproven drafts
+# must live HERE and nowhere else -- never move this under Shared/.
+GENERATED_CANDIDATES_DIR = D2CONFORM_DIR / "_generated_candidates"
+DRAFT_RUNNER_PATH = GENERATED_CANDIDATES_DIR / "draft_runner.cpp"
+DRAFT_VECTORS_PATH = GENERATED_CANDIDATES_DIR / "draft_vectors.json"
+
+# Isolated scratch CMake build dir for the draft harness only. Never
+# build_allegro/build_sdl (Ben's own build dirs) -- those stay untouched.
+# Matches the `build_*/` .gitignore pattern, so it's never accidentally
+# committed.
+DRAFT_BUILD_DIR = OPEND2_REPO / "build_port_pipeline"
+CMAKE_GENERATOR = os.environ.get("FUNDOC_CMAKE_GENERATOR", "Visual Studio 17 2022")
+CMAKE_ARCH = os.environ.get("FUNDOC_CMAKE_ARCH", "Win32")
+
+_GP_REGISTERS = {"EAX", "EBX", "ECX", "EDX", "ESI", "EDI", "EBP", "ESP"}
+
+
+def _ghidra_get(endpoint, params=None, timeout=15):
+    import requests
+    try:
+        r = requests.get(f"{GHIDRA_HTTP}/{endpoint.lstrip('/')}", params=params, timeout=timeout)
+        r.raise_for_status()
+        return r.text
+    except Exception as exc:  # noqa: BLE001 - surfaced to the caller as an error string
+        return f"<ghidra fetch failed: {exc}>"
+
+
+def _ghidra_post(endpoint, data=None, params=None, timeout=30):
+    import requests
+    try:
+        # json=, not data= -- BODY-sourced @Param fields (address, registers,
+        # etc.) are read from a JSON request body, not form-encoding. Matches
+        # fun_doc.ghidra_post's convention exactly (confirmed live: data=
+        # produced "Address parameter is required" from every /emulate_
+        # function call before this fix).
+        r = requests.post(
+            f"{GHIDRA_HTTP}/{endpoint.lstrip('/')}", json=data, params=params, timeout=timeout
+        )
+        r.raise_for_status()
+        try:
+            return r.json()
+        except ValueError:
+            return {"error": f"non-JSON response: {r.text[:500]}"}
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"ghidra post failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# classify_function -- pure/leaf heuristic (picks the oracle mode)
+# ---------------------------------------------------------------------------
+
+# Signals that a decompiled function touches global state or deep pointer
+# chains -- exactly what makes the static-emulation oracle unreliable (per
+# EMULATION_CONFORMANCE_PLAN.md Sec 3, mode 1 vs mode 2/3). Conservative by
+# design: classify_function must fail CLOSED (call it "stateful") on any
+# ambiguity, since a false "leaf" would silently hand a stateful function to
+# an oracle that can't prove it.
+#
+# IMPORTANT: a pointer parameter is NOT automatically disqualifying. The
+# d2-port-function skill's own Step 3 classifies "reads args + maybe a seed
+# pointer; no global state" as pure/leaf -- e.g. SEED_GetRandomNumberAlt
+# takes `ulonglong *pSeed` (an in/out scalar blob the caller owns) and is
+# PROVEN via static emulation (rng.json, 20/20). What actually disqualifies
+# a function is a pointer to a *named struct/class type* (UnitAny*, Room*,
+# StatList*) implying pre-existing game-world state that can't be
+# constructed from scalar inputs -- that's the real "deep pointer chain"
+# the plan means. Distinguish by base type: plain scalar/blob pointer types
+# are fine; anything else is treated as a struct pointer -> stateful.
+# Global access -> stateful (out of the STATIC emulation harness's scope: it
+# can't populate a global's memory + the struct it points to). Two forms:
+#   DAT_<hex>       -- Ghidra's auto-named data globals
+#   _g_* / g_*      -- NAMED globals (e.g. _g_pDataTables, the data-tables root
+#                      that every DATATBLS_* accessor dereferences). Found by
+#                      hand 2026-07-07: the DAT_-only regex let these named
+#                      globals through as "leaf", so the pipeline drafted them,
+#                      minted (unusable) vectors, and only discovered the problem
+#                      at STATIC-harness link time ("unresolved external symbol
+#                      _g_pDataTables") -- three wasted LLM calls + builds per
+#                      function. These are provable LIVE (the running game has
+#                      the global populated), but that needs the runtime-resolver
+#                      reimpl shape + a live-only path (see the note in
+#                      classify_function); until then they are honestly stateful.
+_GLOBAL_ACCESS_RE = re.compile(r"\bDAT_[0-9a-fA-F]+\b|\b_?g_[A-Za-z_]\w*\b")
+# Split the two global forms: a NAMED global (g_*/_g_*) is resolvable by name via
+# the D2MOO live resolver (D2MOO_Resolve) -> the function is provable LIVE against
+# the running game even though it can't be proven statically. A DAT_<hex> global is
+# an unnamed raw address NOT in the resolver -> still hard-stateful.
+_DAT_GLOBAL_RE = re.compile(r"\bDAT_[0-9a-fA-F]+\b")
+_NAMED_GLOBAL_RE = re.compile(r"\b_?g_[A-Za-z_]\w*\b")
+_STRUCT_ACCESS_RE = re.compile(r"->\s*\w+")
+# `TYPE *name` (a pointer declaration) and `a * b` (a multiplication
+# expression) are IDENTICAL at the token level -- "word, *, word" -- so a
+# whole-text regex can't tell them apart (confirmed false positive:
+# `(nMultiplier * in_EAX)` inside a return expression matched as if
+# "nMultiplier" were a pointer type). Fixed by restricting the scan to
+# where pointer declarations actually appear in Ghidra's decompiler output:
+# the parameter list (inside the signature's outer parens, before the first
+# `{`) and standalone local-declaration lines (a line that is ENTIRELY
+# `TYPE *name;`, nothing else -- multiplication only ever appears inside a
+# larger statement with `=`/`return`/operators, never as a bare `a * b;`
+# line by itself).
+_POINTER_PARAM_RE = re.compile(r"(?:^|,)\s*(\w+)\s*\*+\s*\w+\s*(?=,|$)", re.MULTILINE)
+_POINTER_LOCAL_LINE_RE = re.compile(r"^\s*(?:\w+\s+)?(\w+)\s*\*+\s*\w+\s*;\s*$", re.MULTILINE)
+_C_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+# DOUBLE dereference: `*(TYPE *)(*var ...)` -- reading a POINTER out of another
+# pointer and dereferencing it. That's a struct-with-pointers / pointer-to-pointer
+# chain (e.g. Room.pSubRooms[i]), which the static /emulate_function harness can't
+# build -> stateful, even when the base pointer is typed int*/void* so the
+# pointer-base-type check below never fires. Found by hand 2026-07-07:
+# FindRoomByCoordinates (Room* typed as int*, `*(int *)(*in_EAX + i*4)`) sailed
+# through as "leaf", got drafted, and failed the harness -- a wasted cycle that
+# recurs on every Room*/Unit* accessor Ghidra types as a bare int*.
+_DEEP_DEREF_RE = re.compile(r"\*\s*\(\s*\w+\s*\*+\s*\)\s*\(\s*\*")
+# A pointer Ghidra types as a bare SCALAR (int*/short*/void*) that is actually a
+# LIVE-STRUCT base: indexed at a NONZERO offset (`pUnit[0xc]`, `pUnit[4]`) or
+# cast-double-dereferenced (`**(short **)pItemCode`). The scalar-pointer allowlist
+# wrongly calls these "pure leaf", so they dead-end in the static /emulate harness
+# (no_vectors / harness_failed) -- yet they are TRIVIAL live-pointer getters,
+# provable via SHADOW (the game passes the real pointer; original+reimpl both read
+# it and compare). Distinct from "stateful" (complex / delegating / global-reading)
+# because the body is a simple field read. Class = "shadow_leaf". Found 2026-07-07
+# running the hot backlog: GetPathFieldByUnitType (pUnit[0xc], 617M hits) and
+# DATATBLS_GetItemDataByCode (**(short**)p, 334M hits) both wasted static cycles.
+_STRUCT_PTR_INDEX_RE = re.compile(r"\b\w+\s*\[\s*(?:0x0*[1-9a-fA-F][0-9a-fA-F]*|[1-9]\d*)\s*\]")
+_CAST_DOUBLE_DEREF_RE = re.compile(r"\*\s*\*\s*\(\s*\w+\s*\*\s*\*\s*\)")
+# Clean double-deref of a variable in UNARY position (`return **p;`, `= **p`,
+# `(**p`) -- the cast-free form. Once a param's type is corrected to T** (e.g. the
+# write-back that fixed DATATBLS_GetItemDataByCode short*->short**), Ghidra drops
+# the `**(short**)` cast and emits a bare `**p`, which _CAST_DOUBLE_DEREF_RE misses.
+# Anchored to a unary lead-in so `a ** b` (a * (*b)) can't false-match.
+_CLEAN_DOUBLE_DEREF_RE = re.compile(r"(?:^|return|[=(,)])\s*\*\s*\*\s*\w")
+# A param Ghidra typed as a BARE scalar integer (plain `int`, not `int*`) that the
+# BODY uses as a live-STRUCT base -- `*(T *)(param + off)`, `*(T *)param`, or
+# `param[idx]`. Ghidra frequently types a struct pointer as plain `int` on
+# single-field getters (found 2026-07-08: PATH_GetDynamicX `int pPath` /
+# `*(dword *)(pPath + 0xc)` sailed through as "leaf" and dead-ended in the static
+# harness). _POINTER_PARAM_RE requires a `*` in the decl, so it misses these; this
+# recovers them into shadow_leaf, where they prove trivially via the handle path.
+_SCALAR_PARAM_DECL_RE = re.compile(
+    r"(?:^|[,(])\s*(?:const\s+)?"
+    r"(?:int|uint|dword|long|ulong|__int32|uint32_t|int32_t|intptr_t|uintptr_t)\s+"
+    r"(\w+)\s*(?=[,)]|$)")
+
+
+def _scalar_params_used_as_ptr(params_text, body):
+    """Names of BARE-scalar params the body dereferences as a pointer base (cast
+    `*(T *)(name...` / `*(T *)name`) or indexes as an array base (`name[idx]`).
+    These are struct pointers Ghidra under-typed as `int`."""
+    names = []
+    for m in _SCALAR_PARAM_DECL_RE.finditer(params_text):
+        name = m.group(1)
+        esc = re.escape(name)
+        # cast-and-deref: *(TYPE *) [(] name ...   -- name is the pointer base
+        cast_deref = re.search(r"\*\s*\(\s*\w[\w ]*\*+\s*\)\s*\(?\s*" + esc + r"\b", body)
+        # array-base index at a nonzero offset: name[0xNN] / name[1..]
+        arr_index = re.search(esc + r"\s*\[\s*(?:0x0*[1-9a-fA-F]|[1-9])", body)
+        if cast_deref or arr_index:
+            names.append(name)
+    return names
+
+# --- handle_leaf gate: a READ-ONLY live-object getter provable via the oracle
+# capture path (a real captured object passed to orig+reimpl). It takes exactly one
+# pointer, reads its fields, touches NO globals, calls NO real delegates, and
+# MUTATES nothing through the pointer. These are the biggest hot-path class, marked
+# "stateful" today only because Ghidra types the pointer as a named struct. ---
+_CALL_ID_RE = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
+# Calls that DON'T disqualify: control flow, abort/exit helpers (null-guard paths),
+# and decompiler intrinsics (CONCAT/SUB/ZEXT/... are bit ops, not real functions).
+_SAFE_CALL_RE = re.compile(
+    r"^(if|while|for|switch|return|sizeof|do|GetReturnAddress|CleanupAndAbort|"
+    r"_?exit|abort|assert\w*|CONCAT\d+|SUB\d+|ZEXT\d+|SEXT\d+|CARRY\d+|SBORROW\d+)$")
+# A WRITE through a pointer/struct: `p->f =`, `*p =`, `a[i] =`, `*(T*)(..) =`.
+# CRITICAL SAFETY GATE -- a fn that mutates the pointed-to object must NEVER be
+# handle-proven: passing a live captured game object would CORRUPT it. `==` excluded.
+_PTR_WRITE_RE = re.compile(r"(?:->\s*\w+|\]|\*\s*\([^;{}]*\)|\*\s*\w+)\s*=(?!=)")
+
+
+def _has_delegate_call(body):
+    """True if `body` calls any function that is NOT control-flow / an abort helper
+    / a decompiler intrinsic -- i.e. a real delegate a passthrough reimpl can't
+    reproduce from field reads alone."""
+    for m in _CALL_ID_RE.finditer(body):
+        if not _SAFE_CALL_RE.match(m.group(1)):
+            return True
+    return False
+
+
+def _strip_comments(text):
+    """Drop /* ... */ blocks before classification. fun-doc's plate comments
+    are English prose (algorithm descriptions, parameter docs) that can
+    accidentally look like C pointer declarations to a regex -- e.g. a
+    module-name aside like "(SEED_* module)" false-matches a "type *ident"
+    pattern. Only the real decompiled code should drive classification."""
+    return _C_COMMENT_RE.sub(" ", text)
+
+
+def _extract_signature_params(text):
+    """Return the raw text between the function signature's outer parens
+    (the parameter list) -- the first top-level paren group in the
+    decompile, matching Ghidra's standard "ReturnType FuncName(params)"
+    shape. "" if no parens found. Isolating this substring is what makes
+    _POINTER_PARAM_RE safe: a bare multiplication expression like
+    "(nMultiplier * in_EAX)" inside the function BODY never gets scanned as
+    if it were a parameter declaration."""
+    start = text.find("(")
+    if start == -1:
+        return ""
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1:i]
+    return ""
+
+# Ghidra/decompiler spellings for scalar or opaque-blob pointer base types.
+# A pointer to any of these is an in/out value, not a struct/world-state
+# reference -- does not disqualify static emulation.
+_SCALAR_POINTER_BASE_TYPES = {
+    "void", "char", "uchar", "byte", "sbyte", "bool", "boolean",
+    "short", "ushort", "int", "uint", "long", "ulong",
+    "longlong", "ulonglong", "float", "double",
+    "undefined", "undefined1", "undefined2", "undefined4", "undefined8",
+    "int8", "int16", "int32", "int64",
+    "uint8", "uint32", "uint32_t", "uint16", "uint16_t", "uint8_t", "uint64", "uint64_t",
+    "int8_t", "int16_t", "int32_t", "int64_t",
+    "wchar_t", "wchar16",
+}
+
+
+def classify_function(decompiled_text, variables=None):
+    """Classify a function for the port pipeline. Returns:
+      "leaf"        -- pure/leaf, provable via static /emulate_function.
+      "global_leaf" -- reads only NAMED globals, provable LIVE via the resolver.
+      "shadow_leaf" -- trivial LIVE-POINTER getter (a scalar-typed pointer used as
+                       a struct base): not statically emulable, provable via SHADOW
+                       (the game passes the real pointer). The hot-path getter class.
+      "stateful"    -- complex/struct-pointer/delegating; out of auto-port scope.
+      "unknown"     -- decompile fetch failed; treat as do-not-auto-port.
+
+    Heuristic (deliberately conservative -- see module docstring):
+    - Any DAT_<addr> OR named g_*/_g_* global reference in the decompile
+      -> stateful.
+    - Any `->` struct-field navigation -> stateful (deep pointer chains,
+      per the d2-port-function skill's Step 3).
+    - Any pointer parameter/local whose base type is NOT a known
+      scalar/blob type (i.e. looks like a named struct, e.g. UnitAny*,
+      Room*) -> stateful. A scalar/blob pointer (uint*, ulonglong*, an
+      in/out seed or accumulator the caller owns) does NOT disqualify.
+    - Otherwise -> leaf.
+
+    NOTE (future work, 2026-07-07): the named-global class (e.g. every
+    DATATBLS_* accessor dereferencing _g_pDataTables) is skipped as
+    "stateful" here because the STATIC /emulate_function harness can't
+    populate a global + the struct it points to. But this class IS
+    provable LIVE against the running game (the global is populated there)
+    -- exactly how the D2MOO conformance work proves GetDataTableRowEntryCount
+    by hand. Automating it needs (a) a reimpl draft that resolves the global
+    at runtime via the injected resolver (D2MOO_Resolve), not an OpenD2-style
+    `extern _g_pDataTables`, and (b) a live-prove-ONLY path that skips the
+    static harness for this class. Until both exist, skipping is the honest
+    behavior (better than burning LLM calls + builds on a guaranteed static
+    link failure).
+    """
+    if not decompiled_text or decompiled_text.startswith("<ghidra fetch failed"):
+        return "unknown"
+
+    text = _strip_comments(str(decompiled_text))
+    # Pointer-type checks are scoped to where declarations actually appear
+    # (signature params + standalone local-decl lines), NOT the whole text -- a
+    # whole-text scan can't tell `TYPE *name` (declaration) from `a * b`
+    # (multiplication). See _extract_signature_params/_POINTER_LOCAL_LINE_RE.
+    header, _, body = text.partition("{")
+    params_text = _extract_signature_params(header)
+    has_ptr_param = bool(_POINTER_PARAM_RE.search(params_text))
+
+    # handle_leaf FIRST -- a READ-ONLY live-object getter: EXACTLY ONE pointer arg,
+    # reads its fields (struct access), touches NO globals, calls NO real delegate,
+    # and writes NOTHING through the pointer. Provable via the oracle handle path (a
+    # real captured object passed to orig+reimpl -- the GetPathFieldByUnitType /
+    # UNIT_GetMode mechanism). Checked BEFORE the stateful guards, which a struct
+    # getter would otherwise trip (`->` / named-struct param), because it is the
+    # biggest hot-path class and IS provable. SAFETY: the no-write gate is REQUIRED
+    # -- handle-proving a mutator would corrupt the live captured game object.
+    struct_access = bool(_STRUCT_ACCESS_RE.search(body) or _STRUCT_PTR_INDEX_RE.search(body)
+                         or _CAST_DOUBLE_DEREF_RE.search(body) or _CLEAN_DOUBLE_DEREF_RE.search(body))
+    # A single live-pointer param can be either a declared pointer (`T *p`) OR a
+    # bare scalar Ghidra under-typed (`int p` used as `*(T*)(p+off)`). Count both so
+    # the under-typed getters (PATH_GetDynamicX etc.) reach shadow_leaf instead of
+    # dead-ending in the static harness.
+    declared_ptr_params = _POINTER_PARAM_RE.findall(params_text)
+    scalar_ptr_params = _scalar_params_used_as_ptr(params_text, body)
+    total_ptr_params = len(declared_ptr_params) + len(scalar_ptr_params)
+    if (total_ptr_params == 1 and (struct_access or scalar_ptr_params)
+            and not _DAT_GLOBAL_RE.search(text) and not _NAMED_GLOBAL_RE.search(text)
+            and not _has_delegate_call(body) and not _PTR_WRITE_RE.search(body)):
+        return "shadow_leaf"
+
+    # NAMED-GLOBAL TABLE GETTER (before the ->/deep-deref guards): a function that
+    # reads a NAMED global (g_*/_g_*), takes NO live-object pointer param (only scalar/
+    # index args), and does NOT delegate, is provable LIVE via the resolver regardless
+    # of Ghidra TYPING. Its `->`/deep derefs are on a pointer COMPUTED from the named
+    # global + a scalar index (`records[idx]->field`) -- fully resolvable, NOT a captured-
+    # object chain (which needs a pointer PARAM). Without this, typing a record ptr
+    # (`rec->field` -> `->`) mis-routes it to stateful while the structurally-identical
+    # UNTYPED getter reaches global_leaf. (DATATBLS batch 2026-07-08: GetItemTypeFieldE
+    # global_leaf+proved vs identical GetItemTypeField10 stateful-skipped, only because
+    # its record ptr was typed -> `->`.) Gated: named global, no unnamed DAT_, no pointer
+    # param at all, no delegate -> the derefs can only be global/scalar-derived.
+    if (_NAMED_GLOBAL_RE.search(text) and not _DAT_GLOBAL_RE.search(text)
+            and not has_ptr_param and not scalar_ptr_params
+            and not _has_delegate_call(body)):
+        return "global_leaf"
+
+    # HARD-stateful signals (not provable statically AND not simply live-resolvable):
+    if _DAT_GLOBAL_RE.search(text):
+        return "stateful"  # unnamed raw-address global -- not in the name resolver
+    if _STRUCT_ACCESS_RE.search(text):
+        return "stateful"  # `->` struct navigation
+    if _DEEP_DEREF_RE.search(text):
+        return "stateful"  # pointer-to-pointer / struct-with-pointers chain
+
+    for m in _POINTER_PARAM_RE.finditer(params_text):
+        base_type = m.group(1).lower().replace("const", "").strip()
+        if base_type not in _SCALAR_POINTER_BASE_TYPES:
+            return "stateful"
+    for m in _POINTER_LOCAL_LINE_RE.finditer(body):
+        base_type = m.group(1).lower().replace("const", "").strip()
+        if base_type not in _SCALAR_POINTER_BASE_TYPES:
+            return "stateful"
+
+    if isinstance(variables, dict):
+        for group in ("parameters", "locals"):
+            for v in variables.get(group, []) or []:
+                dtype = str(v.get("data_type") or v.get("type") or "")
+                if "*" in dtype:
+                    base_type = dtype.split("*")[0].strip().lower()
+                    if base_type not in _SCALAR_POINTER_BASE_TYPES:
+                        return "stateful"
+
+    # (The live-pointer GETTER class 'shadow_leaf' is decided EARLY, above, with the
+    # full read-only/no-global/no-delegate safety gate -- it must precede the
+    # stateful guards a struct getter would otherwise trip.)
+
+    # No hard-stateful signal. If the only "state" it touches is a NAMED global
+    # (g_*/_g_*), it's provable LIVE via the D2MOO resolver (D2MOO_Resolve gives
+    # the real running-game address) -- a distinct class the live-prove path
+    # handles, not a static-harness candidate. Otherwise it's a pure leaf.
+    if _NAMED_GLOBAL_RE.search(text):
+        return "global_leaf"
+    return "leaf"
+
+
+# ---------------------------------------------------------------------------
+# mint_vectors -- Stage 3 input, static-emulation oracle only (Mode 1)
+# ---------------------------------------------------------------------------
+
+def _hex_to_int(value, signed_bits=None):
+    if isinstance(value, int):
+        v = value
+    else:
+        v = int(str(value), 16) if str(value).lower().startswith("0x") else int(value)
+    if signed_bits:
+        half = 1 << (signed_bits - 1)
+        full = 1 << signed_bits
+        if v >= half:
+            v -= full
+    return v
+
+
+def mint_vectors(program, address, fn_name, param_layout, input_sets, *, max_steps=10000, timeout=30):
+    """Mint golden vectors for one leaf/pure function via the static
+    `/emulate_function` oracle. Fully automatable -- no live game process.
+
+    param_layout: {
+        "inputs":  [{"name": "seedLo", "register": "ECX", "signed": false}, ...],
+        "outputs": [{"name": "ret",    "register": "EAX", "signed": false}, ...],
+    }
+    input_sets: list of {name: int_value, ...} dicts, one per case. Callers
+    (the port_pipeline drafting step, or the d2-port-function skill for a
+    manual mint) are responsible for covering edge cases (0, 1, powers of
+    two, decompiler-flagged overflow guards) -- see EMULATION_CONFORMANCE_PLAN
+    Sec 8 "coverage, not overfitting".
+
+    Returns (vectors, errors): vectors is a list of {fn, in, out, note}
+    dicts ready for vectors/_pending/<system>.json; errors is a list of
+    per-case failure strings (emulation fault, timeout, etc.) for cases that
+    could not be minted -- callers should not silently drop these.
+    """
+    vectors = []
+    errors = []
+    return_registers = ",".join(o["register"] for o in param_layout["outputs"])
+
+    for case in input_sets:
+        registers = {}
+        for inp in param_layout["inputs"]:
+            if inp["name"] not in case:
+                errors.append(f"case {case!r} missing input '{inp['name']}'")
+                registers = None
+                break
+            # The model's input_sets sometimes use hex STRINGS for
+            # pointer-looking values (e.g. "0x10000000") rather than a plain
+            # int -- _hex_to_int (already used for the OUTPUT side below)
+            # normalizes either form. Found by hand 2026-07-07: an int-only
+            # `&` here raised an unhandled TypeError that killed the entire
+            # worker pass, not just this one candidate.
+            registers[inp["register"]] = f"0x{_hex_to_int(case[inp['name']]) & 0xFFFFFFFF:x}"
+        if registers is None:
+            continue
+
+        result = _ghidra_post(
+            "/emulate_function",
+            data={
+                "address": address if str(address).startswith("0x") else f"0x{address}",
+                "registers": json.dumps(registers),
+                "max_steps": max_steps,
+                "return_registers": return_registers,
+            },
+            # `program` defaults to ParamSource.QUERY (no `source = BODY` on
+            # that @Param) -- POST endpoints must send it as a URL query
+            # param, not in the JSON body (CLAUDE.md's Code Conventions).
+            # Confirmed live: putting it in `data` silently resolved against
+            # whatever program Ghidra treats as "current" instead of the one
+            # named here, producing "No function at address" for a real,
+            # valid entry point.
+            params={"program": program},
+            timeout=timeout,
+        )
+        if result.get("error"):
+            errors.append(f"case {case!r}: {result['error']}")
+            continue
+        if not result.get("success") or not result.get("hit_return"):
+            errors.append(
+                f"case {case!r}: emulation did not return cleanly "
+                f"(stop_reason={result.get('stop_reason')!r})"
+            )
+            continue
+
+        reg_values = result.get("registers", {})
+        out = {}
+        ok = True
+        for outp in param_layout["outputs"]:
+            raw = reg_values.get(outp["register"])
+            if raw is None:
+                errors.append(f"case {case!r}: missing return register {outp['register']!r}")
+                ok = False
+                break
+            out[outp["name"]] = _hex_to_int(raw, signed_bits=32 if outp.get("signed") else None)
+        if not ok:
+            continue
+
+        vectors.append({
+            "fn": fn_name,
+            "in": dict(case),
+            "out": out,
+            "note": f"PD2-S12; src {program} 0x{str(address).replace('0x', '')}",
+        })
+
+    return vectors, errors
+
+
+def write_pending_vectors(system_name, vectors):
+    """Append/merge vectors into vectors/_pending/<system>.json (existing
+    staging convention -- see the treasureclass.json precedent). Returns the
+    path written."""
+    PENDING_VECTORS_DIR.mkdir(parents=True, exist_ok=True)
+    path = PENDING_VECTORS_DIR / f"{system_name}.json"
+    existing = []
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = []
+    existing.extend(vectors)
+    path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# run_harness -- Stage 3 gate. Builds + runs the isolated d2conform_draft
+# target (see CMakeLists.txt's D2CONFORM_ENABLE_DRAFTS option). Never
+# touches d2conform.cpp (hand-maintained production harness) or Shared/.
+# ---------------------------------------------------------------------------
+
+_DRAFT_RUNNER_TEMPLATE = '''\
+// ============================================================================
+//  d2conform_draft - single-candidate draft port runner (GENERATED)
+//
+//  Regenerated by fun-doc's port_pipeline.write_draft() for whichever ONE
+//  candidate is currently being proven. Do not hand-edit -- see
+//  Tools/d2conform/_generated_candidates/ and CMakeLists.txt's
+//  D2CONFORM_ENABLE_DRAFTS option.
+// ============================================================================
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <map>
+#include <fstream>
+#include <sstream>
+
+#include "{header_name}"   // candidate under test
+
+#ifndef D2CONFORM_DRAFT_VECTOR_DIR
+#define D2CONFORM_DRAFT_VECTOR_DIR "."
+#endif
+
+struct JVal
+{{
+	enum Type {{ NUL, BOOL, NUM, STR, ARR, OBJ }} type = NUL;
+	bool          b = false;
+	long long     num = 0;
+	std::string   str;
+	std::vector<JVal>          arr;
+	std::map<std::string,JVal> obj;
+
+	const JVal* find(const char* k) const
+	{{
+		auto it = obj.find(k);
+		return it == obj.end() ? nullptr : &it->second;
+	}}
+	long long n(const char* k, long long dflt = 0) const
+	{{
+		const JVal* v = find(k);
+		return v ? v->num : dflt;
+	}}
+	bool has(const char* k) const {{ return find(k) != nullptr; }}
+}};
+
+struct JParser
+{{
+	const char* p;
+	const char* end;
+	bool ok = true;
+
+	explicit JParser(const std::string& s) : p(s.c_str()), end(s.c_str() + s.size()) {{}}
+
+	void ws() {{ while (p < end && (*p==' '||*p=='\\t'||*p=='\\n'||*p=='\\r')) ++p; }}
+
+	JVal parse() {{ ws(); return value(); }}
+
+	JVal value()
+	{{
+		ws();
+		if (p >= end) {{ ok = false; return {{}}; }}
+		char c = *p;
+		if (c == '{{') return object();
+		if (c == '[') return array();
+		if (c == '"') {{ JVal v; v.type = JVal::STR; v.str = str(); return v; }}
+		if (c == 't' || c == 'f') return boolean();
+		if (c == 'n') {{ p += 4; JVal v; v.type = JVal::NUL; return v; }}
+		return number();
+	}}
+
+	JVal object()
+	{{
+		JVal v; v.type = JVal::OBJ; ++p; ws();
+		if (p < end && *p == '}}') {{ ++p; return v; }}
+		while (p < end)
+		{{
+			ws();
+			std::string key = str(); ws();
+			if (p < end && *p == ':') ++p;
+			v.obj[key] = value(); ws();
+			if (p < end && *p == ',') {{ ++p; continue; }}
+			if (p < end && *p == '}}') {{ ++p; break; }}
+			break;
+		}}
+		return v;
+	}}
+
+	JVal array()
+	{{
+		JVal v; v.type = JVal::ARR; ++p; ws();
+		if (p < end && *p == ']') {{ ++p; return v; }}
+		while (p < end)
+		{{
+			v.arr.push_back(value()); ws();
+			if (p < end && *p == ',') {{ ++p; continue; }}
+			if (p < end && *p == ']') {{ ++p; break; }}
+			break;
+		}}
+		return v;
+	}}
+
+	std::string str()
+	{{
+		std::string s;
+		if (p < end && *p == '"') ++p;
+		while (p < end && *p != '"')
+		{{
+			if (*p == '\\\\' && p + 1 < end) {{ ++p; s.push_back(*p++); }}
+			else s.push_back(*p++);
+		}}
+		if (p < end && *p == '"') ++p;
+		return s;
+	}}
+
+	JVal boolean()
+	{{
+		JVal v; v.type = JVal::BOOL;
+		if (*p == 't') {{ v.b = true;  p += 4; }}
+		else           {{ v.b = false; p += 5; }}
+		return v;
+	}}
+
+	JVal number()
+	{{
+		JVal v; v.type = JVal::NUM;
+		const char* s = p;
+		while (p < end && (*p=='-'||*p=='+'||(*p>='0'&&*p<='9')||*p=='.'||*p=='e'||*p=='E')) ++p;
+		std::string tok(s, p);
+		v.num = (long long)strtoll(tok.c_str(), nullptr, 10);
+		return v;
+	}}
+}};
+
+static bool run_case(const JVal& c, int idx)
+{{
+	const JVal* fnv = c.find("fn");
+	const JVal* in  = c.find("in");
+	const JVal* out = c.find("out");
+	if (!fnv || !in || !out) {{ printf("  FAIL [%d]: malformed case\\n", idx); return false; }}
+	const std::string& fn = fnv->str;
+
+{dispatch_body}
+
+	printf("  FAIL [%d]: no candidate staged ('%s' requested)\\n", idx, fn.c_str());
+	return false;
+}}
+
+int main()
+{{
+	std::string path = std::string(D2CONFORM_DRAFT_VECTOR_DIR) + "/draft_vectors.json";
+	std::ifstream f(path, std::ios::binary);
+	if (!f)
+	{{
+		printf("ERROR: cannot open vector file '%s'\\n", path.c_str());
+		return 1;
+	}}
+	std::stringstream ss; ss << f.rdbuf();
+	std::string text = ss.str();  // named, not a temporary -- JParser stores raw pointers into it
+	JParser jp(text);
+	JVal root = jp.parse();
+	if (root.type != JVal::ARR)
+	{{
+		printf("ERROR: '%s' is not a JSON array of cases\\n", path.c_str());
+		return 1;
+	}}
+
+	printf("d2conform_draft - single-candidate draft runner\\n");
+	int pass = 0, fail = 0;
+	for (size_t i = 0; i < root.arr.size(); ++i)
+	{{
+		if (run_case(root.arr[i], (int)i)) ++pass;
+		else ++fail;
+	}}
+	printf("%d/%d passed%s\\n", pass, pass + fail, fail ? "   <<< FAIL" : "");
+	return fail == 0 ? 0 : 1;
+}}
+'''
+
+
+def write_draft(module, symbol, header_content, dispatch_body, vectors):
+    """Stage the candidate for proving. Writes ONLY to
+    _generated_candidates/ -- never Shared/*.hpp, never a git commit.
+
+    dispatch_body: C++ source implementing the `if (fn == "...") {...}`
+    block(s) for this candidate's function(s), matching d2conform.cpp's
+    run_case style (see Tools/d2conform/d2conform.cpp for the pattern).
+
+    Returns {header_path, runner_path, vectors_path}.
+    """
+    GENERATED_CANDIDATES_DIR.mkdir(parents=True, exist_ok=True)
+    header_name = f"{module}_{symbol}.hpp"
+    header_path = GENERATED_CANDIDATES_DIR / header_name
+    header_path.write_text(header_content, encoding="utf-8")
+
+    DRAFT_VECTORS_PATH.write_text(json.dumps(vectors, indent=2) + "\n", encoding="utf-8")
+
+    runner_src = _DRAFT_RUNNER_TEMPLATE.format(header_name=header_name, dispatch_body=dispatch_body)
+    DRAFT_RUNNER_PATH.write_text(runner_src, encoding="utf-8")
+
+    return {
+        "header_path": str(header_path),
+        "runner_path": str(DRAFT_RUNNER_PATH),
+        "vectors_path": str(DRAFT_VECTORS_PATH),
+    }
+
+
+_HARNESS_LINE_RE = re.compile(r"^(\d+)/(\d+) passed")
+
+
+def run_harness(*, configure=True, build_timeout=180, run_timeout=30):
+    """Build + run the isolated d2conform_draft target against whatever is
+    currently staged in _generated_candidates/. Returns:
+        {ok: bool, passed: int, total: int, output: str, exit_code: int|None,
+         stage: "configure"|"build"|"run"|"done", error: str|None}
+
+    `ok` is True only when the build succeeded AND every vector passed.
+    Never touches build_allegro/build_sdl (Ben's own build dirs) -- always
+    uses the isolated DRAFT_BUILD_DIR.
+    """
+    if configure or not (DRAFT_BUILD_DIR / "CMakeCache.txt").exists():
+        cfg = subprocess.run(
+            [
+                "cmake", "-B", str(DRAFT_BUILD_DIR),
+                "-G", CMAKE_GENERATOR, "-A", CMAKE_ARCH,
+                "-DD2CONFORM_ENABLE_DRAFTS=ON",
+                "-DBUILD_GAME=OFF", "-DBUILD_D2CLIENT=OFF", "-DBUILD_D2SERVER=OFF",
+            ],
+            cwd=str(OPEND2_REPO),
+            capture_output=True, text=True, timeout=build_timeout,
+        )
+        if cfg.returncode != 0:
+            return {
+                "ok": False, "passed": 0, "total": 0,
+                "output": cfg.stdout + cfg.stderr, "exit_code": cfg.returncode,
+                "stage": "configure", "error": "cmake configure failed",
+            }
+
+    build = subprocess.run(
+        ["cmake", "--build", str(DRAFT_BUILD_DIR), "--config", "Debug", "--target", "d2conform_draft"],
+        cwd=str(OPEND2_REPO),
+        capture_output=True, text=True, timeout=build_timeout,
+    )
+    if build.returncode != 0:
+        return {
+            "ok": False, "passed": 0, "total": 0,
+            "output": build.stdout + build.stderr, "exit_code": build.returncode,
+            "stage": "build", "error": "build failed",
+        }
+
+    exe_path = DRAFT_BUILD_DIR / "Debug" / "d2conform_draft.exe"
+    if not exe_path.exists():
+        exe_path = DRAFT_BUILD_DIR / "d2conform_draft.exe"
+    try:
+        run = subprocess.run(
+            [str(exe_path)], capture_output=True, text=True, timeout=run_timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False, "passed": 0, "total": 0,
+            "output": "", "exit_code": None,
+            "stage": "run", "error": f"draft runner exceeded {run_timeout}s (possible infinite loop)",
+        }
+
+    output = run.stdout + run.stderr
+    passed = total = 0
+    for line in output.splitlines():
+        m = _HARNESS_LINE_RE.match(line.strip())
+        if m:
+            passed, total = int(m.group(1)), int(m.group(2))
+            break
+
+    return {
+        "ok": run.returncode == 0 and total > 0,
+        "passed": passed, "total": total,
+        "output": output, "exit_code": run.returncode,
+        "stage": "done", "error": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# select_port_candidates -- Stage 2 candidate selection.
+#
+# Deliberately NOT a copy of fun_doc.select_candidates: that selector's score
+# gate means "needs more Stage-1 documentation work" (score < good_enough).
+# Stage 2 wants the OPPOSITE population -- functions Stage 1 already
+# finished -- so score >= good_enough_score is a requirement here, not an
+# exclusion. Everything else (thunks/externals/library_code/conformance-
+# protected exclusion) mirrors select_candidates' filters exactly.
+# ---------------------------------------------------------------------------
+
+_BINARY_PORT_PRIORITY = {"D2Common.dll": 0, "D2Game.dll": 1, "D2Client.dll": 2}
+
+# Library / C-runtime / FLIRT-matched functions that are NOT D2 game logic and must
+# never be port candidates -- they're linked-in CRT/STL, not something to reimplement.
+# Found by hand 2026-07-07: a --count 20 batch wasted cycles on FID_conflict:_memcpy,
+# FID_conflict:_atoi, __cinit, doexit, STL template instantiations, etc. -- they score
+# HIGH (a FLIRT match gives them a real name) so they sail through the score>=80 gate.
+# The `library_code` flag doesn't catch them (detector missed them), but the NAME is a
+# dead giveaway. D2's own exports are PREFIX_Name / CamelCase and never start with '_'.
+_KNOWN_CRT_NAMES = frozenset({"doexit", "mainret", "_initterm", "_cinit", "atexit"})
+
+
+def _looks_like_library_or_runtime(name):
+    if not name:
+        return False
+    if name[0] == "_":                       # _initterm, __cinit, _Tidy, _ftol, _memcpy
+        return True
+    for p in ("FID_", "FUN_", "thunk_", "j_"):
+        if name.startswith(p):               # FLIRT matches, unnamed, thunks
+            return True
+    if "<" in name or ">" in name:           # STL template instantiations
+        return True
+    return name in _KNOWN_CRT_NAMES
+
+# port_status values that mean "already resolved -- do NOT re-select". Found by
+# hand 2026-07-07: without this, select_port_candidates returns the SAME
+# deterministically-sorted top-N every call, so a continuous loop re-processed
+# the identical 3 functions every batch and never advanced to new ones. Terminal
+# outcomes are excluded so the loop moves forward; `blocked` (quota/transient)
+# is intentionally NOT terminal so it retries later. To deliberately re-attempt
+# a terminal function (e.g. after a prompt/generator fix), clear its port_status
+# in state -- see scripts or the --retry-failed path.
+_PORT_TERMINAL_STATUSES = frozenset({
+    "proven_pending_review",       # static harness succeeded, awaiting human promotion
+    "proven_live_pending_review",  # LIVE oracle proof succeeded, awaiting human promotion
+    "stateful_skip",               # classified out of scope (deterministic)
+    "harness_failed",              # exhausted the bounded fix-retry loop
+    "live_prove_failed",           # live-path reimpl drafted but didn't prove
+    "unsupported_abi",             # register layout outside the oracle marshaller
+    "malformed_response",          # provider never returned parseable blocks after retries
+    "no_vectors",                  # /emulate_function couldn't mint any vectors
+    "unknown_skip",                # decompile fetch failed
+    "error",                       # unexpected pipeline exception (guarded per-candidate)
+})
+
+
+def select_port_candidates(funcs, conformance_protected, active_binary=None,
+                            good_enough_score=80, limit=20,
+                            include_terminal=False):
+    """Select functions eligible for Stage 2 (port) work.
+
+    `funcs`: the same {key: func_dict} state fun_doc.select_candidates
+    consumes. `conformance_protected`: the set from
+    fun_doc.load_conformance_protected() -- passed in, not loaded here (this
+    module has no fun_doc import; see module docstring).
+
+    Does NOT run classify_function -- that needs a live decompile fetch per
+    candidate, which the caller (the PORT worker) does one candidate at a
+    time, skipping any that classify "stateful". This function only narrows
+    the pool to "Stage 1 complete, not already conformance-tracked, priority-
+    ordered" candidates.
+
+    Sort: binary priority (D2Common -> D2Game -> D2Client, per
+    EMULATION_CONFORMANCE_PLAN.md Sec 15) first, then leaves before callers
+    (bottom-up, matching select_candidates' own readiness ordering), then
+    highest caller_count (more xrefs = more valuable to prove first).
+    """
+    out = []
+    for key, func in funcs.items():
+        if func.get("is_thunk") or func.get("is_external"):
+            continue
+        if func.get("library_code") or _looks_like_library_or_runtime(func.get("name")):
+            continue
+        if key in conformance_protected:
+            continue
+        binary_name = func.get("program_name", "") or ""
+        if active_binary and binary_name != active_binary:
+            continue
+
+        score = func.get("effective_score", func.get("score", 0)) or 0
+        if score < good_enough_score:
+            continue  # Stage 1 not finished yet -- not ready for Stage 2
+
+        if not include_terminal and func.get("port_status") in _PORT_TERMINAL_STATUSES:
+            continue  # already resolved -- don't re-select (loop must advance)
+
+        # "program" must be the full project path (func["program"], e.g.
+        # /Mods/PD2-S12/D2Common.dll), NOT the bare binary name: the PORT
+        # worker keys update_function_state with f"{program}::{address}", and
+        # only the full path matches fun_doc's state key. Found live
+        # 2026-07-07: emitting program_name here made every port_status write
+        # upsert a nameless, scoreless skeleton row (D2Common.dll::<addr>)
+        # while the real row never advanced past re-selection.
+        program = func.get("program") or binary_name
+        out.append({
+            "key": key,
+            "func": func,
+            "program": program,
+            "binary_priority": _BINARY_PORT_PRIORITY.get(binary_name, 99),
+            "caller_count": func.get("caller_count", 0),
+            "is_leaf": not func.get("callees"),
+        })
+
+    out.sort(key=lambda c: (c["binary_priority"], not c["is_leaf"], -c["caller_count"]))
+    return out[:limit] if limit else out
+
+
+# ---------------------------------------------------------------------------
+# Drafting prompts -- Stage 2. Mirrors fun_doc.py's build_full_doc_prompt /
+# build_fix_prompt shape: (func_name, address, ..., program) -> str. Kept
+# here (not fun_doc.py) since these are port-pipeline-specific and this
+# module owns the OpenD2-side conventions (house style, harness contract).
+# ---------------------------------------------------------------------------
+
+def _few_shot_style_examples(repo=None, limit=3):
+    """Pull existing PROVEN/PORTED functions from the OpenD2 repo as style
+    anchors, via conformance_workbench (already scans @PD2S12 markers)."""
+    import conformance_workbench as cw
+    idx = cw.build_index(repo)
+    # Prefer PROVEN examples -- they're validated, not just drafted.
+    idx.sort(key=lambda e: e.get("state") != "PROVEN")
+    examples = []
+    for entry in idx[:limit]:
+        code, _ = cw._extract_source_symbol(
+            repo or cw.OPEND2_REPO, entry["file"], entry["symbol"], entry.get("line")
+        )
+        if code:
+            examples.append({**entry, "code": code})
+    return examples
+
+
+def build_port_prompt(func_name, address, program, decompiled_text, style_examples=None):
+    """Assemble a Stage-2 drafting prompt. Follows the d2-port-function
+    skill's Step 5 ("port the ALGORITHM, not the decompiled C... no STL in
+    engine/modcode hot paths, bounded fixed arrays, plain C-ish C++") and
+    Step 6's harness dispatch contract (see Tools/d2conform/d2conform.cpp's
+    run_case for the exact shape the dispatch snippet must match).
+
+    Returns a prompt string. The model must respond with exactly two fenced
+    ```cpp blocks: the header-only port, then the draft_runner dispatch
+    snippet -- parse_port_response() extracts them mechanically.
+    """
+    if style_examples is None:
+        style_examples = _few_shot_style_examples()
+
+    sections = []
+    sections.append("## Task: port a Diablo II function into OpenD2 (Stage 2 of document -> port -> prove)")
+    sections.append("")
+    sections.append(
+        "OUTPUT CONTRACT (read first -- a machine parses your reply, a human never sees it): "
+        "reply with EXACTLY THREE fenced code blocks and NOTHING that matters outside them, "
+        "in THIS order:\n"
+        "  BLOCK 1  ```cpp   -- the ENTIRE header-only port: the function AND every helper it "
+        "needs, all in this ONE block (never split code across multiple cpp blocks).\n"
+        "  BLOCK 2  ```cpp   -- the single draft_runner dispatch snippet.\n"
+        "  BLOCK 3  ```json  -- the vector spec.\n"
+        "Tag them literally ```cpp / ```cpp / ```json (NOT ```c++, ```C, or untagged). Produce "
+        "exactly two cpp blocks and exactly one json block -- no more, no fewer. If you must think, "
+        "do it briefly BEFORE block 1; put nothing between or after the blocks. Getting this shape "
+        "wrong wastes the whole attempt.")
+    sections.append("")
+    sections.append(
+        "You are drafting an OpenD2 C++ port of a Ghidra-analyzed PD2-S12 function. This draft "
+        "will be PROVEN or REJECTED by an automated harness that replays golden vectors minted "
+        "from the original binary -- your draft is a hypothesis, not the final word. Port the "
+        "ALGORITHM described in the plate comment, not a literal transliteration of the decompiled "
+        "pseudocode (decompiler artifacts like Unwind_*/extraout_* are not real behavior)."
+    )
+    sections.append("")
+    sections.append(f"Function: {func_name} at 0x{address}")
+    sections.append(f"Program: {program}")
+    sections.append("")
+    sections.append("## Decompiled source (includes the plate comment -- this IS the spec)")
+    sections.append("```")
+    sections.append(str(decompiled_text))
+    sections.append("```")
+    sections.append("")
+
+    if style_examples:
+        sections.append("## House style -- existing proven ports (match this exactly)")
+        for ex in style_examples:
+            sections.append(f"### {ex['file']} :: {ex['symbol']} ({ex.get('state', '?')})")
+            sections.append("```cpp")
+            sections.append(ex.get("code") or "")
+            sections.append("```")
+        sections.append("")
+
+    sections.append("## House style rules (OpenD2 Shared/ conventions)")
+    sections.append("- Header-only: `#pragma once`, `inline` functions, `namespace D2Lib { ... }`.")
+    sections.append("- No STL in hot paths. Plain C-ish C++, bounded fixed arrays (ARM target).")
+    sections.append(
+        "- Preserve every magic constant, integer width, and overflow/rounding behavior EXACTLY "
+        "(e.g. 0x6AC690C5 is the D2 RNG LCG multiplier -- never approximate)."
+    )
+    sections.append(
+        "- Reproduce in-place side effects (e.g. seed-state mutation via a pointer/reference "
+        "parameter) -- the harness checks mutated state, not just the return value."
+    )
+    sections.append(
+        "- NEVER call a COMPILER-INTERNAL runtime helper by name. The decompiler shows "
+        "`__alldiv`/`__aulldiv`/`__allmul`/`__allrem`/`__allshl`/`__allshr` etc. because MSVC "
+        "EMITS those for 64-bit `/ % * << >>` on 32-bit x86 -- they are NOT callable identifiers "
+        "(you'll get `error C3861: identifier not found`). Write the plain C++ operator on the "
+        "correct fixed-width type instead and let the compiler emit the helper: e.g. a 64-bit "
+        "signed divide is `(int32_t)((int64_t)a * (int64_t)b / (int64_t)divisor)`, NOT "
+        "`__alldiv(lo, hi, ...)`."
+    )
+    sections.append("")
+
+    sections.append("## Output format -- exactly three fenced code blocks, nothing else")
+    sections.append(
+        "1. A ```cpp block: the complete header-only port. Put the function AND all helpers it "
+        "needs INSIDE this single block -- do NOT open a second cpp block for helpers.")
+    sections.append(
+        "2. A ```cpp block: a draft_runner.cpp dispatch snippet in this EXACT shape (see "
+        "Tools/d2conform/d2conform.cpp's run_case for the pattern):"
+    )
+    sections.append("```cpp")
+    sections.append('if (fn == "YourPortFunctionName")')
+    sections.append("{")
+    sections.append('\t// extract typed inputs via in->n("field"), call the port, compare against out->n("field")')
+    sections.append('\t// on mismatch: printf("  FAIL [%d] %s(...): expected %d got %d\\n", idx, fn.c_str(), ...); return false;')
+    sections.append("\treturn true;")
+    sections.append("}")
+    sections.append("```")
+    sections.append(
+        "3. A ```json block describing how to mint golden vectors via ghidra-mcp's static "
+        "`/emulate_function` oracle -- YOU must read the plate comment's register mapping "
+        "(explicit params + any IMPLICIT register like EAX/ESI/EDX) and propose the exact "
+        "layout, since this is D2's non-standard calling convention, not something inferable "
+        "mechanically. Shape:"
+    )
+    sections.append("```json")
+    sections.append(json.dumps({
+        "fn": "YourPortFunctionName",
+        "param_layout": {
+            "inputs": [{"name": "example_input", "register": "ECX", "signed": False}],
+            "outputs": [{"name": "ret", "register": "EAX", "signed": False}],
+        },
+        "input_sets": [{"example_input": 0}, {"example_input": 1}],
+    }, indent=2))
+    sections.append("```")
+    sections.append(
+        "Cover the edge cases the plate comment/decompile flag: 0, 1, powers of two "
+        "(the RNG family has a bitwise-AND fast path vs modulo -- exercise BOTH), and any "
+        "documented overflow/underflow guards. Aim for at least 15-20 input_sets, not one sample "
+        "-- one matching case is not proof (EMULATION_CONFORMANCE_PLAN.md Sec 8)."
+    )
+    sections.append("")
+    sections.append(
+        "Reminder -- the parser is mechanical (parse_port_response_full). These specific mistakes "
+        "make your ENTIRE reply unusable, so double-check before you send:\n"
+        "  - splitting the port across more than one cpp block (all code goes in block 1);\n"
+        "  - tagging a block ```c++ / ```C / ```C++ or leaving it untagged instead of ```cpp;\n"
+        "  - tagging the vector spec anything other than ```json, or wrapping it in ```cpp;\n"
+        "  - emitting more or fewer than exactly two cpp blocks + one json block;\n"
+        "  - trailing prose or a fourth block after the json.\n"
+        "Output the three blocks and stop."
+    )
+    return "\n".join(sections)
+
+
+def build_port_fix_prompt(func_name, address, program, decompiled_text,
+                           prior_header, prior_dispatch, harness_output):
+    """Assemble a Stage-2 retry prompt after a harness FAIL. Mirrors
+    fun_doc.build_fix_prompt's pattern: feed back the SPECIFIC mismatch, not
+    just "try again" (see d2-port-function Step 6: "a single mismatch means
+    the port is WRONG... do not weaken a vector to force a pass")."""
+    sections = []
+    sections.append("## Task: fix a failing OpenD2 port draft (Stage 2 retry)")
+    sections.append("")
+    sections.append(
+        "Your previous draft for this function FAILED the conformance harness. A single mismatch "
+        "means the port is WRONG -- re-read the decompilation for an integer-width, sign, rounding, "
+        "or missed-side-effect bug. Do NOT change the vectors; they were minted from the real binary. "
+        "Never weaken a vector to force a pass."
+    )
+    sections.append("")
+    sections.append(f"Function: {func_name} at 0x{address}")
+    sections.append(f"Program: {program}")
+    sections.append("")
+    sections.append("## Decompiled source (the spec)")
+    sections.append("```")
+    sections.append(str(decompiled_text))
+    sections.append("```")
+    sections.append("")
+    sections.append("## Your previous header")
+    sections.append("```cpp")
+    sections.append(prior_header)
+    sections.append("```")
+    sections.append("")
+    sections.append("## Your previous dispatch snippet")
+    sections.append("```cpp")
+    sections.append(prior_dispatch)
+    sections.append("```")
+    sections.append("")
+    sections.append("## Harness output (the failure -- read it carefully)")
+    sections.append("```")
+    sections.append(harness_output)
+    sections.append("```")
+    sections.append("")
+    sections.append(
+        "## Output format -- exactly TWO fenced ```cpp blocks, nothing that matters outside them: "
+        "BLOCK 1 = the full corrected header (function + all helpers in this one block), BLOCK 2 = "
+        "the dispatch snippet. Tag both literally ```cpp (never ```c++/```C/untagged). Do NOT emit "
+        "a json block on a fix (the vectors are frozen). A machine parses this; wrong shape wastes "
+        "the retry."
+    )
+    return "\n".join(sections)
+
+
+# Lang tag capture allows `+`/`#`/`.`/`-` so a ```c++ / ```c# fence is captured at
+# all (the old `\w*` couldn't match the `+`, silently DROPPING the whole block and
+# turning a perfectly good draft into a "malformed_response" -- a real flakiness
+# source with models that tag C++ as `c++`). Normalization below maps the whole
+# C/C++ family onto "cpp".
+_CODE_BLOCK_RE = re.compile(r"```([\w+#.\-]*)[ \t]*\r?\n(.*?)```", re.DOTALL)
+_CPP_LANGS = {"", "cpp", "c++", "cxx", "cc", "c", "hpp", "hxx", "hh", "h", "cplusplus"}
+_JSON_LANGS = {"json", "jsonc", "json5"}
+
+
+def _fenced_blocks(response_text):
+    """Return [(lang, content), ...] for every fenced code block, in order."""
+    return [(lang.lower(), content) for lang, content in _CODE_BLOCK_RE.findall(response_text)]
+
+
+def parse_port_response(response_text):
+    """Extract (header_content, dispatch_body) from a build_port_fix_prompt
+    response (2 blocks: header, dispatch -- no vector spec on a retry, since
+    vectors must not change once minted). Returns (None, None) if fewer than
+    two cpp-family blocks are found."""
+    cpp_blocks = [content for lang, content in _fenced_blocks(response_text) if lang in _CPP_LANGS]
+    if len(cpp_blocks) < 2:
+        return None, None
+    return cpp_blocks[0].strip() + "\n", cpp_blocks[1].strip()
+
+
+def parse_port_response_full(response_text):
+    """Extract (header_content, dispatch_body, vector_spec) from a
+    build_port_prompt response (3 blocks: ```cpp header, ```cpp dispatch,
+    ```json vector spec with {fn, param_layout, input_sets}). Returns
+    (None, None, None) on any parse failure -- malformed JSON, missing
+    blocks, or a vector spec missing required keys -- so callers treat it
+    uniformly as "retry the draft", not a partial success."""
+    blocks = _fenced_blocks(response_text)
+    cpp_blocks = [content for lang, content in blocks if lang in _CPP_LANGS]
+    json_blocks = [content for lang, content in blocks if lang in _JSON_LANGS]
+    if len(cpp_blocks) < 2 or not json_blocks:
+        return None, None, None
+    try:
+        spec = json.loads(json_blocks[0])
+    except json.JSONDecodeError:
+        return None, None, None
+    if not all(k in spec for k in ("fn", "param_layout", "input_sets")):
+        return None, None, None
+    if not all(k in spec["param_layout"] for k in ("inputs", "outputs")):
+        return None, None, None
+    return cpp_blocks[0].strip() + "\n", cpp_blocks[1].strip(), spec

--- a/fun-doc/port_targets.py
+++ b/fun-doc/port_targets.py
@@ -1,0 +1,304 @@
+"""port_targets.py -- port a SPECIFIC list of functions (by address), in order.
+
+The `fun_doc.py --port` auto-selector (port_pipeline.select_port_candidates) only
+picks functions that are ALREADY Stage-1 documented (score>=80) and sorts them
+leaf-first by address -- so it sweeps low-address library/string leaves, NOT the
+hot backlog. It also has no way to aim at a target list.
+
+This driver bypasses the selector and calls fun_doc.process_port_candidate
+DIRECTLY for each target address (that function takes an explicit address and does
+its own classify -> draft -> prove, so it does not need pre-documentation and is
+not gated by the score>=80 filter). It reads the profiler's hot backlog
+(conformance/profiler/hot_backlog.json) by default, or an explicit --names /
+--addresses list.
+
+SAFETY: it skips library/runtime-looking names (the STRCHR_/STR* string scanners
+whose raw char* arg crashed the oracle marshaller during a blind batch). Genuine
+game-logic getters take an int index (safe scalar vectors) or a unit pointer
+(classified "stateful" -> skipped, no oracle call), so targeting the hot backlog
+is inherently safer than the auto-selector's low-address string picks.
+
+Usage (from fun-doc/, venv active, game live on :8790):
+    python port_targets.py --backlog --count 5
+    python port_targets.py --names GetPathFieldByUnitType,DATATBLS_GetItemDataByCode
+    python port_targets.py --backlog --plan               # PRE-FLIGHT: partition, no proving
+    python port_targets.py --backlog --plan --wire-globals  # + stage missing globals
+
+--plan (2026-07-08): the pre-flight partitioner. The July batch restarted the game
+THREE times because needs (missing resolver globals, abort-class vector safety, a
+delegate) were discovered serially, one failure at a time. The planner sweeps every
+target FIRST -- decompile + disassembly, mechanical ABI (abi_static), abort-path
+detection, resolver-global gap check against the generated resolve table -- and
+partitions the batch into:
+    provable-now / needs-globals(+rebuild+restart) / delegate-rung / abort-class /
+    register-explicit / not-a-leaf
+so ALL resolve-table wiring lands in ONE rebuild + ONE restart, abort-class fns get
+in-envelope vectors from the start, and nothing is discovered by crashing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+import fun_doc
+import port_pipeline as pp
+import abi_static
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+BACKLOG = D2MOO_REPO / "conformance" / "profiler" / "hot_backlog.json"
+RESOLVE_GEN = D2MOO_REPO / "D2.Detours.patches" / "1.13c" / "D2Common_ResolveTable.gen.h"
+PENDING_GLOBALS = D2MOO_REPO / "conformance" / "tools" / "pending_globals.json"
+D2COMMON_BASE = 0x6FD50000
+# fun-doc keys/looks up functions under the Ghidra program PATH, not the bare name.
+PROGRAM_PATH = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+
+
+def _targets_from_backlog(count: int) -> list[dict]:
+    if not BACKLOG.exists():
+        raise SystemExit(f"[fatal] no backlog at {BACKLOG} -- run profiler_feed.py first")
+    data = json.loads(BACKLOG.read_text(encoding="utf-8"))
+    rows = data.get("backlog", data if isinstance(data, list) else [])
+    return rows[:count]
+
+
+def _addr_hex(row: dict) -> str:
+    """Bare lowercase hex address (no 0x) -- fun_doc's state-key convention."""
+    if row.get("address"):
+        return str(row["address"]).replace("0x", "").lower()
+    return f"{D2COMMON_BASE + int(row['offset']):x}"
+
+
+def _resolved_addrs() -> set:
+    """Addresses already in the generated resolve table (what the live resolver
+    can serve). Names aren't enough: the planner checks by ADDRESS so a global the
+    disasm derefs is 'wired' regardless of what we called it."""
+    try:
+        text = RESOLVE_GEN.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return {int(m.group(1), 16) for m in re.finditer(r"0x([0-9a-fA-F]+)u", text)}
+
+
+def _proven_names() -> set:
+    """Names already CONF_LIVE+ in the registry -- a plan should surface these as
+    done, not re-partition them (post-proof Ghidra write-backs retype params, which
+    legitimately changes their classify_function answer)."""
+    reg = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+    try:
+        return {json.loads(l)["name"] for l in reg.read_text(encoding="utf-8").splitlines()
+                if l.strip()}
+    except OSError:
+        return set()
+
+
+def _internal_caller_count(addr_hex: str) -> int | None:
+    """Count INTERNAL callers of a function from Ghidra xrefs. An export with ONLY
+    'Entry Point [EXTERNAL]' (0 internal callers) is almost certainly INLINED at
+    every call site -> the running game never invokes the standalone export -> it
+    can NEVER reach CONF_BATTLETESTED via shadow (nothing to observe). Flagging that
+    up front avoids wasting a shadow-stage + rebuild + restart + dispatcher slot on
+    a function that will sit at 0 hits forever; route it to the offline CONF_
+    REGRESSION freeze instead (its terminal rung). NOTE: this is a HINT -- xrefs
+    can't see CROSS-DLL callers (D2Game etc. calling a D2Common export), so the
+    empirical shadow hit count remains the final arbiter. Returns None on fetch
+    failure (treat as unknown, not zero)."""
+    res = fun_doc.ghidra_get("/get_function_xrefs",
+                             params={"address": f"0x{addr_hex}", "program": PROGRAM_PATH})
+    if res is None or fun_doc._is_error_response(res):
+        return None
+    text = res.get("result", "") if isinstance(res, dict) else str(res)
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    # each line is one xref; internal = not the export entry-point / external table
+    internal = [ln for ln in lines
+                if "[EXTERNAL]" not in ln and "Entry Point" not in ln]
+    return len(internal)
+
+
+def plan_targets(rows: list, *, wire_globals: bool = False) -> dict:
+    """PRE-FLIGHT: partition targets by what they need BEFORE any prove runs.
+    Read-only against Ghidra; never touches the oracle. See module docstring."""
+    wired = _resolved_addrs()
+    proven = _proven_names()
+    plan = {"already_proven": [], "provable_now": [], "needs_globals": [], "delegate": [],
+            "abort_class": [], "register_explicit": [], "not_leaf": [],
+            "shadow_unreachable_risk": [], "fetch_failed": []}
+    pending: dict = {}
+    for r in rows:
+        name, addr = r["name"], _addr_hex(r)
+        if name in proven:
+            plan["already_proven"].append({"name": name, "addr": addr})
+            continue
+        dec = fun_doc.ghidra_get("/decompile_function",
+                                 params={"address": f"0x{addr}", "program": PROGRAM_PATH})
+        dis = fun_doc.ghidra_get("/disassemble_function",
+                                 params={"address": f"0x{addr}", "program": PROGRAM_PATH})
+        if not dec or fun_doc._is_error_response(dec):
+            plan["fetch_failed"].append({"name": name, "addr": addr})
+            continue
+        cls = pp.classify_function(dec)
+        abi = abi_static.derive_abi(str(dis)) if dis and not fun_doc._is_error_response(dis) else None
+        abort = abi_static.detect_abort_path(str(dec))
+        missing = [g for g in (abi or {}).get("data_globals", []) if g not in wired]
+        # SHADOW-REACHABILITY HINT: a getter-class export with 0 internal callers is
+        # likely inlined everywhere -> shadow can never observe it -> CONF_BATTLETESTED
+        # unreachable; its terminal is the offline CONF_REGRESSION freeze. (Hint only;
+        # cross-DLL callers are invisible here -> shadow hits are the final arbiter.)
+        internal_callers = _internal_caller_count(addr)
+        shadow_risk = (internal_callers == 0 and cls in ("shadow_leaf", "leaf"))
+        entry = {"name": name, "addr": addr, "class": cls,
+                 "abi": {k: abi[k] for k in ("ret_imm", "slots", "used_slots",
+                                              "reg_args", "callconv", "approx")} if abi else None,
+                 "abort_class": abort,
+                 "internal_callers": internal_callers,
+                 "shadow_risk": shadow_risk,
+                 "calls": (abi or {}).get("calls", []),
+                 "missing_globals": [f"0x{g:x}" for g in missing]}
+        if shadow_risk:
+            plan["shadow_unreachable_risk"].append(entry)
+        # partition priority: the property that changes HOW you may prove it wins
+        if abort:
+            plan["abort_class"].append(entry)     # in-envelope vectors ONLY, no V1
+        if abi and abi["callconv"] == "register_explicit":
+            plan["register_explicit"].append(entry)
+        if (abi or {}).get("calls"):
+            plan["delegate"].append(entry)        # delegate-rung: resolve + call through
+        if missing:
+            plan["needs_globals"].append(entry)
+            for g in missing:
+                pending.setdefault(f"g_dat_{g:x}", g)
+        if not abort and not missing and not (abi or {}).get("calls") \
+                and (abi is None or abi["callconv"] != "register_explicit"):
+            plan["provable_now"].append(entry)
+        elif (abi or {}).get("calls") and cls in ("stateful",):
+            plan["not_leaf"].append(entry)
+
+    if wire_globals and pending:
+        # Stage every missing global for ONE rebuild+restart. Auto-names are
+        # PLACEHOLDERS (g_dat_<hex>) -- rename in pending_globals.json before the
+        # rebuild if the semantic name is known; gen_resolve_table merges the file.
+        existing = {}
+        if PENDING_GLOBALS.exists():
+            existing = json.loads(PENDING_GLOBALS.read_text(encoding="utf-8"))
+        for n, a in pending.items():
+            existing.setdefault(n, f"0x{a:x}")
+        PENDING_GLOBALS.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+        print(f"[wire-globals] staged {len(pending)} address(es) -> {PENDING_GLOBALS}")
+        print("               review the auto-names, then: gen_resolve_table.py + rebuild "
+              "D2Common patch + ONE game restart activates all of them")
+    return plan
+
+
+def print_plan(plan: dict) -> None:
+    order = [("already_proven", "ALREADY PROVEN (CONF_LIVE+ in the registry)"),
+             ("provable_now", "PROVABLE NOW (no wiring, no restart)"),
+             ("needs_globals", "NEEDS GLOBALS (wire -> ONE rebuild+restart for all)"),
+             ("delegate", "DELEGATE-RUNG (calls a subroutine: resolve callee + call through)"),
+             ("abort_class", "ABORT CLASS (fatal out-of-range: in-envelope vectors, NO V1)"),
+             ("register_explicit", "REGISTER-EXPLICIT (orig_regs marshal path)"),
+             ("not_leaf", "NOT A LEAF (stateful + delegates -- manual)"),
+             ("shadow_unreachable_risk", "SHADOW-UNREACHABLE RISK (0 internal callers = likely "
+              "inlined; oracle-provable but will NOT battletest -> freeze offline as CONF_REGRESSION)"),
+             ("fetch_failed", "FETCH FAILED")]
+    print("=" * 72)
+    print("PRE-FLIGHT PLAN (no oracle calls made)")
+    print("=" * 72)
+    for k, title in order:
+        rows = plan.get(k, [])
+        if not rows:
+            continue
+        print(f"\n-- {title} --")
+        for e in rows:
+            abi = e.get("abi") or {}
+            bits = []
+            if abi:
+                bits.append(f"{abi.get('callconv')}/{abi.get('slots')} slot(s)")
+            if e.get("missing_globals"):
+                bits.append("globals: " + ",".join(e["missing_globals"]))
+            if e.get("calls"):
+                bits.append(f"{len(e['calls'])} callee(s)")
+            print(f"  {e['name']:<38} @{e['addr']}  {'; '.join(bits)}")
+    print()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--backlog", action="store_true", help="target the profiler hot backlog")
+    ap.add_argument("--count", type=int, default=5, help="how many backlog entries to port")
+    ap.add_argument("--names", help="comma-separated function names (needs backlog for addrs)")
+    ap.add_argument("--provider", default=os.environ.get("AI_PROVIDER"))
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--include-library", action="store_true",
+                    help="don't skip library/string-looking names (unsafe: oracle-crash risk)")
+    ap.add_argument("--plan", action="store_true",
+                    help="PRE-FLIGHT ONLY: partition targets (ABI/abort/globals/delegates), "
+                         "print the plan, prove nothing")
+    ap.add_argument("--wire-globals", action="store_true",
+                    help="with --plan: stage missing resolver globals into pending_globals.json")
+    args = ap.parse_args()
+
+    # live-prove + doc-tags + shadow-promote ON, matching `fun_doc.py --port`.
+    os.environ.setdefault("FUNDOC_LIVE_PROVE", "1")
+    os.environ.setdefault("FUNDOC_DOC_TAGS", "1")
+    os.environ.setdefault("FUNDOC_SHADOW_PROMOTE", "1")
+
+    rows = _targets_from_backlog(10000)          # load all available backlog rows
+    if args.names:
+        want = [n.strip() for n in args.names.split(",")]
+        by_name = {r["name"]: r for r in rows}
+        missing = [n for n in want if n not in by_name]
+        if missing:
+            print(f"[warn] not in backlog (regenerate profiler_feed with a larger --top): {missing}")
+        rows = [by_name[n] for n in want if n in by_name]
+    else:
+        rows = rows[:args.count]
+
+    if args.plan:
+        plan = plan_targets(rows, wire_globals=args.wire_globals)
+        print_plan(plan)
+        out = D2MOO_REPO / "conformance" / "profiler" / "port_plan.json"
+        out.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+        print(f"[plan] written to {out}")
+        return 0
+
+    import port_live_prove as plp
+    results = []
+    for r in rows:
+        name = r["name"]
+        if not args.include_library and pp._looks_like_library_or_runtime(name):
+            print(f"[skip] {name}: library/runtime-looking name (oracle-crash risk)")
+            results.append((name, "skipped-library"))
+            continue
+        addr = _addr_hex(r)
+        print(f"\n=== port {name} @ 0x{addr}  ({r.get('hits', '?')} hits) ===")
+        try:
+            res = fun_doc.process_port_candidate(
+                PROGRAM_PATH, addr, name,
+                provider=args.provider or fun_doc.AI_PROVIDER, model=args.model,
+                worker_id="port_targets")
+        except Exception as e:  # never let one target kill the batch
+            res = f"error: {type(e).__name__}: {e}"
+        print(f"    -> {res}")
+        results.append((name, res))
+        # ORACLE-DEATH GUARD: if the bridge died during this target, every further
+        # prove is guaranteed to fail (and would burn LLM drafts against a dead
+        # server). Halt, NAME the killer, leave the rest of the batch untouched.
+        if "oracle" in str(res) or not plp.check_oracle_alive():
+            if not plp.check_oracle_alive():
+                print(f"\n[HALT] the oracle bridge died while porting {name} -- "
+                      f"remaining targets skipped (relaunch the game, then re-run; "
+                      f"suspect an abort-class/ABI issue in {name})")
+                results.append(("(batch halted)", f"oracle_died_during {name}"))
+                break
+
+    print("\n" + "=" * 60)
+    for name, res in results:
+        print(f"  {res:<40} {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/prove_doc.py
+++ b/fun-doc/prove_doc.py
@@ -1,0 +1,583 @@
+"""prove_doc.py -- the UNIFIED prove-to-document driver (single worker).
+
+Takes a COMPLETELY UNDOCUMENTED function all the way to proof-backed Ghidra
+documentation in one run:
+
+    classify -> draft 1:1 equivalent -> prove DISCRIMINATING bit-exact (CONF_LIVE)
+    -> CONSISTENCY GATE (auto-fix mechanical, flag semantic)
+    -> struct-field ledger -> DOC_VERIFIED (proof-backed)
+
+Design decisions (user-ratified 2026-07-08):
+  * Proof-preferred: a discriminating CONF_LIVE proof of a hand-written equivalent
+    is what EARNS DOC_VERIFIED. Unprovable functions cap at DOC_REVIEWED, marked
+    unproven. (Battletest/regression are bonus confidence, not doc gates.)
+  * Consistency gate: every proof re-derives the docs from the PROVEN equivalent
+    and diffs against Ghidra. MECHANICAL facts (return width/sign, param count,
+    calling convention, field offsets) are auto-corrected; SEMANTIC disagreements
+    (function name, plate narrative) FLAG and block DOC_VERIFIED until reconciled.
+    This is the gate that would have caught the WeaponStyle hallucinated plate.
+  * Struct-field ledger: every proof contributes its (struct, offset, width, type)
+    facts to a shared per-struct ledger so naming compounds across functions.
+  * This is the SANCTIONED path -- ad-hoc proof scripts that skip the doc
+    write-back are how stale plates survive. Use prove_doc, not one-offs.
+
+Usage (game live on :8790 for the prove stage):
+    python prove_doc.py --address 0x6fd72f80 --name DATATBLS_GetItemTypeField10
+    python prove_doc.py --address ... --name ... --skip-prove   # gate-only re-run
+    python prove_doc.py --selftest                              # offline self-test
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+PROGRAM_PATH = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+REGISTRY = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+CANDIDATES = D2MOO_REPO / "conformance" / "reimpl_provider" / "candidates"
+STRUCT_LEDGER_DIR = D2MOO_REPO / "conformance" / "doc_ledger"
+
+# proof kinds that DISCRIMINATE by construction (a wrong offset would FAIL):
+# synth/synth2 read a unique-byte pattern; gated variants patch preconditions;
+# delegate_call_through requires orig-variance across indices (weak_uniform else).
+_DISCRIMINATING_KINDS = {"synth", "synth2", "delegate_call_through"}
+
+
+# ---------------------------------------------------------------------------
+# pure logic (offline-testable)
+# ---------------------------------------------------------------------------
+
+def registry_row(name: str, address: str = None) -> dict | None:
+    """Latest registry row for a function (last write wins)."""
+    try:
+        rows = [json.loads(l) for l in REGISTRY.read_text(encoding="utf-8").splitlines()
+                if l.strip()]
+    except OSError:
+        return None
+    hit = None
+    for r in rows:
+        if r.get("name") == name and (address is None or r.get("address") == address):
+            hit = r
+    return hit
+
+
+def is_discriminating(row: dict) -> tuple:
+    """(bool, reason). A proof earns DOC_VERIFIED only if it DISCRIMINATES --
+    a wrong reimpl would have FAILED. weak_proof (degenerate capture) never
+    qualifies; synth-family kinds qualify by construction; a plain handle/live
+    proof qualifies only if the ORIGINAL returned >1 distinct value (variance)."""
+    if not row:
+        return False, "no registry row (not proven)"
+    if row.get("weak_proof"):
+        return False, f"weak_proof: {str(row['weak_proof'])[:60]}"
+    if row.get("conf") not in ("CONF_LIVE", "CONF_BATTLETESTED", "CONF_REGRESSION"):
+        return False, f"conf rung {row.get('conf')} below CONF_LIVE"
+    kind = row.get("proof_kind")
+    if kind in _DISCRIMINATING_KINDS:
+        return True, f"discriminating by construction ({kind})"
+    if (row.get("total") or 0) >= 2 and not row.get("weak_proof"):
+        # multi-vector live/handle proof that the degenerate-capture detector
+        # (which flags identical-original-on-all-vectors) did NOT flag -> the
+        # original varied -> discriminating.
+        return True, f"multi-vector live proof, original varied ({row.get('passed')}/{row.get('total')})"
+    return False, "single-vector non-synth proof -- cannot rule out match-by-luck"
+
+
+def parse_reimpl_facts(cpp: str) -> dict:
+    """MECHANICAL facts from the proven equivalent's source (no model):
+    param count/callconv from the extern signature, every fixed-offset field
+    READ (offset, width, DEPTH) from the raw casts, resolver globals and
+    call-through callees by name, type-gates. These are ground truth -- the code
+    BIT-MATCHED the original.
+
+    DEPTH tracks pointer-deref level so field reads attribute to the RIGHT struct:
+    a gated getter reads dwType off the PARAM struct (depth 0), loads a sub-struct
+    pointer (`r = *(char**)(r + 0x14)`), then reads the field off the SUB-struct
+    (depth 1). Bucketing both under one struct corrupted the ledger."""
+    facts = {"params": None, "callconv": None, "harness_ret": None,
+             "field_reads": [], "globals": [], "callees": [], "gates": [],
+             "pointer_loads": [], "max_depth": 0}
+    m = re.search(r'extern\s+"C"\s+([\w\s\*]+?)\s+(__\w+)\s+\w+\s*\(([^)]*)\)', cpp)
+    if m:
+        facts["harness_ret"] = m.group(1).strip()
+        facts["callconv"] = m.group(2).lstrip("_")
+        args = [a.strip() for a in m.group(3).split(",") if a.strip() and a.strip() != "void"]
+        facts["params"] = len(args)
+    for g in re.finditer(r'D2MOO_Resolve\("([^"]+)"\)', cpp):
+        nm = g.group(1)
+        (facts["callees"] if not nm.startswith(("g_", "_g_")) else facts["globals"]).append(nm)
+
+    # walk LINE-ORDERED so depth reassignments apply to subsequent reads.
+    depth = {}          # var -> deref depth (0 = the param/base struct)
+    _PTRLOAD = re.compile(r'(\w+)\s*=\s*(?:\(\s*char\s*\*\s*\)\s*)?\*\s*\(\s*(?:char|void)\s*'
+                          r'\*\s*\*\s*\)\s*\(\s*(\w+)\s*\+\s*0x([0-9a-fA-F]+)\s*\)')
+    _READ = re.compile(r'\*\s*\(\s*(unsigned\s+char|signed\s+char|char|unsigned\s+short|short|'
+                       r'unsigned\s+int|int)\s*\*\s*\)\s*\(\s*(\w+)\s*\+\s*0x([0-9a-fA-F]+)\s*\)')
+    _CALLRES = re.compile(r'(\w+)\s*=\s*\(\s*char\s*\*\s*\)\s*_f\s*\(')
+    _PTRLOAD0 = re.compile(r'(\w+)\s*=\s*\(\s*char\s*\*\s*\)\s*\*\s*\(\s*void\s*\*\s*\*\s*\)'
+                           r'\s*(\w+)\s*;')          # base = (char*)*(void**)_g;  (no offset)
+    _ARITH = re.compile(r'char\s*\*\s*(\w+)\s*=\s*(\w+)\s*\+')   # rec = records + idx*stride
+    for line in cpp.splitlines():
+        pm = _PTRLOAD.search(line)
+        if pm:
+            dst, src, off = pm.group(1), pm.group(2), int(pm.group(3), 16)
+            d = depth.get(src, 0)
+            facts["pointer_loads"].append({"base": src, "off": off, "depth": d})
+            depth[dst] = d + 1
+            facts["max_depth"] = max(facts["max_depth"], d + 1)
+            continue
+        p0 = _PTRLOAD0.search(line)
+        if p0:
+            d = depth.get(p0.group(2), 0)
+            depth[p0.group(1)] = d + 1               # deref of a resolved global's value
+            facts["max_depth"] = max(facts["max_depth"], d + 1)
+            continue
+        am = _ARITH.search(line)
+        if am and am.group(2) in depth:
+            depth[am.group(1)] = depth[am.group(2)]  # pointer arithmetic: SAME struct level
+            continue
+        cm = _CALLRES.search(line)
+        if cm:
+            # a call-through result is a FRESH struct (the callee's record) -- its own
+            # level, conventionally the "final" struct for delegates.
+            depth[cm.group(1)] = facts["max_depth"] = facts["max_depth"] + 1
+            continue
+        for r_ in _READ.finditer(line):
+            width = {"char": 1, "short": 2, "int": 4}[r_.group(1).split()[-1]]
+            signed = not r_.group(1).startswith("unsigned")
+            base = r_.group(2)
+            facts["field_reads"].append({"base": base, "off": int(r_.group(3), 16),
+                                         "width": width, "signed": signed,
+                                         "depth": depth.get(base, 0)})
+    for g_ in re.finditer(r'\(\s*(\w+)\s*\+\s*0x([0-9a-fA-F]+)\s*\)\s*!=\s*0x([0-9a-fA-F]+)u?\)'
+                          r'\s*return', cpp):
+        facts["gates"].append({"base": g_.group(1), "off": int(g_.group(2), 16),
+                               "imm": int(g_.group(3), 16)})
+    return facts
+
+
+def gate_verdict(mech_applied: list, semantic_flags: list, discriminating: bool) -> dict:
+    """The DOC-rung decision. DOC_VERIFIED requires BOTH a discriminating proof
+    AND zero unresolved semantic flags. Mechanical fixes never block (the proof
+    is authoritative for them). Otherwise cap at DOC_REVIEWED with the reasons."""
+    if discriminating and not semantic_flags:
+        return {"doc_level": "DOC_VERIFIED", "blocked": False,
+                "why": "discriminating proof + docs consistent with proven behavior"}
+    reasons = []
+    if not discriminating:
+        reasons.append("proof not discriminating")
+    reasons += [f"semantic conflict: {f}" for f in semantic_flags]
+    return {"doc_level": "DOC_REVIEWED", "blocked": True, "why": "; ".join(reasons)}
+
+
+# ---------------------------------------------------------------------------
+# the consistency gate (needs Ghidra; model for the semantic diff only)
+# ---------------------------------------------------------------------------
+
+_GATE_PROMPT = """You are auditing reverse-engineering documentation against PROVEN ground truth.
+
+A hand-written reimplementation of `{name}` was proven BIT-EXACT against the original
+(discriminating live proof). The reimpl below is therefore authoritative for BEHAVIOR.
+
+## PROVEN equivalent (authoritative)
+```cpp
+{reimpl}
+```
+
+## Ground-truth disassembly
+```
+{disasm}
+```
+
+## Current Ghidra documentation
+Function name: {name}
+Prototype: {prototype}
+Plate comment:
+```
+{plate}
+```
+
+Compare the CURRENT documentation against the PROVEN behavior. Judge:
+1. prototype: do return width/signedness and parameter types match the proven
+   semantic behavior? (The proven reimpl may return a WIDENED harness type; judge
+   the SEMANTIC width from the final field read, e.g. a byte read = byte return.)
+2. plate: does the plate's described algorithm match the proven behavior? A plate
+   describing branches, callees, or logic that DO NOT EXIST in the disassembly is
+   a hallucination -> conflict. Extra detail that is consistent is fine.
+3. name: does the name contradict the proven behavior? (Only flag CONTRADICTION,
+   not mere vagueness.)
+
+If the current plate is EMPTY, a placeholder/stub, or clearly not describing this
+function, set plate verdict "missing" and WRITE a complete replacement plate derived
+from the PROVEN behavior: 1-line summary, Algorithm steps, Parameters, Returns,
+Special Cases, and a Structure Layout table for every proven field offset. State only
+what the proof establishes; mark semantic meaning you cannot prove as unproven.
+
+Output ONLY strict JSON:
+{{"prototype": {{"verdict": "ok|fix", "corrected": "<full prototype or empty>", "reason": "..."}},
+  "plate": {{"verdict": "ok|conflict|missing", "reason": "...", "regenerated": "<full plate text when missing, else empty>"}},
+  "name": {{"verdict": "ok|conflict", "suggested": "<name or empty>", "reason": "..."}}}}"""
+
+
+def consistency_gate(program: str, address: str, name: str, reimpl_cpp: str, *,
+                     provider=None, model=None, log=print) -> dict:
+    """Re-derive docs from the proven equivalent and diff against Ghidra.
+    AUTO-FIX mechanical (prototype width/callconv -- proof-backed, bounded by
+    Ghidra's own prototype validation). FLAG semantic (plate narrative, name)."""
+    import fun_doc
+    prog_name = Path(program).name
+    addr = address if str(address).startswith("0x") else f"0x{address}"
+    provider = provider or fun_doc.AI_PROVIDER
+    if model is None:                    # some providers require an explicit model
+        try:
+            model = fun_doc.get_configured_model(provider, "FULL")
+        except Exception:
+            model = None
+
+    disasm = str(fun_doc.ghidra_get("/disassemble_function",
+                                    params={"address": addr, "program": program}))
+    plate = str(fun_doc.ghidra_get("/get_plate_comment",
+                                   params={"address": addr, "program": program}))
+    # MECHANICAL stub detection -- never trust the model to notice absence. Strip the
+    # routing/bench markers; if no substantive BEHAVIORAL text remains, the plate is
+    # missing and MUST be regenerated (its absence blocks DOC_VERIFIED if that fails).
+    _behavioral = re.sub(r"\[(CONFORMANCE|GOLDEN-BENCH|CONSISTENCY GATE)[^\]]*\][^\n]*",
+                         "", plate)
+    _behavioral = re.sub(r"(shadow_leaf|live-pointer getter|Not statically emulable|"
+                         r"SHADOW-provable|documentation intentionally cleared)[^\n]*",
+                         "", _behavioral)
+    plate_is_stub = len(re.sub(r"[\s\\n]+", "", _behavioral)) < 120
+    dec = str(fun_doc.ghidra_get("/decompile_function",
+                                 params={"address": addr, "program": program}))
+    proto_m = re.search(r"^\s*([\w\s\*]+?\s\*?\s*" + re.escape(name) + r"\s*\([^)]*\))",
+                        dec.replace("\r", ""), re.MULTILINE)
+    prototype = proto_m.group(1).strip() if proto_m else "(unknown)"
+
+    prompt = _GATE_PROMPT.format(name=name, reimpl=reimpl_cpp[:4000],
+                                 disasm=disasm[:4000], prototype=prototype,
+                                 plate=plate[:4000])
+    if plate_is_stub:
+        prompt += ("\n\nNOTE: the current plate has been mechanically determined to be a "
+                   "STUB (no behavioral documentation). You MUST set plate verdict "
+                   "\"missing\" and supply the full regenerated plate.")
+    obj = None
+    for _try in range(3):                # provider variance: retry until a JSON verdict
+        text, _meta = fun_doc.invoke_claude(prompt, model=model, max_turns=2,
+                                            provider=provider or fun_doc.AI_PROVIDER,
+                                            complexity_tier=None)
+        obj = fun_doc._extract_first_json(text or "")
+        if isinstance(obj, dict) and obj.get("plate") is not None:
+            break
+        prompt_retry = prompt + ("\n\nREMINDER: your ENTIRE final message must be the "
+                                 "single strict-JSON object specified above -- no prose, "
+                                 "no tool calls, no markdown fences.")
+        prompt = prompt_retry
+        obj = None
+    if not isinstance(obj, dict):
+        return {"ok": False, "error": "gate model returned no JSON verdict (3 tries)",
+                "mechanical_applied": [], "semantic_flags": ["gate audit failed to run"]}
+
+    mech_applied, semantic_flags = [], []
+
+    # MECHANICAL: prototype fix is proof-backed -> auto-apply (Ghidra validates).
+    p = obj.get("prototype") or {}
+    if str(p.get("verdict")).lower() == "fix" and p.get("corrected"):
+        r = fun_doc.ghidra_post("/set_function_prototype",
+                                data={"function_address": addr,
+                                      "prototype": str(p["corrected"])},
+                                params={"program": prog_name})
+        ok = not (isinstance(r, dict) and r.get("error"))
+        mech_applied.append(f"prototype -> {p['corrected']} ({'applied' if ok else 'REJECTED'})")
+
+    # SEMANTIC: plate / name conflicts FLAG (block VERIFIED) + annotate for review.
+    # A MISSING/stub plate is not a conflict -- it is absence: WRITE the plate from
+    # the proven behavior (that IS the ground-up documentation this flow exists for).
+    pl = obj.get("plate") or {}
+    plate_written = False
+    if (str(pl.get("verdict")).lower() == "missing" or plate_is_stub) and pl.get("regenerated"):
+        stamp = datetime.date.today().isoformat()
+        body = str(pl["regenerated"]).strip()
+        body += (f"\n\nPROVEN one-to-one (consistency-gated {stamp}): documentation "
+                 f"derived from a reimplementation proven bit-exact against the "
+                 f"original by a discriminating live proof.")
+        r = fun_doc.ghidra_post("/set_plate_comment",
+                                data={"address": addr, "comment": body},
+                                params={"program": program})
+        plate_written = not (isinstance(r, dict) and r.get("error"))
+        mech_applied.append(f"plate regenerated from proven behavior "
+                            f"({'applied' if plate_written else 'REJECTED'})")
+    elif str(pl.get("verdict")).lower() == "conflict":
+        semantic_flags.append(f"plate: {pl.get('reason', '(no reason)')}")
+    if plate_is_stub and not plate_written:
+        # no behavioral documentation exists and none was produced -> the doc is NOT
+        # superb -> block DOC_VERIFIED. Absence fails closed, same as a conflict.
+        semantic_flags.append("plate: missing/stub and regeneration did not apply")
+    nm = obj.get("name") or {}
+    if str(nm.get("verdict")).lower() == "conflict":
+        semantic_flags.append(f"name: {nm.get('reason', '(no reason)')}"
+                              + (f" (suggested: {nm['suggested']})" if nm.get("suggested") else ""))
+
+    if semantic_flags:
+        stamp = datetime.date.today().isoformat()
+        note = (f"[CONSISTENCY GATE {stamp}] Proven behavior DISAGREES with this "
+                f"documentation -- blocked from DOC_VERIFIED until reconciled: "
+                + " | ".join(semantic_flags))
+        cur = plate if plate and "error" not in plate[:40].lower() else ""
+        if "[CONSISTENCY GATE" not in cur:
+            fun_doc.ghidra_post("/set_plate_comment",
+                                data={"address": addr, "comment": (note + "\n\n" + cur).strip()},
+                                params={"program": program})
+    if mech_applied or semantic_flags:
+        fun_doc.ghidra_post("/save_program", data={"program": prog_name})
+    return {"ok": True, "mechanical_applied": mech_applied,
+            "semantic_flags": semantic_flags, "prototype_seen": prototype}
+
+
+# ---------------------------------------------------------------------------
+# struct-field ledger (shared: one proof improves every user of the struct)
+# ---------------------------------------------------------------------------
+
+def ledger_contribute(name: str, address: str, facts: dict, struct_hint: str = None) -> Path | None:
+    """Append this proof's PROVEN (offset,width,signed) field facts to the shared
+    per-struct ledger. The struct HINT names the FINAL struct the getter reads
+    (deepest deref level) -- only max-depth reads attribute to it; shallower reads
+    (the param struct's dwType gate, a table header's count/base) go to
+    `<hint>__lvl<d>` side-buckets so they are kept but never misattributed."""
+    reads = facts.get("field_reads") or []
+    if not reads:
+        return None
+    STRUCT_LEDGER_DIR.mkdir(parents=True, exist_ok=True)
+    key = struct_hint or "unattributed"
+    maxd = max((r_.get("depth", 0) for r_ in reads), default=0)
+    path = STRUCT_LEDGER_DIR / f"{key}.jsonl"
+    by_bucket = {}
+    for r_ in reads:
+        d = r_.get("depth", 0)
+        bucket = key if d == maxd else f"{key}__lvl{d}"
+        by_bucket.setdefault(bucket, []).append(r_)
+    for bucket, rs in by_bucket.items():
+        with open(STRUCT_LEDGER_DIR / f"{bucket}.jsonl", "a", encoding="utf-8") as f:
+            for r_ in rs:
+                f.write(json.dumps({"struct": bucket, "off": r_["off"], "width": r_["width"],
+                                    "signed": r_["signed"], "base_var": r_["base"],
+                                    "depth": r_.get("depth", 0), "final": r_.get("depth", 0) == maxd,
+                                    "from_fn": name, "address": address,
+                                    "date": datetime.date.today().isoformat()}) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# the unified driver
+# ---------------------------------------------------------------------------
+
+def prove_doc(address: str, name: str, *, program: str = PROGRAM_PATH,
+              provider=None, model=None, skip_prove: bool = False,
+              struct_hint: str = None, log=print) -> dict:
+    """Undocumented function -> proven equivalent -> consistency-gated docs.
+    Returns a summary dict; every stage's outcome is explicit and honest."""
+    import fun_doc
+    import port_live_prove as plp
+    addr_bare = str(address).replace("0x", "").lower()
+    addr_hex = f"0x{addr_bare}"
+    summary = {"name": name, "address": addr_hex, "stages": {}}
+
+    # 1) PROVE (the existing port pipeline: classify -> draft -> prove -> audits)
+    if not skip_prove:
+        outcome = fun_doc.process_port_candidate(
+            program, addr_bare, name,
+            provider=provider or fun_doc.AI_PROVIDER, model=model,
+            worker_id="prove_doc")
+        summary["stages"]["prove"] = outcome
+        if outcome != "proven_live_pending_review":
+            # honest cap: unproven -> the doc rung this run can support is REVIEWED
+            # at most (set by the doc workflow, not us) -- report and stop.
+            summary["result"] = f"not proven ({outcome}) -- no doc promotion"
+            return summary
+    else:
+        summary["stages"]["prove"] = "(skipped -- gate-only re-run)"
+
+    # 2) EVIDENCE: registry row + the proven candidate source
+    row = registry_row(name)
+    disc, disc_why = is_discriminating(row)
+    summary["stages"]["discriminating"] = f"{disc} ({disc_why})"
+    cand = CANDIDATES / f"{name}.cpp"
+    reimpl = cand.read_text(encoding="utf-8") if cand.exists() else ""
+    if not reimpl:
+        summary["result"] = "proven but candidate source missing -- cannot gate"
+        return summary
+    facts = parse_reimpl_facts(reimpl)
+    summary["stages"]["facts"] = {k: v for k, v in facts.items() if v}
+
+    # 3) CONSISTENCY GATE
+    gate = consistency_gate(program, addr_hex, name, reimpl,
+                            provider=provider, model=model, log=log)
+    summary["stages"]["gate"] = gate
+    flags = gate.get("semantic_flags") if gate.get("ok") else ["gate failed to run"]
+
+    # 3b) CANONICAL NAMING: if the name is offset-derived (GetItemTypeField10), resolve
+    # the REAL field from the D2MOO struct headers and rename -- transcription -> under-
+    # standing. Authoritative via the DataTables header (also corrects a wrong subsystem
+    # guess). Only fires when the field is genuinely resolvable; offset name stays flagged
+    # otherwise. This is where we STOP creating offset names in the first place. 2026-07-09.
+    try:
+        import d2moo_names
+        if d2moo_names.is_offset_name(name):
+            c = d2moo_names.canonicalize(name, reimpl)
+            if c.get("ok"):
+                rr = fun_doc.ghidra_post("/rename_function_by_address",
+                                         data={"function_address": addr_hex,
+                                               "new_name": c["proposed_name"]},
+                                         params={"program": Path(program).name})
+                renamed = "success" in str(rr).lower()
+                if renamed:
+                    stamp = datetime.date.today().isoformat()
+                    note = (f"[D2MOO-DERIVED NAME {stamp}] was '{name}' (offset-derived); "
+                            f"real field per D2MOO: {c['reason']}."
+                            + ("  SUBSYSTEM CORRECTED." if c.get("corrected_subsystem") else ""))
+                    cur = str(fun_doc.ghidra_get("/get_plate_comment",
+                                                 params={"address": addr_hex, "program": program}))
+                    if "[D2MOO-DERIVED NAME" not in cur:
+                        fun_doc.ghidra_post("/set_plate_comment",
+                                            data={"address": addr_hex, "comment": (note + "\n\n"
+                                                  + (cur if "error" not in cur[:40].lower() else "")).strip()},
+                                            params={"program": program})
+                    fun_doc.ghidra_post("/save_program", data={"program": Path(program).name})
+                    name = c["proposed_name"]
+                summary["stages"]["canonical_name"] = {"to": c["proposed_name"], "applied": renamed,
+                                                       "reason": c["reason"],
+                                                       "corrected_subsystem": c.get("corrected_subsystem")}
+            else:
+                summary["stages"]["canonical_name"] = {"unresolved": c.get("reason")}
+    except Exception as e:
+        summary["stages"]["canonical_name"] = {"error": str(e)}
+
+    # 4) STRUCT LEDGER
+    lp = ledger_contribute(name, addr_hex, facts, struct_hint=struct_hint)
+    summary["stages"]["ledger"] = str(lp) if lp else "(no field reads)"
+
+    # 5) DOC RUNG (proof-preferred coupling)
+    v = gate_verdict(gate.get("mechanical_applied", []), flags or [], disc)
+    r = plp.set_doc_level(addr_hex, v["doc_level"], program=Path(program).name)
+    summary["stages"]["doc_rung"] = {**v, "write": r}
+    summary["result"] = f"{v['doc_level']}" + ("" if not v["blocked"] else f" (blocked: {v['why']})")
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# self-test (offline, no Ghidra/oracle/model)
+# ---------------------------------------------------------------------------
+
+def _selftest() -> int:
+    # parse_reimpl_facts on a real translator-emitted candidate shape
+    cpp = '''#include "../provider_runtime.h"
+// D2MOO_REIMPL_EXPORT: DATATBLS_GetItemTypeField10
+extern "C" unsigned int __stdcall DATATBLS_GetItemTypeField10(int idx)
+{
+    if (idx < 0) return 0x0;
+    void* _g = D2MOO_Resolve("g_pDataTables");
+    if (_g == nullptr) return 0x0;
+    char* base = (char*)*(void**)_g;
+    if (base == nullptr) return 0x0;
+    if (idx >= *(int*)(base + 0xbfc)) return 0x0;
+    char* records = (char*)*(void**)(base + 0xbf8);
+    char* rec = records + (int)idx * 0xe4;
+    if (rec == nullptr) return 0x0;
+    return (unsigned int)*(unsigned char*)(rec + 0x10);
+}
+'''
+    f = parse_reimpl_facts(cpp)
+    assert f["params"] == 1 and f["callconv"] == "stdcall", f
+    assert f["globals"] == ["g_pDataTables"] and not f["callees"], f
+    offs = {(r["off"], r["width"]) for r in f["field_reads"]}
+    assert (0x10, 1) in offs and (0xbfc, 4) in offs, offs
+    # DEPTH attribution: the table-header reads (count @0xbfc) are a SHALLOWER level
+    # than the final record read (@0x10) -- they must NOT share a struct bucket.
+    by_off = {r["off"]: r["depth"] for r in f["field_reads"]}
+    assert by_off[0x10] > by_off[0xbfc], by_off
+    # gated 2-level getter: dwType gate (depth 0) vs the sub-struct field (depth 1)
+    cpp_gated = '''extern "C" unsigned short __stdcall F(void* p)
+{
+    if (p == nullptr) return 0;
+    char* r = (char*)p;
+    if (*(unsigned int*)(r + 0x0) != 0x4u) return 0;
+    r = *(char**)(r + 0x14);
+    if (r == nullptr) return 0;
+    return *(unsigned short*)(r + 0x32);
+}
+'''
+    fg = parse_reimpl_facts(cpp_gated)
+    dm = {r["off"]: r["depth"] for r in fg["field_reads"]}
+    assert dm[0x0] == 0 and dm[0x32] == 1, dm
+    assert fg["pointer_loads"] == [{"base": "r", "off": 0x14, "depth": 0}], fg["pointer_loads"]
+
+    # a delegate call-through: callee vs global routing
+    cpp2 = '''extern "C" unsigned short __stdcall F(void* p)
+{
+    _callee_t _f = (_callee_t)D2MOO_Resolve("GetItemDataRecord");
+    unsigned short _v = *(unsigned short*)(_rec + 0x108);
+    return _v;
+}
+'''
+    f2 = parse_reimpl_facts(cpp2)
+    assert f2["callees"] == ["GetItemDataRecord"] and not f2["globals"], f2
+    assert f2["field_reads"][0]["off"] == 0x108 and f2["field_reads"][0]["width"] == 2, f2
+
+    # is_discriminating: the ladder of evidence
+    ok, _ = is_discriminating({"conf": "CONF_LIVE", "proof_kind": "synth2"})
+    assert ok
+    ok, why = is_discriminating({"conf": "CONF_LIVE", "weak_proof": "DEGENERATE"})
+    assert not ok and "weak_proof" in why
+    ok, _ = is_discriminating({"conf": "CONF_LIVE", "passed": 8, "total": 8})
+    assert ok            # multi-vector, degeneracy detector didn't flag it
+    ok, why = is_discriminating({"conf": "CONF_LIVE", "passed": 1, "total": 1})
+    assert not ok and "match-by-luck" in why
+    ok, _ = is_discriminating(None)
+    assert not ok
+
+    # gate_verdict: the DOC-rung coupling
+    v = gate_verdict([], [], True)
+    assert v["doc_level"] == "DOC_VERIFIED" and not v["blocked"]
+    v = gate_verdict(["prototype -> short f(void*)"], [], True)
+    assert v["doc_level"] == "DOC_VERIFIED"          # mechanical fixes never block
+    v = gate_verdict([], ["plate: describes branches that don't exist"], True)
+    assert v["doc_level"] == "DOC_REVIEWED" and v["blocked"]
+    v = gate_verdict([], [], False)
+    assert v["doc_level"] == "DOC_REVIEWED" and "not discriminating" in v["why"]
+
+    print("[ok] prove_doc self-test: facts parser + discriminating ladder + gate verdict pass")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--address", help="function address (0x...)")
+    ap.add_argument("--name", help="function name")
+    ap.add_argument("--program", default=PROGRAM_PATH)
+    ap.add_argument("--provider", default=os.environ.get("AI_PROVIDER"))
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--skip-prove", action="store_true",
+                    help="already proven: run gate/ledger/doc-rung only")
+    ap.add_argument("--struct-hint", default=None,
+                    help="struct name for the field ledger (e.g. ItemTypeData)")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    if not (args.address and args.name):
+        ap.error("--address and --name required (or --selftest)")
+    os.environ.setdefault("FUNDOC_LIVE_PROVE", "1")
+    s = prove_doc(args.address, args.name, program=args.program,
+                  provider=args.provider, model=args.model,
+                  skip_prove=args.skip_prove, struct_hint=args.struct_hint)
+    print(json.dumps(s, indent=2, default=str))
+    return 0 if "DOC_VERIFIED" in str(s.get("result")) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/recanonicalize.py
+++ b/fun-doc/recanonicalize.py
@@ -1,0 +1,225 @@
+"""recanonicalize.py -- replace offset-derived function names with REAL D2MOO field names.
+
+Iterates the proven registry, finds functions whose name is offset-derived
+(GetItemTypeField10, Field104, Short0x10...), resolves the REAL field from the D2MOO
+struct headers (d2moo_names.canonicalize, via the proven candidate's stride/offset), and
+renames the function + stamps a provenance plate + updates the registry. Offset names are
+kept only where D2MOO genuinely has no field there (honest last resort, flagged).
+
+    python recanonicalize.py --plan            # dry-run: what resolves, what doesn't
+    python recanonicalize.py --apply           # rename in Ghidra + update registry
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+from pathlib import Path
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+PROGRAM = os.environ.get("FUNDOC_GHIDRA_PROGRAM", "/Mods/PD2-S12/D2Common.dll")
+REGISTRY = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+CANDIDATES = D2MOO_REPO / "conformance" / "reimpl_provider" / "candidates"
+
+
+def _rows():
+    return [json.loads(l) for l in REGISTRY.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def plan() -> dict:
+    import d2moo_names as dn
+    seen, buckets = set(), {"resolved": [], "no_field": [], "no_struct": [], "no_candidate": []}
+    for r in _rows():
+        name, addr = r.get("name"), r.get("address")
+        if not name or name in seen or not dn.is_offset_name(name):
+            continue
+        seen.add(name)
+        cand = CANDIDATES / f"{name}.cpp"
+        if not cand.exists():
+            buckets["no_candidate"].append((name, addr))
+            continue
+        c = dn.canonicalize(name, cand.read_text(encoding="utf-8"))
+        if c.get("ok"):
+            buckets["resolved"].append((name, addr, c["proposed_name"], c["reason"]))
+        elif c.get("struct"):
+            buckets["no_field"].append((name, addr, c["reason"]))
+        else:
+            buckets["no_struct"].append((name, addr, c.get("reason")))
+    return buckets
+
+
+def _rewrite_plate_body(text: str, c: dict, dn) -> tuple:
+    """Rewrite stale offset-derived field references in an EXISTING plate body to the
+    canonical names, so the whole plate is self-consistent (not just a truth-note prepended
+    on top of stale prose). Two safe, structural substitutions only -- descriptive prose is
+    left alone unless it is an exact stale token:
+      1. Ghidra field placeholder  `field_0x45` / `bField45` -> the real field (`nInvPage`).
+      2. Wrong union-member stem    `PlayerData` -> the member this getter uses (`ItemData`),
+         which fixes the identifier (pPlayerData), the type (PlayerData*) and PascalCase prose
+         in one pass; plus the spaced lowercase form ("player data" -> "item data").
+    Only the LIVING documentation prose is rewritten; dated `[...]` stamp paragraphs (the
+    [CORRECTED]/[AUDIT]/[CONFORMANCE]/[D2MOO-DERIVED NAME] history log) are left verbatim so
+    the audit trail stays honest. Returns (new_text, [edit-descriptions])."""
+    off, field, edits = c.get("read_off"), c.get("field"), []
+    if off is None or not field:
+        return text, edits
+    tok = re.compile(rf"\b[bwdn]?[Ff]ield_?(?:0x)?0*{off:x}\b")
+    member = c.get("member")
+    correct = member[1:] if member and member.startswith("p") else None   # pItemData->ItemData
+    correct_spaced = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", correct).lower() if correct else None
+    wrong_members = ([m for m in dn.unit_union_member_names()
+                      if m.endswith("Data") and m.startswith("p") and m != member]
+                     if correct else [])
+    tally = {}
+
+    def _sub(para: str) -> str:
+        para, n = tok.subn(field, para)                        # field_0x45 -> nInvPage
+        if n:
+            tally[f"field_0x{off:x} -> {field}"] = tally.get(f"field_0x{off:x} -> {field}", 0) + n
+        for wrong in wrong_members:
+            stem = wrong[1:]                                   # PlayerData
+            para, na = re.subn(re.escape(wrong), member, para)        # pPlayerData -> pItemData
+            para, nb = re.subn(rf"(?<![A-Za-z]){stem}", correct, para)  # PlayerData* -> ItemData*
+            if na + nb:
+                tally[f"{stem} -> {correct}"] = tally.get(f"{stem} -> {correct}", 0) + na + nb
+            spaced = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", stem).lower()   # "player data"
+            para, nc = re.subn(re.escape(spaced), correct_spaced, para, flags=re.I)
+            if nc:
+                k = f'"{spaced}" -> {correct_spaced}'
+                tally[k] = tally.get(k, 0) + nc
+        return para
+
+    # rewrite paragraph-by-paragraph, skipping dated [...] stamp paragraphs (the history log)
+    paras = text.split("\n\n")
+    out = [p if p.lstrip().startswith("[") else _sub(p) for p in paras]
+    edits = [f"{k} ({v}x)" for k, v in tally.items()]
+    return "\n\n".join(out), edits
+
+
+def rewrite_plates(program: str = PROGRAM, do_apply: bool = False) -> dict:
+    """Second pass over already-renamed functions: make each plate BODY canonical, not just
+    its header note. Preview by default; --apply writes + saves."""
+    import d2moo_names as dn
+    import fun_doc
+    prog = Path(program).name
+    touched = []
+    for r in _rows():
+        if not r.get("_prev_name"):
+            continue                                           # only functions we canonicalized
+        name, addr = r.get("name"), r.get("address")
+        cand = CANDIDATES / f"{r['_prev_name']}.cpp"
+        if not cand.exists():
+            continue
+        c = dn.canonicalize(name, cand.read_text(encoding="utf-8"))
+        if not c.get("ok"):
+            continue
+        cur = fun_doc.ghidra_get("/get_plate_comment", params={"address": addr, "program": program})
+        cur_txt = cur.get("comment", "") if isinstance(cur, dict) else str(cur)
+        new_txt, edits = _rewrite_plate_body(cur_txt, c, dn)
+        if not edits or new_txt == cur_txt:
+            continue
+        touched.append((name, edits))
+        if do_apply:
+            fun_doc.ghidra_post("/set_plate_comment",
+                                data={"address": addr, "comment": new_txt},
+                                params={"program": program})
+    if do_apply and touched:
+        fun_doc.ghidra_post("/save_program", data={"program": prog})
+    return {"touched": touched}
+
+
+def apply(program: str = PROGRAM) -> dict:
+    import d2moo_names as dn
+    import fun_doc
+    prog = Path(program).name
+    b = plan()
+    applied, renames = [], {}
+    stamp = datetime.date.today().isoformat()
+    for name, addr, proposed, reason in b["resolved"]:
+        r = fun_doc.ghidra_post("/rename_function_by_address",
+                                data={"function_address": addr, "new_name": proposed},
+                                params={"program": prog})
+        ok = not (isinstance(r, dict) and r.get("error")) and "success" in str(r).lower()
+        if ok:
+            cur = fun_doc.ghidra_get("/get_plate_comment", params={"address": addr, "program": program})
+            cur_txt = cur.get("comment", "") if isinstance(cur, dict) else str(cur)
+            note = (f"[D2MOO-DERIVED NAME {stamp}] was '{name}' (offset-derived transcription); "
+                    f"real field per D2MOO reimplementation: {reason}. Community-canonical.")
+            if "[D2MOO-DERIVED NAME" not in cur_txt:
+                fun_doc.ghidra_post("/set_plate_comment",
+                                    data={"address": addr, "comment": (note + "\n\n" + cur_txt).strip()},
+                                    params={"program": program})
+            applied.append((name, proposed))
+            renames[name] = proposed
+    # stamp a REVIEW note on SUSPECT cases (D2MOO field disagrees with the getter's use --
+    # keep the honest offset name, but flag the discrepancy for a human to resolve).
+    for name, addr, reason in b["no_field"]:
+        if "SUSPECT" not in str(reason):
+            continue
+        cur = fun_doc.ghidra_get("/get_plate_comment", params={"address": addr, "program": program})
+        cur_txt = cur.get("comment", "") if isinstance(cur, dict) else str(cur)
+        if "[D2MOO REVIEW" not in cur_txt:
+            fun_doc.ghidra_post("/set_plate_comment",
+                                data={"address": addr, "comment":
+                                      (f"[D2MOO REVIEW {stamp}] {reason}\n\n" + cur_txt).strip()},
+                                params={"program": program})
+            applied.append((name, "(review-flagged, not renamed)"))
+    if applied:
+        fun_doc.ghidra_post("/save_program", data={"program": prog})
+        # update registry names (name is a key for downstream tooling)
+        rows = _rows()
+        for row in rows:
+            if row.get("name") in renames:
+                row["_prev_name"] = row["name"]
+                row["name"] = renames[row["name"]]
+        REGISTRY.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return {"applied": applied, "plan": {k: len(v) for k, v in b.items()}}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--plan", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--rewrite-plates", action="store_true",
+                    help="second pass: make already-renamed functions' plate BODIES canonical "
+                         "(field_0x45->nInvPage, PlayerData->ItemData). Preview unless --apply.")
+    ap.add_argument("--program", default=PROGRAM)
+    args = ap.parse_args()
+    if args.rewrite_plates:
+        out = rewrite_plates(program=args.program, do_apply=args.apply)
+        verb = "REWROTE" if args.apply else "would rewrite"
+        print(f"{verb} plate bodies for {len(out['touched'])} functions"
+              f"{'' if args.apply else ' (preview -- add --apply to write)'}:")
+        for name, edits in out["touched"]:
+            print(f"  {name}")
+            for e in edits:
+                print(f"       {e}")
+        return 0
+    if args.apply:
+        out = apply(program=args.program)
+        print(f"RENAMED {len(out['applied'])} functions; plan counts: {out['plan']}")
+        for old, new in out["applied"]:
+            print(f"  {old}  ->  {new}")
+        return 0
+    b = plan()
+    print(f"offset-named proven functions: resolved={len(b['resolved'])} "
+          f"no_field={len(b['no_field'])} no_struct={len(b['no_struct'])} "
+          f"no_candidate={len(b['no_candidate'])}")
+    print("\n-- RESOLVED (would rename) --")
+    for name, addr, proposed, reason in b["resolved"]:
+        print(f"  {name:<34} -> {proposed:<38} [{reason}]")
+    if b["no_field"]:
+        print("\n-- struct found, NO D2MOO field at offset (offset name is honest) --")
+        for name, addr, reason in b["no_field"]:
+            print(f"  {name:<34} {reason}")
+    if b["no_struct"]:
+        print("\n-- struct NOT identified (needs chain/context) --")
+        for name, addr, reason in b["no_struct"][:20]:
+            print(f"  {name:<34} {reason}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun-doc/scripts/gen_conformance_protected.py
+++ b/fun-doc/scripts/gen_conformance_protected.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Regenerate conformance_protected.json from live Ghidra function tags.
+
+conformance_protected.json has, since it was created, carried a note saying
+it's "regenerated from Ghidra tags via scripts/gen_conformance_protected.py
+(or the in-scan ingest once landed)" -- but that script never existed until
+now. Until this script, the file was maintained by hand.
+
+Source of truth: the four OpenD2 conformance lifecycle tags applied to
+Ghidra functions (see OpenD2/docs/EMULATION_CONFORMANCE_PLAN.md Sec 13):
+    ANALYZED_RUNTIME | ORACLE | PORTED | PROVEN
+Queried live via ghidra-mcp's /search_functions_by_tag endpoint, across
+every currently-OPEN program (tags on closed programs aren't queryable --
+the MCP plugin only sees the live Program objects Ghidra has open).
+
+Usage:
+    python -m scripts.gen_conformance_protected --dry-run   (default; prints a diff)
+    python -m scripts.gen_conformance_protected --apply     (writes the file)
+
+Always dry-run first -- if Ghidra doesn't have all the usual PD2-S12
+programs open, a --apply would shrink the protected set and silently
+un-protect functions the auto-doc worker must never touch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+import requests
+
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "conformance_protected.json"
+
+CONFORMANCE_TAGS = ["ANALYZED_RUNTIME", "ORACLE", "PORTED", "PROVEN"]
+
+# Default scope: the conformance tags are an OpenD2/PD2-S12 concept only --
+# every existing conformance_protected.json key lives under this prefix.
+# Scanning it (not "every open program") matters for two reasons: (1)
+# correctness -- instance_info's `open` flag does NOT mean "queryable via
+# /search_functions_by_tag" (confirmed live: D2Game.dll reports open=false
+# yet resolves fine and returns real tagged functions -- filtering on
+# `open` silently dropped it), so path-prefix is the right scope signal,
+# not the open flag; (2) a live instance can have 100+ programs loaded
+# across multiple projects/versions -- scanning all of them (4 tag queries
+# apiece) is slow and pointless outside the PD2-S12 oracle set.
+DEFAULT_PROGRAM_PREFIX = "/Mods/PD2-S12/"
+
+
+def _get(endpoint, params=None, timeout=15):
+    r = requests.get(f"{GHIDRA_HTTP}/{endpoint.lstrip('/')}", params=params, timeout=timeout)
+    r.raise_for_status()
+    return r.json()
+
+
+def _matching_programs(prefix):
+    """[(name, path), ...] for every program whose path starts with `prefix`
+    -- NOT filtered by instance_info's `open` flag (see DEFAULT_PROGRAM_PREFIX
+    docstring for why that flag is the wrong signal here)."""
+    info = _get("/mcp/instance_info")
+    return [
+        (p["name"], p["path"])
+        for p in info.get("programs", [])
+        if p.get("path", "").startswith(prefix)
+    ]
+
+
+def build_protected_keys(prefix=DEFAULT_PROGRAM_PREFIX):
+    """Query every program under `prefix` for each conformance tag. Returns
+    {key: [tags...]} where key = "<program_path>::<address_no_0x_lowercase>",
+    matching fun_doc.load_conformance_protected's expected format."""
+    protected: dict[str, list[str]] = {}
+    programs = _matching_programs(prefix)
+    if not programs:
+        print(f"WARNING: no programs found under prefix {prefix!r}", file=sys.stderr)
+
+    for name, path in programs:
+        for tag in CONFORMANCE_TAGS:
+            try:
+                result = _get("/search_functions_by_tag", params={"tag": tag, "program": path, "limit": 1000})
+            except requests.HTTPError as exc:
+                if exc.response is not None and exc.response.status_code == 400:
+                    continue  # tag not defined on this program -- normal, not an error
+                print(f"  WARNING: {path} tag={tag}: {exc}", file=sys.stderr)
+                continue
+            except requests.RequestException as exc:
+                print(f"  WARNING: {path} tag={tag}: {exc}", file=sys.stderr)
+                continue
+
+            for fn in result.get("functions", []):
+                addr = str(fn.get("address", "")).lower()
+                if addr.startswith("0x"):
+                    addr = addr[2:]
+                key = f"{path}::{addr}"
+                protected.setdefault(key, [])
+                if tag not in protected[key]:
+                    protected[key].append(tag)
+
+    return protected
+
+
+def load_existing():
+    if not OUTPUT_PATH.exists():
+        return {}
+    try:
+        return json.loads(OUTPUT_PATH.read_text(encoding="utf-8")).get("protected_keys", {})
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def diff_summary(old, new):
+    added = sorted(set(new) - set(old))
+    removed = sorted(set(old) - set(new))
+    changed = sorted(k for k in (set(new) & set(old)) if sorted(new[k]) != sorted(old[k]))
+    return added, removed, changed
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--apply", action="store_true", help="Write conformance_protected.json (default: dry-run only)")
+    parser.add_argument(
+        "--program-prefix", default=DEFAULT_PROGRAM_PREFIX,
+        help=f"Only scan programs whose path starts with this (default: {DEFAULT_PROGRAM_PREFIX!r}). "
+             "Widen only if conformance tags start getting applied outside PD2-S12.",
+    )
+    args = parser.parse_args(argv)
+
+    old = load_existing()
+    new = build_protected_keys(prefix=args.program_prefix)
+    added, removed, changed = diff_summary(old, new)
+
+    programs = _matching_programs(args.program_prefix)
+    print(f"Scanned {len(programs)} program(s) under {args.program_prefix!r} for tags: {', '.join(CONFORMANCE_TAGS)}")
+    print(f"Current file: {len(old)} protected key(s). Live scan: {len(new)} protected key(s).")
+    if added:
+        print(f"\n+{len(added)} newly protected:")
+        for k in added[:20]:
+            print(f"    + {k}  {new[k]}")
+        if len(added) > 20:
+            print(f"    ... and {len(added) - 20} more")
+    if removed:
+        print(f"\n-{len(removed)} no longer tagged (would be UN-protected on --apply):")
+        for k in removed[:20]:
+            print(f"    - {k}  {old[k]}")
+        if len(removed) > 20:
+            print(f"    ... and {len(removed) - 20} more")
+    if changed:
+        print(f"\n~{len(changed)} tag set changed:")
+        for k in changed[:20]:
+            print(f"    ~ {k}  {old[k]} -> {new[k]}")
+
+    if not (added or removed or changed):
+        print("\nNo changes.")
+
+    if not args.apply:
+        print("\nDry run only -- pass --apply to write conformance_protected.json.")
+        if removed:
+            print(
+                "NOTE: this scan removed protected keys. If any open program is missing "
+                "(Ghidra not fully loaded, a program not opened), --apply would silently "
+                "un-protect real PROVEN/PORTED functions. Verify all expected programs are "
+                "open before applying."
+            )
+        return 0
+
+    payload = {
+        "generated": date.today().isoformat(),
+        "note": (
+            "Functions carrying an OpenD2 conformance tag in Ghidra (ANALYZED_RUNTIME / "
+            "ORACLE / PORTED / PROVEN). These are hand-verified against the live PD2-S12 "
+            "process and/or ported to the OpenD2 clone; they are EXCLUDED from the auto-doc "
+            "selector so a cheap worker cannot overwrite a runtime-verified plate. Keys are "
+            "fun-doc function keys: '<program_path>::<address>'. Regenerated from live Ghidra "
+            "tags via scripts/gen_conformance_protected.py --apply. Pinning a function in the "
+            "dashboard bypasses this protection for a deliberate re-document."
+        ),
+        "protected_keys": dict(sorted(new.items())),
+    }
+    OUTPUT_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"\nWrote {OUTPUT_PATH} ({len(new)} protected keys).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fun-doc/shadow_promote.py
+++ b/fun-doc/shadow_promote.py
@@ -1,0 +1,294 @@
+"""shadow_promote.py -- the "shadow the original function to verify it" leg of
+the continuous port-and-prove loop (D2MOO's conformance/D2COMMON_FULL_SHADOW_PLAN.md).
+
+Sibling to port_live_prove.py, which proves a reimpl bit-exact via the ONE-SHOT
+direct-call oracle (CONF_LIVE: our chosen inputs, checked once). This module
+promotes an already-CONF_LIVE function to a live SHADOW DISPATCHER: hooked into
+the real game's call path, comparing original vs reimpl on EVERY real call the
+game makes, at volume, for free. That is the strictly stronger CONF_BATTLETESTED
+rung -- battletest_promoter.py (sibling) closes the loop by watching shadow
+hit/divergence counters and promoting once real-play evidence crosses a bar.
+
+Design constraints (learned by hand, 2026-07-07, before this module existed):
+  1. `translate_layout_to_spec` (port_live_prove.py) only ever emits i32-slot
+     args + an EAX-only return -- so every candidate it can prove today is
+     naturally "Class A" (return-value integer) shaped for
+     conformance/tools/gen_shadow_dispatch.py's generator. A `void`-return spec
+     captures NOTHING (compare=[]) -- promoting it would be a shadow dispatcher
+     that can never observe a divergence, which is false confidence, not proof.
+     Such specs are DEFERRED, not silently promoted.
+  2. A reimpl whose decompiled source calls a wall-clock/tick/rand function is
+     NON-DETERMINISTIC -- a correct reimpl would still show spurious
+     "divergences" from timing drift between the two calls. Deferred.
+  3. A reimpl whose decompiled source can reach an abort/exit path is a REAL
+     hazard for autonomous vector generation elsewhere in the pipeline (a stray
+     out-of-range input is a hard process termination, not a catchable fault)
+     -- flagged for human review rather than silently promoted, even though
+     shadowing itself (game-supplied inputs only) would be safe.
+  4. Promotion here only STAGES the manifest + regenerates the generated header
+     (cheap, local, reversible). It deliberately does NOT rebuild D2Common.dll
+     or restart the game -- that is a separate, explicit, batched step
+     (rebuild_and_stage_batch / the `--build` CLI flag) so an autonomous loop
+     never kills the user's running game out from under them without opt-in.
+
+Standalone (imports nothing from fun_doc), like port_pipeline.py / port_live_prove.py.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+
+GHIDRA_HTTP = os.environ.get("GHIDRA_MCP_URL", "http://127.0.0.1:8089").rstrip("/")
+
+D2MOO_REPO = Path(os.environ.get("FUNDOC_D2MOO_REPO", r"C:\Users\benam\source\cpp\D2MOO"))
+MANIFEST_PATH = D2MOO_REPO / "conformance" / "shadow_manifest.json"
+GEN_SCRIPT = D2MOO_REPO / "conformance" / "tools" / "gen_shadow_dispatch.py"
+REGISTRY_PATH = D2MOO_REPO / "conformance" / "proven_functions.jsonl"
+BUILD_TREE = os.environ.get("FUNDOC_D2MOO_BUILD_TREE", str(D2MOO_REPO / "build-1.13c"))
+
+_D2COMMON_BASE = 0x6FD50000
+
+# Hazard heuristics over the DECOMPILED SOURCE TEXT. Deliberately conservative --
+# false positives just mean an extra function waits for human review; false
+# negatives mean a real hazard (crash, flaky divergence) reaches production.
+_NONDETERMINISTIC_RE = re.compile(
+    r"\b(GetTickCount|QueryPerformanceCounter|timeGetTime|__time32|_time32|"
+    r"FID_conflict___time32|\btime\s*\(|\brand\s*\(|srand\s*\()", re.IGNORECASE)
+_ABORT_PATH_RE = re.compile(
+    r"\b(CleanupAndAbort|_exit\s*\(|\bexit\s*\(|ExitProcess|abort\s*\(|"
+    r"RaiseException|std::terminate)", re.IGNORECASE)
+
+
+class DeferPromotion(Exception):
+    """Function is not safe/meaningful to promote yet. .reason is human-readable."""
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def check_shadow_reachable(address, program: str = "D2Common.dll") -> None:
+    """Raise DeferPromotion if the function has ZERO internal callers -- an export
+    the compiler inlined at every call site is NEVER invoked at runtime, so a shadow
+    dispatcher for it sits at 0 hits forever and can't reach CONF_BATTLETESTED. Route
+    it to the offline CONF_REGRESSION freeze instead of wasting a stage+rebuild+
+    restart+dispatcher slot (2026-07-08: 5 PATH getters discovered this way AFTER
+    staging). HINT only -- cross-DLL callers are invisible; the shadow hit count is
+    the final arbiter, so this only fires on a confident 0. Best-effort: any fetch
+    failure -> no block (let the empirical hit count decide)."""
+    addr = f"0x{address:x}" if isinstance(address, int) else str(address)
+    try:
+        u = urllib.parse.urlparse(GHIDRA_HTTP)
+        c = http.client.HTTPConnection(u.hostname, u.port or 8089, timeout=10)
+        c.request("GET", "/get_function_xrefs?" + urllib.parse.urlencode(
+            {"address": addr, "program": program}))
+        raw = c.getresponse().read().decode("utf-8", "replace")
+        c.close()
+    except OSError:
+        return
+    try:
+        obj = json.loads(raw)
+        text = obj.get("result", "") if isinstance(obj, dict) else str(obj)
+    except json.JSONDecodeError:
+        text = raw
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    internal = [ln for ln in lines if "[EXTERNAL]" not in ln and "Entry Point" not in ln]
+    if lines and not internal:
+        raise DeferPromotion(
+            "shadow-unreachable: 0 internal callers (export-only, inlined at call sites) "
+            "-> never invoked at runtime; freeze offline as CONF_REGRESSION instead of "
+            "shadow-staging")
+
+
+def check_weak_proof(name: str) -> None:
+    """Raise DeferPromotion if the registry row for `name` carries a `weak_proof`
+    flag -- a CONF_LIVE proof the oracle stamped DEGENERATE (the original returned
+    an identical value on every vector, so a wrong reimpl matched by luck; see
+    port_live_prove._degenerate_capture_note). Promoting one to a shadow dispatcher
+    on that basis is how STAT_GetActiveSkillFieldC 'passed 8/8' then diverged ~99%
+    under real gameplay. Best-effort: no registry -> no block."""
+    try:
+        for line in REGISTRY_PATH.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            if r.get("name") == name and r.get("weak_proof"):
+                raise DeferPromotion(f"weak proof (degenerate capture): {r['weak_proof']}")
+    except (OSError, json.JSONDecodeError):
+        return
+
+
+def classify_dispatcher_shape(spec: dict) -> str:
+    """spec (port_live_prove.translate_layout_to_spec's output) -> generator
+    Class letter, or raises DeferPromotion if this shape isn't safe/meaningful
+    to promote given the CURRENT generator (Class A only; see module docstring)."""
+    orig_regs = spec.get("orig_regs")
+    if orig_regs:
+        # Class D: register-explicit ABI. The generator's v1 naked thunk supports
+        # the single-EAX-input, u32/pointer-return pattern (the DATATBLS_* accessors).
+        # Anything else (multi-register, ESI/EDI inputs, stack args, non-u32 return)
+        # still defers.
+        args = spec.get("args", [])
+        ret = spec.get("ret")
+        if (list(orig_regs.keys()) == ["EAX"] and len(args) == 1
+                and ret in ("u32", "i32") and spec.get("compare") == ["ret"]
+                and all(a.get("kind") in (None, "i32") for a in args)):
+            return "D"
+        raise DeferPromotion(
+            f"register-explicit ABI {orig_regs} outside Class D v1 (single EAX "
+            f"input, u32 return) -- multi-register/stack marshalling not implemented")
+    if spec.get("ret") in (None, "void") or not spec.get("compare"):
+        raise DeferPromotion(
+            "void/uncaptured return -- this spec's oracle proof (EAX-only) "
+            "observes nothing, so a shadow dispatcher for it could never show "
+            "a divergence; not meaningful proof. Needs out-param modeling "
+            "(Class B) in translate_layout_to_spec before this is provable.")
+    ret_bits = 32
+    if spec["ret"] in ("u8", "i8"):
+        ret_bits = 8
+    elif spec["ret"] in ("u16", "i16"):
+        ret_bits = 16
+    if any(a.get("kind") not in (None, "i32") for a in spec.get("args", [])):
+        raise DeferPromotion(f"unsupported arg kind(s) in {spec.get('args')}")
+    return "A"  # only shape this pipeline can produce today; ret_bits carried separately
+
+
+def check_hazards(decompiled_text: str) -> None:
+    """Raise DeferPromotion if the decompiled source shows a known-dangerous
+    pattern. Best-effort text heuristic, not a substitute for human review of
+    anything genuinely borderline."""
+    text = decompiled_text or ""
+    m = _NONDETERMINISTIC_RE.search(text)
+    if m:
+        raise DeferPromotion(
+            f"non-deterministic (matched {m.group(0)!r}) -- a correct reimpl "
+            f"would still show spurious shadow divergences from timing drift")
+    m = _ABORT_PATH_RE.search(text)
+    if m:
+        raise DeferPromotion(
+            f"reaches an abort/exit path (matched {m.group(0)!r}) -- shadowing "
+            f"real gameplay calls is safe (the game only supplies values its own "
+            f"code already validated), but flagged for human review before "
+            f"promotion since a HARD process termination is not the same "
+            f"failure mode as a catchable access violation")
+
+
+def _load_manifest() -> dict:
+    if MANIFEST_PATH.exists():
+        return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return {"_comment": "shadow-dispatcher promotion manifest (auto-managed by "
+                         "fun-doc/shadow_promote.py + hand-authored entries).",
+            "entries": []}
+
+
+def _save_manifest(manifest: dict) -> None:
+    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+def regenerate_dispatch_header() -> dict:
+    """Re-run the generator so D2Common_ShadowDispatch.gen.h reflects the
+    manifest. Cheap (pure codegen, no compile). Best-effort."""
+    if not GEN_SCRIPT.exists():
+        return {"ok": False, "error": f"generator not found: {GEN_SCRIPT}"}
+    try:
+        proc = subprocess.run([sys.executable, str(GEN_SCRIPT)],
+                               capture_output=True, text=True, timeout=60)
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "generator timed out"}
+    return {"ok": proc.returncode == 0, "output": (proc.stdout + proc.stderr).strip()}
+
+
+def maybe_promote(name: str, address, spec: dict, decompiled_text: str = "") -> dict:
+    """Given a function that just passed CONF_LIVE (one-shot oracle proof),
+    decide whether it's safe+meaningful to promote to a live shadow dispatcher,
+    and if so STAGE it (manifest + regenerated header; NOT built/deployed --
+    see module docstring). Never raises; returns a status dict:
+        {"promoted": bool, "reason": str, "class": str|None}
+    Best-effort and non-fatal, matching port_live_prove.py's write-back contract
+    -- a promotion failure must never fail the underlying proof."""
+    try:
+        check_weak_proof(name)               # degenerate-capture proofs must not auto-promote
+        check_shadow_reachable(address)      # export-only/inlined -> freeze offline, don't shadow-stage
+        check_hazards(decompiled_text)
+        cls = classify_dispatcher_shape(spec)
+    except DeferPromotion as e:
+        return {"promoted": False, "reason": e.reason, "class": None}
+    except Exception as e:  # never let a promotion bug fail the caller's proof
+        return {"promoted": False, "reason": f"error: {e}", "class": None}
+
+    try:
+        if isinstance(address, str):
+            try:
+                addr_int = int(address, 0)      # "0x6fd51250"
+            except ValueError:
+                addr_int = int(address, 16)     # bare hex "6fd51250" (fun_doc convention)
+        else:
+            addr_int = int(address)
+        offset = addr_int - _D2COMMON_BASE
+        if offset < 0:
+            return {"promoted": False, "reason": f"address below D2Common base: {address}", "class": None}
+
+        ret_bits = {"u8": 8, "i8": 8, "u16": 16, "i16": 16}.get(spec["ret"], 32)
+        args = [a["id"] for a in spec.get("args", [])] or []  # generator normalizes strings -> i32
+
+        manifest = _load_manifest()
+        entries = manifest.setdefault("entries", [])
+        if any(e["name"] == name for e in entries):
+            return {"promoted": True, "reason": "already staged", "class": cls}
+
+        entries.append({
+            "name": name, "offset": f"0x{offset:x}", "callconv": spec["callconv"],
+            "args": args, "ret_bits": ret_bits, "class": cls,
+            "note": f"auto-staged by fun-doc/shadow_promote.py from a CONF_LIVE oracle proof",
+        })
+        _save_manifest(manifest)
+        gen = regenerate_dispatch_header()
+        if not gen.get("ok"):
+            return {"promoted": False, "reason": f"manifest staged but codegen failed: {gen.get('error') or gen.get('output')}", "class": cls}
+        return {"promoted": True, "reason": "staged (manifest + header regenerated; "
+                                             "build+deploy is a separate batched step)", "class": cls}
+    except Exception as e:
+        return {"promoted": False, "reason": f"error: {e}", "class": None}
+
+
+if __name__ == "__main__":
+    # Self-test: hazard + shape classification, no side effects on the real manifest.
+    try:
+        check_hazards("int Foo(int a) { return FID_conflict___time32(0) + a; }")
+        raise SystemExit("FAIL: expected DeferPromotion for time32 call")
+    except DeferPromotion as e:
+        assert "non-deterministic" in e.reason, e.reason
+
+    try:
+        check_hazards("void Foo(int a) { if (a<0) CleanupAndAbort(); }")
+        raise SystemExit("FAIL: expected DeferPromotion for abort path")
+    except DeferPromotion as e:
+        assert "abort" in e.reason, e.reason
+
+    check_hazards("int Foo(int a) { return a + 1; }")  # should NOT raise
+
+    ok_spec = {"callconv": "stdcall", "ret": "u8", "args": [{"id": "act", "kind": "i32"}], "compare": ["ret"]}
+    assert classify_dispatcher_shape(ok_spec) == "A"
+
+    void_spec = {"callconv": "stdcall", "ret": "void", "args": [], "compare": []}
+    try:
+        classify_dispatcher_shape(void_spec)
+        raise SystemExit("FAIL: expected DeferPromotion for void/uncaptured spec")
+    except DeferPromotion:
+        pass
+
+    regs_spec = {"callconv": "fastcall", "ret": "u32", "args": [{"id": "x", "kind": "i32"}],
+                 "compare": ["ret"], "orig_regs": {"EAX": "x"}}
+    try:
+        classify_dispatcher_shape(regs_spec)
+        raise SystemExit("FAIL: expected DeferPromotion for orig_regs")
+    except DeferPromotion:
+        pass
+
+    print("[ok] shadow_promote unit checks passed")

--- a/fun-doc/storage/models.py
+++ b/fun-doc/storage/models.py
@@ -116,6 +116,13 @@ def build_metadata(schema: str | None = None) -> MetaData:
         # JSONB blobs
         Column("deductions", JSON),
         Column("callees", JSON),
+        # OpenD2 conformance port pipeline (document -> port -> prove, see
+        # EMULATION_CONFORMANCE_PLAN.md Sec 14). Populated only for functions
+        # the PORT worker has touched; NULL/none for everything else.
+        Column("port_status", String),
+        Column("port_attempts", Integer, default=0),
+        Column("port_draft_path", String),
+        Column("port_last_result", String),
         # timestamps
         Column("created_at", DateTime(timezone=True)),
         Column("updated_at", DateTime(timezone=True)),

--- a/fun-doc/verify_shadow_fix.py
+++ b/fun-doc/verify_shadow_fix.py
@@ -1,0 +1,157 @@
+"""verify_shadow_fix.py -- first-class hot-reload shadow-delta verification.
+
+The fastest correct way to verify a re-drafted reimpl (2026-07-08): rebuild ONLY
+the provider DLL, hot-reload it, flip the dispatcher to shadow, and watch the
+divergence DELTA on REAL game calls. Seconds, no restart, real input distribution --
+strictly better than the town-capture oracle that produced the original false
+positive. This automates the loop I ran by hand:
+
+    1. snapshot the dispatcher's baseline (hits, divergences)
+    2. (optional) POST /reimpl/reload  -- bind the freshly rebuilt provider
+    3. set the dispatcher to shadow mode
+    4. poll until N NEW clean hits accrue  -> VERIFIED
+       or any NEW divergence appears        -> STILL DIVERGING
+       or the hit budget stalls             -> INSUFFICIENT (needs gameplay)
+    5. on VERIFIED: set the promotion EPOCH (battletest_promoter) so the fixed
+       function auto-promotes to CONF_BATTLETESTED on new clean calls -- no restart
+       needed to clear the poisoned pre-fix cumulative divergences.
+
+The verdict math is pure + unit-tested (verdict()); the live flow needs the game
+on :8790.
+
+    python verify_shadow_fix.py STAT_GetActiveSkillFieldC --reload --target 2000
+"""
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import time
+import urllib.parse
+
+ORACLE_URL = os.environ.get("D2DBG_MCP_URL", "http://127.0.0.1:8790")
+
+
+def _get(path: str, timeout: int = 6) -> dict:
+    u = urllib.parse.urlparse(ORACLE_URL)
+    c = http.client.HTTPConnection(u.hostname, u.port or 8790, timeout=timeout)
+    try:
+        c.request("GET", path)
+        return json.loads(c.getresponse().read().decode("utf-8", "replace"))
+    finally:
+        c.close()
+
+
+def _post(path: str, body: dict | None = None, timeout: int = 20) -> dict:
+    u = urllib.parse.urlparse(ORACLE_URL)
+    c = http.client.HTTPConnection(u.hostname, u.port or 8790, timeout=timeout)
+    try:
+        payload = json.dumps(body).encode() if body is not None else None
+        c.request("POST", path, body=payload,
+                  headers={"Content-Type": "application/json"} if payload else {})
+        return json.loads(c.getresponse().read().decode("utf-8", "replace"))
+    finally:
+        c.close()
+
+
+def _find(name: str) -> dict | None:
+    for d in _get("/dispatchers").get("dispatchers", []):
+        if d["name"] == name:
+            return d
+    return None
+
+
+def verdict(base: dict, cur: dict, target_hits: int) -> dict:
+    """PURE decision from a baseline and current counter snapshot. Returns
+    {status, dhits, ddivs} with status in verified | diverging | insufficient."""
+    dhits = cur["hits"] - base["hits"]
+    ddivs = cur["divergences"] - base["divergences"]
+    if ddivs > 0:
+        status = "diverging"          # a NEW divergence -> the fix is still wrong
+    elif dhits >= target_hits:
+        status = "verified"           # enough NEW calls, all matched
+    else:
+        status = "insufficient"       # clean so far but not enough calls yet
+    return {"status": status, "dhits": dhits, "ddivs": ddivs}
+
+
+def run(name: str, *, target_hits: int = 1000, reload: bool = True,
+        poll_secs: int = 3, budget_secs: int = 180, set_epoch: bool = True) -> dict:
+    d = _find(name)
+    if d is None:
+        return {"ok": False, "error": f"{name} is not a live dispatcher"}
+    idx = d["index"]
+    base = {"hits": d["hits"], "divergences": d["divergences"]}
+    print(f"[baseline] {name} idx={idx} hits={base['hits']} divergences={base['divergences']}")
+
+    if reload:
+        rl = _post("/reimpl/reload")
+        print(f"[reload] {rl.get('provider', rl.get('error'))}")
+
+    sm = _post(f"/dispatcher/{idx}/mode", {"mode": "shadow"})
+    if not sm.get("ok"):
+        return {"ok": False, "error": f"set shadow failed: {sm.get('error')}"}
+    print(f"[shadow] {name} -> shadow; watching for {target_hits} clean new hits "
+          f"(budget {budget_secs}s)")
+
+    waited = 0
+    last = base
+    while waited < budget_secs:
+        time.sleep(poll_secs)
+        waited += poll_secs
+        cur_d = _find(name)
+        if cur_d is None:
+            return {"ok": False, "error": "dispatcher vanished (bridge died?)"}
+        cur = {"hits": cur_d["hits"], "divergences": cur_d["divergences"]}
+        v = verdict(base, cur, target_hits)
+        print(f"  t={waited:>3}s  +{v['dhits']} hits  +{v['ddivs']} div  -> {v['status']}")
+        if v["status"] == "diverging":
+            return {"ok": True, "verified": False, "status": "diverging",
+                    "new_divergences": v["ddivs"], "new_hits": v["dhits"],
+                    "note": "the re-drafted reimpl STILL diverges on real calls -- re-check the disasm"}
+        if v["status"] == "verified":
+            out = {"ok": True, "verified": True, "status": "verified",
+                   "new_hits": v["dhits"], "new_divergences": 0}
+            if set_epoch:
+                try:
+                    import battletest_promoter as bp
+                    ep = bp.set_shadow_epoch(name)
+                    out["epoch"] = ep
+                    print(f"[epoch] set promotion baseline -> it auto-promotes on new clean calls: {ep}")
+                except Exception as e:  # noqa: BLE001
+                    out["epoch_error"] = str(e)
+            return out
+        last = cur
+
+    return {"ok": True, "verified": False, "status": "insufficient",
+            "new_hits": last["hits"] - base["hits"], "new_divergences": last["divergences"] - base["divergences"],
+            "note": f"only {last['hits'] - base['hits']} new hits in {budget_secs}s and 0 divergences -- "
+                    f"clean so far but under target; play/move to exercise it, or lower --target"}
+
+
+def _selftest() -> int:
+    b = {"hits": 100, "divergences": 50}
+    assert verdict(b, {"hits": 2000, "divergences": 50}, 1000)["status"] == "verified"
+    assert verdict(b, {"hits": 2000, "divergences": 51}, 1000)["status"] == "diverging"
+    assert verdict(b, {"hits": 300, "divergences": 50}, 1000)["status"] == "insufficient"
+    # a diverging verdict wins even past the hit target
+    assert verdict(b, {"hits": 9999, "divergences": 60}, 1000)["status"] == "diverging"
+    print("[ok] verify_shadow_fix verdict self-test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("name", nargs="?", help="dispatcher/function name to verify")
+    ap.add_argument("--target", type=int, default=1000, help="clean new hits required to VERIFY")
+    ap.add_argument("--no-reload", action="store_true", help="skip provider hot-reload")
+    ap.add_argument("--budget", type=int, default=180, help="seconds to watch before INSUFFICIENT")
+    ap.add_argument("--no-epoch", action="store_true", help="don't set the promotion epoch on verify")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest or not args.name:
+        raise SystemExit(_selftest())
+    print(json.dumps(run(args.name, target_hits=args.target, reload=not args.no_reload,
+                         budget_secs=args.budget, set_epoch=not args.no_epoch), indent=2))

--- a/tests/performance/test_abi_static.py
+++ b/tests/performance/test_abi_static.py
@@ -1,0 +1,80 @@
+"""Offline unit tests for abi_static.py.
+
+abi_static derives ground-truth ABI facts from a function's disassembly and
+translates pure getters to C -- all static string analysis, no Ghidra/oracle.
+The module ships a known-answer corpus (`_CORPUS`) + `_selftest()` that pins the
+derive_abi / translator contracts; we run it here so the corpus is a CI gate,
+plus a few direct checks on the smaller pure helpers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+FUN_DOC_DIR = Path(__file__).resolve().parents[2] / "fun-doc"
+if str(FUN_DOC_DIR) not in sys.path:
+    sys.path.insert(0, str(FUN_DOC_DIR))
+
+import abi_static as abi  # noqa: E402
+
+
+def test_selftest_known_answer_corpus_passes():
+    # Exercises derive_abi across the whole _CORPUS + the getter translators +
+    # abort detection. Returns 0 on success; asserts internally otherwise.
+    assert abi._selftest() == 0
+
+
+def test_parse_disasm_shape():
+    text = (
+        "6fd70000: MOV EAX,dword ptr [ESP + 0x4]\n"
+        "6fd70004: TEST EAX,EAX\n"
+        "6fd70006: RET 0x4\n"
+    )
+    rows = abi.parse_disasm(text)
+    assert rows[0] == (0x6FD70000, "MOV", "EAX,dword ptr [ESP + 0x4]")
+    assert rows[1][1] == "TEST"
+    assert rows[2] == (0x6FD70006, "RET", "0x4")
+    # blank / non-matching lines are dropped
+    assert abi.parse_disasm("") == []
+    assert abi.parse_disasm("not a disasm line") == []
+
+
+def test_regs_in_normalizes_subregisters():
+    # sub-registers fold to their parent 32-bit GP register
+    regs = abi._regs_in("MOV AL,byte ptr [ECX + 0x8]")
+    assert "ECX" in regs
+    assert "EAX" in regs  # AL -> EAX
+    assert abi._regs_in("") == set()
+
+
+def test_detect_abort_path():
+    assert abi.detect_abort_path("/* WARNING: Subroutine does not return */ _exit(-1);")
+    assert abi.detect_abort_path("CleanupAndAbort();")
+    assert not abi.detect_abort_path("return pRecords[idx].nField;")
+
+
+def test_clamp_abort_vectors_keeps_in_range_and_backfills():
+    # returns (surviving_vectors, count). A mix: only the in-range vector survives.
+    kept, _n = abi.clamp_abort_vectors([{"idx": 3}, {"idx": 9999}], max_index=32)
+    assert {"idx": 3} in kept
+    assert {"idx": 9999} not in kept
+    # all out-of-range -> a dense in-range sweep is synthesized (non-empty, in range)
+    synth, _m = abi.clamp_abort_vectors([{"idx": 9999}], max_index=8)
+    assert synth, "must backfill an in-range sweep when nothing survives"
+    assert all(0 <= list(v.values())[0] for v in synth)
+
+
+def test_resolve_reverse_map_parses_gen_header(tmp_path):
+    # address(int) -> name, parsed from the `{ "name", 0xADDRu }` initializer table.
+    hdr = tmp_path / "resolve.gen.h"
+    hdr.write_text(
+        'static const Entry kTable[] = {\n'
+        '  { "FOG_10021_BSearch", 0x6fd59240u },\n'
+        '  { "D2Common_10426_GetItemsBin", 0x6fdefb94u },\n'
+        '};\n',
+        encoding="utf-8",
+    )
+    rev = abi.resolve_reverse_map(str(hdr))
+    assert rev[0x6FD59240] == "FOG_10021_BSearch"
+    assert rev[0x6FDEFB94] == "D2Common_10426_GetItemsBin"

--- a/tests/performance/test_bench_score.py
+++ b/tests/performance/test_bench_score.py
@@ -1,0 +1,59 @@
+"""Offline unit tests for bench_score.py.
+
+bench_score grades the facts the production translators recover from a fresh
+binary against a known answer key -- pure comparison arithmetic, no Ghidra/LLM.
+Runs the module's `_selftest()` (scoring axes) as a CI gate plus direct checks
+on the `score_function` scoring contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+FUN_DOC_DIR = Path(__file__).resolve().parents[2] / "fun-doc"
+if str(FUN_DOC_DIR) not in sys.path:
+    sys.path.insert(0, str(FUN_DOC_DIR))
+
+# bench_score sets os.environ["FUN_DOC_PROJECT_FOLDER"]="/benchmark" at import
+# (it's a benchmark harness). Snapshot + restore around the import so it can't
+# leak into sibling tests collected afterwards (e.g. test_ghidra_offline, which
+# asserts on fetch_function_data's project-folder-dependent behavior).
+_SAVED_PROJECT_FOLDER = os.environ.get("FUN_DOC_PROJECT_FOLDER", "\0__UNSET__")
+import bench_score as bs  # noqa: E402
+if _SAVED_PROJECT_FOLDER == "\0__UNSET__":
+    os.environ.pop("FUN_DOC_PROJECT_FOLDER", None)
+else:
+    os.environ["FUN_DOC_PROJECT_FOLDER"] = _SAVED_PROJECT_FOLDER
+
+
+def test_selftest_scoring_axes_pass():
+    assert bs._selftest() == 0
+
+
+def test_score_function_perfect_match():
+    ak = {
+        "ret": {"width": 2},
+        "reads": [{"off": 0x8, "width": 4}, {"off": 0x4, "width": 2}],
+        "gates": [{"off": 0, "imm": 2}],
+    }
+    rec = {
+        "matched": "flat_getter",
+        "ret": "u16",
+        "reads": [{"off": 0x8, "width": 4}, {"off": 0x4, "width": 2}],
+        "gates": [{"off": 0, "imm": 2}],
+    }
+    s = bs.score_function(ak, rec)
+    assert s["score"] == 1.0
+    assert s["axes"]["ret_width"] == 1.0
+    assert s["axes"]["field_reads"] == 1.0
+
+
+def test_score_function_penalizes_wrong_return_width():
+    ak = {"ret": {"width": 2}, "reads": [{"off": 0x8, "width": 4}], "gates": []}
+    rec = {"matched": "flat_getter", "ret": "u32",  # u32 != width 2
+           "reads": [{"off": 0x8, "width": 4}], "gates": []}
+    s = bs.score_function(ak, rec)
+    assert s["axes"]["ret_width"] == 0.0
+    assert s["score"] < 1.0

--- a/tests/performance/test_d2moo_names.py
+++ b/tests/performance/test_d2moo_names.py
@@ -1,0 +1,102 @@
+"""Offline unit tests for d2moo_names.py.
+
+d2moo_names resolves a proven getter's REAL field/struct name from the D2MOO
+reimpl headers (community-canonical names like nThrowable, not offset-derived
+GetItemTypeField10). The header *load* reads an external D2MOO checkout, so we
+drive the pure parsing/derivation logic with an inline fixture header + explicit
+`structs` dicts -- no external repo needed, CI-safe.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+FUN_DOC_DIR = Path(__file__).resolve().parents[2] / "fun-doc"
+if str(FUN_DOC_DIR) not in sys.path:
+    sys.path.insert(0, str(FUN_DOC_DIR))
+
+import d2moo_names as dn  # noqa: E402
+
+
+# A minimal D2MOO-shaped header: `<type> <name>;  // 0x<offset>`.
+FIXTURE_HEADER = """
+struct D2ItemTypesTxt {
+    unsigned short wShoots;  // 0x0c
+    unsigned char nThrowable;  // 0x10
+    unsigned char pad[0xd3];  // 0x11
+};
+
+struct D2OverlayTxt {
+    unsigned int dwFlags;  // 0x00
+};
+"""
+
+
+def _parsed():
+    structs = {}
+    dn._parse_file(FIXTURE_HEADER, structs)
+    return structs
+
+
+def test_parse_file_reads_offset_annotated_fields():
+    s = _parsed()
+    assert "D2ItemTypesTxt" in s
+    it = s["D2ItemTypesTxt"]
+    assert it["fields"][0x10]["name"] == "nThrowable"
+    assert it["fields"][0x0C]["name"] == "wShoots"
+    assert it["fields"][0x0C]["width"] == 2  # unsigned short
+    # size is max(offset + width) across fields -- past the last field's offset
+    assert it["size"] > 0x11
+    assert it["fields"][0x11]["array"] is True  # pad[0xd3] is an array field
+
+
+def test_by_size_bridges_stride_to_struct():
+    s = _parsed()
+    size = s["D2ItemTypesTxt"]["size"]
+    assert "D2ItemTypesTxt" in dn.by_size(size, s)
+    assert dn.by_size(0x1, s) == []  # nothing that small
+
+
+def test_semantic_suffix_strips_hungarian_prefix():
+    assert dn.semantic_suffix("nThrowable") == "Throwable"
+    assert dn.semantic_suffix("wShoots") == "Shoots"
+    assert dn.semantic_suffix("dwFlags") == "Flags"
+    # no recognizable prefix -> PascalCased as-is
+    assert dn.semantic_suffix("Cost")[:1] == "C"
+
+
+def test_is_offset_name_detects_offset_derived_tokens():
+    assert dn.is_offset_name("DATATBLS_GetItemTypeField10")
+    assert dn.is_offset_name("ITEMS_GetItemRecordField104")
+    assert not dn.is_offset_name("DATATBLS_GetItemTypeThrowable")
+
+
+def test_domain_shortens_struct_to_name_core():
+    assert dn._domain("D2ItemTypesTxt") == "ItemType"
+    assert dn._domain("D2OverlayTxt") == "Overlay"
+    assert dn._domain("D2ItemsTxt") == "Item"
+
+
+def test_derive_getter_name_from_field():
+    s = _parsed()
+    d = dn.derive_getter_name("DATATBLS_GetItemTypeField10", "D2ItemTypesTxt", 0x10, s)
+    assert d["ok"]
+    assert d["field"] == "nThrowable"
+    assert "Throwable" in d["proposed_name"]
+    # no field at the given offset -> not ok (offset name stays honest)
+    d2 = dn.derive_getter_name("X", "D2ItemTypesTxt", 0x999, s)
+    assert not d2["ok"]
+
+
+def test_extract_from_candidate_pulls_stride_and_offsets():
+    cpp = (
+        'extern "C" unsigned char __stdcall DATATBLS_GetItemTypeField10(int idx){\n'
+        '  char* records = (char*)*(void**)(base + 0xbf8);\n'
+        '  char* rec = records + (int)idx * 0xe4;\n'
+        '  return *(unsigned char*)(rec + 0x10);\n'
+        '}\n'
+    )
+    out = dn._extract_from_candidate(cpp)
+    assert out["stride"] == 0xE4
+    assert out["read_off"] == 0x10

--- a/tests/performance/test_fast_path.py
+++ b/tests/performance/test_fast_path.py
@@ -1,0 +1,64 @@
+"""Offline unit tests for fast_path.py.
+
+fast_path routes a decompiled/disassembled getter to a (class, reimpl, prover)
+without touching Ghidra or the oracle -- the routing (`classify_and_draft`) is
+pure string analysis. The module's `_selftest()` drives canned disasm through
+the router; we run it as a CI gate, plus direct checks on the small helpers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+FUN_DOC_DIR = Path(__file__).resolve().parents[2] / "fun-doc"
+if str(FUN_DOC_DIR) not in sys.path:
+    sys.path.insert(0, str(FUN_DOC_DIR))
+
+import fast_path as fp  # noqa: E402
+
+
+def test_selftest_routing_passes():
+    # Routes canned flat/two-level getters (no oracle/Ghidra); asserts internally.
+    assert fp._selftest() == 0
+
+
+def test_flat_gated_getter_routes_to_synth():
+    flat = (
+        "6fd70000: MOV EAX,dword ptr [ESP + 0x4]\n"
+        "6fd70004: TEST EAX,EAX\n"
+        "6fd70006: JZ 0x6fd70012\n"
+        "6fd70008: MOV EAX,dword ptr [EAX + 0x40]\n"
+        "6fd7000c: RET 0x4\n"
+        "6fd70012: XOR EAX,EAX\n"
+        "6fd70014: RET 0x4\n"
+    )
+    r = fp.classify_and_draft("SomeFlagGetter", "", flat)
+    assert r["cls"] == "flat"
+    assert r["prover"] == "synth"
+
+
+def test_two_level_nonzero_default_routes_to_synth2():
+    gq = (
+        "6fd73b40: MOV EAX,dword ptr [ESP + 0x4]\n"
+        "6fd73b44: TEST EAX,EAX\n6fd73b46: JZ 0x6fd73b59\n"
+        "6fd73b48: CMP dword ptr [EAX],0x4\n6fd73b4b: JNZ 0x6fd73b59\n"
+        "6fd73b4d: MOV EAX,dword ptr [EAX + 0x14]\n6fd73b50: TEST EAX,EAX\n"
+        "6fd73b52: JZ 0x6fd73b59\n6fd73b54: MOV EAX,dword ptr [EAX]\n"
+        "6fd73b56: RET 0x4\n6fd73b59: MOV EAX,0x2\n6fd73b5e: RET 0x4\n"
+    )
+    r = fp.classify_and_draft("ITEMS_GetItemQuality", "", gq)
+    assert r["cls"] == "two_level"
+    assert r["prover"] == "synth2"
+
+
+def test_addr_hex_normalizes():
+    assert fp._addr_hex(0x6FD70000) == "0x6fd70000"
+    assert fp._addr_hex("0x6fd70000") == "0x6fd70000"
+
+
+def test_name_of_skips_keywords_and_null_guards():
+    dec = "int __fastcall DATATBLS_GetItemTypeThrowable(int idx)\n{\n  if (idx == 0) return 0;\n}"
+    assert fp._name_of(dec) == "DATATBLS_GetItemTypeThrowable"
+    # a naive regex grabs `if`/`return`; _name_of must skip stop-words
+    assert fp._name_of("if (x) { return NULL; }") != "if"

--- a/tests/performance/test_port_pipeline.py
+++ b/tests/performance/test_port_pipeline.py
@@ -1,0 +1,371 @@
+"""
+Regression tests for fun-doc's port_pipeline.py -- Stage 2/3 ("port" +
+"prove") of the OpenD2 conformance pipeline (see OpenD2/docs/
+EMULATION_CONFORMANCE_PLAN.md Sec 14).
+
+These exercise only the offline-testable pieces: classify_function's
+regex heuristic, select_port_candidates' filtering/sort, and the prompt
+build/parse round trip. Fast, pure Python, no network, no Ghidra, no LLM.
+
+mint_vectors/run_harness/write_draft (CMake build + live Ghidra
+/emulate_function) and process_port_candidate/run_port_worker_pass (live
+LLM calls) are exercised manually against the real OpenD2 repo + Ghidra
+instance -- see the port_pipeline module docstring and CLAUDE.md's OpenD2
+conformance section for that workflow; they are not practical to run in an
+offline unit suite (they shell out to cmake/msbuild and a real HTTP oracle).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure fun-doc is importable
+FUN_DOC = Path(__file__).parent.parent.parent / "fun-doc"
+sys.path.insert(0, str(FUN_DOC))
+
+import port_pipeline as pp  # noqa: E402
+from fun_doc import _state_func_to_row, _row_to_state_func, _STATE_DIRECT_FIELDS  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# classify_function
+# ---------------------------------------------------------------------------
+
+class TestClassifyFunction:
+    def test_empty_or_error_is_unknown(self):
+        assert pp.classify_function(None) == "unknown"
+        assert pp.classify_function("") == "unknown"
+        assert pp.classify_function("<ghidra fetch failed: timeout>") == "unknown"
+
+    def test_scalar_pointer_param_is_leaf(self):
+        # SEED_GetRandomNumberAlt's real shape: a pointer to an 8-byte seed
+        # blob the caller owns -- documented exception, not a struct pointer.
+        text = """
+        uint __fastcall SEED_GetRandomNumberAlt(ulonglong *pSeed)
+        {
+            ulonglong qwNewSeed;
+            if ((int)dwMax < 1) { return 0; }
+            qwNewSeed = (ulonglong)(uint)*pSeed * 0x6ac690c5;
+            *pSeed = qwNewSeed;
+            return (uint)(qwNewSeed & 0xffffffff);
+        }
+        """
+        assert pp.classify_function(text) == "leaf"
+
+    def test_readonly_struct_pointer_getter_is_shadow_leaf(self):
+        # A read-only getter over EXACTLY ONE struct pointer -- reads a field,
+        # touches no globals, calls no delegate, writes nothing through the
+        # pointer -- is the shadow_leaf class: provable LIVE via the oracle
+        # handle path (a real captured object passed to orig+reimpl). This is
+        # checked BEFORE the `->` stateful guard on purpose (classify_function
+        # lines ~328-348); it is the biggest hot-path class and IS provable, so
+        # a named-struct-pointer getter must NOT dead-end as "stateful".
+        text = """
+        int __fastcall CalcDamageBonusByLevel(CalcDamageBonusByLevel_MonsterData *pMonsterData)
+        {
+            if (pMonsterData->bDamageBonusEnabled != 0) { return 1; }
+            return 0;
+        }
+        """
+        assert pp.classify_function(text) == "shadow_leaf"
+
+    def test_struct_pointer_that_writes_is_stateful(self):
+        # The shadow_leaf gate REQUIRES read-only (no write through the pointer):
+        # handle-proving a mutator would corrupt the live captured game object.
+        # A struct pointer that is written through stays "stateful".
+        text = """
+        void __fastcall SetDamageBonus(CalcDamageBonusByLevel_MonsterData *pMonsterData, int v)
+        {
+            pMonsterData->bDamageBonusEnabled = v;
+        }
+        """
+        assert pp.classify_function(text) == "stateful"
+
+    def test_global_reference_is_stateful(self):
+        text = "int Foo(void) { return DAT_006fd123 + 1; }"
+        assert pp.classify_function(text) == "stateful"
+
+    def test_plate_comment_prose_does_not_false_positive(self):
+        # Regression: "(SEED_* module)" in an English plate comment aside
+        # used to false-match the pointer-param regex ("SEED_" as a type,
+        # "module" as the identifier) before comments were stripped first.
+        text = """
+        /* Get Random Number from Seed
+           Source: D2Common.dll (SEED_* module)
+        */
+        uint __fastcall SEED_GetRandomNumber(ulonglong *pSeedState)
+        {
+            return (uint)*pSeedState;
+        }
+        """
+        assert pp.classify_function(text) == "leaf"
+
+    def test_no_pointer_params_is_leaf(self):
+        text = "int __fastcall D2_ToHitPercent(int AR, int DEF, int aLvl, int dLvl) { return 50; }"
+        assert pp.classify_function(text) == "leaf"
+
+    def test_multiplication_expression_does_not_false_positive(self):
+        # Regression: "(nMultiplier * in_EAX)" inside a body expression
+        # (real COMMON_ScaledMultiplyDivide shape) used to false-match the
+        # pointer-param regex ("nMultiplier" read as a pointer TYPE) before
+        # the scan was scoped to the signature params + whole-line locals.
+        # "TYPE *name" and "a * b" are identical at the token level.
+        text = """
+        int __fastcall COMMON_ScaledMultiplyDivide(uint dwDivisor,int nMultiplier)
+        {
+            int in_EAX;
+            longlong lVar1;
+            if (dwDivisor == 0) { return 0; }
+            if (nMultiplier < 0x100001) {
+                if (in_EAX < 0x10001) {
+                    return (nMultiplier * in_EAX) / (int)dwDivisor;
+                }
+            }
+            return 0;
+        }
+        """
+        assert pp.classify_function(text) == "leaf"
+
+    def test_pointer_local_declaration_line_is_detected(self):
+        # A standalone `TYPE *name;` local-decl line (not a param) should
+        # still be caught -- e.g. a locally-declared struct-pointer helper.
+        text = """
+        int Foo(int x)
+        {
+            SomeStruct *pHelper;
+            return x + 1;
+        }
+        """
+        assert pp.classify_function(text) == "stateful"
+
+
+# ---------------------------------------------------------------------------
+# select_port_candidates
+# ---------------------------------------------------------------------------
+
+class TestSelectPortCandidates:
+    def _funcs(self):
+        return {
+            "D2Common.dll::100": {
+                "program_name": "D2Common.dll", "effective_score": 100,
+                "caller_count": 5, "callees": [],
+            },
+            "D2Common.dll::200_not_done": {
+                "program_name": "D2Common.dll", "effective_score": 40,
+                "caller_count": 10, "callees": [],
+            },
+            "D2Game.dll::300": {
+                "program_name": "D2Game.dll", "effective_score": 100,
+                "caller_count": 3, "callees": ["x"],
+            },
+            "D2Common.dll::400_thunk": {
+                "program_name": "D2Common.dll", "effective_score": 100,
+                "caller_count": 1, "callees": [], "is_thunk": True,
+            },
+            "D2Common.dll::500_lib": {
+                "program_name": "D2Common.dll", "effective_score": 100,
+                "caller_count": 1, "callees": [], "library_code": True,
+            },
+        }
+
+    def test_excludes_not_stage1_complete(self):
+        cands = pp.select_port_candidates(self._funcs(), set())
+        keys = [c["key"] for c in cands]
+        assert "D2Common.dll::200_not_done" not in keys
+
+    def test_excludes_thunks_and_library_code(self):
+        cands = pp.select_port_candidates(self._funcs(), set())
+        keys = [c["key"] for c in cands]
+        assert "D2Common.dll::400_thunk" not in keys
+        assert "D2Common.dll::500_lib" not in keys
+
+    def test_excludes_conformance_protected(self):
+        cands = pp.select_port_candidates(self._funcs(), {"D2Common.dll::100"})
+        keys = [c["key"] for c in cands]
+        assert "D2Common.dll::100" not in keys
+
+    def test_binary_priority_order(self):
+        # D2Common before D2Game (EMULATION_CONFORMANCE_PLAN.md Sec 15)
+        cands = pp.select_port_candidates(self._funcs(), set())
+        keys = [c["key"] for c in cands]
+        assert keys.index("D2Common.dll::100") < keys.index("D2Game.dll::300")
+
+    def test_active_binary_filter(self):
+        cands = pp.select_port_candidates(self._funcs(), set(), active_binary="D2Game.dll")
+        keys = [c["key"] for c in cands]
+        assert keys == ["D2Game.dll::300"]
+
+    def test_limit(self):
+        cands = pp.select_port_candidates(self._funcs(), set(), limit=1)
+        assert len(cands) == 1
+
+
+# ---------------------------------------------------------------------------
+# Prompt build + parse round trip
+# ---------------------------------------------------------------------------
+
+class TestPromptRoundTrip:
+    def test_build_port_prompt_shape(self):
+        prompt = pp.build_port_prompt(
+            "TestFn", "1234", "/Mods/PD2-S12/D2Common.dll",
+            "int TestFn(uint x) { return x; }", style_examples=[],
+        )
+        assert "TestFn" in prompt
+        assert "0x1234" in prompt
+        assert "three fenced code blocks" in prompt
+
+    def test_parse_port_response_full_round_trip(self):
+        response = '''Sure, here it is.
+```cpp
+#pragma once
+namespace D2Lib { inline int TestFn(unsigned int x) { return (int)x; } }
+```
+```cpp
+if (fn == "TestFn") { return (int)D2Lib::TestFn((unsigned int)in->n("x")) == (int)out->n("ret"); }
+```
+```json
+{"fn": "TestFn", "param_layout": {"inputs": [{"name": "x", "register": "ECX"}], "outputs": [{"name": "ret", "register": "EAX"}]}, "input_sets": [{"x": 0}, {"x": 1}]}
+```
+'''
+        header, dispatch, spec = pp.parse_port_response_full(response)
+        assert header is not None and "namespace D2Lib" in header
+        assert dispatch is not None and "TestFn" in dispatch
+        assert spec["fn"] == "TestFn"
+        assert spec["input_sets"] == [{"x": 0}, {"x": 1}]
+
+    def test_parse_port_response_full_rejects_missing_json_block(self):
+        response = "```cpp\nheader\n```\n```cpp\ndispatch\n```"
+        header, dispatch, spec = pp.parse_port_response_full(response)
+        assert (header, dispatch, spec) == (None, None, None)
+
+    def test_parse_port_response_full_rejects_malformed_json(self):
+        response = '```cpp\nheader\n```\n```cpp\ndispatch\n```\n```json\nnot json{{{\n```'
+        header, dispatch, spec = pp.parse_port_response_full(response)
+        assert (header, dispatch, spec) == (None, None, None)
+
+    def test_parse_port_response_full_rejects_missing_required_keys(self):
+        response = (
+            '```cpp\nheader\n```\n```cpp\ndispatch\n```\n'
+            '```json\n{"fn": "X"}\n```'
+        )
+        header, dispatch, spec = pp.parse_port_response_full(response)
+        assert (header, dispatch, spec) == (None, None, None)
+
+    def test_parse_port_response_two_block_retry(self):
+        response = "```cpp\nheader content\n```\n```cpp\ndispatch content\n```"
+        header, dispatch = pp.parse_port_response(response)
+        assert header.strip() == "header content"
+        assert dispatch.strip() == "dispatch content"
+
+    def test_parse_port_response_needs_two_blocks(self):
+        header, dispatch = pp.parse_port_response("```cpp\njust one\n```")
+        assert (header, dispatch) == (None, None)
+
+
+class TestPascalToSnakeCase:
+    def test_mixed_acronym_and_camel_case(self):
+        # Regression: naively inserting "_" before every capital produced
+        # "c_o_m_m_o_n__scaled_multiply_divide" for this exact real D2
+        # symbol (confirmed live) -- ALL_CAPS module-prefix runs must stay
+        # intact; only a lowercase/digit -> uppercase boundary is a real
+        # camelCase hump.
+        assert pp.pascal_to_snake_case("COMMON_ScaledMultiplyDivide") == "common_scaled_multiply_divide"
+
+    def test_plain_camel_case(self):
+        assert pp.pascal_to_snake_case("ScaledMultiplyDivide") == "scaled_multiply_divide"
+
+    def test_all_caps_stays_intact(self):
+        assert pp.pascal_to_snake_case("SEED_GetRandomNumberAlt") == "seed_get_random_number_alt"
+
+
+# ---------------------------------------------------------------------------
+# port_status persistence round trip (fun_doc.py, not port_pipeline.py).
+#
+# Regression: repository.py's _UPDATABLE_WORKFLOW_FIELDS is NOT the only
+# allowlist a partial update passes through. fun_doc._state_func_to_row runs
+# FIRST (state.json-dict -> workflow-row-dict) and is gated by a SEPARATE
+# allowlist, _STATE_DIRECT_FIELDS -- a field missing from the SECOND gate
+# gets silently dropped before repository.py's gate ever sees it. Confirmed
+# live: update_function_state(key, {"port_status": ...}) returned
+# successfully (no exception) but the write never reached the database,
+# because _STATE_DIRECT_FIELDS didn't list the port_* fields yet. Both
+# allowlists must be kept in sync for any new pass-through field.
+# ---------------------------------------------------------------------------
+
+class TestPortStatusPersistenceRoundTrip:
+    def test_port_fields_are_in_state_direct_fields(self):
+        for field in ("port_status", "port_attempts", "port_draft_path", "port_last_result"):
+            assert field in _STATE_DIRECT_FIELDS, (
+                f"{field!r} missing from _STATE_DIRECT_FIELDS -- a partial "
+                "update_function_state() call setting only this field would "
+                "silently no-op (see _state_func_to_row)"
+            )
+
+    def test_state_func_to_row_carries_port_fields(self):
+        rec = {
+            "program": "/Mods/PD2-S12/D2Common.dll",
+            "address": "6fd511e0",
+            "port_status": "proven_pending_review",
+            "port_attempts": 1,
+            "port_draft_path": "/some/path.hpp",
+            "port_last_result": "20/20 passed",
+        }
+        row = _state_func_to_row("/Mods/PD2-S12/D2Common.dll::6fd511e0", rec)
+        assert row["port_status"] == "proven_pending_review"
+        assert row["port_attempts"] == 1
+        assert row["port_draft_path"] == "/some/path.hpp"
+        assert row["port_last_result"] == "20/20 passed"
+
+    def test_row_to_state_func_round_trips_port_fields(self):
+        row = {
+            "program_path": "/Mods/PD2-S12/D2Common.dll",
+            "binary_name": "D2Common.dll",
+            "address": "6fd511e0",
+            "port_status": "harness_failed",
+            "port_attempts": 3,
+            "port_draft_path": "/some/path.hpp",
+            "port_last_result": "18/20 passed",
+        }
+        rec = _row_to_state_func(row)
+        assert rec["port_status"] == "harness_failed"
+        assert rec["port_attempts"] == 3
+        assert rec["port_draft_path"] == "/some/path.hpp"
+        assert rec["port_last_result"] == "18/20 passed"
+
+
+# ---------------------------------------------------------------------------
+# write_draft template rendering (no build -- just checks the .format()
+# escaping is correct, which is easy to get wrong with braces in embedded
+# C++ source; see the module's _DRAFT_RUNNER_TEMPLATE).
+# ---------------------------------------------------------------------------
+
+class TestWriteDraftTemplate:
+    def test_template_renders_without_stray_braces(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pp, "GENERATED_CANDIDATES_DIR", tmp_path)
+        monkeypatch.setattr(pp, "DRAFT_RUNNER_PATH", tmp_path / "draft_runner.cpp")
+        monkeypatch.setattr(pp, "DRAFT_VECTORS_PATH", tmp_path / "draft_vectors.json")
+
+        paths = pp.write_draft(
+            "Test", "Fn",
+            "#pragma once\nnamespace D2Lib { inline int Fn() { return 1; } }\n",
+            'if (fn == "Fn") { return true; }',
+            [{"fn": "Fn", "in": {}, "out": {"ret": 1}}],
+        )
+        runner_text = Path(paths["runner_path"]).read_text(encoding="utf-8")
+        # The JSON-parser struct bodies must survive with real braces (not
+        # left as literal "{{"/"}}" from an unescaped .format() call).
+        assert "{{" not in runner_text
+        assert "}}" not in runner_text
+        assert "struct JVal" in runner_text
+        assert '#include "Test_Fn.hpp"' in runner_text
+        assert 'if (fn == "Fn")' in runner_text
+
+        header_text = Path(paths["header_path"]).read_text(encoding="utf-8")
+        assert "namespace D2Lib" in header_text
+
+        vectors_text = Path(paths["vectors_path"]).read_text(encoding="utf-8")
+        assert '"Fn"' in vectors_text
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/performance/test_tooling_selftests.py
+++ b/tests/performance/test_tooling_selftests.py
@@ -1,0 +1,41 @@
+"""Run the port-pipeline tooling modules' built-in `_selftest()` known-answer
+checks as offline CI gates.
+
+Each of these modules ships a self-contained `_selftest()` that validates its
+core pure logic against inline fixtures -- no Ghidra, oracle, network, or
+external repo. Running them here turns those authored known-answer checks into
+enforced regression gates (and exercises the modules' logic under coverage).
+
+`d2moo_names._selftest()` is intentionally NOT run here: it loads struct headers
+from an external D2MOO checkout that doesn't exist in CI. Its pure parsing/
+derivation logic is covered by test_d2moo_names.py with an inline fixture.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+FUN_DOC_DIR = Path(__file__).resolve().parents[2] / "fun-doc"
+if str(FUN_DOC_DIR) not in sys.path:
+    sys.path.insert(0, str(FUN_DOC_DIR))
+
+
+# abi_static / fast_path / bench_score have dedicated test modules that already
+# run their _selftest() plus direct checks; these five are gated only here.
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "prove_doc",
+        "bench_d2common",
+        "golden_bench",
+        "ledger_apply",
+        "verify_shadow_fix",
+    ],
+)
+def test_module_selftest_passes(module_name):
+    module = __import__(module_name)
+    assert hasattr(module, "_selftest"), f"{module_name} lost its _selftest()"
+    assert module._selftest() == 0, f"{module_name}._selftest() reported failure"


### PR DESCRIPTION
## What

The **self-contained port-pipeline tooling** from #370, rebuilt cleanly on current `main`. #370 had diverged (its dashboard-perf half merged via #371, and its globals-worker changes conflict with the globals-worker work already on main). This PR carries **only** the unique tooling — no globals-worker or dashboard files — so it's fully additive and green.

The pipeline: classify a target function → draft an OpenD2 reimpl → live-prove it against the D2MOO oracle → write the proof back as Ghidra documentation.

## Contents
- **Drivers:** `port_pipeline.py`, `port_live_prove.py`, `port_targets.py`, `prove_doc.py`
- **Stages:** `fast_path.py`, `abi_static.py`, `d2moo_names.py`, `recanonicalize.py`, `shadow_promote.py`, `adversarial_reproof.py`, `battletest_promoter.py`, `verify_shadow_fix.py`, `ledger_apply.py`, `batch_assess.py`
- **Benchmark:** `golden_bench.py`, `bench_d2common.py`, `bench_score.py`
- **`fun_doc.py`** (purely additive, +1758): `process_port_candidate` / `run_port_worker_pass` + live processors + `port_status` persistence
- **Storage:** `storage/models.py` port columns + `db/migrations/0005_port_pipeline`
- **Tests:** `tests/performance/test_port_pipeline.py`

## Verification
Full offline perf suite: **500 passed, 30 skipped**. Zero deletions; no globals-worker/dashboard/web files touched. Supersedes the tooling portion of #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
