### PR TITLE
Deploy the freshest plugin archive

### DIFF
--- a/tests/unit/test_setup_ghidra.py
+++ b/tests/unit/test_setup_ghidra.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -320,7 +321,7 @@ def _stub_version(
 
 
 class TestFindPluginArchive:
-    def test_prefers_gradle_output_over_maven(
+    def test_prefers_newest_exact_version_archive(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         _stub_version(monkeypatch, tmp_path)
@@ -330,8 +331,10 @@ class TestFindPluginArchive:
         maven_zip.parent.mkdir(parents=True)
         gradle_zip.write_bytes(b"gradle")
         maven_zip.write_bytes(b"maven")
+        os.utime(gradle_zip, (100, 100))
+        os.utime(maven_zip, (200, 200))
 
-        assert find_plugin_archive(tmp_path) == gradle_zip
+        assert find_plugin_archive(tmp_path) == maven_zip
 
     def test_falls_back_to_maven_target_when_gradle_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tools/setup/ghidra.py
+++ b/tools/setup/ghidra.py
@@ -465,15 +465,16 @@ def find_ghidra_executable(ghidra_path: Path) -> Path:
 
 def find_plugin_archive(repo_root: Path) -> Path:
     version = read_pom_versions(repo_root).project_version
-    # Check Gradle output first, then Maven target/ for backward compatibility during transition.
+    # Prefer the freshest current-version output. Both backends may leave artifacts behind,
+    # so fixed backend priority can silently deploy a stale archive.
     candidates = [
         repo_root / "build" / "distributions" / f"GhidraMCP-{version}.zip",
         repo_root / "target" / f"GhidraMCP-{version}.zip",
         repo_root / "target" / "GhidraMCP.zip",
     ]
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
+    existing_candidates = [candidate for candidate in candidates if candidate.is_file()]
+    if existing_candidates:
+        return max(existing_candidates, key=lambda path: path.stat().st_mtime)
 
     for search_dir in [repo_root / "build" / "distributions", repo_root / "target"]:
         archives = sorted(


### PR DESCRIPTION
Selects the freshest current-version plugin archive for deployment. This fixes a real-world stale archive issue.