### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Complete version history for the Ghidra MCP Server project.
 
 ### Added
 
+- **Autohand Code MCP setup documentation.** The stdio quick start now includes
+  the `autohand mcp add` command for launching the bridge from a cloned checkout.
 - **Coverage gates and baselines across all test tiers.**
   - CI unit job now runs with coverage and a `--cov-fail-under=46` ratchet
     (baseline 53%); the offline fun-doc job adds `--cov=fun-doc` with a floor of

--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ yay -S ghidra-mcp        # or ghidra-mcp-git
 uv run bridge-mcp-ghidra          # or: python -m bridge_mcp_ghidra
 ```
 
+To add the bridge to [Autohand Code](https://github.com/autohandai/code-cli/) from a cloned checkout:
+
+```bash
+autohand mcp add ghidra uv run --directory /path/to/ghidra-mcp bridge-mcp-ghidra
+```
+
+Add `--scope project` before `ghidra` to save the server in the current project's `.autohand` configuration instead of your user configuration.
+
 #### Option 2: Streamable HTTP Transport (Recommended for web/HTTP clients)
 ```bash
 uv run bridge-mcp-ghidra --transport streamable-http --mcp-host 127.0.0.1 --mcp-port 8081


### PR DESCRIPTION
## What changed

Added an Autohand Code stdio setup command to the bridge quick start and noted the documentation change under Unreleased.

## Why

Ghidra MCP already provides generic Cursor/Claude configuration and both stdio and HTTP bridge modes. The new command reuses the documented `uv run --directory` path so Autohand Code can launch the same local bridge without a separate adapter.

## Validation

- Verified the command against the current Autohand Code MCP CLI implementation
- Ran `git diff --check`

This is documentation-only; no runtime behavior changed.
