### PR TITLE
Add clear_flow_and_repair MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MCP server bridging Ghidra reverse engineering with AI tools. 270 MCP tools for binary analysis.
+MCP server bridging Ghidra reverse engineering with AI tools. 271 MCP tools for binary analysis.
 
 - **Package**: `com.xebyte` | **Version**: 5.17.0 | **Java**: 21 LTS | **Ghidra**: 12.1.2
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 >
 > If Ghidra MCP saves you time, consider [sponsoring the project](https://github.com/sponsors/bethington). One-time and recurring support both help fund compatibility updates, production hardening, docs, and new tooling.
 
-A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **270 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
+A production-ready Model Context Protocol (MCP) server that bridges Ghidra's powerful reverse engineering capabilities with modern AI tools and automation frameworks. **271 MCP tools**, battle-tested AI workflows, and the most comprehensive Ghidra-MCP integration available — now including P-code emulation, live debugger integration, and PCode-graph data flow analysis.
 
 ## Why Ghidra MCP?
 
 Most Ghidra MCP implementations give you a handful of read-only tools and call it a day. This project is different — it was built by a reverse engineer who uses it daily on real binaries, not as a demo.
 
-- **270 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
+- **271 MCP tools** — 3x more than any competing implementation. Not just read operations — full write access for renaming, typing, commenting, structure creation, script execution, P-code emulation, and live debugging.
 - **Battle-tested AI workflows** — Proven documentation workflows (V5) refined across hundreds of functions. Includes step-by-step prompts, Hungarian notation reference, batch processing guides, and orphaned code discovery.
 - **Production-grade reliability** — Atomic transactions, batch operations (93% API call reduction), configurable timeouts, and graceful error handling. No silent failures.
 - **Cross-binary documentation transfer** — SHA-256 function hash matching propagates documentation across binary versions automatically. Document once, apply everywhere.
@@ -56,7 +56,7 @@ v5.0 moves conventions from "things to remember" into the tool layer, where they
 
 ### Core MCP Integration
 - **Full MCP Compatibility** — Complete implementation of Model Context Protocol
-- **270 MCP tools** — Comprehensive API surface covering every aspect of binary analysis
+- **271 MCP tools** — Comprehensive API surface covering every aspect of binary analysis
 - **Production-Ready Reliability** — Atomic transactions, batch operations, configurable timeouts
 - **Real-time Analysis** — Live integration with Ghidra's analysis engine
 
@@ -608,7 +608,7 @@ python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1.2_PUBLIC
 
 ## 📊 Production Performance
 
-- **MCP Tools**: 270 tools fully implemented
+- **MCP Tools**: 271 tools fully implemented
 - **Speed**: Sub-second response for most operations
 - **Efficiency**: 93% reduction in API calls via batch operations
 - **Reliability**: Atomic transactions with all-or-nothing semantics
@@ -619,7 +619,7 @@ python -m tools.setup install-ghidra-deps --ghidra-path "C:\ghidra_12.1.2_PUBLIC
 
 <!-- BEGIN GENERATED API REFERENCE (tools/gen_readme_api_reference.py) -->
 
-270 MCP tools backed by HTTP endpoints, grouped by catalog category. Generated from [tests/endpoints.json](tests/endpoints.json) by `python -m tools.gen_readme_api_reference --write`; the live schema at `/mcp/schema` is authoritative at runtime. Usage patterns: [docs/prompts/TOOL_USAGE_GUIDE.md](docs/prompts/TOOL_USAGE_GUIDE.md).
+271 MCP tools backed by HTTP endpoints, grouped by catalog category. Generated from [tests/endpoints.json](tests/endpoints.json) by `python -m tools.gen_readme_api_reference --write`; the live schema at `/mcp/schema` is authoritative at runtime. Usage patterns: [docs/prompts/TOOL_USAGE_GUIDE.md](docs/prompts/TOOL_USAGE_GUIDE.md).
 
 ### Program & Session Management
 
@@ -737,6 +737,7 @@ Available on the standalone headless server (`GhidraMCPHeadlessServer`).
 - `add_function_tag` - Attach one or more tags to a function
 - `batch_add_function_tags` - Attach tags to many functions in one transaction
 - `batch_remove_function_tags` - Detach tags from many functions in one transaction
+- `clear_flow_and_repair` - Run Ghidra's GUI 'Clear Flow and Repair' action on a seed range: clears instruction flow reachable from the seed, then repairs function bodies and re-disassembles retained flow (ClearFlowAndRepairCmd with clear_data=false, clear_labels=false, repair=true)
 - `create_function_tag` - Create a program-wide function tag definition with an optional comment
 - `delete_function_tag` - Delete a program-wide function tag definition
 - `get_function_tags` - List all tags assigned to a specific function

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -3,13 +3,18 @@ package com.xebyte.core;
 import ghidra.app.cmd.disassemble.DisassembleCommand;
 import ghidra.app.decompiler.DecompInterface;
 import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.plugin.core.clear.ClearFlowAndRepairCmd;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressOutOfBoundsException;
+import ghidra.program.model.address.AddressOverflowException;
 import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.data.DataType;
 import ghidra.program.model.data.DataTypeManager;
 import ghidra.program.model.data.Pointer;
 import ghidra.program.model.data.Structure;
 import ghidra.program.model.listing.*;
+import ghidra.program.model.lang.InjectPayload;
 import ghidra.program.model.symbol.Namespace;
 import ghidra.program.model.pcode.HighFunction;
 import ghidra.program.model.pcode.HighFunctionDBUtil;
@@ -17,6 +22,8 @@ import ghidra.program.model.pcode.HighFunctionDBUtil.ReturnCommitOption;
 import ghidra.program.model.pcode.HighSymbol;
 import ghidra.program.model.pcode.HighVariable;
 import ghidra.program.model.pcode.LocalSymbolMap;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.program.model.symbol.SymbolIterator;
 import ghidra.program.model.symbol.SymbolTable;
@@ -2979,6 +2986,290 @@ public class FunctionService {
                                    boolean restrictToExecuteMemory, String programName) {
         return disassembleBytes(startAddress, endAddress, length, restrictToExecuteMemory,
                                 true, 1000, programName);
+    }
+
+    // ========================================================================
+    // Clear Flow and Repair
+    // ========================================================================
+
+    /** Command failure inside the write transaction; thrown so executeWrite rolls back. */
+    private static final class ClearFlowFailedException extends RuntimeException {
+        ClearFlowFailedException(String message) {
+            super(message);
+        }
+    }
+
+    @McpTool(path = "/clear_flow_and_repair", method = "POST",
+             description = "Run Ghidra's GUI 'Clear Flow and Repair' action on a seed range: clears instruction flow reachable from the seed, then repairs function bodies and re-disassembles retained flow (ClearFlowAndRepairCmd with clear_data=false, clear_labels=false, repair=true). Use to rebuild regions whose flow was created under wrong assumptions, e.g. a function truncated while a callee was incorrectly marked non-returning. The command follows control flow BEYOND the seed range; the reported observations are seed-local only and do not describe everything the command changed. The flow traversal is not cancellable — a very large connected flow can hold the write lock (GUI: the Swing thread) until it completes. Ghidra treats a seed with exactly one candidate flow start (an instruction that is neither a function entry nor reached by fallthrough from inside the seed) as the flow being intentionally removed and does not reseed that start during repair; consequently, applying this action to otherwise healthy flow can clear code, matching the GUI action's behavior. The response's seed_range.end_address_exclusive is null when the seed ends at its address space's maximum address, since that boundary has no representable exclusive successor. Results are reachability-dependent and the command is not idempotent: some damaged regions may require more than one application to rebuild, while applying it again to healthy flow can clear code — inspect the before/after observations and resulting disassembly after every call.",
+             category = "function")
+    public Response clearFlowAndRepair(
+            @Param(value = "start_address", paramType = "address", source = ParamSource.BODY,
+                   description = "Seed start. Accepts 0x<hex> (default space) or <space>:<hex> (e.g., mem:1000). "
+                               + "Use get_address_spaces first on multi-space programs.") String startAddress,
+            @Param(value = "end_address", paramType = "address", source = ParamSource.BODY, defaultValue = "",
+                   description = "Exclusive seed end (consistent with disassemble_bytes). Must be in the same "
+                               + "address space as start_address and strictly greater. Omitted: one-address seed; "
+                               + "the command still follows flow from there like clicking one address in the GUI.") String endAddress,
+            @Param(value = "program", defaultValue = "") String programName) {
+
+        if (startAddress == null || startAddress.isEmpty()) {
+            return Response.err("start_address parameter required");
+        }
+
+        ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
+        if (pe.hasError()) return pe.error();
+        Program program = pe.program();
+
+        Address start = ServiceUtils.parseAddress(program, startAddress);
+        if (start == null) return Response.err(ServiceUtils.getLastParseError());
+
+        Address seedEnd = start;
+        if (endAddress != null && !endAddress.isEmpty()) {
+            Address end = ServiceUtils.parseAddress(program, endAddress);
+            if (end == null) return Response.err(ServiceUtils.getLastParseError());
+            if (!end.getAddressSpace().equals(start.getAddressSpace())) {
+                return Response.err("end_address must be in the same address space as start_address");
+            }
+            if (end.compareTo(start) <= 0) {
+                return Response.err("end_address must be greater than start_address (end_address is exclusive)");
+            }
+            seedEnd = end.subtract(1);
+        }
+
+        final AddressSet seed = new AddressSet(start, seedEnd);
+
+        // Computed before the transaction: a seed ending at the address-space maximum has no
+        // representable exclusive end.
+        String endExclusive;
+        try {
+            endExclusive = seedEnd.add(1).toString();
+        } catch (AddressOutOfBoundsException e) {
+            endExclusive = null;
+        }
+        final String endExclusiveStr = endExclusive;
+
+        try {
+            Map<String, Object> data = threadingStrategy.executeWrite(program, "Clear Flow and Repair", () -> {
+                Listing listing = program.getListing();
+                long instructionsBefore = countInstructionsIn(listing, seed);
+                List<Map<String, Object>> functionsBefore = snapshotFunctionsOverlapping(program, seed);
+
+                rejectDestructiveNoReturnBoundaries(program, listing, seed);
+                redisassembleStaleNoReturnCalls(program, listing, seed);
+                rejectDestructiveNoReturnBoundaries(program, listing, seed);
+
+                ClearFlowAndRepairCmd cmd = new ClearFlowAndRepairCmd(seed, false, false, true);
+                if (!cmd.applyTo(program, ghidra.util.task.TaskMonitor.DUMMY)) {
+                    String status = cmd.getStatusMsg();
+                    throw new ClearFlowFailedException(status != null && !status.isBlank()
+                            ? status : "Clear Flow and Repair returned false without a status message");
+                }
+                rejectDestructiveNoReturnBoundaries(program, listing, seed);
+
+                long instructionsAfter = countInstructionsIn(listing, seed);
+                List<Map<String, Object>> functionsAfter = snapshotFunctionsOverlapping(program, seed);
+
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put("success", true);
+                Map<String, Object> seedRange = new LinkedHashMap<>();
+                seedRange.put("start_address", start.toString());
+                seedRange.put("end_address_exclusive", endExclusiveStr);
+                result.put("seed_range", seedRange);
+                result.put("repair", true);
+                result.put("clear_data", false);
+                result.put("clear_labels", false);
+                Map<String, Object> observations = new LinkedHashMap<>();
+                observations.put("instructions_in_seed_before", instructionsBefore);
+                observations.put("instructions_in_seed_after", instructionsAfter);
+                observations.put("instruction_count_delta_in_seed", instructionsAfter - instructionsBefore);
+                observations.put("functions_intersecting_seed_before", functionsBefore);
+                observations.put("functions_intersecting_seed_after", functionsAfter);
+                observations.put("noreturn_call_boundaries_in_seed",
+                    snapshotUndefinedNoReturnBoundaries(program, listing, seed));
+                result.put("observations", observations);
+                return result;
+            });
+            return Response.ok(data);
+        } catch (ClearFlowFailedException e) {
+            return Response.err(e.getMessage());
+        } catch (Exception e) {
+            return Response.err(e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    private static void redisassembleStaleNoReturnCalls(Program program, Listing listing,
+                                                        AddressSetView seed) {
+        List<Address> staleCalls = new ArrayList<>();
+        InstructionIterator instructions = listing.getInstructions(seed, true);
+        while (instructions.hasNext()) {
+            Instruction instruction = instructions.next();
+            if (instruction.getFlowOverride() != FlowOverride.CALL_RETURN ||
+                instruction.isFallThroughOverridden() || !isOriginalCall(instruction)) {
+                continue;
+            }
+
+            Address[] flows = instruction.getFlows();
+            if (flows.length != 1) {
+                continue;
+            }
+            Function target = program.getFunctionManager().getFunctionAt(flows[0]);
+            if (target != null && !calleeStopsFallthrough(program, target)) {
+                staleCalls.add(instruction.getAddress());
+            }
+        }
+
+        for (Address address : staleCalls) {
+            Instruction instruction = listing.getInstructionAt(address);
+            if (instruction == null || instruction.getFlowOverride() != FlowOverride.CALL_RETURN) {
+                continue;
+            }
+
+            listing.clearCodeUnits(address, instruction.getMaxAddress(), false);
+            DisassembleCommand disassemble = new DisassembleCommand(address, seed, true);
+            disassemble.enableCodeAnalysis(false);
+            boolean success = disassemble.applyTo(program, ghidra.util.task.TaskMonitor.DUMMY);
+            Instruction repaired = listing.getInstructionAt(address);
+            if (!success || repaired == null || repaired.getFlowOverride() == FlowOverride.CALL_RETURN) {
+                String status = disassemble.getStatusMsg();
+                throw new ClearFlowFailedException(status != null && !status.isBlank()
+                        ? status : "Failed to re-disassemble stale no-return call at " + address);
+            }
+        }
+    }
+
+    private static void rejectDestructiveNoReturnBoundaries(Program program, Listing listing,
+                                                              AddressSetView seed) {
+        List<Map<String, Object>> boundaries = new ArrayList<>();
+        InstructionIterator instructions = listing.getInstructions(seed, true);
+        while (instructions.hasNext()) {
+            Instruction call = instructions.next();
+            Function target = getDirectCallTarget(program, call);
+            Address next = getSequentialAddress(call);
+            if (target == null || next == null || call.isFallThroughOverridden() ||
+                !calleeStopsFallthrough(program, target) || listing.getInstructionAt(next) == null ||
+                hasIndependentEntry(program, listing, call, next)) {
+                continue;
+            }
+            boundaries.add(snapshotNoReturnBoundary(call, target, next));
+        }
+        if (!boundaries.isEmpty()) {
+            throw new ClearFlowFailedException(
+                "Repair would delete defined continuation after no-return call(s): " + boundaries);
+        }
+    }
+
+    private static List<Map<String, Object>> snapshotUndefinedNoReturnBoundaries(
+            Program program, Listing listing, AddressSetView seed) {
+        List<Map<String, Object>> boundaries = new ArrayList<>();
+        InstructionIterator instructions = listing.getInstructions(seed, true);
+        while (instructions.hasNext()) {
+            Instruction call = instructions.next();
+            Function target = getDirectCallTarget(program, call);
+            Address next = getSequentialAddress(call);
+            if (target != null && next != null && calleeStopsFallthrough(program, target) &&
+                listing.getInstructionAt(next) == null) {
+                boundaries.add(snapshotNoReturnBoundary(call, target, next));
+            }
+        }
+        return boundaries;
+    }
+
+    private static Function getDirectCallTarget(Program program, Instruction instruction) {
+        if (!isOriginalCall(instruction)) {
+            return null;
+        }
+        Address[] flows = instruction.getFlows();
+        if (flows.length != 1) {
+            return null;
+        }
+        return program.getFunctionManager().getFunctionAt(flows[0]);
+    }
+
+    private static boolean isOriginalCall(Instruction instruction) {
+        return instruction.getPrototype().getFlowType(instruction.getInstructionContext()).isCall();
+    }
+
+    private static boolean calleeStopsFallthrough(Program program, Function target) {
+        if (target.hasNoReturn()) {
+            return true;
+        }
+        String callFixup = target.getCallFixup();
+        if (callFixup == null || callFixup.isEmpty()) {
+            return false;
+        }
+        InjectPayload payload = program.getCompilerSpec().getPcodeInjectLibrary()
+            .getPayload(InjectPayload.CALLFIXUP_TYPE, callFixup);
+        return payload != null && !payload.isFallThru();
+    }
+
+    private static Address getSequentialAddress(Instruction instruction) {
+        try {
+            return instruction.getAddress().addNoWrap(instruction.getDefaultFallThroughOffset());
+        }
+        catch (AddressOverflowException e) {
+            return null;
+        }
+    }
+
+    private static boolean hasIndependentEntry(Program program, Listing listing,
+                                                Instruction call, Address next) {
+        Address fallFrom = listing.getInstructionAt(next).getFallFrom();
+        if (fallFrom != null && !fallFrom.equals(call.getAddress())) {
+            return true;
+        }
+        ReferenceIterator references = program.getReferenceManager().getReferencesTo(next);
+        while (references.hasNext()) {
+            Reference reference = references.next();
+            if (reference.getReferenceType().isFlow() &&
+                !reference.getFromAddress().equals(call.getAddress())) {
+                return true;
+            }
+        }
+        if (program.getFunctionManager().getFunctionAt(next) != null ||
+            program.getSymbolTable().isExternalEntryPoint(next)) {
+            return true;
+        }
+        Symbol symbol = program.getSymbolTable().getPrimarySymbol(next);
+        return symbol != null && symbol.getSource() != SourceType.DEFAULT;
+    }
+
+    private static Map<String, Object> snapshotNoReturnBoundary(Instruction call, Function target,
+                                                                 Address next) {
+        Map<String, Object> boundary = new LinkedHashMap<>();
+        boundary.put("call_address", call.getAddress().toString());
+        boundary.put("callee_address", target.getEntryPoint().toString());
+        boundary.put("callee_name", target.getName());
+        boundary.put("callee_is_thunk", target.isThunk());
+        Function thunked = target.getThunkedFunction(false);
+        boundary.put("thunked_function", thunked != null ? thunked.getEntryPoint().toString() : null);
+        boundary.put("next_address", next.toString());
+        return boundary;
+    }
+
+    private static long countInstructionsIn(Listing listing, AddressSetView set) {
+        long count = 0;
+        for (InstructionIterator it = listing.getInstructions(set, true); it.hasNext(); it.next()) {
+            count++;
+        }
+        return count;
+    }
+
+    /** Immutable name/entry snapshots, entry-ascending; Function objects must not outlive the transaction. */
+    private static List<Map<String, Object>> snapshotFunctionsOverlapping(Program program, AddressSetView set) {
+        List<Function> funcs = new ArrayList<>();
+        java.util.Iterator<Function> it = program.getFunctionManager().getFunctionsOverlapping(set);
+        while (it.hasNext()) {
+            funcs.add(it.next());
+        }
+        funcs.sort(java.util.Comparator.comparing(Function::getEntryPoint));
+        List<Map<String, Object>> out = new ArrayList<>(funcs.size());
+        for (Function f : funcs) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("name", f.getName());
+            m.put("entry", f.getEntryPoint().toString());
+            out.add(m);
+        }
+        return out;
     }
 
     // ========================================================================

--- a/src/test/java/com/xebyte/core/FunctionServiceClearFlowAndRepairGhidraTest.java
+++ b/src/test/java/com/xebyte/core/FunctionServiceClearFlowAndRepairGhidraTest.java
@@ -1,0 +1,250 @@
+package com.xebyte.core;
+
+import com.xebyte.headless.DirectThreadingStrategy;
+import com.xebyte.headless.HeadlessProgramProvider;
+import ghidra.GhidraApplicationLayout;
+import ghidra.app.cmd.disassemble.DisassembleCommand;
+import ghidra.framework.Application;
+import ghidra.framework.ApplicationConfiguration;
+import ghidra.program.database.ProgramBuilder;
+import ghidra.program.database.ProgramDB;
+import ghidra.program.disassemble.Disassembler;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.listing.FlowOverride;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.Program;
+import ghidra.util.task.TaskMonitor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class FunctionServiceClearFlowAndRepairGhidraTest {
+
+    private ProgramBuilder builder;
+    private ProgramDB program;
+
+    @BeforeClass
+    public static void initializeGhidra() throws Exception {
+        String installDir = System.getenv("GHIDRA_INSTALL_DIR");
+        assumeTrue("GHIDRA_INSTALL_DIR is required for real Ghidra tests",
+            installDir != null && !installDir.isBlank());
+        if (!Application.isInitialized()) {
+            ApplicationConfiguration configuration = new ApplicationConfiguration();
+            configuration.setInitializeLogging(false);
+            Application.initializeApplication(new GhidraApplicationLayout(new File(installDir)),
+                configuration);
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        builder = new ProgramBuilder("clear-flow-repair", ProgramBuilder._X64, "gcc", this);
+        program = builder.getProgram();
+        builder.createMemory(".text", "0x1000", 0x1100);
+
+        // CALL 0x2000; TEST EAX,EAX; MOV EAX,1; RET
+        builder.setBytes("0x1000", "e8 fb 0f 00 00 85 c0 b8 01 00 00 00 c3");
+        builder.setBytes("0x2000", "c3");
+        builder.disassemble("0x2000", 1);
+        Function target = builder.createFunction("0x2000");
+        builder.withTransaction(() -> target.setNoReturn(true));
+
+        builder.withTransaction(() -> {
+            DisassembleCommand command = new DisassembleCommand(builder.addr("0x1000"),
+                new AddressSet(builder.addr("0x1000"), builder.addr("0x100c")), true);
+            assertTrue(command.getStatusMsg(), command.applyTo(program, TaskMonitor.DUMMY));
+        });
+        builder.createFunction("0x1000");
+    }
+
+    @After
+    public void tearDown() {
+        if (builder != null) {
+            builder.dispose();
+        }
+    }
+
+    @Test
+    public void repairsFallthroughAfterCalleeChangesFromNoReturnToReturning() {
+        Instruction call = program.getListing().getInstructionAt(builder.addr("0x1000"));
+        assertEquals(FlowOverride.CALL_RETURN, call.getFlowOverride());
+        assertNull(program.getListing().getInstructionAt(builder.addr("0x1005")));
+
+        Function target = program.getFunctionManager().getFunctionAt(builder.addr("0x2000"));
+        builder.withTransaction(() -> target.setNoReturn(false));
+
+        HeadlessProgramProvider provider = new HeadlessProgramProvider();
+        provider.setCurrentProgram(program);
+        FunctionService service = new FunctionService(provider, new DirectThreadingStrategy());
+        Response response = service.clearFlowAndRepair("0x1000", "0x100d", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Ok);
+        assertNotNull("post-call fallthrough was not disassembled",
+            program.getListing().getInstructionAt(builder.addr("0x1005")));
+        Instruction repairedCall = program.getListing().getInstructionAt(builder.addr("0x1000"));
+        assertNotNull("call instruction was not restored", repairedCall);
+        assertEquals(FlowOverride.NONE, repairedCall.getFlowOverride());
+    }
+
+    @Test
+    public void leavesCallReturnOverrideWhenTargetIsStillNoReturn() {
+        HeadlessProgramProvider provider = new HeadlessProgramProvider();
+        provider.setCurrentProgram(program);
+        FunctionService service = new FunctionService(provider, new DirectThreadingStrategy());
+
+        Response response = service.clearFlowAndRepair("0x1000", "0x100d", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Ok);
+        Instruction call = program.getListing().getInstructionAt(builder.addr("0x1000"));
+        assertNotNull("call instruction was not retained", call);
+        assertEquals(FlowOverride.CALL_RETURN, call.getFlowOverride());
+        assertNull(program.getListing().getInstructionAt(builder.addr("0x1005")));
+        assertTrue(response.toJson(),
+            response.toJson().contains("noreturn_call_boundaries_in_seed"));
+        assertTrue(response.toJson(), response.toJson().contains("1005"));
+    }
+
+    @Test
+    public void preservesCallReturnCreatedByNonReturningCallFixup() {
+        Function target = program.getFunctionManager().getFunctionAt(builder.addr("0x2000"));
+        builder.withTransaction(() -> {
+            target.setNoReturn(false);
+            target.setCallFixup("x86_return_thunk");
+        });
+
+        Response response = service().clearFlowAndRepair("0x1000", "0x100d", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Ok);
+        Instruction call = program.getListing().getInstructionAt(builder.addr("0x1000"));
+        assertNotNull(call);
+        assertEquals(FlowOverride.CALL_RETURN, call.getFlowOverride());
+    }
+
+    @Test
+    public void failedRedisassemblyRollsBackClearedCall() {
+        Function target = program.getFunctionManager().getFunctionAt(builder.addr("0x2000"));
+        builder.withTransaction(() -> {
+            target.setNoReturn(false);
+            program.getMemory().getBlock(".text").setExecute(false);
+            program.getOptions(Program.DISASSEMBLER_PROPERTIES).setBoolean(
+                Disassembler.RESTRICT_DISASSEMBLY_TO_EXECUTE_MEMORY_PROPERTY, true);
+        });
+
+        HeadlessProgramProvider provider = new HeadlessProgramProvider();
+        provider.setCurrentProgram(program);
+        FunctionService service = new FunctionService(provider, new DirectThreadingStrategy());
+        Response response = service.clearFlowAndRepair("0x1000", "0x100d", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Err);
+        Instruction call = program.getListing().getInstructionAt(builder.addr("0x1000"));
+        assertNotNull("cleared call was not restored by transaction rollback", call);
+        assertEquals(FlowOverride.CALL_RETURN, call.getFlowOverride());
+        assertNull(program.getListing().getInstructionAt(builder.addr("0x1005")));
+    }
+
+    @Test
+    public void refusesBeforeRepairWhenLaterNoReturnCallWouldDeleteDefinedContinuation() {
+        configureTwoCallProgram(true);
+
+        Function firstTarget = program.getFunctionManager().getFunctionAt(builder.addr("0x2000"));
+        builder.withTransaction(() -> firstTarget.setNoReturn(false));
+
+        Response response = service().clearFlowAndRepair("0x1000", "0x1011", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Err);
+        assertTrue(response.toJson(), response.toJson().contains("1005"));
+        assertTrue(response.toJson(), response.toJson().contains("2010"));
+        assertEquals(FlowOverride.CALL_RETURN,
+            program.getListing().getInstructionAt(builder.addr("0x1000")).getFlowOverride());
+        assertNotNull(program.getListing().getInstructionAt(builder.addr("0x100a")));
+    }
+
+    @Test
+    public void restoresCallerPastTwoCorrectedNoReturnCalleesInOneRepair() {
+        configureTwoCallProgram(true);
+        Function firstTarget = program.getFunctionManager().getFunctionAt(builder.addr("0x2000"));
+        Function secondTarget = program.getFunctionManager().getFunctionAt(builder.addr("0x2010"));
+        builder.withTransaction(() -> {
+            firstTarget.setNoReturn(false);
+            secondTarget.setNoReturn(false);
+        });
+
+        Response response = service().clearFlowAndRepair("0x1000", "0x1011", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Ok);
+        assertEquals(FlowOverride.NONE,
+            program.getListing().getInstructionAt(builder.addr("0x1000")).getFlowOverride());
+        assertEquals(FlowOverride.NONE,
+            program.getListing().getInstructionAt(builder.addr("0x1005")).getFlowOverride());
+        assertNotNull(program.getListing().getInstructionAt(builder.addr("0x100a")));
+        assertNotNull(program.getListing().getInstructionAt(builder.addr("0x100f")));
+    }
+
+    @Test
+    public void refusesBeforeRepairWhenReturningCallWouldBecomeNoReturnDuringRedisassembly() {
+        configureTwoCallProgram(false);
+        Function secondTarget = program.getFunctionManager().getFunctionAt(builder.addr("0x2010"));
+        builder.withTransaction(() -> secondTarget.setNoReturn(true));
+
+        assertEquals(FlowOverride.NONE,
+            program.getListing().getInstructionAt(builder.addr("0x1005")).getFlowOverride());
+        Response response = service().clearFlowAndRepair("0x1000", "0x1011", "");
+
+        assertTrue(response.toJson(), response instanceof Response.Err);
+        assertTrue(response.toJson(), response.toJson().contains("1005"));
+        assertTrue(response.toJson(), response.toJson().contains("2010"));
+        assertNotNull(program.getListing().getInstructionAt(builder.addr("0x100a")));
+        assertEquals(FlowOverride.NONE,
+            program.getListing().getInstructionAt(builder.addr("0x1005")).getFlowOverride());
+    }
+
+    private void configureTwoCallProgram(boolean targetsStartNoReturn) {
+        builder.dispose();
+        try {
+            builder = new ProgramBuilder("clear-flow-repair-two-calls", ProgramBuilder._X64,
+                "gcc", this);
+            program = builder.getProgram();
+            builder.createMemory(".text", "0x1000", 0x1100);
+            // CALL 0x2000; CALL 0x2010; MOV EAX,1; RET
+            builder.setBytes("0x1000", "e8 fb 0f 00 00 e8 06 10 00 00 b8 01 00 00 00 c3");
+            builder.setBytes("0x2000", "c3");
+            builder.setBytes("0x2010", "c3");
+            builder.disassemble("0x2000", 1);
+            builder.disassemble("0x2010", 1);
+            Function firstTarget = builder.createFunction("0x2000");
+            Function secondTarget = builder.createFunction("0x2010");
+            builder.withTransaction(() -> {
+                firstTarget.setNoReturn(targetsStartNoReturn);
+                secondTarget.setNoReturn(targetsStartNoReturn);
+            });
+            builder.withTransaction(() -> {
+                DisassembleCommand command = new DisassembleCommand(builder.addr("0x1000"),
+                    new AddressSet(builder.addr("0x1000"), builder.addr("0x100f")), true);
+                assertTrue(command.getStatusMsg(), command.applyTo(program, TaskMonitor.DUMMY));
+                if (targetsStartNoReturn) {
+                    assertTrue(new DisassembleCommand(builder.addr("0x1005"), null, true)
+                        .applyTo(program, TaskMonitor.DUMMY));
+                    assertTrue(new DisassembleCommand(builder.addr("0x100a"), null, true)
+                        .applyTo(program, TaskMonitor.DUMMY));
+                }
+            });
+            builder.createFunction("0x1000");
+        }
+        catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private FunctionService service() {
+        HeadlessProgramProvider provider = new HeadlessProgramProvider();
+        provider.setCurrentProgram(program);
+        return new FunctionService(provider, new DirectThreadingStrategy());
+    }
+}

--- a/src/test/java/com/xebyte/offline/FunctionServiceClearFlowAndRepairTest.java
+++ b/src/test/java/com/xebyte/offline/FunctionServiceClearFlowAndRepairTest.java
@@ -1,0 +1,38 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.FunctionService;
+import com.xebyte.core.Response;
+import com.xebyte.core.ThreadingStrategy;
+import junit.framework.TestCase;
+
+/**
+ * Validation + graceful-degradation coverage for the /clear_flow_and_repair endpoint.
+ * Range validation (end > start, same space) requires a program, so it is covered by the
+ * integration tests in tests/integration/test_clear_flow_and_repair.py.
+ */
+public class FunctionServiceClearFlowAndRepairTest extends TestCase {
+
+    private FunctionService functions;
+
+    @Override
+    protected void setUp() {
+        ThreadingStrategy ts = new NoopThreadingStrategy();
+        functions = new FunctionService(ServiceFactory.stubProvider(), ts);
+    }
+
+    public void testRejectsMissingStartAddress() {
+        Response r = functions.clearFlowAndRepair(null, "", "");
+        assertTrue(r instanceof Response.Err);
+        assertTrue(((Response.Err) r).message().contains("start_address parameter required"));
+
+        r = functions.clearFlowAndRepair("", "", "");
+        assertTrue(r instanceof Response.Err);
+    }
+
+    public void testDegradesGracefullyWithNoProgram() {
+        Response r = functions.clearFlowAndRepair("0x401000", "", "");
+        assertTrue(r instanceof Response.Err);
+        assertTrue("expected 'No program loaded', got: " + r.toJson(),
+                r.toJson().contains("No program loaded"));
+    }
+}

--- a/tests/endpoints.json
+++ b/tests/endpoints.json
@@ -1,7 +1,7 @@
 {
   "version": "5.17.0",
   "description": "GhidraMCP REST API Endpoint Specification",
-  "total_endpoints": 270,
+  "total_endpoints": 271,
   "categories": {
     "listing": "List program data",
     "getter": "Get specific data",
@@ -446,6 +446,17 @@
         "keep_checked_out"
       ],
       "description": "Check an open program back in to the shared Ghidra Server as a new version"
+    },
+    {
+      "path": "/clear_flow_and_repair",
+      "method": "POST",
+      "category": "function",
+      "params": [
+        "start_address",
+        "end_address",
+        "program"
+      ],
+      "description": "Run Ghidra's GUI 'Clear Flow and Repair' action on a seed range: clears instruction flow reachable from the seed, then repairs function bodies and re-disassembles retained flow (ClearFlowAndRepairCmd with clear_data=false, clear_labels=false, repair=true). Use to rebuild regions whose flow was created under wrong assumptions, e.g. a function truncated while a callee was incorrectly marked non-returning. The command follows control flow BEYOND the seed range; the reported observations are seed-local only and do not describe everything the command changed. The flow traversal is not cancellable — a very large connected flow can hold the write lock (GUI: the Swing thread) until it completes. Ghidra treats a seed with exactly one candidate flow start (an instruction that is neither a function entry nor reached by fallthrough from inside the seed) as the flow being intentionally removed and does not reseed that start during repair; consequently, applying this action to otherwise healthy flow can clear code, matching the GUI action's behavior. The response's seed_range.end_address_exclusive is null when the seed ends at its address space's maximum address, since that boundary has no representable exclusive successor. Results are reachability-dependent and the command is not idempotent: some damaged regions may require more than one application to rebuild, while applying it again to healthy flow can clear code — inspect the before/after observations and resulting disassembly after every call."
     },
     {
       "path": "/clear_function_comments",

--- a/tests/integration/test_clear_flow_and_repair.py
+++ b/tests/integration/test_clear_flow_and_repair.py
@@ -1,0 +1,243 @@
+"""
+Integration tests for /clear_flow_and_repair.
+
+Generic tests (TestValidation, TestRepairSmoke) run against any live server + program and do
+not mutate program state beyond the repair itself.
+
+Controlled tests (TestControlledRoundTrip) require a program containing the compute/helper
+pair from the Task 4 test binary (cfr_target); they skip elsewhere. They prove the issue's
+scenario end-to-end: a wrong no-return flag on the callee truncates the caller's flow on
+repair, and correcting the flag + repairing twice more restores the exact baseline (against
+this binary's topology, one post-reset repair converges only partway; see
+TestControlledRoundTrip's docstring for why).
+"""
+
+import re
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("require_server_and_program"),
+]
+
+
+@pytest.fixture(scope="module")
+def require_server_and_program(server_available, program_loaded):
+    if not server_available:
+        pytest.skip("MCP server is not running")
+    if not program_loaded:
+        pytest.skip("No program loaded in Ghidra")
+
+
+def addr_add(addr, delta):
+    """Add delta to an address string, preserving any space prefix (split at the FINAL colon
+    so overlay names containing punctuation survive)."""
+    space, _, offset_str = addr.rpartition(":")
+    offset = int(offset_str.removeprefix("0x"), 16)
+    result = format(offset + delta, "x")
+    return f"{space}:{result}" if space else f"0x{result}"
+
+
+def repair(http_client, start, end=None):
+    payload = {"start_address": start}
+    if end is not None:
+        payload["end_address"] = end
+    return http_client.post("/clear_flow_and_repair", json_data=payload)
+
+
+def function_body(http_client, address):
+    """Return (body_min, body_max) parsed from /get_function_by_address, prefixes preserved."""
+    r = http_client.get("/get_function_by_address", params={"address": address})
+    m = re.search(r"Body:\s*(\S+)\s*-\s*(\S+)", r.text)
+    if not m:
+        pytest.skip(f"Cannot parse function body from: {r.text[:200]}")
+    return m.group(1), m.group(2)
+
+
+def find_function_by_name(http_client, name):
+    """Entry address of a named function from /list_functions, or None."""
+    r = http_client.get("/list_functions")
+    if r.status_code != 200:
+        return None
+    m = re.search(rf"\b{re.escape(name)}\b\s+at\s+((?:\w+:)?(?:0x)?[0-9a-fA-F]+)", r.text)
+    return m.group(1) if m else None
+
+
+_DISASM_LINE_RE = re.compile(r"^([0-9a-fA-F]+):\s+(.*)$")
+
+
+def disassemble_function(http_client, address):
+    """Fetch a function's disassembly and parse it into (address, mnemonic-and-operands)
+    tuples. Live format is e.g. "00101162: PUSH RBP" -- plain hex address, no 0x prefix."""
+    r = http_client.get("/disassemble_function", params={"address": address})
+    instructions = []
+    for line in r.text.splitlines():
+        m = _DISASM_LINE_RE.match(line.strip())
+        if m:
+            instructions.append((m.group(1), m.group(2)))
+    return instructions
+
+
+def _addr_value(addr):
+    """Integer value of an address string, stripping an optional space prefix and 0x."""
+    _, _, offset = addr.rpartition(":")
+    return int(offset.removeprefix("0x"), 16)
+
+
+@pytest.fixture
+def any_function(http_client):
+    """Entry address of any function, prefix preserved."""
+    r = http_client.get("/list_functions")
+    if r.status_code != 200:
+        pytest.skip("Cannot list functions")
+    m = re.search(r"at\s+((?:\w+:)?(?:0x)?[0-9a-fA-F]{4,})", r.text)
+    if not m:
+        pytest.skip("No functions found")
+    return m.group(1)
+
+
+class TestValidation:
+    def test_missing_start_address_rejected(self, http_client):
+        r = http_client.post("/clear_flow_and_repair", json_data={})
+        assert "start_address parameter required" in r.text
+
+    def test_end_equals_start_rejected(self, http_client, any_function):
+        r = repair(http_client, any_function, any_function)
+        assert "end_address must be greater than start_address" in r.text
+
+    def test_end_before_start_rejected(self, http_client, any_function):
+        r = repair(http_client, any_function, addr_add(any_function, -4))
+        assert "end_address must be greater than start_address" in r.text
+
+
+class TestRepairSmoke:
+    """Weak assertions only: arbitrary programs may contain malformed flow, so repair may
+    legitimately change counts. A full-body repair is deliberately NOT exercised here -- it
+    can clear otherwise-healthy flow (see TestControlledRoundTrip's docstring), and this tier
+    runs against whatever program happens to be loaded, so full-body coverage (and the
+    success-payload shape it would assert) lives only in the controlled round trip below,
+    where the target function and its flow topology are known."""
+
+    def test_single_address_seed(self, http_client, any_function):
+        r = repair(http_client, any_function)
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["success"] is True
+        assert data["repair"] is True
+        assert data["clear_data"] is False
+        assert data["clear_labels"] is False
+        assert data["seed_range"]["start_address"]
+
+
+class TestControlledRoundTrip:
+    """Deterministic proof against the Task 4 cfr_target binary (compute calls helper,
+    -O0 -fno-inline, helper genuinely returns so restoring no_return=False is correct).
+
+    This endpoint is NOT a safe idempotent "repair a healthy function" operation: Ghidra's
+    ClearFlowAndRepairCmd does not directly reseed an address that is a seed's sole candidate
+    flow start (an instruction that is neither a function entry nor reached by fallthrough
+    from inside the seed) -- but repair's disassembly follows flow transitively, so such an
+    address can still get rebuilt if another retained/repaired path transitively reaches it.
+    Whether healthy code survives a repair is therefore reachability-dependent, not guaranteed
+    by "exactly one candidate": it can clear otherwise-healthy code, it does not always. The
+    pristine full-body repair on compute's own baseline observably lost its back-edge-only
+    loop body (22 instructions in the seed dropped to 14), because that repair left the loop
+    body unreachable from any reseed point. That is why a pristine baseline can never come
+    from a repair call here -- it must come from read endpoints only. This class proves the
+    round trip: read the pristine state, damage it via a wrong no_return on helper, repair
+    (which legitimately shrinks the seed because the call to helper no longer flows through),
+    fix no_return, then repair TWICE more to restore the exact pristine baseline. Against this
+    binary, one repair on the freshly-reset flag is itself another instance of the same
+    reachability-dependent repair (compute -> 8 instructions, well short of the pristine 22);
+    only a second repair on top of that -- now operating on flow the first repair already
+    rebuilt -- fully re-converges to the pristine 22, byte-identical disassembly. Two
+    applications are required for this controlled topology; do not generalize this to "repeat
+    until converged" as a general recipe -- repair is not monotonic (it took the healthy
+    22-instruction body down to 14 in the pristine characterization above), so more
+    applications are not always better.
+    """
+
+    @pytest.fixture
+    def compute_and_helper(self, http_client):
+        compute = find_function_by_name(http_client, "compute")
+        helper = find_function_by_name(http_client, "helper")
+        if not compute or not helper:
+            pytest.skip("Program does not contain the controlled compute/helper pair")
+        return compute, helper
+
+    def test_no_return_damage_then_restore(self, http_client, compute_and_helper):
+        compute, helper = compute_and_helper
+        body_min, body_max = function_body(http_client, compute)
+        end_exclusive = addr_add(body_max, 1)
+
+        # Pristine baseline comes from reads only -- see class docstring for why a repair
+        # call cannot be used here.
+        instructions = disassemble_function(http_client, compute)
+        n_pristine = len(instructions)
+
+        # Prove n_pristine is the complete function, not a truncated coincidence: a call to
+        # helper is present, there is real code after that call, and the last instruction
+        # sits at the function's own body_max (loop tail / RET).
+        call_addr = None
+        for addr, text in instructions:
+            if text.startswith("CALL"):
+                operand = text.split(maxsplit=1)[1].strip()
+                try:
+                    if _addr_value(operand) == _addr_value(helper):
+                        call_addr = addr
+                        break
+                except ValueError:
+                    # Indirect/register CALL operands (e.g. "CALL RAX") aren't hex
+                    # addresses; they're real and expected here, not defensive noise.
+                    continue
+        assert call_addr is not None, "expected a CALL to helper in compute's disassembly"
+        assert any(_addr_value(addr) > _addr_value(call_addr) for addr, _ in instructions), \
+            "expected post-call code after the call to helper"
+        # Compare by value, not text: /disassemble_function and /get_function_by_address
+        # don't necessarily render the same address in the same textual form.
+        assert _addr_value(instructions[-1][0]) == _addr_value(body_max)
+
+        try:
+            r = http_client.post("/set_function_no_return",
+                                 json_data={"function_address": helper, "no_return": True})
+            assert r.status_code == 200, r.text
+
+            damaged = repair(http_client, body_min, end_exclusive).json()
+            assert damaged["success"] is True
+            # Flow stops at the call to the (wrongly) non-returning helper: strictly fewer
+            # instructions in the seed. This is the evidence that the endpoint re-follows
+            # flow rather than doing nothing.
+            assert damaged["observations"]["instructions_in_seed_after"] < n_pristine
+        finally:
+            reset = http_client.post("/set_function_no_return",
+                                     json_data={"function_address": helper, "no_return": False})
+            # Load-bearing even though the repair calls below carry no assertions: an
+            # unrestored flag poisons every later test against this program.
+            assert reset.status_code == 200, reset.text
+            # Best-effort cleanup/convergence, no assertions of any kind: a mid-test assertion
+            # failure above must never be masked by a failure in this repair. Against this
+            # binary this call is itself another instance of the same reachability-dependent
+            # repair (see class docstring): it converges compute to 8 instructions, well short
+            # of pristine. The second repair below -- outside try/finally, so it only runs on
+            # the success path -- is the one that fully restores the baseline and carries the
+            # restoration assertions.
+            repair(http_client, body_min, end_exclusive)
+
+        # Second post-reset repair over the same range: this is the one that actually
+        # reconverges to the pristine baseline (see class docstring for why one isn't enough
+        # against this binary's topology).
+        restored = repair(http_client, body_min, end_exclusive)
+        assert restored.status_code == 200, restored.text
+        data = restored.json()
+        assert data["success"] is True
+        obs = data["observations"]
+        assert obs["instructions_in_seed_after"] == n_pristine
+        # Payload-shape assertions formerly covered by the deleted arbitrary-program
+        # full-body smoke test; this full-body repair response is already in hand.
+        functions_after = obs["functions_intersecting_seed_after"]
+        assert isinstance(functions_after, list)
+        assert any(f["name"] == "compute" for f in functions_after)
+        # Semantic boundary check: the body max is back too, not just a coincidental count.
+        _, body_max_restored = function_body(http_client, compute)
+        assert body_max_restored == body_max


### PR DESCRIPTION
Adds a `clear_flow_and_repair` MCP tool wrapping Ghidra's `ClearFlowAndRepairCmd`. This covers the real-world malformed function-flow use case described in the issue.

Closes #384.