### PR TITLE
Disable hardcoded archive and BSim destinations

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -99,11 +99,16 @@ TOOLS_SETUP_BACKEND=maven
 # =============================================================================
 # Used by knowledge DB MCP tools (store_function_knowledge, query_knowledge_context, etc.)
 # The bridge gracefully degrades if the DB is unreachable.
-# KNOWLEDGE_DB_HOST=10.0.10.30
+# KNOWLEDGE_DB_HOST=127.0.0.1
 # KNOWLEDGE_DB_PORT=5432
 # KNOWLEDGE_DB_NAME=bsim
-# KNOWLEDGE_DB_USER=ben
+# KNOWLEDGE_DB_USER=
 # KNOWLEDGE_DB_PASSWORD=
+
+# Cross-version archive exchange is disabled by default. Setting either URL
+# opts the corresponding component in to sending analysis data to that service.
+# GHIDRA_MCP_ARCHIVE_URL=
+# RE_KB_ARCHIVE_URL=
 
 # =============================================================================
 # Conformance oracle (PD2-S12 live debugging) -- used by start-oracle.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ Complete version history for the Ghidra MCP Server project.
   clean checkout. Covered by `tests/unit/test_setup_ghidra.py`.
 
 - **Thunk no-return metadata repair.** `set_function_no_return` now synchronizes the requested flag across every thunk hop and its terminal target instead of relying on Ghidra's asymmetric delegated setter/local getter behavior. Successful responses include verified `function_no_return` and `terminal_no_return` values, allowing later flow repair to restore valid call fallthrough.
+- **Outbound archive and BSim defaults now fail closed.** Removed the
+  maintainer-specific private archive/database address from runtime code,
+  examples, and documentation. Cross-version archive exchange is disabled
+  unless its URL is explicitly configured, and headless BSim scripts now
+  require a database URL instead of silently selecting a destination.
 - **WOW64 exception-filter gaps found in review of #366/#367.** #366 and #367
   shipped with no test coverage of `_on_exception`, `_our_bp_addrs`, or the
   fast path, and their design docs assumed contradictory models of how a
@@ -1725,8 +1730,8 @@ time, capped at -20 aggregate per function:
   tools and skips the LLM. Bus events `archive_pushed`,
   `archive_lookup`, `archive_applied`, `archive_apply_failed`,
   `archive_push_failed` for dashboard visibility.
-- Required env: `RE_KB_ARCHIVE_URL` (defaults to
-  `http://10.0.10.30:8422`); empty disables both hooks.
+- Archive exchange is disabled by default. Set `RE_KB_ARCHIVE_URL` to opt
+  fun-doc into the read and write hooks.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,9 +310,9 @@ After a worker documents a function, a different provider re-examines the result
 
 When enabled, every run writes an `audit_outcome` field into `logs/runs.jsonl` (`improved` / `regressed` / `no_change` / `skipped_good` / `skipped_delta`). The dashboard's "Audit:" line under run stats renders the aggregate. Current default pairing: **minimax** does the primary doc pass, **gemini** does audits (complementary family per model-routing memory).
 
-## Cross-version doc archive (re-kb on bsim Postgres)
+## Cross-version doc archive (optional re-kb service)
 
-Stored at `re_kb.functions` on the bsim Postgres at `10.0.10.30:5432`. Exposed via the re-kb FastAPI service at `http://10.0.10.30:8422`. Source: `re-universe/services/re-kb/`. The system has six pieces:
+When explicitly configured, documentation is stored in `re_kb.functions` on a user-selected Postgres instance and exposed through a user-selected re-kb FastAPI service. Source: `re-universe/services/re-kb/`. The system has six pieces:
 
 1. **Schema** — `re_kb.functions` augmented with matching keys (`opcode_hash`, `bsim_signature LSHVECTOR`, shape stats), full doc payload (`locals`, `instruction_comments`, `referenced_data_types`, `referenced_globals`, `referenced_labels`, `equates_referenced` JSONB), and metadata. Companion tables: `doc_field_provenance` (per-field decision history), `doc_conflict_queue` (AI judge backlog), `doc_match_log` (lookup audit).
 2. **REST API** (5 endpoints) — `POST /v1/doc_archive/upsert`, `POST /v1/doc_archive/match`, `GET /v1/doc_archive/{id}/full`, `GET /v1/doc_archive/conflicts`, `POST /v1/doc_archive/conflicts/{id}/resolve`.
@@ -321,7 +321,7 @@ Stored at `re_kb.functions` on the bsim Postgres at `10.0.10.30:5432`. Exposed v
 5. **fun-doc hooks** — write hook in `process_function` after `save_program` calls `/archive_ingest_function`. Read hook before LLM checks `/v1/doc_archive/match`; on Q5-D gate pass (hash exact OR `BSim ≥0.9 AND score ≥80`), applies name + plate via existing MCP tools and skips LLM. `bus_emit("archive_pushed"|"archive_lookup"|"archive_applied"|"archive_apply_failed"|"archive_push_failed")` for dashboard visibility.
 6. **AI conflict worker** — `re-kb-conflict-worker` docker container, polls `/v1/doc_archive/conflicts`, asks Claude Haiku for structured JSON decisions, POSTs back. Idle when queue empty.
 
-Q1-Q6 design decisions are locked in; design rationale lives in commit history. Migration `003_function_doc_archive.sql` applied to bsim DB. Required env: `RE_KB_ARCHIVE_URL` (defaults to `http://10.0.10.30:8422`); empty disables both hooks.
+Q1-Q6 design decisions are locked in; design rationale lives in commit history. Migration `003_function_doc_archive.sql` applies to the selected BSim database. Archive exchange is disabled by default; set `RE_KB_ARCHIVE_URL` for fun-doc and `GHIDRA_MCP_ARCHIVE_URL` for the Java service to opt in.
 
 **BSim signature backfill** is a one-shot Ghidra script — `C:\tmp\ghidra_recovery_scripts\Backfill_BSimSignatures.java` — run per binary from CodeBrowser to populate the `bsim_signature` column and unlock tier-2 LSH similarity matching. Tier 1 (opcode hash) works without it.
 

--- a/fun-doc/README.md
+++ b/fun-doc/README.md
@@ -60,7 +60,7 @@ Configuration in `priority_queue.json`:
   "config": {
     "storage": {
       "backend": "postgres",
-      "url": "postgresql://re_kb:***@10.0.10.30:5432/bsim",
+      "url": "postgresql://re_kb:***@127.0.0.1:5432/bsim",
       "schema": "fun_doc"
     }
   }

--- a/fun-doc/fun_doc.py
+++ b/fun-doc/fun_doc.py
@@ -209,10 +209,10 @@ except ImportError:
 
 GHIDRA_URL = os.environ.get("GHIDRA_SERVER_URL", "http://127.0.0.1:8089").rstrip("/")
 
-# Cross-version doc archive (re-kb FastAPI on bsim postgres host).
-# Empty string disables Phase 2 write hooks and Phase 3 read hooks entirely
-# so unit tests / offline runs don't touch the network.
-ARCHIVE_URL = os.environ.get("RE_KB_ARCHIVE_URL", "http://10.0.10.30:8422").rstrip("/")
+# Cross-version doc archive (re-kb FastAPI). Disabled by default so ordinary
+# and offline runs never send analysis data to another service. Set a non-empty
+# RE_KB_ARCHIVE_URL to opt in to the Phase 2 write and Phase 3 read hooks.
+ARCHIVE_URL = os.environ.get("RE_KB_ARCHIVE_URL", "").strip().rstrip("/")
 
 # Project folder scope guard (Layer 1).
 #

--- a/fun-doc/storage/__init__.py
+++ b/fun-doc/storage/__init__.py
@@ -16,7 +16,7 @@ plus the ``FUN_DOC_DB_URL`` env var, which always wins when set:
       "config": {
         "storage": {
           "backend": "postgres",
-          "url": "postgresql://re_kb:***@10.0.10.30:5432/bsim",
+          "url": "postgresql://re_kb:***@127.0.0.1:5432/bsim",
           "schema": "fun_doc"
         }
       }

--- a/ghidra_scripts/BSimBulkQuery.java
+++ b/ghidra_scripts/BSimBulkQuery.java
@@ -2,14 +2,14 @@
 // Finds functions that still have default names and queries each against BSim
 // to find matches from other ingested binaries. Returns a JSON summary.
 //
-// Script args: [0] = BSim URL (default: postgresql://10.0.10.30:5432/bsim)
+// Script args: [0] = BSim URL (required in headless/MCP mode)
 //              [1] = max matches per function (default: 5)
 //              [2] = similarity threshold 0.0-1.0 (default: 0.7)
 //              [3] = confidence/significance threshold (default: 10.0)
 //              [4] = max functions to query, 0=all (default: 0)
 //
-// Usage from MCP: run_script("BSimBulkQuery", args=["postgresql://10.0.10.30:5432/bsim"])
-// Usage from MCP: run_script("BSimBulkQuery", args=["postgresql://10.0.10.30:5432/bsim", "5", "0.7", "10.0", "100"])
+// Usage from MCP: run_script("BSimBulkQuery", args=["postgresql://127.0.0.1:5432/bsim"])
+// Usage from MCP: run_script("BSimBulkQuery", args=["postgresql://127.0.0.1:5432/bsim", "5", "0.7", "10.0", "100"])
 //@category BSim
 //@keybinding
 //@menupath
@@ -37,7 +37,6 @@ import ghidra.program.model.listing.FunctionManager;
 
 public class BSimBulkQuery extends GhidraScript {
 
-    private static final String DEFAULT_BSIM_URL = "postgresql://10.0.10.30:5432/bsim";
     private static final int DEFAULT_MAX_MATCHES = 5;
     private static final double DEFAULT_SIMILARITY = 0.7;
     private static final double DEFAULT_CONFIDENCE = 10.0;
@@ -52,7 +51,7 @@ public class BSimBulkQuery extends GhidraScript {
 
         // Parse arguments
         String[] args = getScriptArgs();
-        String bsimUrl = DEFAULT_BSIM_URL;
+        String bsimUrl = null;
         int maxMatches = DEFAULT_MAX_MATCHES;
         double similarityThresh = DEFAULT_SIMILARITY;
         double confidenceThresh = DEFAULT_CONFIDENCE;
@@ -62,7 +61,7 @@ public class BSimBulkQuery extends GhidraScript {
             bsimUrl = args[0].trim();
         } else if (!isRunningHeadless()) {
             bsimUrl = askString("BSim Bulk Query",
-                "Enter BSim database URL:", DEFAULT_BSIM_URL);
+                "Enter BSim database URL:", "").trim();
         }
         if (args != null && args.length > 1 && args[1] != null && !args[1].isEmpty()) {
             maxMatches = Integer.parseInt(args[1].trim());
@@ -75,6 +74,11 @@ public class BSimBulkQuery extends GhidraScript {
         }
         if (args != null && args.length > 4 && args[4] != null && !args[4].isEmpty()) {
             maxFunctions = Integer.parseInt(args[4].trim());
+        }
+
+        if (bsimUrl == null || bsimUrl.isEmpty()) {
+            println("{\"status\": \"error\", \"error\": \"BSim URL is required; no default destination is configured\"}");
+            return;
         }
 
         // Collect all undocumented functions (FUN_* prefix = default auto-analysis names)

--- a/ghidra_scripts/BSimIngestProgram.java
+++ b/ghidra_scripts/BSimIngestProgram.java
@@ -2,9 +2,9 @@
 // This generates BSim feature vectors (LSH signatures) for every function and
 // inserts them into the database's exetable/desctable. One-time per binary.
 //
-// Script args: [0] = BSim URL (default: postgresql://10.0.10.30:5432/bsim)
+// Script args: [0] = BSim URL (required in headless/MCP mode)
 //
-// Usage from MCP: run_script("BSimIngestProgram", args=["postgresql://10.0.10.30:5432/bsim"])
+// Usage from MCP: run_script("BSimIngestProgram", args=["postgresql://127.0.0.1:5432/bsim"])
 // Usage from Ghidra Script Manager: will prompt for URL if no args provided
 //
 // IMPORTANT: The program must be saved before ingestion. BSim needs a stable
@@ -36,8 +36,6 @@ import ghidra.program.model.listing.FunctionManager;
 
 public class BSimIngestProgram extends GhidraScript {
 
-    private static final String DEFAULT_BSIM_URL = "postgresql://10.0.10.30:5432/bsim";
-
     @Override
     protected void run() throws Exception {
         if (currentProgram == null) {
@@ -45,7 +43,7 @@ public class BSimIngestProgram extends GhidraScript {
             return;
         }
 
-        String bsimUrl = DEFAULT_BSIM_URL;
+        String bsimUrl = null;
 
         // Check script args first (headless/MCP mode)
         String[] args = getScriptArgs();
@@ -53,7 +51,12 @@ public class BSimIngestProgram extends GhidraScript {
             bsimUrl = args[0].trim();
         } else if (!isRunningHeadless()) {
             bsimUrl = askString("BSim Ingest Program",
-                "Enter BSim database URL:", DEFAULT_BSIM_URL);
+                "Enter BSim database URL:", "").trim();
+        }
+
+        if (bsimUrl == null || bsimUrl.isEmpty()) {
+            println("{\"status\": \"error\", \"error\": \"BSim URL is required; no default destination is configured\"}");
+            return;
         }
 
         String programName = currentProgram.getName();

--- a/ghidra_scripts/BSimQueryAndPropagate.java
+++ b/ghidra_scripts/BSimQueryAndPropagate.java
@@ -2,13 +2,12 @@
 // Designed for use in the RE loop PROPAGATE phase to find cross-version matches.
 //
 // Script args: [0] = function address (hex, e.g. "0x10001000")
-//              [1] = BSim URL (default: postgresql://10.0.10.30:5432/bsim)
+//              [1] = BSim URL (required in headless/MCP mode)
 //              [2] = max matches per function (default: 10)
 //              [3] = similarity threshold 0.0-1.0 (default: 0.7)
 //              [4] = confidence/significance threshold (default: 0.0)
 //
-// Usage from MCP: run_script("BSimQueryAndPropagate", args=["0x10001000"])
-// Usage from MCP: run_script("BSimQueryAndPropagate", args=["0x10001000", "postgresql://10.0.10.30:5432/bsim", "10", "0.7", "0.0"])
+// Usage from MCP: run_script("BSimQueryAndPropagate", args=["0x10001000", "postgresql://127.0.0.1:5432/bsim", "10", "0.7", "0.0"])
 //@category BSim
 //@keybinding
 //@menupath
@@ -33,7 +32,6 @@ import ghidra.program.model.listing.Function;
 
 public class BSimQueryAndPropagate extends GhidraScript {
 
-    private static final String DEFAULT_BSIM_URL = "postgresql://10.0.10.30:5432/bsim";
     private static final int DEFAULT_MAX_MATCHES = 10;
     private static final double DEFAULT_SIMILARITY = 0.7;
     private static final double DEFAULT_CONFIDENCE = 0.0;
@@ -48,7 +46,7 @@ public class BSimQueryAndPropagate extends GhidraScript {
         // Parse arguments
         String[] args = getScriptArgs();
         String addressStr = null;
-        String bsimUrl = DEFAULT_BSIM_URL;
+        String bsimUrl = null;
         int maxMatches = DEFAULT_MAX_MATCHES;
         double similarityThresh = DEFAULT_SIMILARITY;
         double confidenceThresh = DEFAULT_CONFIDENCE;
@@ -78,6 +76,15 @@ public class BSimQueryAndPropagate extends GhidraScript {
                 // Use current address in headless mode
                 addressStr = currentAddress != null ? currentAddress.toString() : null;
             }
+        }
+
+        if (bsimUrl == null && !isRunningHeadless()) {
+            bsimUrl = askString("BSim Query",
+                "Enter BSim database URL:", "").trim();
+        }
+        if (bsimUrl == null || bsimUrl.isEmpty()) {
+            println("{\"status\": \"error\", \"error\": \"BSim URL is required; no default destination is configured\"}");
+            return;
         }
 
         if (addressStr == null || addressStr.isEmpty()) {

--- a/ghidra_scripts/BSimTestConnection.java
+++ b/ghidra_scripts/BSimTestConnection.java
@@ -1,7 +1,7 @@
 // Test connectivity to a BSim PostgreSQL database and report database info as JSON.
-// Script args: [0] = BSim URL (default: postgresql://10.0.10.30:5432/bsim)
+// Script args: [0] = BSim URL (required in headless/MCP mode)
 //
-// Usage from MCP: run_script("BSimTestConnection", args=["postgresql://10.0.10.30:5432/bsim"])
+// Usage from MCP: run_script("BSimTestConnection", args=["postgresql://127.0.0.1:5432/bsim"])
 // Usage from Ghidra Script Manager: will prompt for URL if no args provided
 //@category BSim
 //@keybinding
@@ -21,11 +21,9 @@ import ghidra.features.bsim.query.protocol.ResponseInfo;
 
 public class BSimTestConnection extends GhidraScript {
 
-    private static final String DEFAULT_BSIM_URL = "postgresql://10.0.10.30:5432/bsim";
-
     @Override
     protected void run() throws Exception {
-        String bsimUrl = DEFAULT_BSIM_URL;
+        String bsimUrl = null;
 
         // Check script args first (headless/MCP mode)
         String[] args = getScriptArgs();
@@ -34,7 +32,12 @@ public class BSimTestConnection extends GhidraScript {
         } else if (!isRunningHeadless()) {
             // Interactive mode: prompt the user
             bsimUrl = askString("BSim Connection Test",
-                "Enter BSim database URL:", DEFAULT_BSIM_URL);
+                "Enter BSim database URL:", "").trim();
+        }
+
+        if (bsimUrl == null || bsimUrl.isEmpty()) {
+            println("{\"status\": \"error\", \"error\": \"BSim URL is required; no default destination is configured\"}");
+            return;
         }
 
         println("{");

--- a/src/main/java/com/xebyte/core/DocumentationHashService.java
+++ b/src/main/java/com/xebyte/core/DocumentationHashService.java
@@ -1610,8 +1610,8 @@ public class DocumentationHashService {
     // route through the field-level merge resolution on the archive side.
     //
     // Configuration:
-    //   - Archive URL via env var GHIDRA_MCP_ARCHIVE_URL (default
-    //     http://10.0.10.30:8422). Empty string disables.
+    //   - Archive exchange is disabled by default. Set a non-empty
+    //     GHIDRA_MCP_ARCHIVE_URL to opt in to an explicitly chosen service.
     //
     // Identity scheme:
     //   - binary_name: program name (e.g. "Bnclient.dll")
@@ -1620,12 +1620,9 @@ public class DocumentationHashService {
     //                  the second segment. Override via version_override param.
     //   - address:     "0x" + hex (canonical Ghidra form)
 
-    private static final String DEFAULT_ARCHIVE_URL = "http://10.0.10.30:8422";
-
     private static String getArchiveUrl() {
         String env = System.getenv("GHIDRA_MCP_ARCHIVE_URL");
-        if (env != null && !env.isEmpty()) return env;
-        return DEFAULT_ARCHIVE_URL;
+        return env == null ? "" : env.trim();
     }
 
     /**
@@ -1663,6 +1660,9 @@ public class DocumentationHashService {
                 defaultValue = "") String versionOverride,
             @Param(value = "dry_run", source = ParamSource.QUERY, defaultValue = "false",
                 description = "Build payload but skip the POST") boolean dryRun) {
+        if (!dryRun && getArchiveUrl().isEmpty()) {
+            return Response.err("archive exchange is disabled; set GHIDRA_MCP_ARCHIVE_URL to opt in");
+        }
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -1715,6 +1715,9 @@ public class DocumentationHashService {
                 description = "Skip functions whose name is FUN_/LAB_/etc. (default-named)") boolean skipDefault,
             @Param(value = "dry_run", source = ParamSource.QUERY, defaultValue = "false",
                 description = "Build all payloads but skip the POSTs") boolean dryRun) {
+        if (!dryRun && getArchiveUrl().isEmpty()) {
+            return Response.err("archive exchange is disabled; set GHIDRA_MCP_ARCHIVE_URL to opt in");
+        }
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/test/java/com/xebyte/offline/ProgramLoadResultTest.java
+++ b/src/test/java/com/xebyte/offline/ProgramLoadResultTest.java
@@ -120,9 +120,9 @@ public class ProgramLoadResultTest extends TestCase {
     // -------------------------------------------------------------------
 
     public void testServerBindingInfoBound() {
-        ServerBindingInfo b = new ServerBindingInfo(true, "10.0.10.30:13100", "diablo2");
+        ServerBindingInfo b = new ServerBindingInfo(true, "192.0.2.10:13100", "diablo2");
         assertTrue(b.serverBound);
-        assertEquals("10.0.10.30:13100", b.serverInfo);
+        assertEquals("192.0.2.10:13100", b.serverInfo);
         assertEquals("diablo2", b.repoName);
     }
 

--- a/tests/unit/test_bridge_utils.py
+++ b/tests/unit/test_bridge_utils.py
@@ -930,7 +930,7 @@ class TestValidateServerUrl(unittest.TestCase):
         self.assertFalse(self._validate("http://localhost"))
 
     def test_rejects_non_local_host(self):
-        self.assertFalse(self._validate("http://10.0.10.30:8089"))
+        self.assertFalse(self._validate("http://192.0.2.10:8089"))
         self.assertFalse(self._validate("http://evil.example.com:8089"))
 
     def test_rejects_malformed_url(self):

--- a/tests/unit/test_no_default_data_egress.py
+++ b/tests/unit/test_no_default_data_egress.py
@@ -1,0 +1,47 @@
+"""Regression tests for outbound archive and BSim defaults."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_archive_exchange_is_disabled_by_default():
+    java_source = _read(
+        "src/main/java/com/xebyte/core/DocumentationHashService.java"
+    )
+    fun_doc_source = _read("fun-doc/fun_doc.py")
+
+    assert 'env == null ? "" : env.trim()' in java_source
+    assert 'os.environ.get("RE_KB_ARCHIVE_URL", "")' in fun_doc_source
+    assert "DEFAULT_ARCHIVE_URL" not in java_source
+
+
+def test_bsim_scripts_have_no_default_destination():
+    for script in (REPO_ROOT / "ghidra_scripts").glob("BSim*.java"):
+        source = script.read_text(encoding="utf-8")
+        assert "DEFAULT_BSIM_URL" not in source, script
+
+
+def test_removed_private_destination_does_not_reappear():
+    removed_destination = ".".join(("10", "0", "10", "30"))
+    checked_paths = [
+        REPO_ROOT / "src",
+        REPO_ROOT / "fun-doc",
+        REPO_ROOT / "ghidra_scripts",
+        REPO_ROOT / "docker",
+        REPO_ROOT / "scripts",
+        REPO_ROOT / "tests",
+    ]
+    for root in checked_paths:
+        for path in root.rglob("*"):
+            if path.is_file():
+                try:
+                    source = path.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    continue
+                assert removed_destination not in source, path


### PR DESCRIPTION
• ## Summary

 Removes the maintainer-specific 10.0.10.30 archive and BSim defaults to prevent unexpected connections on networks or VPNs that route this private address.

  ## Changes

  - Disables archive exchange by default.
  - Keeps archive support available through:
      - GHIDRA_MCP_ARCHIVE_URL for Java
      - RE_KB_ARCHIVE_URL for fun-doc

  - Requires an explicit BSim URL for headless/MCP script execution.
  - Continues prompting for the BSim URL in interactive Ghidra sessions.
  - Removes the private address from source, examples, tests, and documentation.
  - Adds regression tests preventing the destination from being reintroduced.

  ## Compatibility

  Headless BSim calls that previously omitted the database URL must now provide it as a script argument. Other MCP and headless functionality is unaffected.

  ## Validation

  - Confirmed the removed address no longer appears in the repository.
  - Added and ran fail-closed egress regression checks.
  - Passed Python syntax and diff-integrity checks.