### PR TITLE
fix(setup): fail early when Maven uses unsupported Java

### DIFF
--- a/tools/setup/cli.py
+++ b/tools/setup/cli.py
@@ -16,7 +16,7 @@ from .ghidra import (
     start_ghidra,
 )
 from .python_env import detect_repo_root, find_repo_python
-from .maven import find_maven_command, run_gradle, run_maven
+from .maven import ensure_maven_java_supported, find_maven_command, run_gradle, run_maven
 from .requirements import (
     ensure_uv_available,
     execute_install_plan,
@@ -385,6 +385,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
         return 1
     print(f"Python: {python_executable}")
     print(f"Maven: {maven_command}")
+    if not ensure_maven_java_supported(maven_command):
+        return 1
     try:
         ensure_uv_available()
     except FileNotFoundError as exc:

--- a/tools/setup/maven.py
+++ b/tools/setup/maven.py
@@ -1,10 +1,38 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+REQUIRED_JAVA_MAJOR = 21
+
+
+def ensure_maven_java_supported(maven_command: Path) -> bool:
+    completed = subprocess.run(
+        [str(maven_command), "-version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = f"{completed.stdout}\n{completed.stderr}"
+    match = re.search(r"(?im)^Java version:\s*(?:1\.)?(\d+)", output)
+    if not match or int(match.group(1)) >= REQUIRED_JAVA_MAJOR:
+        return True
+
+    print(
+        f"Java {REQUIRED_JAVA_MAJOR}+ is required to build ghidra-mcp; "
+        f"Maven is running on Java {match.group(1)}.",
+        file=sys.stderr,
+    )
+    print(
+        "Set JAVA_HOME to a JDK 21 install and put %JAVA_HOME%\\bin first on PATH.",
+        file=sys.stderr,
+    )
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -142,10 +170,13 @@ def find_maven_command() -> Path:
 
 
 def run_maven(repo_root: Path, goals: list[str], dry_run: bool = False) -> int:
-    command = [str(find_maven_command()), *goals]
+    maven_command = find_maven_command()
+    command = [str(maven_command), *goals]
     if dry_run:
         print("DRY RUN:", " ".join(command))
         return 0
+    if not ensure_maven_java_supported(maven_command):
+        return 1
 
     completed = subprocess.run(command, cwd=repo_root, check=False)
     return completed.returncode


### PR DESCRIPTION
## Description
Make Maven-backed setup commands fail early when Maven is running on unsupported Java.

## Changes
- Check Maven's runtime Java version during `tools.setup preflight`
- Check Maven's runtime Java version before `tools.setup build`
- Print a clear JDK 21 requirement instead of letting Java 8 produce noisy compiler syntax errors

## Testing
- `python -m tools.setup preflight --ghidra-path "F:\ghidra_12.1.2_PUBLIC"` with Maven on Java 8 now fails early with the Java 21 message
- `python -m tools.setup build` succeeds with JDK 21 selected

## Checklist
- [x] No breaking changes
- [x] Tested manually