### PR TITLE
Preserve catalog-only endpoint parameters

### DIFF
--- a/src/test/java/com/xebyte/offline/RegenerateEndpointsJson.java
+++ b/src/test/java/com/xebyte/offline/RegenerateEndpointsJson.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -32,9 +33,15 @@ import java.util.TreeMap;
  * <p>Merge rules:
  * <ul>
  *   <li>For every {@code @McpTool}-scanned endpoint: write/overwrite the entry
- *       with scanner data (path, method, params, category). Description is
- *       preserved from the existing catalog if present; otherwise taken from
- *       the scanner.</li>
+ *       with scanner data (path, method). Description and category are
+ *       preserved from the existing catalog if non-empty; otherwise taken from
+ *       the scanner. Params are an ordered-set union: scanner names in
+ *       declaration order, then catalog-only names in their existing order,
+ *       each emitted once (case-sensitive comparison). Catalog-only names may
+ *       be hand-registered route extras (e.g. {@code /open_project}'s
+ *       {@code headless}/{@code program}) or stale annotation names — they
+ *       linger until removed by hand, and the run summary lists them per path
+ *       for manual review. Silent loss is the failure mode this prevents.</li>
  *   <li>For every existing catalog entry that is NOT annotation-scanned
  *       (e.g. hand-registered routes like {@code /check_connection} or
  *       {@code /server/checkouts}): kept verbatim.</li>
@@ -44,6 +51,68 @@ import java.util.TreeMap;
 public class RegenerateEndpointsJson extends TestCase {
 
     private static final String CATALOG_PATH = "tests/endpoints.json";
+
+    /** Result of merging one scanned tool with its existing catalog entry. */
+    static final class MergeResult {
+        final JsonObject entry;
+        final List<String> retainedCatalogParams;
+
+        MergeResult(JsonObject entry, List<String> retainedCatalogParams) {
+            this.entry = entry;
+            this.retainedCatalogParams = List.copyOf(retainedCatalogParams);
+        }
+    }
+
+    /**
+     * Build the regenerated catalog entry for one scanned tool. Pure: never mutates
+     * {@code existing}, never prints. Params are the ordered-set union of scanner names
+     * (declaration order) and catalog-only names (existing order); the latter are also
+     * returned so the caller can report them.
+     */
+    static MergeResult mergeEntry(AnnotationScanner.ToolDescriptor tool, JsonObject existing) {
+        JsonObject next = new JsonObject();
+        next.addProperty("path", tool.path());
+        next.addProperty("method", tool.method());
+
+        String category;
+        if (existing != null && existing.has("category")
+                && !existing.get("category").getAsString().isEmpty()) {
+            category = existing.get("category").getAsString();
+        } else {
+            category = tool.category() != null ? tool.category() : "";
+        }
+        next.addProperty("category", category);
+
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (AnnotationScanner.ParamDescriptor p : tool.params()) {
+            names.add(p.name());
+        }
+        List<String> retained = new ArrayList<>();
+        if (existing != null && existing.has("params")) {
+            for (JsonElement el : existing.getAsJsonArray("params")) {
+                String name = el.getAsString();
+                if (names.add(name)) {
+                    retained.add(name);
+                }
+            }
+        }
+        JsonArray params = new JsonArray();
+        for (String name : names) {
+            params.add(name);
+        }
+        next.add("params", params);
+
+        String description;
+        if (existing != null && existing.has("description")
+                && !existing.get("description").getAsString().isEmpty()) {
+            description = existing.get("description").getAsString();
+        } else {
+            description = tool.description() != null ? tool.description() : "";
+        }
+        next.addProperty("description", description);
+
+        return new MergeResult(next, retained);
+    }
 
     public void testRegenerateIfRequested() throws IOException {
         if (!"true".equalsIgnoreCase(System.getProperty("regenerate"))) {
@@ -70,48 +139,23 @@ public class RegenerateEndpointsJson extends TestCase {
 
         int added = 0;
         int updated = 0;
+        Map<String, List<String>> keptByPath = new LinkedHashMap<>();
         for (AnnotationScanner.ToolDescriptor tool : scanner.getDescriptors()) {
-            JsonObject existing = merged.get(tool.path());
-            JsonObject next = new JsonObject();
-            next.addProperty("path", tool.path());
-            next.addProperty("method", tool.method());
-
-            // Category: prefer existing if set (some hand-curated entries have
-            // more specific categories than the default class name).
-            String category;
-            if (existing != null && existing.has("category")
-                    && !existing.get("category").getAsString().isEmpty()) {
-                category = existing.get("category").getAsString();
-            } else {
-                category = tool.category() != null ? tool.category() : "";
-            }
-            next.addProperty("category", category);
-
-            // Params list = scanner's param names in declaration order.
-            JsonArray params = new JsonArray();
-            for (AnnotationScanner.ParamDescriptor p : tool.params()) {
-                params.add(p.name());
-            }
-            next.add("params", params);
-
-            // Description: prefer existing non-empty description (they are
-            // hand-authored and more informative than the @McpTool description),
-            // fall back to scanner description.
-            String description;
-            if (existing != null && existing.has("description")
-                    && !existing.get("description").getAsString().isEmpty()) {
-                description = existing.get("description").getAsString();
-            } else {
-                description = tool.description() != null ? tool.description() : "";
-            }
-            next.addProperty("description", description);
+            // Look up the original catalog entry, not `merged`: if two descriptors ever shared a
+            // path, merging against `merged` would self-union the first descriptor's output and
+            // report its params as catalog-only.
+            JsonObject existing = existingByPath.get(tool.path());
+            MergeResult result = mergeEntry(tool, existing);
 
             if (existing == null) {
                 added++;
-            } else if (!existing.toString().equals(next.toString())) {
+            } else if (!existing.toString().equals(result.entry.toString())) {
                 updated++;
             }
-            merged.put(tool.path(), next);
+            if (!result.retainedCatalogParams.isEmpty()) {
+                keptByPath.put(tool.path(), result.retainedCatalogParams);
+            }
+            merged.put(tool.path(), result.entry);
         }
 
         // 4. Build output: preserve top-level metadata, replace endpoints array.
@@ -141,5 +185,8 @@ public class RegenerateEndpointsJson extends TestCase {
         System.out.println("  updated from scanner: " + updated);
         System.out.println("  preserved (hand-registered): "
             + (outArr.size() - scanner.getDescriptors().size()));
+        for (Map.Entry<String, List<String>> e : keptByPath.entrySet()) {
+            System.out.println("  kept catalog-only params: " + e.getKey() + " " + e.getValue());
+        }
     }
 }

--- a/src/test/java/com/xebyte/offline/RegenerateEndpointsJsonMergeTest.java
+++ b/src/test/java/com/xebyte/offline/RegenerateEndpointsJsonMergeTest.java
@@ -1,0 +1,131 @@
+package com.xebyte.offline;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.xebyte.core.AnnotationScanner;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit coverage for {@link RegenerateEndpointsJson#mergeEntry}: the params ordered-set union
+ * that keeps catalog-only params (hand-registered route extras like /open_project's
+ * headless/program — or stale annotation names, which linger visibly for manual cleanup)
+ * instead of clobbering them from the scanner.
+ */
+public class RegenerateEndpointsJsonMergeTest extends TestCase {
+
+    private static AnnotationScanner.ToolDescriptor tool(String... paramNames) {
+        List<AnnotationScanner.ParamDescriptor> params = new ArrayList<>();
+        for (String n : paramNames) {
+            params.add(new AnnotationScanner.ParamDescriptor(n, "String", "BODY", false, null, "", "string"));
+        }
+        return new AnnotationScanner.ToolDescriptor("/open_project", "POST", "scanner description",
+                "headless", null, params);
+    }
+
+    private static JsonObject entry(String description, String category, String... paramNames) {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("path", "/open_project");
+        obj.addProperty("method", "POST");
+        obj.addProperty("category", category);
+        JsonArray params = new JsonArray();
+        for (String n : paramNames) {
+            params.add(n);
+        }
+        obj.add("params", params);
+        obj.addProperty("description", description);
+        return obj;
+    }
+
+    private static List<String> paramsOf(JsonObject entry) {
+        List<String> names = new ArrayList<>();
+        for (JsonElement el : entry.getAsJsonArray("params")) {
+            names.add(el.getAsString());
+        }
+        return names;
+    }
+
+    public void testOpenProjectCatalogExtrasKept() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("path"), entry("Open a project", "headless", "path", "headless", "program"));
+        assertEquals(List.of("path", "headless", "program"), paramsOf(result.entry));
+        assertEquals(List.of("headless", "program"), result.retainedCatalogParams);
+    }
+
+    public void testScannerOrderWinsOnOverlap() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("a", "b"), entry("d", "c", "b", "x"));
+        assertEquals(List.of("a", "b", "x"), paramsOf(result.entry));
+        assertEquals(List.of("x"), result.retainedCatalogParams);
+    }
+
+    public void testDuplicateNamesEmittedOnce() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("path", "path"), entry("d", "c", "headless", "headless"));
+        assertEquals(List.of("path", "headless"), paramsOf(result.entry));
+        assertEquals(List.of("headless"), result.retainedCatalogParams);
+    }
+
+    public void testNoExistingEntryUsesScannerParams() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(tool("path"), null);
+        assertEquals(List.of("path"), paramsOf(result.entry));
+        assertTrue(result.retainedCatalogParams.isEmpty());
+        assertEquals("scanner description", result.entry.get("description").getAsString());
+        assertEquals("headless", result.entry.get("category").getAsString());
+    }
+
+    public void testNoExistingEntryDeduplicatesScannerParams() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("path", "path"), null);
+        assertEquals(List.of("path"), paramsOf(result.entry));
+        assertTrue(result.retainedCatalogParams.isEmpty());
+    }
+
+    public void testExistingEntryWithoutParamsArray() {
+        JsonObject existing = entry("d", "c");
+        existing.remove("params");
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(tool("path"), existing);
+        assertEquals(List.of("path"), paramsOf(result.entry));
+        assertTrue(result.retainedCatalogParams.isEmpty());
+    }
+
+    public void testNonEmptyDescriptionAndCategoryPreserved() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("path"), entry("hand-authored", "project", "path"));
+        assertEquals("hand-authored", result.entry.get("description").getAsString());
+        assertEquals("project", result.entry.get("category").getAsString());
+    }
+
+    public void testEmptyDescriptionAndCategoryFallBackToScanner() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("path"), entry("", "", "path"));
+        assertEquals("scanner description", result.entry.get("description").getAsString());
+        assertEquals("headless", result.entry.get("category").getAsString());
+    }
+
+    public void testAbsentDescriptionAndCategoryFallBackToScanner() {
+        JsonObject existing = entry("d", "c", "path");
+        existing.remove("description");
+        existing.remove("category");
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(tool("path"), existing);
+        assertEquals("scanner description", result.entry.get("description").getAsString());
+        assertEquals("headless", result.entry.get("category").getAsString());
+    }
+
+    public void testRetainedNamesKeepExistingOrder() {
+        RegenerateEndpointsJson.MergeResult result = RegenerateEndpointsJson.mergeEntry(
+                tool("path"), entry("d", "c", "program", "headless", "path"));
+        assertEquals(List.of("path", "program", "headless"), paramsOf(result.entry));
+        assertEquals(List.of("program", "headless"), result.retainedCatalogParams);
+    }
+
+    public void testExistingEntryNotMutated() {
+        JsonObject existing = entry("d", "c", "path", "headless");
+        String before = existing.toString();
+        RegenerateEndpointsJson.mergeEntry(tool("path"), existing);
+        assertEquals(before, existing.toString());
+    }
+}


### PR DESCRIPTION
Preserves catalog-only parameters when regenerating the endpoint catalog. This fixes a real-world catalog regeneration issue.