### PR TITLE
Fix /mcp/schema completeness: 34 GUI + 30 headless routes were live but invisible

### DIFF
--- a/src/main/java/com/xebyte/GhidraMCPPlugin.java
+++ b/src/main/java/com/xebyte/GhidraMCPPlugin.java
@@ -660,10 +660,30 @@ public class GhidraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
                 }
             }));
         }
+        // These routes are registered below via their own server.createContext(...)
+        // calls (utility/server/project/tool endpoints that predate the @McpTool
+        // convention), so they are already live and callable. Without this they
+        // stayed invisible in /mcp/schema -- and therefore invisible to the Python
+        // bridge's dynamic tool discovery -- even though a caller who knew the raw
+        // path could reach them. Found via a live-schema-vs-catalog diff (v6.0.0).
+        com.xebyte.core.ManualToolDescriptors.addAll(scanner,
+            "/batch_apply_documentation", "/batch_set_variable_types", "/check_connection",
+            "/exit_ghidra", "/get_current_address", "/get_current_function",
+            "/get_current_selection", "/get_data_type_size", "/get_version",
+            "/mcp/health", "/mcp/schema", "/open_project", "/project/info",
+            "/server/admin/set_permissions", "/server/admin/terminate_all_checkouts",
+            "/server/admin/terminate_checkout", "/server/admin/users", "/server/authenticate",
+            "/server/checkouts", "/server/connect", "/server/disconnect",
+            "/server/repositories", "/server/repository/create", "/server/repository/file",
+            "/server/repository/files", "/server/status", "/server/version_control/add",
+            "/server/version_control/checkin", "/server/version_control/checkout",
+            "/server/version_control/undo_checkout", "/server/version_history",
+            "/tool/goto_address", "/tool/launch_codebrowser", "/tool/running_tools");
         // Reflect the live count so /get_version.endpoint_count matches
-        // what /mcp/schema actually serves. Previously a hardcoded constant
-        // that drifted as services added new @McpTool methods.
-        VersionInfo.setEndpointCount(scanner.getEndpoints().size());
+        // what /mcp/schema actually serves. Includes both the dispatch-table
+        // (@McpTool-scanned) endpoints and the manually-registered routes just
+        // added to the schema above.
+        VersionInfo.setEndpointCount(scanner.getDescriptors().size());
 
         // ==========================================================================
         // SCHEMA ENDPOINT — Serves machine-readable API metadata

--- a/src/main/java/com/xebyte/core/AnnotationScanner.java
+++ b/src/main/java/com/xebyte/core/AnnotationScanner.java
@@ -75,6 +75,21 @@ public class AnnotationScanner {
         return Collections.unmodifiableList(descriptors);
     }
 
+    /**
+     * Add a descriptor to the schema output for a route that is registered
+     * directly (e.g. {@code server.createContext(...)}/{@code safeContext(...)})
+     * rather than discovered via {@code @McpTool} reflection. Unlike
+     * {@link #scanService(Object)}, this does NOT add a dispatch entry to
+     * {@link #getEndpoints()} — the caller already owns routing for the path.
+     * Used by {@link ManualToolDescriptors} so hand-registered utility/server/
+     * project routes appear in {@code /mcp/schema} (and therefore the bridge's
+     * dynamic tool discovery) instead of being live-but-invisible.
+     */
+    public void addManualDescriptor(ToolDescriptor descriptor) {
+        descriptors.add(descriptor);
+        descriptors.sort(Comparator.comparing(ToolDescriptor::path));
+    }
+
     /** Generate a JSON schema string describing all discovered tools. */
     public String generateSchema() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/xebyte/core/ManualToolDescriptors.java
+++ b/src/main/java/com/xebyte/core/ManualToolDescriptors.java
@@ -1,0 +1,125 @@
+package com.xebyte.core;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hand-authored {@link AnnotationScanner.ToolDescriptor}s for HTTP routes that are
+ * registered directly via {@code createContext}/{@code safeContext} in
+ * {@link com.xebyte.GhidraMCPPlugin} and/or
+ * {@link com.xebyte.headless.GhidraMCPHeadlessServer}, rather than discovered via
+ * {@code @McpTool} reflection (utility/server/project/tool routes that predate the
+ * annotation-scanner convention). Without this registry these routes are fully live
+ * and callable but invisible in {@code /mcp/schema} -- the Python bridge's dynamic
+ * tool discovery reads only that schema, so an AI agent connected through the bridge
+ * could never see or call them (found via a live-schema-vs-catalog diff, v6.0.0).
+ *
+ * <p>Path/method/category/description/params are sourced verbatim from
+ * {@code tests/endpoints.json}'s hand-registered entries (see
+ * {@code RegenerateEndpointsJson}'s "preserved (hand-registered)" merge rule --
+ * that file is the existing source of truth for these routes' metadata). Params
+ * carry only a name and a source inferred from the route's HTTP method (GET -&gt;
+ * query, POST -&gt; body); the catalog does not track per-param type/required detail
+ * for hand-registered routes, and every one of these handlers already parses its
+ * own params permissively, so marking them optional-string is accurate enough for
+ * tool discovery without overclaiming precision the source data doesn't have.
+ *
+ * <p>{@code ManualToolDescriptorsParityTest} enforces that every path a server
+ * registers manually has an entry here, so a future added route can't silently
+ * repeat this gap.
+ */
+public final class ManualToolDescriptors {
+
+    private ManualToolDescriptors() {}
+
+    private static AnnotationScanner.ParamDescriptor p(String name, String source) {
+        return new AnnotationScanner.ParamDescriptor(name, "string", source, true, null, "", "");
+    }
+
+    private static List<AnnotationScanner.ParamDescriptor> params(String method, String... names) {
+        String source = "GET".equalsIgnoreCase(method) ? "query" : "body";
+        List<AnnotationScanner.ParamDescriptor> out = new java.util.ArrayList<>();
+        for (String n : names) out.add(p(n, source));
+        return out;
+    }
+
+    private static void add(Map<String, AnnotationScanner.ToolDescriptor> m,
+            String path, String method, String category, String description, String... paramNames) {
+        m.put(path, new AnnotationScanner.ToolDescriptor(
+            path, method, description, category, "", params(method, paramNames)));
+    }
+
+    /** Keyed by path. Built once; entries never mutate after class init. */
+    private static final Map<String, AnnotationScanner.ToolDescriptor> ALL = buildAll();
+
+    private static Map<String, AnnotationScanner.ToolDescriptor> buildAll() {
+        Map<String, AnnotationScanner.ToolDescriptor> m = new LinkedHashMap<>();
+        add(m, "/batch_apply_documentation", "POST", "analysis", "Apply all documentation to a function in one call", "address", "name", "prototype", "calling_convention", "variable_types", "variable_renames", "plate_comment", "decompiler_comments", "disassembly_comments", "goto", "score", "program");
+        add(m, "/batch_set_variable_types", "POST", "datatype", "Set multiple variable types", "function_address", "variable_types", "program");
+        add(m, "/check_connection", "GET", "utility", "Health check endpoint");
+        add(m, "/configure_analyzer", "POST", "analysis", "Configure an analysis plugin", "name", "enabled", "program");
+        add(m, "/delete_project", "POST", "project", "Delete a Ghidra project", "projectPath");
+        add(m, "/exit_ghidra", "POST", "program", "Save and exit Ghidra");
+        add(m, "/get_current_address", "GET", "getter", "Get cursor address (GUI only)");
+        add(m, "/get_current_function", "GET", "getter", "Get function at cursor (GUI only)");
+        add(m, "/get_current_selection", "GET", "getter", "Get highlighted address ranges in the CodeBrowser listing (GUI only). Returns {program, is_empty, ranges:[{start,end,length}], min_address, max_address, num_addresses} or an empty-selection payload when nothing is highlighted.");
+        add(m, "/get_data_type_size", "GET", "datatype", "Get data type size in bytes", "type_name", "program");
+        add(m, "/get_version", "GET", "utility", "Get plugin version");
+        add(m, "/health", "GET", "utility", "Health check endpoint for headless server");
+        add(m, "/list_projects", "GET", "project", "List available Ghidra projects", "searchDir");
+        add(m, "/mcp/health", "GET", "utility", "HTTP server health: pool stats, uptime, memory, active request count");
+        add(m, "/mcp/schema", "GET", "utility", "Machine-readable API schema with endpoint metadata");
+        add(m, "/move_file", "POST", "project", "Move a file to another project folder", "filePath", "destFolder");
+        add(m, "/move_folder", "POST", "project", "Move a folder to another location", "sourcePath", "destPath");
+        add(m, "/open_project", "POST", "headless", "Open an existing Ghidra project (.gpr file or directory). GUI mode adds optional `headless` (default true) to suppress auto-launching CodeBrowser, and optional `program` to auto-launch CodeBrowser for a specific file when headless=false. Headless server ignores the extra params.", "path", "headless", "program");
+        add(m, "/project/info", "GET", "project", "Get detailed project info including running tools and open programs");
+        add(m, "/server/admin/set_permissions", "POST", "server", "Set user permissions on a repository", "repo", "user", "accessLevel");
+        add(m, "/server/admin/terminate_all_checkouts", "POST", "server", "Terminate all checkouts in a folder recursively", "repo", "path");
+        add(m, "/server/admin/terminate_checkout", "POST", "server", "Terminate all checkouts on a single file", "repo", "path", "checkoutId", "checkout_id");
+        add(m, "/server/admin/users", "GET", "server", "List all users on the server");
+        add(m, "/server/authenticate", "POST", "server", "Register server credentials for programmatic authentication", "username", "password");
+        add(m, "/server/checkouts", "GET", "server", "List all checked-out files in a folder, including server-side checkouts", "path");
+        add(m, "/server/connect", "POST", "server", "Connect to a Ghidra server", "host", "port");
+        add(m, "/server/disconnect", "POST", "server", "Disconnect from the Ghidra server");
+        add(m, "/server/repositories", "GET", "server", "List repositories on the connected server");
+        add(m, "/server/repository/create", "POST", "server", "Create a new repository on the server", "name");
+        add(m, "/server/repository/file", "GET", "server", "Get file info from a server repository", "repo", "path");
+        add(m, "/server/repository/files", "GET", "server", "List files in a server repository folder", "repo", "path");
+        add(m, "/server/status", "GET", "headless", "Check headless server connection status");
+        add(m, "/server/version_control/add", "POST", "server", "Add a file to version control", "repo", "path", "comment", "keepCheckedOut");
+        add(m, "/server/version_control/checkin", "POST", "server", "Check in a version-controlled file", "repo", "path", "comment", "keepCheckedOut");
+        add(m, "/server/version_control/checkout", "POST", "server", "Check out a version-controlled file", "repo", "path");
+        add(m, "/server/version_control/undo_checkout", "POST", "server", "Undo a file checkout", "repo", "path");
+        add(m, "/server/version_history", "GET", "server", "Get version history for a file", "repo", "path");
+        add(m, "/tool/goto_address", "POST", "utility", "Navigate CodeBrowser listing and decompiler to a specific address", "address");
+        add(m, "/tool/launch_codebrowser", "POST", "utility", "Open a file in CodeBrowser, launching a new one if needed", "path");
+        add(m, "/tool/running_tools", "GET", "utility", "List all running Ghidra tool windows");
+        return m;
+    }
+
+    /**
+     * Add the descriptor for each requested path to {@code scanner}'s schema output.
+     * Fails loudly (not silently) if a path has no registered descriptor -- that means
+     * either this registry drifted from a server's actual createContext/safeContext
+     * calls, or a new manual route was added without a matching entry here.
+     *
+     * @throws IllegalStateException if any path is not present in {@link #ALL}
+     */
+    public static void addAll(AnnotationScanner scanner, String... paths) {
+        for (String path : paths) {
+            AnnotationScanner.ToolDescriptor td = ALL.get(path);
+            if (td == null) {
+                throw new IllegalStateException("No ManualToolDescriptors entry for \"" + path
+                    + "\" -- add one to ManualToolDescriptors.buildAll(), or remove the"
+                    + " createContext/safeContext call if the route no longer exists.");
+            }
+            scanner.addManualDescriptor(td);
+        }
+    }
+
+    /** Every path this registry knows a descriptor for (for parity tests). */
+    public static java.util.Set<String> knownPaths() {
+        return java.util.Collections.unmodifiableSet(ALL.keySet());
+    }
+}

--- a/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
+++ b/src/main/java/com/xebyte/headless/GhidraMCPHeadlessServer.java
@@ -420,8 +420,30 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
             });
         }
 
-        // Store scanner size for dynamic endpoint count reporting
-        registeredEndpointCount = scanner.getEndpoints().size();
+        // These routes are registered below via their own safeContext(...) calls
+        // (utility/server/project endpoints that predate the @McpTool convention),
+        // so they are already live and callable. Without this they stayed
+        // invisible in /mcp/schema -- and therefore invisible to the Python
+        // bridge's dynamic tool discovery. Mirrors the GUI-side wiring in
+        // GhidraMCPPlugin; see ManualToolDescriptors for the shared metadata
+        // source. Found via a live-schema-vs-catalog diff (v6.0.0).
+        com.xebyte.core.ManualToolDescriptors.addAll(scanner,
+            "/batch_set_variable_types", "/check_connection", "/configure_analyzer",
+            "/delete_project", "/exit_ghidra", "/get_current_address",
+            "/get_current_function", "/get_data_type_size", "/get_version", "/health",
+            "/list_projects", "/mcp/schema", "/move_file", "/move_folder",
+            "/server/admin/set_permissions", "/server/admin/terminate_all_checkouts",
+            "/server/admin/terminate_checkout", "/server/admin/users",
+            "/server/checkouts", "/server/connect", "/server/disconnect",
+            "/server/repositories", "/server/repository/create", "/server/repository/file",
+            "/server/repository/files", "/server/version_control/add",
+            "/server/version_control/checkin", "/server/version_control/checkout",
+            "/server/version_control/undo_checkout", "/server/version_history");
+        // Store scanner size for dynamic endpoint count reporting. Now includes
+        // both the dispatch-table (@McpTool-scanned) endpoints and the manually-
+        // registered routes just added to the schema above -- countEndpoints()
+        // no longer needs a hand-maintained "+30" offset for these.
+        registeredEndpointCount = scanner.getDescriptors().size();
 
         // ==========================================================================
         // SCHEMA ENDPOINT — Serves machine-readable API metadata
@@ -613,11 +635,11 @@ public class GhidraMCPHeadlessServer implements GhidraLaunchable {
     }
 
     private int countEndpoints() {
-        // registeredEndpointCount = annotation-scanned (shared services + HeadlessManagementService)
-        // 30 = infrastructure + schema + remaining manual createContext registrations
-        // (was 31; -2 after #180 dropped /create_folder + /delete_file as duplicates)
-        // (was 29; +1 after adding /server/admin/terminate_all_checkouts for GUI parity)
-        return registeredEndpointCount + 30;
+        // registeredEndpointCount now includes both the annotation-scanned
+        // endpoints and the manually-registered routes added via
+        // ManualToolDescriptors.addAll(...) above -- no more hand-maintained
+        // offset to keep in sync as routes are added or removed.
+        return registeredEndpointCount;
     }
 
     public void stop() {

--- a/src/test/java/com/xebyte/offline/ManualToolDescriptorsParityTest.java
+++ b/src/test/java/com/xebyte/offline/ManualToolDescriptorsParityTest.java
@@ -1,0 +1,131 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.ManualToolDescriptors;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Source-level regression pinning {@link ManualToolDescriptors} in sync with
+ * the actual {@code createContext}/{@code safeContext} calls in the GUI and
+ * headless servers.
+ *
+ * <p>Background: {@code /mcp/schema} is generated purely from {@code @McpTool}
+ * reflection. Routes registered directly via {@code createContext}/
+ * {@code safeContext} (utility/server/project/tool endpoints that predate the
+ * annotation-scanner convention) were fully live and callable but invisible in
+ * the schema — and therefore invisible to the Python bridge's dynamic tool
+ * discovery — found via a live-schema-vs-catalog diff while investigating a
+ * "272 vs 222 tools" release-notes discrepancy (v6.0.0).
+ * {@link ManualToolDescriptors} closes that gap with a hand-maintained
+ * registry sourced from {@code tests/endpoints.json}. These tests keep the
+ * registry from silently drifting again in either direction: a new manual
+ * route added without a descriptor (schema regresses to invisible), or a
+ * descriptor left behind after its route is removed (schema advertises a
+ * tool that 404s).
+ *
+ * <p>Pure source-text checks — no Ghidra runtime/classpath required, unlike
+ * {@code EndpointsJsonParityTest} which needs a full service build.
+ */
+public class ManualToolDescriptorsParityTest extends TestCase {
+
+    private static final Pattern GUI_CONTEXT = Pattern.compile(
+        "(?:server|httpServer)\\.createContext\\(\\s*\"([^\"]+)\"");
+    private static final Pattern HEADLESS_CONTEXT = Pattern.compile(
+        "safeContext\\(\\s*\"([^\"]+)\"");
+
+    /**
+     * Routes registered via a literal createContext call that are
+     * intentionally NOT in {@link ManualToolDescriptors} — pure runtime
+     * introspection metadata, not meant to be discoverable/callable as an
+     * MCP tool by an AI agent.
+     */
+    private static final Set<String> EXEMPT = Set.of(
+        "/mcp/instance_info"
+    );
+
+    private static String readSource(String... parts) throws IOException {
+        Path p = Paths.get("src", "main", "java", "com", "xebyte");
+        for (String s : parts) p = p.resolve(s);
+        return new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+    }
+
+    private static Set<String> extractPaths(Pattern pattern, String src) {
+        Set<String> out = new LinkedHashSet<>();
+        Matcher m = pattern.matcher(src);
+        while (m.find()) out.add(m.group(1));
+        return out;
+    }
+
+    public void testEveryGuiManualRouteHasADescriptor() throws IOException {
+        String src = readSource("GhidraMCPPlugin.java");
+        Set<String> guiPaths = extractPaths(GUI_CONTEXT, src);
+        Set<String> known = ManualToolDescriptors.knownPaths();
+
+        for (String path : guiPaths) {
+            if (EXEMPT.contains(path)) continue;
+            assertTrue(
+                "GUI registers \"" + path + "\" via createContext but "
+                    + "ManualToolDescriptors has no entry for it -- the route is "
+                    + "live but invisible in /mcp/schema. Add it to "
+                    + "ManualToolDescriptors.buildAll().",
+                known.contains(path));
+        }
+    }
+
+    public void testEveryHeadlessManualRouteHasADescriptor() throws IOException {
+        String src = readSource("headless", "GhidraMCPHeadlessServer.java");
+        Set<String> headlessPaths = extractPaths(HEADLESS_CONTEXT, src);
+        Set<String> known = ManualToolDescriptors.knownPaths();
+
+        for (String path : headlessPaths) {
+            if (EXEMPT.contains(path)) continue;
+            assertTrue(
+                "Headless registers \"" + path + "\" via safeContext but "
+                    + "ManualToolDescriptors has no entry for it -- the route is "
+                    + "live but invisible in /mcp/schema. Add it to "
+                    + "ManualToolDescriptors.buildAll().",
+                known.contains(path));
+        }
+    }
+
+    public void testNoOrphanedDescriptors() throws IOException {
+        String guiSrc = readSource("GhidraMCPPlugin.java");
+        String headlessSrc = readSource("headless", "GhidraMCPHeadlessServer.java");
+        Set<String> registered = new LinkedHashSet<>();
+        registered.addAll(extractPaths(GUI_CONTEXT, guiSrc));
+        registered.addAll(extractPaths(HEADLESS_CONTEXT, headlessSrc));
+
+        for (String path : ManualToolDescriptors.knownPaths()) {
+            assertTrue(
+                "ManualToolDescriptors has an entry for \"" + path + "\" but "
+                    + "neither server registers it via createContext/safeContext "
+                    + "-- the schema would advertise a tool that 404s. Remove the "
+                    + "stale entry from ManualToolDescriptors.buildAll().",
+                registered.contains(path));
+        }
+    }
+
+    /** Every descriptor must be wired into at least one server's addAll(...) call. */
+    public void testEveryDescriptorIsWiredIntoAtLeastOneServer() throws IOException {
+        String guiSrc = readSource("GhidraMCPPlugin.java");
+        String headlessSrc = readSource("headless", "GhidraMCPHeadlessServer.java");
+        for (String path : ManualToolDescriptors.knownPaths()) {
+            String quoted = "\"" + path + "\"";
+            assertTrue(
+                "ManualToolDescriptors has an entry for \"" + path + "\" but it "
+                    + "is not passed to ManualToolDescriptors.addAll(...) in "
+                    + "either server -- it was registered in the map but never "
+                    + "actually added to a live schema.",
+                guiSrc.contains(quoted) || headlessSrc.contains(quoted));
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

Investigating why the release notes report 272 MCP tools while every live server this session reported 222 turned up a real bug, not a stale number.

**A precise diff between `tests/endpoints.json` (272, accurate) and the live `/mcp/schema` (222) found 0 tools catalogued-but-not-live** — the catalog isn't stale. The 50-tool gap splits cleanly:

- **~16 are genuinely headless-only** (`HeadlessManagementService`) — correctly absent from a GUI instance's schema, not a bug.
- **34 are routes `GhidraMCPPlugin.java` registers directly** via `server.createContext(...)` — utility/server/project/tool endpoints that predate the `@McpTool` convention. They're fully live and callable, just never taught to `AnnotationScanner`, so `/mcp/schema` never listed them. Since the **Python bridge's dynamic tool discovery reads only that schema**, an AI agent connected through the bridge could never see or call `/get_version`, `/server/authenticate`, `/tool/goto_address`, and 31 others — even though a caller who knew the raw path could reach them directly. The headless server has the same class of bug for its own 30 manual routes.

## Fix

- `AnnotationScanner.addManualDescriptor()` — lets a descriptor join the schema without a dispatch entry (the caller already owns routing for that path).
- `ManualToolDescriptors` — a hand-maintained registry keyed by path, sourced **verbatim** from `tests/endpoints.json`'s existing hand-registered entries (no new metadata invented). Both servers call `addAll(...)` right after constructing their scanner: GUI adds its 34, headless adds its 30 (24 overlap; 6 are headless-exclusive).
- `/get_version`'s `endpoint_count` and headless's `countEndpoints()` (previously a hand-maintained `+30` offset with a trail of manual adjustments in its comments) now both derive from `scanner.getDescriptors().size()` — no more separately-tracked count to drift.

## Verification

Not just schema inspection — called the bridge's actual `registry._fetch_and_register_schema()` against the redeployed live server and confirmed `get_version`, `get_current_address`, `server_authenticate`, `tool_goto_address`, `check_connection`, and `tool_running_tools` are now real, callable MCP tools end-to-end. 256/256 schema entries registered minus 1 (`import_file` — a pre-existing, unrelated, by-design collision with an existing static bridge tool).

**256 (GUI live) + 16 (headless-exclusive) = 272 (catalog) now reconciles exactly.** The release notes' "MCP Tools: 272" was always accurate — the live schema was incomplete.

## Tests

New `ManualToolDescriptorsParityTest` (source-level, no Ghidra classpath needed): every manually-registered route has a descriptor, every descriptor corresponds to a real registration, nothing orphaned. Validated with a deliberate negative control (removed one entry, confirmed 2 failures, restored, confirmed byte-identical). Full offline suite green (391 tests; the 26 errors in unrelated pre-existing tests are a known environment gap — `db.util.ErrorHandler` missing from this Maven test classpath — confirmed via stash-and-compare against untouched code, not something this PR introduced).

## Not included

No `@McpTool` annotations changed, so `tests/endpoints.json` needs no regeneration. **CHANGELOG entry + version bump left for release time** — `v6.0.0` is already tagged; this becomes the next release (your call on timing/version number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)