### PR TITLE
fix(bridge): make cancellation and tool updates reliable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,6 +38,10 @@ GHIDRA_SERVER_URL=http://127.0.0.1:8089/
 # Only needed when using debugger_* MCP tools
 GHIDRA_DEBUGGER_URL=http://127.0.0.1:8099
 
+# Maximum bridge requests allowed to execute against Ghidra concurrently.
+# Requests wait in worker threads, leaving the MCP event loop responsive.
+GHIDRA_MCP_MAX_CONCURRENT_REQUESTS=4
+
 # MCP bridge server (the Python side, HTTP transports only)
 MCP_HOST=127.0.0.1
 MCP_PORT=8081

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,12 @@ Complete version history for the Ghidra MCP Server project.
   and passive capture kept working afterward with no run-control poisoning.
   See the docstring on `_on_exception` and the `reference-debugger-sim-runs`
   memory.
+- **Bridge connection collapse under concurrent slow requests.** Dynamic Ghidra
+  tools now offload blocking HTTP work from the FastMCP event loop, while a
+  bounded request semaphore replaces the process-wide serialization lock.
+  Bridge timeouts now outlive Ghidra's requested execution timeout, and network
+  failures distinguish safe pre-send reconnects from unknown outcomes so an
+  in-flight decompilation or write is never blindly duplicated.
 - **fun-doc storage bootstrap race.** `_get_storage_repo()` was an unlocked
   check-then-build singleton and `db/migrate.py` recorded schema versions
   with a bare INSERT, so two threads bootstrapping the same fresh SQLite

--- a/python/bridge_mcp_ghidra/__init__.py
+++ b/python/bridge_mcp_ghidra/__init__.py
@@ -40,9 +40,12 @@ from .config import (  # noqa: F401
     DEFAULT_TCP_PORT,
     DEFAULT_TCP_URL,
     ENDPOINT_TIMEOUTS,
+    MAX_CONCURRENT_GHIDRA_REQUESTS,
+    MAX_REQUEST_TIMEOUT_SECONDS,
     MANAGEMENT_TOOL_NAMES,
     STATIC_TOOL_NAMES,
     TCP_PORT_SCAN_RANGE,
+    REQUEST_TIMEOUT_GRACE_SECONDS,
     _ALL_STATIC_TOOL_NAMES,
     logger,
 )
@@ -62,6 +65,8 @@ from .validation import (  # noqa: F401
     validate_tool_name,
 )
 from .transport import (  # noqa: F401
+    RequestNotSentError,
+    RequestOutcomeUnknownError,
     UnixHTTPConnection,
     do_request,
     get_socket_dir,

--- a/python/bridge_mcp_ghidra/cli.py
+++ b/python/bridge_mcp_ghidra/cli.py
@@ -100,18 +100,14 @@ def _build_http_app(transport: str, bind_host: str):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="GhidraMCP Bridge -- MCP<->HTTP multiplexer"
-    )
+    parser = argparse.ArgumentParser(description="GhidraMCP Bridge -- MCP<->HTTP multiplexer")
     parser.add_argument(
         "--mcp-host",
         type=str,
         default="127.0.0.1",
         help="Host for HTTP transport (streamable-http or sse)",
     )
-    parser.add_argument(
-        "--mcp-port", type=int, help="Port for HTTP transport (streamable-http or sse)"
-    )
+    parser.add_argument("--mcp-port", type=int, help="Port for HTTP transport (streamable-http or sse)")
     parser.add_argument(
         "--transport",
         type=str,
@@ -137,21 +133,16 @@ def main():
         "--default-groups",
         type=str,
         default=None,
-        help="Comma-separated list of default tool groups to load on connect "
-        "(default: listing,function,program)",
+        help="Comma-separated list of default tool groups to load on connect " "(default: listing,function,program)",
     )
     args = parser.parse_args()
 
     state._lazy_mode = args.lazy
     if args.default_groups is not None:
-        state._default_groups = {
-            g.strip() for g in args.default_groups.split(",") if g.strip()
-        }
+        state._default_groups = {g.strip() for g in args.default_groups.split(",") if g.strip()}
 
     if not state._lazy_mode:
-        logger.info(
-            "Loading all tool groups on startup (clients that don't support tools/list_changed need this)"
-        )
+        logger.info("Loading all tool groups on startup (clients that don't support tools/list_changed need this)")
     _auto_connect()
 
     mcp.settings.log_level = "INFO"
@@ -180,9 +171,7 @@ def main():
                     "GHIDRA_MCP_DISABLE_REBIND_PROTECTION=1 — any page in the "
                     "user's browser can drive this server."
                 )
-                mcp.settings.transport_security = TransportSecuritySettings(
-                    enable_dns_rebinding_protection=False
-                )
+                mcp.settings.transport_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
             else:
                 allowed = _wildcard_allowed_hosts()
                 extra = os.environ.get("GHIDRA_MCP_ALLOWED_HOSTS", "")
@@ -193,7 +182,8 @@ def main():
                     "allowed Host headers: %s. Extend with "
                     "GHIDRA_MCP_ALLOWED_HOSTS=host1,host2 if a remote client "
                     "is rejected.",
-                    _host, allowed,
+                    _host,
+                    allowed,
                 )
                 mcp.settings.transport_security = TransportSecuritySettings(
                     enable_dns_rebinding_protection=True,
@@ -207,12 +197,15 @@ def main():
                 allowed_origins=[f"http://{_host}:*", "http://localhost:*", "http://127.0.0.1:*"],
             )
     logger.info(f"Starting MCP bridge ({args.transport})")
-    if args.transport in ("sse", "streamable-http"):
-        host = args.mcp_host
-        port = args.mcp_port if args.mcp_port else mcp.settings.port
-        path = "/sse" if args.transport == "sse" else "/mcp"
-        logger.info(f"MCP endpoint: http://{host}:{port}{path}")
-        app = _build_http_app(args.transport, host)
-        uvicorn.run(app, host=host, port=port, log_level=mcp.settings.log_level.lower())
-    else:
-        mcp.run(transport=args.transport)
+    try:
+        if args.transport in ("sse", "streamable-http"):
+            host = args.mcp_host
+            port = args.mcp_port if args.mcp_port else mcp.settings.port
+            path = "/sse" if args.transport == "sse" else "/mcp"
+            logger.info(f"MCP endpoint: http://{host}:{port}{path}")
+            app = _build_http_app(args.transport, host)
+            uvicorn.run(app, host=host, port=port, log_level=mcp.settings.log_level.lower())
+        else:
+            mcp.run(transport=args.transport)
+    finally:
+        state.shutdown_worker_pool(wait=False)

--- a/python/bridge_mcp_ghidra/config.py
+++ b/python/bridge_mcp_ghidra/config.py
@@ -24,7 +24,10 @@ ENDPOINT_TIMEOUTS = {
     "import_file": 300,
     "run_ghidra_script": 1800,
     "run_script_inline": 1800,
-    "decompile_function": 45,
+    # Ghidra's default decompile cap is 60s. The bridge must outlive it so the
+    # plugin can return a structured timeout instead of writing into a closed
+    # socket after the client has already gone away.
+    "decompile_function": 75,
     "set_function_prototype": 45,
     "rename_function": 45,
     "rename_function_by_address": 45,
@@ -33,6 +36,18 @@ ENDPOINT_TIMEOUTS = {
     "apply_function_documentation": 60,
     "default": 30,
 }
+
+REQUEST_TIMEOUT_GRACE_SECONDS = 15
+# Long-running endpoints may legitimately ask Ghidra to spend 1800 seconds on
+# work (for example run_script_inline/run_ghidra_script or a user-raised
+# decompile timeout). Keep the transport alive slightly longer so the bridge can
+# receive and forward Ghidra's final status instead of closing first.
+MAX_REQUEST_TIMEOUT_SECONDS = 1815
+
+try:
+    MAX_CONCURRENT_GHIDRA_REQUESTS = max(1, int(os.getenv("GHIDRA_MCP_MAX_CONCURRENT_REQUESTS", "4")))
+except ValueError:
+    MAX_CONCURRENT_GHIDRA_REQUESTS = 4
 
 DEFAULT_TCP_URL = "http://127.0.0.1:8089"
 DEFAULT_TCP_PORT = 8089

--- a/python/bridge_mcp_ghidra/debugger.py
+++ b/python/bridge_mcp_ghidra/debugger.py
@@ -5,6 +5,7 @@ Each tool proxies an HTTP request to ``debugger/server.py`` on
 """
 
 import http.client
+import inspect
 import json
 import os
 import sys
@@ -66,7 +67,20 @@ def _debugger_tool(*dargs, **dkwargs):
     exposed as an MCP tool, keeping the tool list uncluttered on non-Windows.
     """
     if _DEBUGGER_ACTIVE:
-        return mcp.tool(*dargs, **dkwargs)
+        registrar = mcp.tool(*dargs, **dkwargs)
+
+        def _register(fn):
+            async def _async_wrapper(*args, **kwargs):
+                return await state.run_blocking_ghidra_call(fn, *args, **kwargs)
+
+            _async_wrapper.__name__ = fn.__name__
+            _async_wrapper.__doc__ = fn.__doc__
+            _async_wrapper.__annotations__ = fn.__annotations__
+            _async_wrapper.__signature__ = inspect.signature(fn)
+            registrar(_async_wrapper)
+            return fn
+
+        return _register
 
     def _skip(fn):
         return fn
@@ -87,20 +101,32 @@ def _debugger_request(
     # GHIDRA_DEBUGGER_URL is operator-set — mirrors the Ghidra TCP URL policy
     # and stops a stray/hostile env value from redirecting debugger traffic.
     if not validate_server_url(DEBUGGER_URL):
-        return json.dumps({
-            "error": f"Refusing to use non-loopback debugger URL: {DEBUGGER_URL}. "
-            "GHIDRA_DEBUGGER_URL must be http://<127.0.0.1|localhost|::1>:<port>."
-        })
+        return json.dumps(
+            {
+                "error": f"Refusing to use non-loopback debugger URL: {DEBUGGER_URL}. "
+                "GHIDRA_DEBUGGER_URL must be http://<127.0.0.1|localhost|::1>:<port>."
+            }
+        )
     parsed = urlparse(DEBUGGER_URL)
     conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=timeout)
+    cancel_handle = state.get_request_cancel_handle()
+    if cancel_handle is not None and not cancel_handle.register_connection(conn):
+        return json.dumps({"error": f"Debugger request aborted before start: {path}"})
     try:
+        conn.connect()
+        if cancel_handle is not None and cancel_handle.aborted:
+            return json.dumps({"error": f"Debugger request aborted before send: {path}"})
         url = path
         if query:
             url += "?" + urlencode(query)
         headers = {"Content-Type": "application/json"} if body else {}
-        conn.request(
-            method, url, body=json.dumps(body) if body else None, headers=headers
-        )
+        if cancel_handle is not None:
+            with cancel_handle.hold_send_window(conn) as can_send:
+                if not can_send:
+                    return json.dumps({"error": f"Debugger request aborted before send: {path}"})
+                conn.request(method, url, body=json.dumps(body) if body else None, headers=headers)
+        else:
+            conn.request(method, url, body=json.dumps(body) if body else None, headers=headers)
         resp = conn.getresponse()
         data = resp.read().decode("utf-8")
         if resp.status >= 400:
@@ -120,6 +146,8 @@ def _debugger_request(
     except Exception as e:
         return json.dumps({"error": f"Debugger request failed: {e}"})
     finally:
+        if cancel_handle is not None:
+            cancel_handle.unregister_connection(conn)
         conn.close()
 
 
@@ -143,11 +171,7 @@ def debugger_attach(target: str) -> str:
             programs_text = dispatch.dispatch_get("/list_open_programs")
             if programs_text:
                 programs_data = json.loads(programs_text)
-                programs = (
-                    programs_data
-                    if isinstance(programs_data, list)
-                    else programs_data.get("programs", [])
-                )
+                programs = programs_data if isinstance(programs_data, list) else programs_data.get("programs", [])
                 # image_base is already present on each /list_open_programs
                 # entry (ProgramScriptService.listOpenPrograms emits it) —
                 # use it directly. The previous /get_metadata round-trip
@@ -168,12 +192,9 @@ def debugger_attach(target: str) -> str:
                     if prog_path and image_base:
                         ghidra_bases[prog_path] = image_base
                 if ghidra_bases:
-                    _debugger_request(
-                        "POST", "/debugger/sync_modules", {"ghidra_bases": ghidra_bases}
-                    )
+                    _debugger_request("POST", "/debugger/sync_modules", {"ghidra_bases": ghidra_bases})
                     logger.info(
-                        "debugger_attach: auto-synced %d Ghidra image base(s) "
-                        "to the debugger address map",
+                        "debugger_attach: auto-synced %d Ghidra image base(s) " "to the debugger address map",
                         len(ghidra_bases),
                     )
                 else:
@@ -222,9 +243,7 @@ def debugger_resolve_ordinal(dll: str, ordinal: int) -> str:
         dll: DLL name (e.g. "D2Common.dll").
         ordinal: Ordinal number (e.g. 10624).
     """
-    return _debugger_request(
-        "GET", "/debugger/ordinal", query={"dll": dll, "ordinal": str(ordinal)}
-    )
+    return _debugger_request("GET", "/debugger/ordinal", query={"dll": dll, "ordinal": str(ordinal)})
 
 
 @_debugger_tool()
@@ -310,9 +329,7 @@ def debugger_registers() -> str:
 
 
 @_debugger_tool()
-def debugger_read_memory(
-    address: str, size: int = 64, address_type: str = "runtime", module: str = ""
-) -> str:
+def debugger_read_memory(address: str, size: int = 64, address_type: str = "runtime", module: str = "") -> str:
     """Read memory from the debugged process.
 
     Returns hex dump and 32-bit DWORD interpretation of the memory region.
@@ -346,9 +363,7 @@ def debugger_stack_trace(depth: int = 20) -> str:
 
 
 @_debugger_tool()
-def debugger_read_args(
-    convention: str = "__stdcall", count: int = 4, arg_names: str = ""
-) -> str:
+def debugger_read_args(convention: str = "__stdcall", count: int = 4, arg_names: str = "") -> str:
     """Read function arguments at the current breakpoint based on calling convention.
 
     Reads arguments from registers and stack according to the calling convention.
@@ -438,9 +453,7 @@ def debugger_trace_list() -> str:
 
 
 @_debugger_tool()
-def debugger_watch_memory(
-    ghidra_address: str, size: int = 4, access: str = "write", module: str = ""
-) -> str:
+def debugger_watch_memory(ghidra_address: str, size: int = 4, access: str = "write", module: str = "") -> str:
     """Set a hardware watchpoint on a memory range to monitor read/write access.
 
     Limited to 4 simultaneous watchpoints (x86 debug register limit).

--- a/python/bridge_mcp_ghidra/discovery.py
+++ b/python/bridge_mcp_ghidra/discovery.py
@@ -47,7 +47,7 @@ def discover_instances() -> list[dict]:
             if dash < 0:
                 continue
             try:
-                pid = int(name[dash + 1:])
+                pid = int(name[dash + 1 :])
             except ValueError:
                 continue
 
@@ -62,9 +62,7 @@ def discover_instances() -> list[dict]:
             info: dict = {"socket": str(sock_file), "pid": pid}
             if uds_ok:
                 try:
-                    text, status = transport.uds_request(
-                        str(sock_file), "GET", "/mcp/instance_info", timeout=5
-                    )
+                    text, status = transport.uds_request(str(sock_file), "GET", "/mcp/instance_info", timeout=5)
                     if status == 200:
                         info.update(_unwrap_response_data(text))
                 except Exception as e:
@@ -85,9 +83,9 @@ def discover_instances() -> list[dict]:
     return instances
 
 
-def _iter_tcp_instances(start_port: int = DEFAULT_TCP_PORT,
-                        range_size: int = TCP_PORT_SCAN_RANGE,
-                        timeout: float = 1.0):
+def _iter_tcp_instances(
+    start_port: int = DEFAULT_TCP_PORT, range_size: int = TCP_PORT_SCAN_RANGE, timeout: float = 1.0
+):
     """Yield (url, instance_info) for every Ghidra plugin in the TCP scan range.
 
     For each port in [start_port, start_port + range_size), issues
@@ -99,27 +97,44 @@ def _iter_tcp_instances(start_port: int = DEFAULT_TCP_PORT,
     """
     for port in range(start_port, start_port + range_size):
         url = f"http://127.0.0.1:{port}"
+        cancel_handle = state.get_request_cancel_handle()
+        conn = None
         try:
             conn = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+            if cancel_handle is not None and not cancel_handle.register_connection(conn):
+                return
             try:
-                conn.request("GET", "/mcp/instance_info")
+                conn.connect()
+                if cancel_handle is not None and cancel_handle.aborted:
+                    return
+                if cancel_handle is not None:
+                    with cancel_handle.hold_send_window(conn) as can_send:
+                        if not can_send:
+                            return
+                        conn.request("GET", "/mcp/instance_info")
+                else:
+                    conn.request("GET", "/mcp/instance_info")
                 resp = conn.getresponse()
                 if resp.status != 200:
                     continue
                 body = resp.read().decode("utf-8", errors="replace")
             finally:
+                if cancel_handle is not None and conn is not None:
+                    cancel_handle.unregister_connection(conn)
                 conn.close()
             info = _unwrap_response_data(body)
             if isinstance(info, dict):
                 yield url, info
         except Exception:
             # Connection refused / timeout / non-JSON response — try next port.
+            if cancel_handle is not None and conn is not None:
+                cancel_handle.unregister_connection(conn)
             continue
 
 
-def _tcp_instances_by_pid(start_port: int = DEFAULT_TCP_PORT,
-                          range_size: int = TCP_PORT_SCAN_RANGE,
-                          timeout: float = 1.0) -> dict[int, dict]:
+def _tcp_instances_by_pid(
+    start_port: int = DEFAULT_TCP_PORT, range_size: int = TCP_PORT_SCAN_RANGE, timeout: float = 1.0
+) -> dict[int, dict]:
     """Map pid -> {"url": ..., **instance_info} for TCP-reachable instances.
 
     Used to enrich UDS socket-file discovery on hosts where Python can't
@@ -135,9 +150,9 @@ def _tcp_instances_by_pid(start_port: int = DEFAULT_TCP_PORT,
     return by_pid
 
 
-def _scan_tcp_for_project(project: str, start_port: int = DEFAULT_TCP_PORT,
-                          range_size: int = TCP_PORT_SCAN_RANGE,
-                          timeout: float = 1.0) -> str | None:
+def _scan_tcp_for_project(
+    project: str, start_port: int = DEFAULT_TCP_PORT, range_size: int = TCP_PORT_SCAN_RANGE, timeout: float = 1.0
+) -> str | None:
     """Scan a small TCP port range for a Ghidra plugin matching `project`.
 
     Used when UDS discovery returns nothing (e.g., TCP-only multi-instance
@@ -177,9 +192,7 @@ def discover_active_tcp_instance() -> dict | None:
         info["project"] = state._connected_project
 
     try:
-        text, status = transport.tcp_request(
-            state._active_tcp, "GET", "/mcp/instance_info", timeout=5
-        )
+        text, status = transport.tcp_request(state._active_tcp, "GET", "/mcp/instance_info", timeout=5)
         if status == 200:
             info.update(_unwrap_response_data(text))
             return info
@@ -187,9 +200,7 @@ def discover_active_tcp_instance() -> dict | None:
         logger.debug(f"Could not query TCP instance info for {state._active_tcp}: {e}")
 
     try:
-        text, status = transport.tcp_request(
-            state._active_tcp, "GET", "/list_open_programs", timeout=5
-        )
+        text, status = transport.tcp_request(state._active_tcp, "GET", "/list_open_programs", timeout=5)
         if status == 200:
             data = _unwrap_response_data(text)
             if isinstance(data, dict):
@@ -197,8 +208,6 @@ def discover_active_tcp_instance() -> dict | None:
                     if key in data:
                         info[key] = data[key]
     except Exception as e:
-        logger.debug(
-            f"Could not query open programs for active TCP instance {state._active_tcp}: {e}"
-        )
+        logger.debug(f"Could not query open programs for active TCP instance {state._active_tcp}: {e}")
 
     return info

--- a/python/bridge_mcp_ghidra/dispatch.py
+++ b/python/bridge_mcp_ghidra/dispatch.py
@@ -7,7 +7,12 @@ from . import discovery
 from . import registry
 from . import state
 from . import transport
-from .config import ENDPOINT_TIMEOUTS, logger
+from .config import (
+    ENDPOINT_TIMEOUTS,
+    MAX_REQUEST_TIMEOUT_SECONDS,
+    REQUEST_TIMEOUT_GRACE_SECONDS,
+    logger,
+)
 
 
 def get_timeout(endpoint: str, payload: dict | None = None) -> int:
@@ -17,6 +22,21 @@ def get_timeout(endpoint: str, payload: dict | None = None) -> int:
 
     if not payload:
         return base
+
+    requested_timeout = payload.get("timeout")
+    if requested_timeout is None:
+        requested_timeout = payload.get("timeout_seconds")
+    if requested_timeout is not None:
+        try:
+            requested_seconds = int(requested_timeout)
+        except (TypeError, ValueError):
+            requested_seconds = 0
+        if requested_seconds > 0:
+            effective_requested_seconds = min(
+                requested_seconds,
+                MAX_REQUEST_TIMEOUT_SECONDS - REQUEST_TIMEOUT_GRACE_SECONDS,
+            )
+            return max(base, effective_requested_seconds + REQUEST_TIMEOUT_GRACE_SECONDS)
 
     if name in {"rename_variables", "batch_rename_variables"}:
         count = len(payload.get("variable_renames", {}))
@@ -64,81 +84,154 @@ def _normalize_post_payload(endpoint: str, data: dict) -> dict:
     return data
 
 
-def _reconnect_via(inst: dict) -> bool:
-    """Point the active transport at `inst` and re-fetch the schema.
+def _normalize_timeout_fields(payload: dict | None) -> dict | None:
+    if not payload:
+        return payload
 
-    Uses UDS when this Python can dial it; otherwise falls back to the TCP
-    url discovery recorded for the instance (Windows CPython lacks AF_UNIX).
-    Returns True on success.
-    """
-    if transport.uds_supported():
-        state._active_socket = inst["socket"]
-        state._active_tcp = None
-        state._transport_mode = "uds"
-        target = inst["socket"]
-    elif inst.get("url"):
-        state._active_tcp = inst["url"]
-        state._active_socket = None
-        state._transport_mode = "tcp"
-        target = inst["url"]
-    else:
-        return False
-    try:
-        registry._fetch_and_register_schema()
-        logger.info(f"Reconnected to project '{inst.get('project')}' via {target}")
-        return True
-    except Exception as e:
-        logger.warning(f"Reconnect schema fetch failed: {e}")
-        return False
+    normalized = dict(payload)
+    max_requested_seconds = MAX_REQUEST_TIMEOUT_SECONDS - REQUEST_TIMEOUT_GRACE_SECONDS
+    for key in ("timeout", "timeout_seconds"):
+        raw = normalized.get(key)
+        if raw is None:
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            capped = min(value, max_requested_seconds)
+            normalized[key] = str(capped) if isinstance(raw, str) else capped
+    return normalized
 
 
-def _try_reconnect() -> bool:
-    """Try to reconnect to the previously connected project after Ghidra restarts.
-
-    Scans for instances matching _connected_project. If found, updates the
-    active transport and re-fetches the schema. Returns True if reconnected.
-    """
-    if not state._connected_project:
-        return False
-
+def _discover_project_connection(project_name: str) -> state.ConnectionSnapshot | None:
+    """Discover a live transport target for one Ghidra project."""
     instances = discovery.discover_instances()
     for inst in instances:
-        if inst.get("project", "") == state._connected_project:
-            return _reconnect_via(inst)
-
-    # Exact match failed, try substring
+        if inst.get("project", "") == project_name:
+            if transport.uds_supported():
+                return state.build_connection_snapshot(
+                    mode="uds",
+                    active_socket=inst["socket"],
+                    connected_project=inst.get("project"),
+                )
+            if inst.get("url"):
+                return state.build_connection_snapshot(
+                    mode="tcp",
+                    active_tcp=inst["url"],
+                    connected_project=inst.get("project"),
+                )
+            return None
     for inst in instances:
-        if state._connected_project.lower() in inst.get("project", "").lower():
-            return _reconnect_via(inst)
+        project = inst.get("project", "")
+        if project_name.lower() in project.lower():
+            if transport.uds_supported():
+                return state.build_connection_snapshot(
+                    mode="uds",
+                    active_socket=inst["socket"],
+                    connected_project=inst.get("project"),
+                )
+            if inst.get("url"):
+                return state.build_connection_snapshot(
+                    mode="tcp",
+                    active_tcp=inst["url"],
+                    connected_project=inst.get("project"),
+                )
+            return None
+    return None
 
-    return False
+
+def _try_reconnect(
+    connection: state.ConnectionSnapshot | None = None,
+) -> state.ConnectionSnapshot | None:
+    """Reconnect one request to its original project without clobbering a switch."""
+    base = connection or state.get_connection_snapshot()
+    if not base.connected_project:
+        return None
+
+    candidate = _discover_project_connection(base.connected_project)
+    if candidate is None:
+        return None
+
+    current = state.get_connection_snapshot()
+    if current != base:
+        target = candidate.active_socket or candidate.active_tcp
+        logger.info(
+            "Reconnected request-scoped project '%s' via %s without changing the global route",
+            candidate.connected_project,
+            target,
+        )
+        return candidate
+
+    try:
+        schema = registry._fetch_schema(connection=candidate)
+    except Exception as e:
+        logger.warning(
+            "Reconnect schema fetch failed for project '%s': %s",
+            candidate.connected_project,
+            e,
+        )
+        return None
+
+    with state._tool_registry_lock:
+        promoted = state.maybe_promote_connection_snapshot(base, candidate)
+        if promoted is not None:
+            registry.register_tools_from_schema(
+                schema,
+                groups=None if not state._lazy_mode else state._default_groups,
+            )
+            state.notify_tools_changed_from_worker()
+            target = promoted.active_socket or promoted.active_tcp
+            logger.info(
+                "Reconnected project '%s' via %s and refreshed the global schema",
+                promoted.connected_project,
+                target,
+            )
+            return promoted
+    return candidate
+
+
+def _resolve_connection_for_request(
+    connection: state.ConnectionSnapshot | None = None,
+) -> tuple[state.ConnectionSnapshot | None, str | None]:
+    """Resolve the concrete transport target for one request."""
+    resolved = connection or state.get_request_connection_snapshot() or state.get_connection_snapshot()
+    if resolved.mode != "none":
+        return resolved, None
+    if resolved.connected_project:
+        reconnected = _try_reconnect(resolved)
+        if reconnected is not None:
+            return reconnected, None
+        return (
+            None,
+            f"Ghidra instance for project '{resolved.connected_project}' is not running. "
+            "Start Ghidra and open the project, then retry.",
+        )
+    return None, "No Ghidra instance connected. Use connect_instance() first."
 
 
 def _ensure_connected() -> str | None:
     """Check connection and attempt reconnect if needed. Returns error string or None."""
-    if state._transport_mode == "none":
-        if state._connected_project:
-            if _try_reconnect():
-                return None
-            return (
-                f"Ghidra instance for project '{state._connected_project}' is not running. "
-                "Start Ghidra and open the project, then retry."
-            )
-        return "No Ghidra instance connected. Use connect_instance() first."
-    return None
+    _resolved, err = _resolve_connection_for_request()
+    return err
 
 
 def dispatch_get(endpoint: str, params: dict | None = None, retries: int = 3) -> str:
     """GET request via active transport. Returns raw response text."""
-    err = _ensure_connected()
+    connection, err = _resolve_connection_for_request()
     if err:
         return json.dumps({"error": err})
 
-    timeout = get_timeout(endpoint)
+    params = _normalize_timeout_fields(params)
+    timeout = get_timeout(endpoint, params)
     for attempt in range(retries):
         try:
             text, status = transport.do_request(
-                "GET", endpoint, params=params, timeout=timeout
+                "GET",
+                endpoint,
+                params=params,
+                timeout=timeout,
+                connection=connection,
             )
             if status == 200:
                 return text
@@ -146,30 +239,37 @@ def dispatch_get(endpoint: str, params: dict | None = None, retries: int = 3) ->
                 time.sleep(2**attempt)
                 continue
             return json.dumps({"error": f"HTTP {status}: {text.strip()}"})
-        except (ConnectionError, OSError) as e:
-            # Connection lost — try reconnect once, then retry
-            if attempt == 0 and _try_reconnect():
+        except transport.RequestNotSentError as e:
+            # Safe to retry only because connect() failed before request bytes
+            # were sent. Re-discover once in case Ghidra restarted.
+            reconnected = _try_reconnect(connection)
+            if reconnected is not None:
+                connection = reconnected
                 continue
             if attempt < retries - 1:
+                time.sleep(2**attempt)
                 continue
             return json.dumps({"error": str(e)})
+        except transport.RequestOutcomeUnknownError as e:
+            logger.warning("Ghidra request outcome unknown; not retrying %s: %s", endpoint, e)
+            return json.dumps({"error": f"{e}. The request may still be running in Ghidra and was not retried."})
+        except (ConnectionError, OSError) as e:
+            return json.dumps({"error": str(e)})
         except Exception as e:
-            if attempt < retries - 1:
-                continue
             return json.dumps({"error": str(e)})
 
     return json.dumps({"error": "Max retries exceeded"})
 
 
-def dispatch_post(
-    endpoint: str, data: dict, retries: int = 3, query_params: dict | None = None
-) -> str:
+def dispatch_post(endpoint: str, data: dict, retries: int = 3, query_params: dict | None = None) -> str:
     """POST JSON request via active transport. Returns raw response text."""
-    err = _ensure_connected()
+    connection, err = _resolve_connection_for_request()
     if err:
         return json.dumps({"error": err})
 
     data = _normalize_post_payload(endpoint, data)
+    data = _normalize_timeout_fields(data)
+    query_params = _normalize_timeout_fields(query_params)
     timeout = get_timeout(endpoint, data)
     # POST endpoints are non-idempotent (rename/create/set/delete/batch writes). Unlike GET,
     # they must NOT be blindly retried: if the request reached the server it may have already
@@ -179,17 +279,30 @@ def dispatch_post(
     for attempt in range(retries):
         try:
             text, status = transport.do_request(
-                "POST", endpoint, params=query_params, json_data=data, timeout=timeout
+                "POST",
+                endpoint,
+                params=query_params,
+                json_data=data,
+                timeout=timeout,
+                connection=connection,
             )
             if status == 200:
                 return text.strip()
             # Request reached the server (got an HTTP status) — do not retry a write.
             return json.dumps({"error": f"HTTP {status}: {text.strip()}"})
-        except (ConnectionError, OSError) as e:
-            # Pre-send connection failure: re-establish once and retry. A drop after the
-            # request was sent is indistinguishable here, so we only ever try this once.
-            if attempt == 0 and _try_reconnect():
+        except transport.RequestNotSentError as e:
+            reconnected = _try_reconnect(connection)
+            if reconnected is not None:
+                connection = reconnected
                 continue
+            if attempt < retries - 1:
+                time.sleep(2**attempt)
+                continue
+            return json.dumps({"error": str(e)})
+        except transport.RequestOutcomeUnknownError as e:
+            logger.warning("Ghidra write outcome unknown; not retrying %s: %s", endpoint, e)
+            return json.dumps({"error": f"{e}. The write may have been applied in Ghidra and was not retried."})
+        except (ConnectionError, OSError) as e:
             return json.dumps({"error": str(e)})
         except Exception as e:
             return json.dumps({"error": str(e)})

--- a/python/bridge_mcp_ghidra/registry.py
+++ b/python/bridge_mcp_ghidra/registry.py
@@ -1,5 +1,6 @@
 """Dynamic tool registration from /mcp/schema, plus tool-group management."""
 
+import asyncio
 import inspect
 import json
 import sys
@@ -33,8 +34,7 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
     # wrong-binary hazard strict mode closes. (open_program/close_program use
     # path/name, so they have no selector here and are unaffected.)
     program_selectors = [
-        name for name in properties
-        if name == "program" or name.endswith("_program") or name.startswith("program_")
+        name for name in properties if name == "program" or name.endswith("_program") or name.startswith("program_")
     ]
     is_post = http_method.upper() == "POST"
     has_schema_dry_run = "dry_run" in properties
@@ -48,11 +48,7 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
     def handler(**kwargs):
         # Sanitize address parameters before dispatch
         for pname, pdef in properties.items():
-            if (
-                pdef.get("param_type") == "address"
-                and pname in kwargs
-                and kwargs[pname] is not None
-            ):
+            if pdef.get("param_type") == "address" and pname in kwargs and kwargs[pname] is not None:
                 kwargs[pname] = sanitize_address(str(kwargs[pname]))
         # Synthetic bridge dry-run goes as a query param. Schema-declared
         # dry_run must stay in kwargs so its declared source (query/body) wins.
@@ -65,11 +61,7 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
         # explicitly provided, but the bridge is schema-driven and doesn't
         # know which were defaults. Empty string is not a meaningful value
         # for any current Ghidra endpoint — safe to filter.
-        filtered = {
-            k: v
-            for k, v in kwargs.items()
-            if v is not None and not (isinstance(v, str) and v == "")
-        }
+        filtered = {k: v for k, v in kwargs.items() if v is not None and not (isinstance(v, str) and v == "")}
         # Strict mode: refuse if any program selector is missing, so a forgotten
         # one fails loudly instead of running against the server's current
         # program. filtered has already dropped None and "", so absence is the
@@ -78,20 +70,20 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
             missing = [p for p in program_selectors if p not in filtered]
             if missing:
                 names = ", ".join(f"`{p}=`" for p in missing)
-                return json.dumps({
-                    "error": (
-                        f"Missing required program selector(s): {names} "
-                        "(GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS is set). "
-                        "Pass each explicitly to target the intended open program(s)."
-                    )
-                })
+                return json.dumps(
+                    {
+                        "error": (
+                            f"Missing required program selector(s): {names} "
+                            "(GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS is set). "
+                            "Pass each explicitly to target the intended open program(s)."
+                        )
+                    }
+                )
         if http_method == "GET":
             str_params = {k: str(v) for k, v in filtered.items()}
             if use_synthetic_dry_run and is_truthy(dry_run):
                 str_params["dry_run"] = "true"
-            return dispatch.dispatch_get(
-                endpoint, params=str_params if str_params else None
-            )
+            return dispatch.dispatch_get(endpoint, params=str_params if str_params else None)
         else:
             body_data = {}
             query_params = {}
@@ -120,9 +112,7 @@ def _build_tool_function(endpoint: str, http_method: str, params_schema: dict):
             default = None
             py_type = py_type | None if py_type != str else str | None
 
-        param = inspect.Parameter(
-            pname, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=py_type
-        )
+        param = inspect.Parameter(pname, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=py_type)
         if default is inspect.Parameter.empty:
             required_params.append(param)
         else:
@@ -157,7 +147,16 @@ def _register_tool_def(tool_def: dict) -> bool:
     http_method = tool_def.get("http_method", "GET")
     input_schema = tool_def.get("input_schema", {"type": "object", "properties": {}})
 
-    handler = _build_tool_function(endpoint, http_method, input_schema)
+    sync_handler = _build_tool_function(endpoint, http_method, input_schema)
+
+    async def handler(**kwargs):
+        # FastMCP calls synchronous tools directly on its event loop. Keep the
+        # blocking Ghidra HTTP lifecycle in a worker thread so one slow request
+        # cannot close or starve the entire MCP session.
+        return await state.run_blocking_ghidra_call(sync_handler, **kwargs)
+
+    handler.__signature__ = sync_handler.__signature__
+    handler.__annotations__ = sync_handler.__annotations__
     handler.__name__ = name
     handler.__doc__ = description
 
@@ -173,16 +172,11 @@ def _report_tool_registration_failures(failures: list[str]) -> None:
 
     shown = "; ".join(failures[:8])
     suffix = "..." if len(failures) > 8 else ""
-    sys.stderr.write(
-        f"[bridge_mcp_ghidra] {len(failures)} tool(s) failed to register: "
-        f"{shown}{suffix}\n"
-    )
+    sys.stderr.write(f"[bridge_mcp_ghidra] {len(failures)} tool(s) failed to register: " f"{shown}{suffix}\n")
     sys.stderr.flush()
 
 
-def register_tools_from_schema(
-    schema: list[dict], groups: set[str] | None = None
-) -> int:
+def register_tools_from_schema(schema: list[dict], groups: set[str] | None = None) -> int:
     """Register MCP tools from parsed schema.
 
     Args:
@@ -191,60 +185,65 @@ def register_tools_from_schema(
 
     Returns: count of registered tools.
     """
-    # Remove previously registered dynamic tools
-    for name in state._dynamic_tool_names:
-        try:
-            mcp._tool_manager._tools.pop(name, None)
-        except Exception as e:
-            # Reaches into FastMCP internals; if its private structure changes this
-            # would silently leak tools across reloads. Log so the breakage is visible.
-            logger.warning(
-                "Failed to unregister dynamic tool %r via mcp._tool_manager._tools "
-                "(FastMCP internals may have changed): %s", name, e)
-    state._dynamic_tool_names.clear()
-    state._loaded_groups.clear()
+    with state._tool_registry_lock:
+        # Remove previously registered dynamic tools
+        for name in state._dynamic_tool_names:
+            try:
+                mcp._tool_manager._tools.pop(name, None)
+            except Exception as e:
+                # Reaches into FastMCP internals; if its private structure changes this
+                # would silently leak tools across reloads. Log so the breakage is visible.
+                logger.warning(
+                    "Failed to unregister dynamic tool %r via mcp._tool_manager._tools "
+                    "(FastMCP internals may have changed): %s",
+                    name,
+                    e,
+                )
+        state._dynamic_tool_names.clear()
+        state._loaded_groups.clear()
 
-    # Store full schema for lazy loading
-    state._full_schema = _normalize_tool_def_names(schema)
+        # Store full schema for lazy loading
+        state._full_schema = _normalize_tool_def_names(schema)
 
-    count = 0
-    failures: list[str] = []
-    for tool_def in state._full_schema:
-        category = tool_def.get("category", "unknown")
-        if groups is not None and category not in groups:
-            continue
-        try:
-            if _register_tool_def(tool_def):
-                state._loaded_groups.add(category)
-                count += 1
-        except Exception as e:
-            name = tool_def.get("name", "<unnamed>")
-            failures.append(f"{name}: {e}")
+        count = 0
+        failures: list[str] = []
+        for tool_def in state._full_schema:
+            category = tool_def.get("category", "unknown")
+            if groups is not None and category not in groups:
+                continue
+            try:
+                if _register_tool_def(tool_def):
+                    state._loaded_groups.add(category)
+                    count += 1
+            except Exception as e:
+                name = tool_def.get("name", "<unnamed>")
+                failures.append(f"{name}: {e}")
 
-    _report_tool_registration_failures(failures)
+        _report_tool_registration_failures(failures)
 
-    return count
+        return count
 
 
 def _load_group(group_name: str) -> list[str]:
     """Load tools for a specific group from cached schema. Returns list of newly loaded tool names."""
-    loaded_names: list[str] = []
-    failures: list[str] = []
-    for tool_def in state._full_schema:
-        if tool_def.get("category") != group_name:
-            continue
-        name = tool_def["name"]
-        if name in state._dynamic_tool_names:
-            continue  # Already loaded
-        try:
-            if _register_tool_def(tool_def):
-                loaded_names.append(name)
-        except Exception as e:
-            failures.append(f"{name}: {e}")
-    if loaded_names:
-        state._loaded_groups.add(group_name)
-    _report_tool_registration_failures(failures)
-    return loaded_names
+    with state._tool_registry_lock:
+        loaded_names: list[str] = []
+        failures: list[str] = []
+        for tool_def in state._full_schema:
+            if tool_def.get("category") != group_name:
+                continue
+            name = tool_def["name"]
+            if name in state._dynamic_tool_names:
+                continue  # Already loaded
+            try:
+                if _register_tool_def(tool_def):
+                    loaded_names.append(name)
+            except Exception as e:
+                failures.append(f"{name}: {e}")
+        if loaded_names:
+            state._loaded_groups.add(group_name)
+        _report_tool_registration_failures(failures)
+        return loaded_names
 
 
 def _unload_group(group_name: str) -> int:
@@ -252,26 +251,29 @@ def _unload_group(group_name: str) -> int:
     if group_name in state._default_groups:
         return 0  # Default groups can't be unloaded
 
-    to_remove = []
-    for tool_def in state._full_schema:
-        if tool_def.get("category") == group_name:
-            name = tool_def["name"]
-            if name in state._dynamic_tool_names:
-                to_remove.append(name)
+    with state._tool_registry_lock:
+        to_remove = []
+        for tool_def in state._full_schema:
+            if tool_def.get("category") == group_name:
+                name = tool_def["name"]
+                if name in state._dynamic_tool_names:
+                    to_remove.append(name)
 
-    for name in to_remove:
-        try:
-            mcp._tool_manager._tools.pop(name, None)
-            state._dynamic_tool_names.remove(name)
-        except Exception as e:
-            # See unregister note above: FastMCP-internals access, log on failure.
-            logger.warning(
-                "Failed to unload tool %r via mcp._tool_manager._tools "
-                "(FastMCP internals may have changed): %s", name, e)
+        for name in to_remove:
+            try:
+                mcp._tool_manager._tools.pop(name, None)
+                state._dynamic_tool_names.remove(name)
+            except Exception as e:
+                # See unregister note above: FastMCP-internals access, log on failure.
+                logger.warning(
+                    "Failed to unload tool %r via mcp._tool_manager._tools " "(FastMCP internals may have changed): %s",
+                    name,
+                    e,
+                )
 
-    if to_remove:
-        state._loaded_groups.discard(group_name)
-    return len(to_remove)
+        if to_remove:
+            state._loaded_groups.discard(group_name)
+        return len(to_remove)
 
 
 def _get_group_info() -> list[dict]:
@@ -299,7 +301,10 @@ def _get_group_info() -> list[dict]:
     return result
 
 
-def _fetch_and_register_schema(load_all: bool = False) -> int:
+def _fetch_and_register_schema(
+    load_all: bool = False,
+    connection: state.ConnectionSnapshot | None = None,
+) -> int:
     """Fetch /mcp/schema from connected instance and register tools.
 
     Args:
@@ -309,16 +314,27 @@ def _fetch_and_register_schema(load_all: bool = False) -> int:
     """
     if not load_all:
         load_all = not state._lazy_mode
-    text, status = transport.do_request("GET", "/mcp/schema", timeout=10)
+    schema = _fetch_schema(connection=connection)
+    groups = None if load_all else state._default_groups
+    return register_tools_from_schema(schema, groups=groups)
+
+
+def _fetch_schema(connection: state.ConnectionSnapshot | None = None) -> list[dict]:
+    """Fetch and parse /mcp/schema without mutating registered tools."""
+    text, status = transport.do_request(
+        "GET",
+        "/mcp/schema",
+        timeout=10,
+        connection=connection,
+    )
     if status != 200:
         raise RuntimeError(f"Failed to fetch schema: HTTP {status}")
     raw = json.loads(text)
-    schema = _parse_schema(raw)
-    groups = None if load_all else state._default_groups
-    return register_tools_from_schema(schema, groups=groups)
+    return _parse_schema(raw)
 
 
 async def _notify_tools_changed(ctx: Context | None) -> None:
     """Send tools/list_changed notification if context is available."""
     if ctx is not None and ctx._request_context is not None:
+        state.remember_tools_changed_context(ctx)
         await ctx.request_context.session.send_tool_list_changed()

--- a/python/bridge_mcp_ghidra/state.py
+++ b/python/bridge_mcp_ghidra/state.py
@@ -6,10 +6,17 @@ Functions in other modules never use ``global`` on these names — they assign
 ``state.<name> = ...`` instead.
 """
 
+import asyncio
+import atexit
+import concurrent.futures
+import contextvars
 import os
 import threading
+from dataclasses import dataclass
+from functools import partial
+from contextlib import contextmanager
 
-from .config import CORE_GROUPS, logger
+from .config import CORE_GROUPS, MAX_CONCURRENT_GHIDRA_REQUESTS, logger
 
 # --------------------------------------------------------------------------
 # Connection state
@@ -19,10 +26,108 @@ _active_socket: str | None = None  # UDS socket path
 _active_tcp: str | None = None  # TCP base URL (e.g. "http://127.0.0.1:8089")
 _transport_mode: str = "none"  # "uds", "tcp", or "none"
 _connected_project: str | None = None  # Project name for auto-reconnect
+_connection_generation = 0
+_executor_lock = threading.Lock()
 
-# Serialization lock for Ghidra HTTP calls — prevents stdout corruption when
-# multiple MCP tool calls arrive concurrently (see GitHub issue #91).
-_ghidra_lock = threading.Lock()
+
+@dataclass(frozen=True)
+class ConnectionSnapshot:
+    mode: str
+    active_socket: str | None
+    active_tcp: str | None
+    connected_project: str | None
+    generation: int
+
+
+class RequestCancelHandle:
+    """Shared cancellation handle for one in-flight worker request."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._aborted = False
+        self._connections: set[object] = set()
+
+    def register_connection(self, conn: object) -> bool:
+        with self._lock:
+            if self._aborted:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                return False
+            self._connections.add(conn)
+            return True
+
+    def unregister_connection(self, conn: object) -> None:
+        with self._lock:
+            self._connections.discard(conn)
+
+    def abort(self) -> None:
+        with self._lock:
+            self._aborted = True
+            conns = list(self._connections)
+        for conn in conns:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    @property
+    def aborted(self) -> bool:
+        with self._lock:
+            return self._aborted
+
+    def run_if_not_aborted(self, func, /, *args, **kwargs):
+        """Run a small critical section only if the request is still live."""
+        with self._lock:
+            if self._aborted:
+                return None
+            return func(*args, **kwargs)
+
+    @contextmanager
+    def hold_send_window(self, conn: object):
+        """Prevent abort() from closing `conn` while a request send starts."""
+        with self._lock:
+            if self._aborted or conn not in self._connections:
+                yield False
+            else:
+                yield True
+
+
+def _create_worker_pool() -> concurrent.futures.ThreadPoolExecutor:
+    return concurrent.futures.ThreadPoolExecutor(
+        max_workers=MAX_CONCURRENT_GHIDRA_REQUESTS,
+        thread_name_prefix="GhidraMCP-Bridge",
+    )
+
+
+# Shared worker pool for blocking bridge-side I/O. The executor itself is the
+# process-wide concurrency limit, so embedded/multi-loop use cannot exceed the
+# configured request cap.
+_ghidra_executor = _create_worker_pool()
+
+# Connection routing is captured at request admission time and propagated via a
+# context variable into the worker thread.
+_request_connection: contextvars.ContextVar[ConnectionSnapshot | None] = contextvars.ContextVar(
+    "ghidra_request_connection", default=None
+)
+_request_cancel_handle: contextvars.ContextVar[RequestCancelHandle | None] = contextvars.ContextVar(
+    "ghidra_request_cancel_handle", default=None
+)
+
+# Multiple failed in-flight requests can notice the same Ghidra restart. Schema
+# discovery and dynamic tool registration mutate shared state and must happen
+# once at a time even though normal HTTP requests may proceed concurrently.
+_reconnect_lock = threading.RLock()
+
+# Dynamic tool registration reaches into FastMCP internals and mutates shared
+# name/group state. Keep those mutations serialized even though normal Ghidra
+# requests are concurrent.
+_tool_registry_lock = threading.RLock()
+_tools_changed_session_lock = threading.Lock()
+_tools_changed_targets: list[tuple[asyncio.AbstractEventLoop, object]] = []
+_active_request_handles_lock = threading.Lock()
+_active_request_handles: set[RequestCancelHandle] = set()
 
 # --------------------------------------------------------------------------
 # Strict program routing
@@ -48,6 +153,229 @@ def _init_require_selectors() -> None:
 
 
 _init_require_selectors()
+
+
+def get_connection_snapshot() -> ConnectionSnapshot:
+    """Capture the current global connection target atomically."""
+    with _reconnect_lock:
+        return ConnectionSnapshot(
+            mode=_transport_mode,
+            active_socket=_active_socket,
+            active_tcp=_active_tcp,
+            connected_project=_connected_project,
+            generation=_connection_generation,
+        )
+
+
+def get_request_connection_snapshot() -> ConnectionSnapshot | None:
+    """Get the request-bound connection snapshot, if one is active."""
+    return _request_connection.get()
+
+
+def get_request_cancel_handle() -> RequestCancelHandle | None:
+    """Get the request-bound cancellation handle, if one is active."""
+    return _request_cancel_handle.get()
+
+
+def set_connection_snapshot(
+    mode: str,
+    *,
+    active_socket: str | None = None,
+    active_tcp: str | None = None,
+    connected_project: str | None = None,
+) -> ConnectionSnapshot:
+    """Install a new global connection target and advance the generation."""
+    global _active_socket, _active_tcp, _transport_mode, _connected_project, _connection_generation
+    with _reconnect_lock:
+        _active_socket = active_socket
+        _active_tcp = active_tcp
+        _transport_mode = mode
+        _connected_project = connected_project
+        _connection_generation += 1
+        return ConnectionSnapshot(
+            mode=_transport_mode,
+            active_socket=_active_socket,
+            active_tcp=_active_tcp,
+            connected_project=_connected_project,
+            generation=_connection_generation,
+        )
+
+
+def maybe_promote_connection_snapshot(
+    previous: ConnectionSnapshot, candidate: ConnectionSnapshot
+) -> ConnectionSnapshot | None:
+    """Install `candidate` only if the global connection still equals `previous`."""
+    global _active_socket, _active_tcp, _transport_mode, _connected_project, _connection_generation
+    with _reconnect_lock:
+        current = ConnectionSnapshot(
+            mode=_transport_mode,
+            active_socket=_active_socket,
+            active_tcp=_active_tcp,
+            connected_project=_connected_project,
+            generation=_connection_generation,
+        )
+        if current != previous:
+            return None
+        _active_socket = candidate.active_socket
+        _active_tcp = candidate.active_tcp
+        _transport_mode = candidate.mode
+        _connected_project = candidate.connected_project
+        _connection_generation += 1
+        return ConnectionSnapshot(
+            mode=_transport_mode,
+            active_socket=_active_socket,
+            active_tcp=_active_tcp,
+            connected_project=_connected_project,
+            generation=_connection_generation,
+        )
+
+
+def build_connection_snapshot(
+    *,
+    mode: str,
+    active_socket: str | None = None,
+    active_tcp: str | None = None,
+    connected_project: str | None = None,
+    generation: int = 0,
+) -> ConnectionSnapshot:
+    """Construct an explicit connection snapshot without mutating global state."""
+    return ConnectionSnapshot(
+        mode=mode,
+        active_socket=active_socket,
+        active_tcp=active_tcp,
+        connected_project=connected_project,
+        generation=generation,
+    )
+
+
+def _capture_request_connection_snapshot() -> ConnectionSnapshot:
+    """Capture a request-bound snapshot atomically with route/schema switches."""
+    with _tool_registry_lock:
+        return get_connection_snapshot()
+
+
+def remember_tools_changed_context(ctx) -> None:
+    """Remember one MCP session that can receive tools/list_changed."""
+    if ctx is None or getattr(ctx, "_request_context", None) is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    session = ctx.request_context.session
+    with _tools_changed_session_lock:
+        for existing_loop, existing_session in _tools_changed_targets:
+            if existing_loop is loop and existing_session is session:
+                return
+        _tools_changed_targets.append((loop, session))
+
+
+def notify_tools_changed_from_worker() -> None:
+    """Best-effort tools/list_changed notification from a worker thread."""
+    with _tools_changed_session_lock:
+        targets = list(_tools_changed_targets)
+    stale: list[tuple[asyncio.AbstractEventLoop, object]] = []
+    for loop, session in targets:
+        if loop.is_closed():
+            stale.append((loop, session))
+            continue
+        try:
+            asyncio.run_coroutine_threadsafe(session.send_tool_list_changed(), loop)
+        except Exception:
+            stale.append((loop, session))
+    if stale:
+        with _tools_changed_session_lock:
+            for target in stale:
+                if target in _tools_changed_targets:
+                    _tools_changed_targets.remove(target)
+
+
+def _get_worker_pool() -> concurrent.futures.ThreadPoolExecutor:
+    global _ghidra_executor
+    with _executor_lock:
+        if _ghidra_executor is None:
+            _ghidra_executor = _create_worker_pool()
+        return _ghidra_executor
+
+
+async def run_in_worker(func, /, *args, done_callback=None, **kwargs):
+    """Run blocking bridge code in a worker thread."""
+    context = contextvars.copy_context()
+    work = partial(context.run, func, *args, **kwargs)
+    future = _get_worker_pool().submit(work)
+    if done_callback is not None:
+
+        def _on_done(done):
+            try:
+                result = done.result()
+            except Exception:
+                return
+            try:
+                done_callback(result)
+            except Exception:
+                logger.exception("run_in_worker done_callback failed")
+
+        future.add_done_callback(_on_done)
+    return await asyncio.wrap_future(future)
+
+
+async def run_blocking_ghidra_call(
+    func,
+    /,
+    *args,
+    bind_connection: bool = True,
+    connection: ConnectionSnapshot | None = None,
+    **kwargs,
+):
+    """Run one blocking Ghidra call with cancellation-safe request binding."""
+    snapshot = connection if bind_connection else None
+    if bind_connection and snapshot is None:
+        snapshot = _capture_request_connection_snapshot()
+    cancel_handle = RequestCancelHandle()
+    with _active_request_handles_lock:
+        _active_request_handles.add(cancel_handle)
+    token = _request_connection.set(snapshot) if bind_connection else None
+    cancel_token = _request_cancel_handle.set(cancel_handle)
+    context = contextvars.copy_context()
+    work = partial(context.run, func, *args, **kwargs)
+    future = _get_worker_pool().submit(work)
+    wrapped = asyncio.wrap_future(future)
+    try:
+        return await asyncio.shield(wrapped)
+    except asyncio.CancelledError:
+        if future.cancel():
+            raise
+        cancel_handle.abort()
+        try:
+            await asyncio.wait_for(wrapped, timeout=1)
+        except asyncio.TimeoutError:
+            pass
+        raise
+    finally:
+        with _active_request_handles_lock:
+            _active_request_handles.discard(cancel_handle)
+        _request_cancel_handle.reset(cancel_token)
+        if token is not None:
+            _request_connection.reset(token)
+
+
+def shutdown_worker_pool(wait: bool = False) -> None:
+    """Stop the shared executor used by bridge-side worker offload."""
+    global _ghidra_executor
+    with _active_request_handles_lock:
+        active_handles = list(_active_request_handles)
+    for handle in active_handles:
+        handle.abort()
+    with _executor_lock:
+        executor = _ghidra_executor
+        if executor is None:
+            return
+        _ghidra_executor = None
+    executor.shutdown(wait=wait, cancel_futures=True)
+
+
+atexit.register(shutdown_worker_pool, False)
+
 
 # --------------------------------------------------------------------------
 # Tool-registration state

--- a/python/bridge_mcp_ghidra/static_tools.py
+++ b/python/bridge_mcp_ghidra/static_tools.py
@@ -14,8 +14,160 @@ from .server import Context, mcp
 from .validation import validate_server_url
 
 
-@mcp.tool()
-def list_instances() -> str:
+def _connect_instance_sync(project: str) -> dict:
+    """Blocking connect_instance implementation for worker-thread execution."""
+    cancel_handle = state.get_request_cancel_handle()
+
+    def _commit_if_live(func, /, *args, **kwargs):
+        if cancel_handle is None:
+            return func(*args, **kwargs)
+        return cancel_handle.run_if_not_aborted(func, *args, **kwargs)
+
+    instances = discovery.discover_instances()
+
+    # Try UDS instances first
+    match = None
+    matched_tcp_url = None
+    if instances:
+        for inst in instances:
+            if inst.get("project", "") == project:
+                match = inst
+                break
+        if not match:
+            for inst in instances:
+                if project.lower() in inst.get("project", "").lower():
+                    match = inst
+                    break
+        if match and not transport.uds_supported():
+            matched_tcp_url = match.get("url")
+        elif match:
+            candidate = state.build_connection_snapshot(
+                mode="uds",
+                active_socket=match["socket"],
+                connected_project=match.get("project"),
+            )
+            try:
+                schema = registry._fetch_schema(connection=candidate)
+            except Exception as e:
+                return {
+                    "error": f"Schema fetch failed: {e}",
+                    "socket": match["socket"],
+                }
+            if cancel_handle is not None and cancel_handle.aborted:
+                return {"error": "connect_instance cancelled before commit"}
+            with state._tool_registry_lock:
+                result = _commit_if_live(
+                    lambda: (
+                        registry.register_tools_from_schema(
+                            schema,
+                            groups=None if not state._lazy_mode else state._default_groups,
+                        ),
+                        state.set_connection_snapshot(
+                            "uds",
+                            active_socket=match["socket"],
+                            active_tcp=None,
+                            connected_project=match.get("project"),
+                        ),
+                    )
+                )
+                if result is None:
+                    return {"error": "connect_instance cancelled before commit"}
+                count, installed = result
+            total = len(state._full_schema)
+            note = (
+                f"Loaded {count}/{total} tools (default groups). Use load_tool_group() for more."
+                if state._lazy_mode
+                else f"Loaded all {count} tools on connect."
+            )
+            return {
+                "connected": True,
+                "transport": "uds",
+                "project": installed.connected_project,
+                "socket": match["socket"],
+                "pid": match.get("pid"),
+                "tools_registered": count,
+                "tools_total": total,
+                "loaded_groups": sorted(state._loaded_groups),
+                "note": note,
+            }
+
+    env_tcp = os.getenv("GHIDRA_MCP_URL")
+    if env_tcp:
+        tcp_url = env_tcp
+    elif matched_tcp_url:
+        tcp_url = matched_tcp_url
+    elif match is None and instances and any(inst.get("project") for inst in instances):
+        available = [inst.get("project", "unknown") for inst in instances]
+        return {
+            "error": (
+                f"No instance matching '{project}' (UDS: {len(instances)} found, "
+                f"none matched). Refusing to use any instance's tcp_port - would "
+                f"connect to the wrong project. Use list_instances() to see what's "
+                f"available."
+            ),
+            "available": available,
+        }
+    else:
+        scanned = discovery._scan_tcp_for_project(project)
+        tcp_url = scanned if scanned else DEFAULT_TCP_URL
+    if not validate_server_url(tcp_url):
+        return {
+            "error": f"Refusing to connect to invalid TCP URL: {tcp_url}. Expected http://<127.0.0.1|localhost|::1>:<port> (http scheme and an explicit port are required)."
+        }
+
+    candidate = state.build_connection_snapshot(
+        mode="tcp",
+        active_tcp=tcp_url,
+        connected_project=match.get("project") if match else None,
+    )
+    try:
+        schema = registry._fetch_schema(connection=candidate)
+    except Exception as e:
+        available = [inst.get("project", "unknown") for inst in instances]
+        return {
+            "error": f"No instance matching '{project}' (UDS: {len(instances)} found, TCP {tcp_url}: {e})",
+            "available": available,
+        }
+    if cancel_handle is not None and cancel_handle.aborted:
+        return {"error": "connect_instance cancelled before commit"}
+
+    with state._tool_registry_lock:
+        result = _commit_if_live(
+            lambda: (
+                registry.register_tools_from_schema(
+                    schema,
+                    groups=None if not state._lazy_mode else state._default_groups,
+                ),
+                state.set_connection_snapshot(
+                    "tcp",
+                    active_socket=None,
+                    active_tcp=tcp_url,
+                    connected_project=match.get("project") if match else None,
+                ),
+            )
+        )
+        if result is None:
+            return {"error": "connect_instance cancelled before commit"}
+        count, _installed = result
+
+    total = len(state._full_schema)
+    note = (
+        f"Loaded {count}/{total} tools (default groups). Use load_tool_group() for more."
+        if state._lazy_mode
+        else f"Loaded all {count} tools on connect."
+    )
+    return {
+        "connected": True,
+        "transport": "tcp",
+        "url": tcp_url,
+        "tools_registered": count,
+        "tools_total": total,
+        "loaded_groups": sorted(state._loaded_groups),
+        "note": note,
+    }
+
+
+def _list_instances_sync() -> str:
     """
     List known Ghidra instances from UDS discovery and the active TCP fallback.
 
@@ -28,27 +180,35 @@ def list_instances() -> str:
         instances.append(tcp_instance)
 
     if not instances:
-        return json.dumps(
-            {"instances": [], "note": "No running Ghidra instances found."}
-        )
+        return json.dumps({"instances": [], "note": "No running Ghidra instances found."})
 
     for inst in instances:
         if inst.get("transport") == "tcp":
-            inst["connected"] = (
-                state._transport_mode == "tcp" and inst.get("url") == state._active_tcp
-            )
+            inst["connected"] = state._transport_mode == "tcp" and inst.get("url") == state._active_tcp
         else:
             # UDS-discovered instances may carry a TCP url too (Windows
             # enrichment) — either transport counts as connected.
             inst["connected"] = inst["socket"] == state._active_socket or (
-                state._transport_mode == "tcp"
-                and bool(inst.get("url"))
-                and inst.get("url") == state._active_tcp
+                state._transport_mode == "tcp" and bool(inst.get("url")) and inst.get("url") == state._active_tcp
             )
 
-    return json.dumps(
-        {"instances": [_summarize_instance(i) for i in instances]}, indent=2
-    )
+    return json.dumps({"instances": [_summarize_instance(i) for i in instances]}, indent=2)
+
+
+def _load_groups_sync(group_names: list[str]) -> list[str]:
+    loaded: list[str] = []
+    for name in group_names:
+        loaded.extend(registry._load_group(name))
+    return loaded
+
+
+@mcp.tool(name="list_instances")
+async def _list_instances_tool() -> str:
+    return await state.run_in_worker(_list_instances_sync)
+
+
+def list_instances() -> str:
+    return _list_instances_sync()
 
 
 # A project can hold hundreds of programs; only the open ones are actionable.
@@ -104,139 +264,14 @@ async def connect_instance(project: str, ctx: Context | None = None) -> str:
     Args:
         project: Project name (or substring) to connect to
     """
-    instances = discovery.discover_instances()
-
-    # Try UDS instances first
-    match = None
-    matched_tcp_url = None
-    if instances:
-        for inst in instances:
-            if inst.get("project", "") == project:
-                match = inst
-                break
-        if not match:
-            for inst in instances:
-                if project.lower() in inst.get("project", "").lower():
-                    match = inst
-                    break
-        if match and not transport.uds_supported():
-            # Windows CPython can't dial the socket it just matched; the
-            # discovery enrichment recorded the instance's TCP url — route
-            # the connection there instead of failing the UDS handshake.
-            matched_tcp_url = match.get("url")
-        elif match:
-            state._active_socket = match["socket"]
-            state._active_tcp = None
-            state._transport_mode = "uds"
-            state._connected_project = match.get("project")
-
-            try:
-                count = registry._fetch_and_register_schema()
-                total = len(state._full_schema)
-                note = (
-                    f"Loaded {count}/{total} tools (default groups). Use load_tool_group() for more."
-                    if state._lazy_mode
-                    else f"Loaded all {count} tools on connect."
-                )
-                await registry._notify_tools_changed(ctx)
-                return json.dumps(
-                    {
-                        "connected": True,
-                        "transport": "uds",
-                        "project": state._connected_project,
-                        "socket": match["socket"],
-                        "pid": match.get("pid"),
-                        "tools_registered": count,
-                        "tools_total": total,
-                        "loaded_groups": sorted(state._loaded_groups),
-                        "note": note,
-                    }
-                )
-            except Exception as e:
-                return json.dumps(
-                    {"error": f"Schema fetch failed: {e}", "socket": state._active_socket}
-                )
-
-    # Try TCP fallback. The behavior depends on what UDS discovery returned:
-    #
-    #   * If GHIDRA_MCP_URL is set, it always wins (explicit user override).
-    #   * If a UDS instance matched but Python can't dial UDS (Windows), use
-    #     the TCP url discovery recorded for that exact instance.
-    #   * If UDS found one or more instances with project metadata and none
-    #     matched the project, refuse to fall back to TCP -- that's how we
-    #     previously silently connected to the wrong instance (Copilot #196
-    #     review item).
-    #   * If UDS found no usable project metadata, scan the TCP port range
-    #     looking for a /mcp/instance_info that matches the project. Handles
-    #     TCP-only and native Windows cases where AF_UNIX is unavailable.
-    #   * If no scan match either, try the default port as a last resort.
-    env_tcp = os.getenv("GHIDRA_MCP_URL")
-    if env_tcp:
-        tcp_url = env_tcp
-    elif matched_tcp_url:
-        tcp_url = matched_tcp_url
-    elif match is None and instances and any(inst.get("project") for inst in instances):
-        # UDS found instances but none matched the requested project. Don't
-        # randomly pick another instance's tcp_port — that connects to the
-        # wrong project. Return the "no match" error directly.
-        available = [inst.get("project", "unknown") for inst in instances]
-        return json.dumps(
-            {
-                "error": (
-                    f"No instance matching '{project}' (UDS: {len(instances)} found, "
-                    f"none matched). Refusing to use any instance's tcp_port — would "
-                    f"connect to the wrong project. Use list_instances() to see what's "
-                    f"available."
-                ),
-                "available": available,
-            }
-        )
-    else:
-        # No usable UDS project metadata. Scan the TCP port range to find one
-        # matching the project. _scan_tcp_for_project returns the URL of the
-        # first matching instance, or None if nothing matched.
-        scanned = discovery._scan_tcp_for_project(project)
-        tcp_url = scanned if scanned else DEFAULT_TCP_URL
-    if not validate_server_url(tcp_url):
-        return json.dumps(
-            {
-                "error": f"Refusing to connect to invalid TCP URL: {tcp_url}. Expected http://<127.0.0.1|localhost|::1>:<port> (http scheme and an explicit port are required)."
-            }
-        )
-    try:
-        state._active_tcp = tcp_url
-        state._active_socket = None
-        state._transport_mode = "tcp"
-        state._connected_project = match.get("project") if match else None
-        count = registry._fetch_and_register_schema()
-        total = len(state._full_schema)
-        note = (
-            f"Loaded {count}/{total} tools (default groups). Use load_tool_group() for more."
-            if state._lazy_mode
-            else f"Loaded all {count} tools on connect."
-        )
+    result = await state.run_blocking_ghidra_call(
+        _connect_instance_sync,
+        project,
+        bind_connection=False,
+    )
+    if result.get("connected"):
         await registry._notify_tools_changed(ctx)
-        return json.dumps(
-            {
-                "connected": True,
-                "transport": "tcp",
-                "url": tcp_url,
-                "tools_registered": count,
-                "tools_total": total,
-                "loaded_groups": sorted(state._loaded_groups),
-                "note": note,
-            }
-        )
-    except Exception as e:
-        state._transport_mode = "none"
-        state._active_tcp = None
-        available = [inst.get("project", "unknown") for inst in instances]
-        return json.dumps(
-            {
-                "error": f"No instance matching '{project}' (UDS: {len(instances)} found, TCP {tcp_url}: {e})",
-                "available": available,
-            }
-        )
+    return json.dumps(result)
 
 
 @mcp.tool()
@@ -248,9 +283,7 @@ def list_tool_groups() -> str:
     Use load_tool_group(group) to load a group's tools.
     """
     if not state._full_schema:
-        return json.dumps(
-            {"error": "No instance connected. Use connect_instance() first."}
-        )
+        return json.dumps({"error": "No instance connected. Use connect_instance() first."})
     groups = registry._get_group_info()
     return json.dumps({"groups": groups, "total_tools": len(state._full_schema)}, indent=2)
 
@@ -266,18 +299,22 @@ async def load_tool_group(group: str, ctx: Context | None = None) -> str:
         group: Category name (e.g. "function", "datatype") or "all"
     """
     if not state._full_schema:
-        return json.dumps(
-            {"error": "No instance connected. Use connect_instance() first."}
-        )
+        return json.dumps({"error": "No instance connected. Use connect_instance() first."})
+
+    state.remember_tools_changed_context(ctx)
+
+    def _notify_if_changed(result):
+        if result:
+            state.notify_tools_changed_from_worker()
 
     if group == "all":
         # Load all unloaded groups
         all_groups = {td.get("category", "unknown") for td in state._full_schema}
-        all_loaded: list[str] = []
-        for g in sorted(all_groups):
-            all_loaded.extend(registry._load_group(g))
-        if all_loaded:
-            await registry._notify_tools_changed(ctx)
+        all_loaded = await state.run_in_worker(
+            _load_groups_sync,
+            sorted(all_groups),
+            done_callback=_notify_if_changed,
+        )
         return json.dumps(
             {
                 "loaded": "all",
@@ -287,14 +324,16 @@ async def load_tool_group(group: str, ctx: Context | None = None) -> str:
             }
         )
 
-    loaded_names = registry._load_group(group)
+    loaded_names = await state.run_in_worker(
+        registry._load_group,
+        group,
+        done_callback=_notify_if_changed,
+    )
     if not loaded_names:
         available = sorted({td.get("category", "unknown") for td in state._full_schema})
         if group in state._loaded_groups:
             # Already loaded — return the tool names so the agent knows what's callable
-            already = sorted(
-                td["name"] for td in state._full_schema if td.get("category") == group
-            )
+            already = sorted(td["name"] for td in state._full_schema if td.get("category") == group)
             return json.dumps(
                 {
                     "message": f"Group '{group}' is already loaded.",
@@ -308,8 +347,6 @@ async def load_tool_group(group: str, ctx: Context | None = None) -> str:
                 "available_groups": available,
             }
         )
-
-    await registry._notify_tools_changed(ctx)
     return json.dumps(
         {
             "loaded": group,
@@ -337,13 +374,15 @@ async def unload_tool_group(group: str, ctx: Context | None = None) -> str:
             }
         )
 
-    removed = registry._unload_group(group)
-    if removed == 0:
-        return json.dumps(
-            {"message": f"Group '{group}' is not loaded or has no tools."}
-        )
+    state.remember_tools_changed_context(ctx)
 
-    await registry._notify_tools_changed(ctx)
+    removed = await state.run_in_worker(
+        registry._unload_group,
+        group,
+        done_callback=lambda result: result > 0 and state.notify_tools_changed_from_worker(),
+    )
+    if removed == 0:
+        return json.dumps({"message": f"Group '{group}' is not loaded or has no tools."})
     return json.dumps(
         {
             "unloaded": group,
@@ -504,7 +543,7 @@ async def import_file(
     if compiler_spec:
         payload["compiler_spec"] = compiler_spec
 
-    result = dispatch.dispatch_post("/import_file", payload)
+    result = await state.run_blocking_ghidra_call(dispatch.dispatch_post, "/import_file", payload)
 
     # Parse result to check if analysis was started
     try:
@@ -522,8 +561,8 @@ async def import_file(
             await asyncio.sleep(5)  # Initial delay
             for _ in range(360):  # Up to 30 minutes
                 try:
-                    status_text = dispatch.dispatch_get(
-                        "/analysis_status", {"program": program_name}
+                    status_text = await state.run_blocking_ghidra_call(
+                        dispatch.dispatch_get, "/analysis_status", {"program": program_name}
                     )
                     status = json.loads(status_text)
                     status_data = status.get("data", status)
@@ -550,48 +589,61 @@ def _auto_connect():
     if len(instances) == 1:
         inst = instances[0]
         if transport.uds_supported():
-            state._active_socket = inst["socket"]
-            state._transport_mode = "uds"
-            state._connected_project = inst.get("project")
-            logger.info(f"Auto-connecting via UDS to {state._connected_project or 'unknown'}")
+            candidate = state.build_connection_snapshot(
+                mode="uds",
+                active_socket=inst["socket"],
+                connected_project=inst.get("project"),
+            )
+            logger.info(f"Auto-connecting via UDS to {inst.get('project') or 'unknown'}")
             try:
-                count = registry._fetch_and_register_schema()
-                logger.info(
-                    f"Auto-registered {count} tools from {state._connected_project or 'unknown'}"
-                )
+                schema = registry._fetch_schema(connection=candidate)
+                with state._tool_registry_lock:
+                    count = registry.register_tools_from_schema(
+                        schema,
+                        groups=None if not state._lazy_mode else state._default_groups,
+                    )
+                    state.set_connection_snapshot(
+                        "uds",
+                        active_socket=inst["socket"],
+                        active_tcp=None,
+                        connected_project=inst.get("project"),
+                    )
+                logger.info(f"Auto-registered {count} tools from {inst.get('project') or 'unknown'}")
                 return
             except Exception as e:
                 logger.warning(f"UDS auto-connect schema fetch failed: {e}")
-                state._active_socket = None
-                state._transport_mode = "none"
         elif inst.get("url") and validate_server_url(inst["url"]):
             # Windows CPython can't dial the discovered socket; discovery
             # enriched it with the instance's TCP url — connect there.
-            state._active_tcp = inst["url"]
-            state._transport_mode = "tcp"
-            state._connected_project = inst.get("project")
+            candidate = state.build_connection_snapshot(
+                mode="tcp",
+                active_tcp=inst["url"],
+                connected_project=inst.get("project"),
+            )
             logger.info(
                 f"Auto-connecting via TCP ({inst['url']}) to "
-                f"{state._connected_project or 'unknown'} (UDS unavailable on this Python)"
+                f"{inst.get('project') or 'unknown'} (UDS unavailable on this Python)"
             )
             try:
-                count = registry._fetch_and_register_schema()
-                logger.info(
-                    f"Auto-registered {count} tools from {state._connected_project or 'unknown'}"
-                )
+                schema = registry._fetch_schema(connection=candidate)
+                with state._tool_registry_lock:
+                    count = registry.register_tools_from_schema(
+                        schema,
+                        groups=None if not state._lazy_mode else state._default_groups,
+                    )
+                    state.set_connection_snapshot(
+                        "tcp",
+                        active_socket=None,
+                        active_tcp=inst["url"],
+                        connected_project=inst.get("project"),
+                    )
+                logger.info(f"Auto-registered {count} tools from {inst.get('project') or 'unknown'}")
                 return
             except Exception as e:
                 logger.warning(f"TCP auto-connect schema fetch failed: {e}")
-                state._active_tcp = None
-                state._transport_mode = "none"
     elif len(instances) > 1:
-        names = ", ".join(
-            i.get("project") or i.get("socket") or "?" for i in instances
-        )
-        logger.info(
-            f"Multiple UDS instances found ({len(instances)}: {names}). "
-            "Use connect_instance() to choose."
-        )
+        names = ", ".join(i.get("project") or i.get("socket") or "?" for i in instances)
+        logger.info(f"Multiple UDS instances found ({len(instances)}: {names}). " "Use connect_instance() to choose.")
         # Do NOT fall through to the TCP fallback — that would silently
         # connect to whichever Ghidra happened to bind 8089 (possibly a
         # third instance entirely) right after telling the user to choose.
@@ -605,14 +657,20 @@ def _auto_connect():
         logger.warning(f"Refusing to auto-connect to non-local URL: {tcp_url}")
         return
     try:
-        state._active_tcp = tcp_url
-        state._transport_mode = "tcp"
-        count = registry._fetch_and_register_schema()
+        candidate = state.build_connection_snapshot(mode="tcp", active_tcp=tcp_url)
+        schema = registry._fetch_schema(connection=candidate)
+        with state._tool_registry_lock:
+            count = registry.register_tools_from_schema(
+                schema,
+                groups=None if not state._lazy_mode else state._default_groups,
+            )
+            state.set_connection_snapshot(
+                "tcp",
+                active_socket=None,
+                active_tcp=tcp_url,
+                connected_project=None,
+            )
         logger.info(f"Auto-connected via TCP to {tcp_url}, registered {count} tools")
     except Exception:
-        state._active_tcp = None
-        state._transport_mode = "none"
         if not instances:
-            logger.info(
-                "No Ghidra instances found. Tools will be registered on connect_instance()."
-            )
+            logger.info("No Ghidra instances found. Tools will be registered on connect_instance().")

--- a/python/bridge_mcp_ghidra/transport.py
+++ b/python/bridge_mcp_ghidra/transport.py
@@ -20,6 +20,54 @@ def _auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {AUTH_TOKEN}"} if AUTH_TOKEN else {}
 
 
+class RequestNotSentError(ConnectionError):
+    """The transport could not connect, so the request was not sent."""
+
+
+class RequestOutcomeUnknownError(ConnectionError):
+    """The request may have reached Ghidra, but no complete response arrived."""
+
+
+def _request_over_connection(
+    conn: http.client.HTTPConnection,
+    method: str,
+    path: str,
+    body: bytes | None,
+    headers: dict[str, str],
+) -> tuple[str, int]:
+    """Execute one request while preserving whether retrying is safe."""
+    cancel_handle = state.get_request_cancel_handle()
+    if cancel_handle is not None and not cancel_handle.register_connection(conn):
+        raise RequestOutcomeUnknownError(f"Request aborted before start for {method} {path}")
+    try:
+        conn.connect()
+    except Exception as exc:
+        conn.close()
+        raise RequestNotSentError(f"Could not connect for {method} {path}: {exc}") from exc
+
+    if cancel_handle is not None and cancel_handle.aborted:
+        conn.close()
+        raise RequestOutcomeUnknownError(f"Request aborted before send for {method} {path}")
+
+    try:
+        if cancel_handle is not None:
+            with cancel_handle.hold_send_window(conn) as can_send:
+                if not can_send:
+                    raise RequestOutcomeUnknownError(f"Request aborted before send for {method} {path}")
+                conn.request(method, path, body=body, headers=headers)
+        else:
+            conn.request(method, path, body=body, headers=headers)
+        response = conn.getresponse()
+        result = response.read().decode("utf-8")
+        return result, response.status
+    except Exception as exc:
+        raise RequestOutcomeUnknownError(f"No complete response for {method} {path}: {exc}") from exc
+    finally:
+        if cancel_handle is not None:
+            cancel_handle.unregister_connection(conn)
+        conn.close()
+
+
 # ==========================================================================
 # UDS Transport
 # ==========================================================================
@@ -191,16 +239,7 @@ def uds_request(
     if body:
         headers["Content-Length"] = str(len(body))
 
-    try:
-        conn.request(method, path, body=body, headers=headers)
-        response = conn.getresponse()
-        result = response.read().decode("utf-8")
-        status = response.status
-        conn.close()
-        return result, status
-    except Exception:
-        conn.close()
-        raise
+    return _request_over_connection(conn, method, path, body, headers)
 
 
 # ==========================================================================
@@ -232,16 +271,7 @@ def tcp_request(
     if body:
         headers["Content-Length"] = str(len(body))
 
-    try:
-        conn.request(method, path, body=body, headers=headers)
-        response = conn.getresponse()
-        result = response.read().decode("utf-8")
-        status = response.status
-        conn.close()
-        return result, status
-    except Exception:
-        conn.close()
-        raise
+    return _request_over_connection(conn, method, path, body, headers)
 
 
 # ==========================================================================
@@ -255,22 +285,19 @@ def do_request(
     params: dict | None = None,
     json_data: dict | None = None,
     timeout: int = 30,
+    connection: state.ConnectionSnapshot | None = None,
 ) -> tuple[str, int]:
-    """Route request to the active transport (UDS or TCP).
+    """Route a request to the active transport.
 
-    All requests are serialized via _ghidra_lock to prevent concurrent
-    responses from corrupting JSON-RPC framing on stdio (GitHub #91).
+    Routing is by an immutable request-bound connection snapshot when present,
+    not by whatever global target happens to be current when the worker finally
+    runs. This keeps in-flight requests pinned to the project they were
+    admitted against even if connect_instance() switches the bridge later.
     """
-    with state._ghidra_lock:
-        if state._transport_mode == "uds" and state._active_socket:
-            return uds_request(
-                state._active_socket, method, endpoint, params, json_data, timeout
-            )
-        elif state._transport_mode == "tcp" and state._active_tcp:
-            return tcp_request(
-                state._active_tcp, method, endpoint, params, json_data, timeout
-            )
-        else:
-            raise ConnectionError(
-                "No Ghidra instance connected. Use connect_instance() first."
-            )
+    connection = connection or state.get_request_connection_snapshot() or state.get_connection_snapshot()
+    if connection.mode == "uds" and connection.active_socket:
+        return uds_request(connection.active_socket, method, endpoint, params, json_data, timeout)
+    elif connection.mode == "tcp" and connection.active_tcp:
+        return tcp_request(connection.active_tcp, method, endpoint, params, json_data, timeout)
+    else:
+        raise ConnectionError("No Ghidra instance connected. Use connect_instance() first.")

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class FunctionService {
 
     private static final int DECOMPILE_TIMEOUT_SECONDS = 60;  // Increased from 30s to 60s for large functions
+    private static final int MAX_DECOMPILE_TIMEOUT_SECONDS = 1800;
 
     /** Matches any of the five Windows calling-convention keywords. */
     private static final Pattern CALLING_CONV_PATTERN = Pattern.compile(
@@ -160,6 +161,9 @@ public class FunctionService {
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
         if (addressStr == null || addressStr.isEmpty()) return Response.err("Address or function name is required");
+        if (timeoutSeconds <= 0 || timeoutSeconds > MAX_DECOMPILE_TIMEOUT_SECONDS) {
+            return Response.err("timeout must be between 1 and " + MAX_DECOMPILE_TIMEOUT_SECONDS + " seconds");
+        }
 
         DecompInterface decomp = null;
         try {

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -24,10 +24,12 @@ import ghidra.app.util.importer.MessageLog;
 import ghidra.app.util.opinion.LoadResults;
 import ghidra.util.Msg;
 import ghidra.util.task.ConsoleTaskMonitor;
+import ghidra.util.task.TimeoutTaskMonitor;
 
 import javax.swing.SwingUtilities;
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,6 +40,8 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @McpToolGroup(value = "program", description = "Program management, script execution, memory read, bookmarks, save")
 public class ProgramScriptService {
+
+    private static final int MAX_SCRIPT_TIMEOUT_SECONDS = 1800;
 
     private final ProgramProvider programProvider;
     private final ThreadingStrategy threadingStrategy;
@@ -1900,6 +1904,10 @@ public class ProgramScriptService {
             @Param(value = "script_path", source = ParamSource.BODY) String scriptPath,
             @Param(value = "args", source = ParamSource.BODY, defaultValue = "") String scriptArgs,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
+        return runGhidraScript(scriptPath, scriptArgs, programName, 0);
+    }
+
+    public Response runGhidraScript(String scriptPath, String scriptArgs, String programName, int timeoutSeconds) {
         // Defense in depth: the script-execution gate belongs on the sink, not
         // only on the callers. runGhidraScriptWithCapture already checks this
         // before delegating here; enforcing it again means no current or future
@@ -1929,6 +1937,7 @@ public class ProgramScriptService {
         // before reading it, otherwise the captured text can be truncated.
         final StringWriter[] scriptWriterHolder = {null};
         final PrintWriter[] scriptPrintWriterHolder = {null};
+        final TimeoutTaskMonitor[] scriptMonitorHolder = {null};
 
         // Get the PluginTool for script state (GUI mode only)
         final PluginTool pluginTool = getToolFromProvider();
@@ -2050,7 +2059,18 @@ public class ProgramScriptService {
                         scriptState = new ghidra.app.script.GhidraState(null, null, program, location, null, null);
                     }
 
-                    ghidra.util.task.TaskMonitor scriptMonitor = new ghidra.util.task.ConsoleTaskMonitor();
+                    ghidra.util.task.TaskMonitor scriptMonitor;
+                    if (timeoutSeconds > 0) {
+                        TimeoutTaskMonitor timeoutMonitor = TimeoutTaskMonitor.timeoutIn(
+                                timeoutSeconds,
+                                TimeUnit.SECONDS,
+                                new ConsoleTaskMonitor());
+                        scriptMonitorHolder[0] = timeoutMonitor;
+                        scriptMonitor = timeoutMonitor;
+                    }
+                    else {
+                        scriptMonitor = new ConsoleTaskMonitor();
+                    }
 
                     script.set(scriptState, scriptMonitor, scriptPrintWriter);
 
@@ -2115,6 +2135,9 @@ public class ProgramScriptService {
 
                     Msg.error(this, "Script execution failed: " + scriptPath, e);
                 } finally {
+                    if (scriptMonitorHolder[0] != null) {
+                        scriptMonitorHolder[0].cancel();
+                    }
                     // Restore original output streams
                     System.setOut(originalOut);
                     System.setErr(originalErr);
@@ -2712,6 +2735,9 @@ public class ProgramScriptService {
         if (scriptName == null || scriptName.isEmpty()) {
             return Response.err("Script name is required");
         }
+        if (timeoutSeconds <= 0 || timeoutSeconds > MAX_SCRIPT_TIMEOUT_SECONDS) {
+            return Response.err("timeout_seconds must be between 1 and " + MAX_SCRIPT_TIMEOUT_SECONDS + " seconds");
+        }
 
         // Fail fast with a clear "program not found" error before doing
         // the script-file search. The Program object isn't used in this
@@ -2777,7 +2803,8 @@ public class ProgramScriptService {
             // "It is fixed for run_script_inline but not fixed for
             //  run_ghidra_script, which always runs for the current program."
             long startTime = System.currentTimeMillis();
-            Response scriptResponse = runGhidraScript(scriptFile.getAbsolutePath(), scriptArgs, programName);
+            Response scriptResponse = runGhidraScript(
+                    scriptFile.getAbsolutePath(), scriptArgs, programName, timeoutSeconds);
             double executionTime = (System.currentTimeMillis() - startTime) / 1000.0;
 
             // Extract output text from the Response

--- a/src/test/java/com/xebyte/offline/RunGhidraScriptProgramPropagationTest.java
+++ b/src/test/java/com/xebyte/offline/RunGhidraScriptProgramPropagationTest.java
@@ -79,19 +79,19 @@ public class RunGhidraScriptProgramPropagationTest extends TestCase {
         String src = readSource();
         String body = extractAnnotatedMethodBody(src, "/run_ghidra_script");
 
-        // The 3-arg runGhidraScript call must be present and must include
-        // programName. We require the literal `programName` token because
+        // The 4-arg runGhidraScript call must be present and must include
+        // programName plus timeoutSeconds. We require the literal `programName` token because
         // the @Param is named that way and it's the parameter the operator
         // actually controls.
-        Pattern threeArgCall = Pattern.compile(
-                "runGhidraScript\\s*\\(\\s*[^,]+,\\s*[^,]+,\\s*programName\\s*\\)",
+        Pattern timeoutAwareCall = Pattern.compile(
+                "runGhidraScript\\s*\\(\\s*[^,]+,\\s*[^,]+,\\s*programName\\s*,\\s*timeoutSeconds\\s*\\)",
                 Pattern.MULTILINE | Pattern.DOTALL);
         assertTrue(
-                "runGhidraScriptWithCapture must call the 3-arg runGhidraScript "
-                        + "and pass `programName` as the third argument — without it, "
+                "runGhidraScriptWithCapture must call the timeout-aware runGhidraScript "
+                        + "and pass `programName` plus `timeoutSeconds` — without it, "
                         + "the script executes against the session currentProgram "
                         + "instead of the operator's requested program.",
-                threeArgCall.matcher(body).find());
+                timeoutAwareCall.matcher(body).find());
     }
 
     public void testRunGhidraScriptWithCaptureDoesNotCallTwoArgOverload() throws IOException {

--- a/tests/unit/test_bridge_utils.py
+++ b/tests/unit/test_bridge_utils.py
@@ -38,9 +38,7 @@ class TestGetSocketDir(unittest.TestCase):
         env = {k: v for k, v in os.environ.items() if k != "XDG_RUNTIME_DIR"}
         env["TMPDIR"] = "/custom/tmp"
         env["USER"] = "testuser"
-        with patch.dict(os.environ, env, clear=True), patch(
-            "os.getuid", return_value=9_999_999, create=True
-        ):
+        with patch.dict(os.environ, env, clear=True), patch("os.getuid", return_value=9_999_999, create=True):
             from bridge_mcp_ghidra import get_socket_dir
 
             result = get_socket_dir()
@@ -67,6 +65,7 @@ class TestTcpPortScan(unittest.TestCase):
             def __init__(self, status, body):
                 self.status = status
                 self._body = body
+
             def read(self):
                 return self._body.encode("utf-8") if isinstance(self._body, str) else self._body
 
@@ -77,11 +76,17 @@ class TestTcpPortScan(unittest.TestCase):
                 self._resp = port_to_response.get(port)
                 if self._resp is None:
                     raise ConnectionRefusedError(f"no listener on {port}")
+
+            def connect(self):
+                pass
+
             def request(self, method, url):
                 pass
+
             def getresponse(self):
                 status, body = self._resp
                 return FakeResponse(status, body)
+
             def close(self):
                 pass
 
@@ -92,10 +97,12 @@ class TestTcpPortScan(unittest.TestCase):
         from unittest.mock import patch
         import bridge_mcp_ghidra as bridge
 
-        FakeConn = self._make_fake_conn({
-            8089: (200, json.dumps({"project": "other"})),
-            8090: (200, json.dumps({"project": "wanted"})),
-        })
+        FakeConn = self._make_fake_conn(
+            {
+                8089: (200, json.dumps({"project": "other"})),
+                8090: (200, json.dumps({"project": "wanted"})),
+            }
+        )
         with patch("http.client.HTTPConnection", FakeConn):
             result = bridge._scan_tcp_for_project("wanted", start_port=8089, range_size=4, timeout=0.5)
         self.assertEqual(result, "http://127.0.0.1:8090")
@@ -106,10 +113,12 @@ class TestTcpPortScan(unittest.TestCase):
         from unittest.mock import patch
         import bridge_mcp_ghidra as bridge
 
-        FakeConn = self._make_fake_conn({
-            8089: (200, json.dumps({"project": "unrelated"})),
-            8090: (200, json.dumps({"project": "alsoNot"})),
-        })
+        FakeConn = self._make_fake_conn(
+            {
+                8089: (200, json.dumps({"project": "unrelated"})),
+                8090: (200, json.dumps({"project": "alsoNot"})),
+            }
+        )
         with patch("http.client.HTTPConnection", FakeConn):
             result = bridge._scan_tcp_for_project("wanted", start_port=8089, range_size=4, timeout=0.5)
         self.assertIsNone(result)
@@ -130,9 +139,11 @@ class TestTcpPortScan(unittest.TestCase):
         from unittest.mock import patch
         import bridge_mcp_ghidra as bridge
 
-        FakeConn = self._make_fake_conn({
-            8089: (200, json.dumps({"project": "MyProjectVariant"})),
-        })
+        FakeConn = self._make_fake_conn(
+            {
+                8089: (200, json.dumps({"project": "MyProjectVariant"})),
+            }
+        )
         with patch("http.client.HTTPConnection", FakeConn):
             result = bridge._scan_tcp_for_project("MyProject", start_port=8089, range_size=4, timeout=0.5)
         self.assertEqual(result, "http://127.0.0.1:8089")
@@ -143,10 +154,12 @@ class TestTcpPortScan(unittest.TestCase):
         from unittest.mock import patch
         import bridge_mcp_ghidra as bridge
 
-        FakeConn = self._make_fake_conn({
-            8089: (200, json.dumps({"project": "Diablo2Mod"})),  # substring of "Diablo2"
-            8091: (200, json.dumps({"project": "Diablo2"})),     # exact match
-        })
+        FakeConn = self._make_fake_conn(
+            {
+                8089: (200, json.dumps({"project": "Diablo2Mod"})),  # substring of "Diablo2"
+                8091: (200, json.dumps({"project": "Diablo2"})),  # exact match
+            }
+        )
         with patch("http.client.HTTPConnection", FakeConn):
             result = bridge._scan_tcp_for_project("Diablo2", start_port=8089, range_size=4, timeout=0.5)
         self.assertEqual(result, "http://127.0.0.1:8091")
@@ -157,9 +170,11 @@ class TestTcpPortScan(unittest.TestCase):
         from unittest.mock import patch
         import bridge_mcp_ghidra as bridge
 
-        FakeConn = self._make_fake_conn({
-            8089: (200, json.dumps({"data": {"project": "wanted"}})),
-        })
+        FakeConn = self._make_fake_conn(
+            {
+                8089: (200, json.dumps({"data": {"project": "wanted"}})),
+            }
+        )
         with patch("http.client.HTTPConnection", FakeConn):
             result = bridge._scan_tcp_for_project("wanted", start_port=8089, range_size=2, timeout=0.5)
         self.assertEqual(result, "http://127.0.0.1:8089")
@@ -191,11 +206,14 @@ class TestConnectInstanceTcpFallback(unittest.TestCase):
 
         instances = [{"socket": "/tmp/ghidra-123.sock", "pid": 123}]
 
-        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
-             patch.object(bridge.discovery, "_scan_tcp_for_project", return_value="http://127.0.0.1:8090") as scan, \
-             patch.object(bridge.static_tools, "validate_server_url", return_value=True), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0), \
-             patch.object(bridge.static_tools, "os") as mock_os:
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=instances),
+            patch.object(bridge.discovery, "_scan_tcp_for_project", return_value="http://127.0.0.1:8090") as scan,
+            patch.object(bridge.static_tools, "validate_server_url", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=0),
+            patch.object(bridge.static_tools, "os") as mock_os,
+        ):
             mock_os.getenv.return_value = None
             bridge.state._full_schema = []
             bridge.state._loaded_groups.clear()
@@ -216,9 +234,11 @@ class TestConnectInstanceTcpFallback(unittest.TestCase):
             {"socket": "/tmp/ghidra-456.sock", "pid": 456, "project": "also_other"},
         ]
 
-        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
-             patch.object(bridge.discovery, "_scan_tcp_for_project") as scan, \
-             patch.object(bridge.static_tools, "os") as mock_os:
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=instances),
+            patch.object(bridge.discovery, "_scan_tcp_for_project") as scan,
+            patch.object(bridge.static_tools, "os") as mock_os,
+        ):
             mock_os.getenv.return_value = None
 
             result = asyncio.run(bridge.connect_instance("wanted"))
@@ -234,9 +254,12 @@ class TestConnectInstanceTcpFallback(unittest.TestCase):
 
         instances = [{"socket": "/tmp/ghidra-123.sock", "pid": 123, "project": "wanted"}]
 
-        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
-             patch.object(bridge.transport, "uds_supported", return_value=True), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0):
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=instances),
+            patch.object(bridge.transport, "uds_supported", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=0),
+        ):
             bridge.state._full_schema = []
             bridge.state._loaded_groups.clear()
 
@@ -253,19 +276,24 @@ class TestConnectInstanceTcpFallback(unittest.TestCase):
         with no port scan (the scan could pick a different instance)."""
         import bridge_mcp_ghidra as bridge
 
-        instances = [{
-            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
-            "pid": 9020,
-            "project": "diablo2",
-            "url": "http://127.0.0.1:8089",
-        }]
+        instances = [
+            {
+                "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+                "pid": 9020,
+                "project": "diablo2",
+                "url": "http://127.0.0.1:8089",
+            }
+        ]
 
-        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
-             patch.object(bridge.transport, "uds_supported", return_value=False), \
-             patch.object(bridge.discovery, "_scan_tcp_for_project") as scan, \
-             patch.object(bridge.static_tools, "validate_server_url", return_value=True), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0), \
-             patch.object(bridge.static_tools, "os") as mock_os:
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=instances),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(bridge.discovery, "_scan_tcp_for_project") as scan,
+            patch.object(bridge.static_tools, "validate_server_url", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=0),
+            patch.object(bridge.static_tools, "os") as mock_os,
+        ):
             mock_os.getenv.return_value = None
             bridge.state._full_schema = []
             bridge.state._loaded_groups.clear()
@@ -285,19 +313,23 @@ class TestConnectInstanceTcpFallback(unittest.TestCase):
         rather than refusing outright."""
         import bridge_mcp_ghidra as bridge
 
-        instances = [{
-            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
-            "pid": 9020,
-            "project": "diablo2",
-        }]
+        instances = [
+            {
+                "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+                "pid": 9020,
+                "project": "diablo2",
+            }
+        ]
 
-        with patch.object(bridge.discovery, "discover_instances", return_value=instances), \
-             patch.object(bridge.transport, "uds_supported", return_value=False), \
-             patch.object(bridge.discovery, "_scan_tcp_for_project",
-                          return_value="http://127.0.0.1:8093") as scan, \
-             patch.object(bridge.static_tools, "validate_server_url", return_value=True), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0), \
-             patch.object(bridge.static_tools, "os") as mock_os:
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=instances),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(bridge.discovery, "_scan_tcp_for_project", return_value="http://127.0.0.1:8093") as scan,
+            patch.object(bridge.static_tools, "validate_server_url", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=0),
+            patch.object(bridge.static_tools, "os") as mock_os,
+        ):
             mock_os.getenv.return_value = None
             bridge.state._full_schema = []
             bridge.state._loaded_groups.clear()
@@ -327,15 +359,20 @@ class TestAutoConnectWindowsTcp(unittest.TestCase):
     def test_single_instance_auto_connects_via_enriched_url(self):
         import bridge_mcp_ghidra as bridge
 
-        one = [{
-            "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
-            "pid": 9020,
-            "project": "diablo2",
-            "url": "http://127.0.0.1:8089",
-        }]
-        with patch.object(bridge.discovery, "discover_instances", return_value=one), \
-             patch.object(bridge.transport, "uds_supported", return_value=False), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=7):
+        one = [
+            {
+                "socket": r"F:\tmp\ghidra-mcp-benam\ghidra-9020.sock",
+                "pid": 9020,
+                "project": "diablo2",
+                "url": "http://127.0.0.1:8089",
+            }
+        ]
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=7),
+        ):
             bridge.state._active_socket = None
             bridge.state._active_tcp = None
             bridge.state._transport_mode = "none"
@@ -382,9 +419,12 @@ class TestTryReconnectTransportRouting(unittest.TestCase):
         import bridge_mcp_ghidra as bridge
 
         inst = self._instance(url="http://127.0.0.1:8089")
-        with patch.object(bridge.discovery, "discover_instances", return_value=[inst]), \
-             patch.object(bridge.transport, "uds_supported", return_value=True), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0):
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[inst]),
+            patch.object(bridge.transport, "uds_supported", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=0),
+        ):
             self.assertTrue(bridge.dispatch._try_reconnect())
 
         self.assertEqual(bridge.state._transport_mode, "uds")
@@ -395,9 +435,12 @@ class TestTryReconnectTransportRouting(unittest.TestCase):
         import bridge_mcp_ghidra as bridge
 
         inst = self._instance(url="http://127.0.0.1:8089")
-        with patch.object(bridge.discovery, "discover_instances", return_value=[inst]), \
-             patch.object(bridge.transport, "uds_supported", return_value=False), \
-             patch.object(bridge.registry, "_fetch_and_register_schema", return_value=0):
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[inst]),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=0),
+        ):
             self.assertTrue(bridge.dispatch._try_reconnect())
 
         self.assertEqual(bridge.state._transport_mode, "tcp")
@@ -408,13 +451,41 @@ class TestTryReconnectTransportRouting(unittest.TestCase):
         import bridge_mcp_ghidra as bridge
 
         inst = self._instance()  # no url — TCP enrichment found nothing
-        with patch.object(bridge.discovery, "discover_instances", return_value=[inst]), \
-             patch.object(bridge.transport, "uds_supported", return_value=False), \
-             patch.object(bridge.registry, "_fetch_and_register_schema") as fetch:
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[inst]),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(bridge.registry, "_fetch_schema") as fetch,
+        ):
             self.assertFalse(bridge.dispatch._try_reconnect())
 
         fetch.assert_not_called()
         self.assertEqual(bridge.state._transport_mode, "none")
+
+    def test_request_reconnect_does_not_override_explicit_switch(self):
+        import bridge_mcp_ghidra as bridge
+
+        previous = bridge.state.set_connection_snapshot(
+            "tcp",
+            active_tcp="http://127.0.0.1:8089",
+            connected_project="diablo2",
+        )
+        bridge.state.set_connection_snapshot(
+            "tcp",
+            active_tcp="http://127.0.0.1:8090",
+            connected_project="other",
+        )
+        inst = self._instance(url="http://127.0.0.1:8089")
+
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[inst]),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+        ):
+            rebound = bridge.dispatch._try_reconnect(previous)
+
+        self.assertIsNotNone(rebound)
+        self.assertEqual(rebound.active_tcp, "http://127.0.0.1:8089")
+        self.assertEqual(bridge.state._active_tcp, "http://127.0.0.1:8090")
+        self.assertEqual(bridge.state._connected_project, "other")
 
 
 class TestGetSocketDirCandidates(unittest.TestCase):
@@ -428,9 +499,7 @@ class TestGetSocketDirCandidates(unittest.TestCase):
         env = {k: v for k, v in os.environ.items() if k not in ("XDG_RUNTIME_DIR",)}
         env["TMPDIR"] = "/custom/tmp"
         env["USER"] = "testuser"
-        with patch.dict(os.environ, env, clear=True), patch(
-            "os.getuid", return_value=9_999_999, create=True
-        ):
+        with patch.dict(os.environ, env, clear=True), patch("os.getuid", return_value=9_999_999, create=True):
             from bridge_mcp_ghidra import get_socket_dir_candidates
 
             # Use pathlib.Path equality, which normalizes separators across OSes.
@@ -485,14 +554,17 @@ class TestGetSocketDirCandidates(unittest.TestCase):
                 return iter([fake_hit])
             return orig_glob(self, pattern)
 
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(Path, "exists", fake_exists), \
-             patch.object(Path, "glob", fake_glob):
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(Path, "exists", fake_exists),
+            patch.object(Path, "glob", fake_glob),
+        ):
             from bridge_mcp_ghidra import get_socket_dir_candidates
 
             candidates = get_socket_dir_candidates()
             self.assertIn(
-                fake_hit, candidates,
+                fake_hit,
+                candidates,
                 f"macOS /var/folders glob hit must appear in candidates: {candidates}",
             )
             # And the POSIX /tmp fallback must still be there too.
@@ -527,14 +599,17 @@ class TestGetSocketDirCandidates(unittest.TestCase):
                 return iter([one_level_hit])
             return orig_glob(self, pattern)
 
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(Path, "exists", fake_exists), \
-             patch.object(Path, "glob", fake_glob):
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(Path, "exists", fake_exists),
+            patch.object(Path, "glob", fake_glob),
+        ):
             from bridge_mcp_ghidra import get_socket_dir_candidates
 
             candidates = get_socket_dir_candidates()
             self.assertNotIn(
-                one_level_hit, candidates,
+                one_level_hit,
+                candidates,
                 f"old one-level glob must not match: {candidates}",
             )
 
@@ -558,17 +633,20 @@ class TestGetSocketDirCandidates(unittest.TestCase):
                 return False
             return orig_exists(self)
 
-        with patch.object(os, "listdrives", create=True,
-                          return_value=["C:\\", "F:\\"]), \
-             patch.object(Path, "exists", fake_exists):
+        with (
+            patch.object(os, "listdrives", create=True, return_value=["C:\\", "F:\\"]),
+            patch.object(Path, "exists", fake_exists),
+        ):
             hits = transport._windows_drive_tmp_candidates("testuser")
 
         self.assertIn(
-            cross_drive_dir, hits,
+            cross_drive_dir,
+            hits,
             f"cross-drive socket dir missing: {hits}",
         )
         self.assertNotIn(
-            same_drive_dir, hits,
+            same_drive_dir,
+            hits,
             f"nonexistent drive-sweep dir must be excluded: {hits}",
         )
 
@@ -579,8 +657,7 @@ class TestGetSocketDirCandidates(unittest.TestCase):
         from bridge_mcp_ghidra import transport
 
         sweep_hit = Path("Q:\\") / "tmp" / "ghidra-mcp-testuser"
-        with patch.object(transport, "_windows_drive_tmp_candidates",
-                          return_value=[sweep_hit]) as sweep:
+        with patch.object(transport, "_windows_drive_tmp_candidates", return_value=[sweep_hit]) as sweep:
             candidates = transport.get_socket_dir_candidates()
         sweep.assert_called_once()
         self.assertIn(sweep_hit, candidates)
@@ -591,8 +668,7 @@ class TestGetSocketDirCandidates(unittest.TestCase):
         be consulted."""
         from bridge_mcp_ghidra import transport
 
-        with patch.object(transport, "_windows_drive_tmp_candidates",
-                          return_value=[]) as sweep:
+        with patch.object(transport, "_windows_drive_tmp_candidates", return_value=[]) as sweep:
             transport.get_socket_dir_candidates()
         sweep.assert_not_called()
 
@@ -619,14 +695,17 @@ class TestGetSocketDirCandidates(unittest.TestCase):
                 return iter([private_hit])
             return orig_glob(self, pattern)
 
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(Path, "exists", fake_exists), \
-             patch.object(Path, "glob", fake_glob):
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(Path, "exists", fake_exists),
+            patch.object(Path, "glob", fake_glob),
+        ):
             from bridge_mcp_ghidra import get_socket_dir_candidates
 
             candidates = get_socket_dir_candidates()
             self.assertIn(
-                private_hit, candidates,
+                private_hit,
+                candidates,
                 f"/private/var/folders hit must appear in candidates: {candidates}",
             )
 
@@ -661,17 +740,27 @@ class TestDiscoverInstancesMultiDir(unittest.TestCase):
             # the test doesn't actually try to connect. Pin uds_supported to
             # True so the UDS query path runs even on Windows CPython (which
             # lacks AF_UNIX and would otherwise take the TCP enrichment path).
-            with patch.object(
-                bridge.transport, "get_socket_dir_candidates",
-                return_value=[Path(d1), Path(d2)],
-            ), patch.object(
-                bridge.transport, "uds_supported", return_value=True,
-            ), patch.object(
-                bridge.transport, "uds_request",
-                return_value=("{}", 500),  # info query fails — that's fine
-            ), patch.object(
-                bridge.validation, "is_pid_alive",
-                side_effect=lambda p: p == pid_alive,
+            with (
+                patch.object(
+                    bridge.transport,
+                    "get_socket_dir_candidates",
+                    return_value=[Path(d1), Path(d2)],
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_supported",
+                    return_value=True,
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_request",
+                    return_value=("{}", 500),  # info query fails — that's fine
+                ),
+                patch.object(
+                    bridge.validation,
+                    "is_pid_alive",
+                    side_effect=lambda p: p == pid_alive,
+                ),
             ):
                 instances = discover_instances()
 
@@ -693,17 +782,27 @@ class TestDiscoverInstancesMultiDir(unittest.TestCase):
             from bridge_mcp_ghidra import discover_instances
             import bridge_mcp_ghidra as bridge
 
-            with patch.object(
-                bridge.transport, "get_socket_dir_candidates",
-                return_value=[Path(d), Path(d)],  # same dir twice
-            ), patch.object(
-                bridge.transport, "uds_supported", return_value=True,
-            ), patch.object(
-                bridge.transport, "uds_request",
-                return_value=("{}", 500),
-            ), patch.object(
-                bridge.validation, "is_pid_alive",
-                side_effect=lambda p: p == pid_alive,
+            with (
+                patch.object(
+                    bridge.transport,
+                    "get_socket_dir_candidates",
+                    return_value=[Path(d), Path(d)],  # same dir twice
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_supported",
+                    return_value=True,
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_request",
+                    return_value=("{}", 500),
+                ),
+                patch.object(
+                    bridge.validation,
+                    "is_pid_alive",
+                    side_effect=lambda p: p == pid_alive,
+                ),
             ):
                 instances = discover_instances()
 
@@ -732,18 +831,31 @@ class TestDiscoverInstancesWindowsTcpEnrichment(unittest.TestCase):
                     "project": "diablo2",
                 }
             }
-            with patch.object(
-                bridge.transport, "get_socket_dir_candidates",
-                return_value=[Path(d)],
-            ), patch.object(
-                bridge.transport, "uds_supported", return_value=False,
-            ), patch.object(
-                bridge.transport, "uds_request",
-            ) as uds_req, patch.object(
-                bridge.discovery, "_tcp_instances_by_pid", return_value=tcp_info,
-            ), patch.object(
-                bridge.validation, "is_pid_alive",
-                side_effect=lambda p: p == pid_alive,
+            with (
+                patch.object(
+                    bridge.transport,
+                    "get_socket_dir_candidates",
+                    return_value=[Path(d)],
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_supported",
+                    return_value=False,
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_request",
+                ) as uds_req,
+                patch.object(
+                    bridge.discovery,
+                    "_tcp_instances_by_pid",
+                    return_value=tcp_info,
+                ),
+                patch.object(
+                    bridge.validation,
+                    "is_pid_alive",
+                    side_effect=lambda p: p == pid_alive,
+                ),
             ):
                 instances = bridge.discover_instances()
 
@@ -763,19 +875,31 @@ class TestDiscoverInstancesWindowsTcpEnrichment(unittest.TestCase):
             pid_alive = os.getpid()
             (Path(d) / f"ghidra-{pid_alive}.sock").touch()
 
-            with patch.object(
-                bridge.transport, "get_socket_dir_candidates",
-                return_value=[Path(d)],
-            ), patch.object(
-                bridge.transport, "uds_supported", return_value=True,
-            ), patch.object(
-                bridge.transport, "uds_request",
-                return_value=(json.dumps({"project": "diablo2"}), 200),
-            ), patch.object(
-                bridge.discovery, "_tcp_instances_by_pid",
-            ) as tcp_scan, patch.object(
-                bridge.validation, "is_pid_alive",
-                side_effect=lambda p: p == pid_alive,
+            with (
+                patch.object(
+                    bridge.transport,
+                    "get_socket_dir_candidates",
+                    return_value=[Path(d)],
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_supported",
+                    return_value=True,
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_request",
+                    return_value=(json.dumps({"project": "diablo2"}), 200),
+                ),
+                patch.object(
+                    bridge.discovery,
+                    "_tcp_instances_by_pid",
+                ) as tcp_scan,
+                patch.object(
+                    bridge.validation,
+                    "is_pid_alive",
+                    side_effect=lambda p: p == pid_alive,
+                ),
             ):
                 instances = bridge.discover_instances()
 
@@ -793,16 +917,27 @@ class TestDiscoverInstancesWindowsTcpEnrichment(unittest.TestCase):
             pid_alive = os.getpid()
             (Path(d) / f"ghidra-{pid_alive}.sock").touch()
 
-            with patch.object(
-                bridge.transport, "get_socket_dir_candidates",
-                return_value=[Path(d)],
-            ), patch.object(
-                bridge.transport, "uds_supported", return_value=False,
-            ), patch.object(
-                bridge.discovery, "_tcp_instances_by_pid", return_value={},
-            ), patch.object(
-                bridge.validation, "is_pid_alive",
-                side_effect=lambda p: p == pid_alive,
+            with (
+                patch.object(
+                    bridge.transport,
+                    "get_socket_dir_candidates",
+                    return_value=[Path(d)],
+                ),
+                patch.object(
+                    bridge.transport,
+                    "uds_supported",
+                    return_value=False,
+                ),
+                patch.object(
+                    bridge.discovery,
+                    "_tcp_instances_by_pid",
+                    return_value={},
+                ),
+                patch.object(
+                    bridge.validation,
+                    "is_pid_alive",
+                    side_effect=lambda p: p == pid_alive,
+                ),
             ):
                 instances = bridge.discover_instances()
 
@@ -829,9 +964,12 @@ class TestAutoConnectMultiInstance(unittest.TestCase):
         # registry._fetch_and_register_schema(); it reads/writes state._*).
         # Patching the flat bridge.* re-exports would NOT intercept those, so
         # the test would pass vacuously regardless of the code under test.
-        with patch.object(bridge.discovery, "discover_instances", return_value=two), \
-             patch.object(bridge.registry, "_fetch_and_register_schema",
-                          side_effect=lambda *a, **kw: fetch_calls.append(1) or 0):
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=two),
+            patch.object(
+                bridge.registry, "_fetch_and_register_schema", side_effect=lambda *a, **kw: fetch_calls.append(1) or 0
+            ),
+        ):
             # Reset connection state so the test is hermetic.
             bridge.state._active_socket = None
             bridge.state._active_tcp = None
@@ -839,9 +977,9 @@ class TestAutoConnectMultiInstance(unittest.TestCase):
             bridge._auto_connect()
 
         self.assertEqual(
-            fetch_calls, [],
-            "schema fetch was called — _auto_connect fell through to TCP "
-            "after the multi-UDS warning"
+            fetch_calls,
+            [],
+            "schema fetch was called — _auto_connect fell through to TCP " "after the multi-UDS warning",
         )
         self.assertEqual(bridge.state._transport_mode, "none")
         self.assertIsNone(bridge.state._active_tcp)
@@ -856,10 +994,12 @@ class TestDebuggerAttachAddressSync(unittest.TestCase):
     def test_uses_image_base_from_list_open_programs(self):
         import bridge_mcp_ghidra as bridge
 
-        programs_payload = json.dumps([
-            {"path": "/proj/Foo.exe", "name": "Foo.exe", "image_base": "0x400000"},
-            {"path": "/proj/Bar.dll", "name": "Bar.dll", "image_base": "0x10000000"},
-        ])
+        programs_payload = json.dumps(
+            [
+                {"path": "/proj/Foo.exe", "name": "Foo.exe", "image_base": "0x400000"},
+                {"path": "/proj/Bar.dll", "name": "Bar.dll", "image_base": "0x10000000"},
+            ]
+        )
         debugger_calls = []
 
         def fake_debugger_request(method, path, body=None, **kw):
@@ -870,14 +1010,14 @@ class TestDebuggerAttachAddressSync(unittest.TestCase):
             if path == "/list_open_programs":
                 return programs_payload
             raise AssertionError(
-                f"unexpected GET {path} — auto-sync must not call "
-                "/get_metadata or any other endpoint"
+                f"unexpected GET {path} — auto-sync must not call " "/get_metadata or any other endpoint"
             )
 
-        with patch.object(bridge.debugger, "_debugger_request",
-                          side_effect=fake_debugger_request), \
-             patch.object(bridge.dispatch, "dispatch_get", side_effect=fake_dispatch_get), \
-             patch.object(bridge.state, "_transport_mode", "tcp"):
+        with (
+            patch.object(bridge.debugger, "_debugger_request", side_effect=fake_debugger_request),
+            patch.object(bridge.dispatch, "dispatch_get", side_effect=fake_dispatch_get),
+            patch.object(bridge.state, "_transport_mode", "tcp"),
+        ):
             bridge.debugger_attach("12345")
 
         sync = [c for c in debugger_calls if c[1] == "/debugger/sync_modules"]
@@ -949,7 +1089,22 @@ class TestGetTimeout(unittest.TestCase):
     def test_decompile_timeout(self):
         from bridge_mcp_ghidra import get_timeout
 
-        self.assertEqual(get_timeout("/decompile_function"), 45)
+        self.assertEqual(get_timeout("/decompile_function"), 75)
+
+    def test_requested_decompile_timeout_includes_transport_grace(self):
+        from bridge_mcp_ghidra import get_timeout
+
+        self.assertEqual(get_timeout("/decompile_function", {"timeout": "120"}), 135)
+
+    def test_timeout_seconds_alias_uses_same_grace(self):
+        from bridge_mcp_ghidra import get_timeout
+
+        self.assertEqual(get_timeout("/run_ghidra_script", {"timeout_seconds": "120"}), 1800)
+
+    def test_requested_timeout_is_capped_with_grace_preserved(self):
+        from bridge_mcp_ghidra import get_timeout
+
+        self.assertEqual(get_timeout("/decompile_function", {"timeout": "1800"}), 1815)
 
     def test_script_timeout(self):
         from bridge_mcp_ghidra import get_timeout
@@ -1189,11 +1344,7 @@ class TestToolNameSanitization(unittest.TestCase):
         import bridge_mcp_ghidra as bridge
 
         pattern = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
-        invalid = [
-            name
-            for name in bridge.mcp._tool_manager._tools
-            if not pattern.fullmatch(name)
-        ]
+        invalid = [name for name in bridge.mcp._tool_manager._tools if not pattern.fullmatch(name)]
         self.assertEqual(invalid, [])
 
     def test_registered_dynamic_tool_names_are_valid(self):
@@ -1213,11 +1364,7 @@ class TestToolNameSanitization(unittest.TestCase):
         bridge.register_tools_from_schema(schema, groups=None)
         pattern = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
         try:
-            invalid = [
-                name
-                for name in bridge.mcp._tool_manager._tools
-                if not pattern.fullmatch(name)
-            ]
+            invalid = [name for name in bridge.mcp._tool_manager._tools if not pattern.fullmatch(name)]
             self.assertEqual(invalid, [])
             self.assertIn("server_status", bridge.mcp._tool_manager._tools)
             # /check/tools collides with the static management tool check_tools
@@ -1386,60 +1533,44 @@ class TestDebuggerEnabled(unittest.TestCase):
     def test_disabled_on_non_windows_with_local_url(self):
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertFalse(
-            _debugger_enabled(url="http://127.0.0.1:8099", platform="linux", override=None)
-        )
+        self.assertFalse(_debugger_enabled(url="http://127.0.0.1:8099", platform="linux", override=None))
 
     def test_disabled_on_non_windows_with_localhost_name(self):
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertFalse(
-            _debugger_enabled(url="http://localhost:8099", platform="darwin", override=None)
-        )
+        self.assertFalse(_debugger_enabled(url="http://localhost:8099", platform="darwin", override=None))
 
     def test_disabled_on_non_windows_with_ipv6_loopback(self):
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertFalse(
-            _debugger_enabled(url="http://[::1]:8099", platform="linux", override=None)
-        )
+        self.assertFalse(_debugger_enabled(url="http://[::1]:8099", platform="linux", override=None))
 
     def test_enabled_on_non_windows_with_remote_host(self):
         """A remote Windows host running the server is reachable from Linux."""
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertTrue(
-            _debugger_enabled(url="http://winbox.lan:8099", platform="linux", override=None)
-        )
+        self.assertTrue(_debugger_enabled(url="http://winbox.lan:8099", platform="linux", override=None))
 
     def test_enabled_on_windows_with_local_url(self):
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertTrue(
-            _debugger_enabled(url="http://127.0.0.1:8099", platform="win32", override=None)
-        )
+        self.assertTrue(_debugger_enabled(url="http://127.0.0.1:8099", platform="win32", override=None))
 
     def test_override_forces_off_even_on_windows(self):
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertFalse(
-            _debugger_enabled(url="http://127.0.0.1:8099", platform="win32", override="0")
-        )
+        self.assertFalse(_debugger_enabled(url="http://127.0.0.1:8099", platform="win32", override="0"))
 
     def test_override_forces_on_even_on_linux_local(self):
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertTrue(
-            _debugger_enabled(url="http://127.0.0.1:8099", platform="linux", override="1")
-        )
+        self.assertTrue(_debugger_enabled(url="http://127.0.0.1:8099", platform="linux", override="1"))
 
     def test_blank_override_is_ignored(self):
         """An empty string (e.g. unset-but-present env) falls back to auto-detect."""
         from bridge_mcp_ghidra import _debugger_enabled
 
-        self.assertFalse(
-            _debugger_enabled(url="http://127.0.0.1:8099", platform="linux", override="")
-        )
+        self.assertFalse(_debugger_enabled(url="http://127.0.0.1:8099", platform="linux", override=""))
 
 
 class TestDebuggerToolRegistration(unittest.TestCase):
@@ -1454,12 +1585,8 @@ class TestDebuggerToolRegistration(unittest.TestCase):
     def test_all_static_names_superset_of_active(self):
         import bridge_mcp_ghidra as bridge
 
-        self.assertTrue(
-            bridge.DEBUGGER_TOOL_NAMES.issubset(bridge._ALL_STATIC_TOOL_NAMES)
-        )
-        self.assertTrue(
-            bridge.STATIC_TOOL_NAMES.issubset(bridge._ALL_STATIC_TOOL_NAMES)
-        )
+        self.assertTrue(bridge.DEBUGGER_TOOL_NAMES.issubset(bridge._ALL_STATIC_TOOL_NAMES))
+        self.assertTrue(bridge.STATIC_TOOL_NAMES.issubset(bridge._ALL_STATIC_TOOL_NAMES))
 
     @unittest.skipIf(sys.platform.startswith("win"), "proxies active on Windows")
     def test_inactive_proxy_frees_clean_name_for_trace_rmi_tool(self):
@@ -1467,9 +1594,7 @@ class TestDebuggerToolRegistration(unittest.TestCase):
         TraceRmi /debugger/status (System B) gets the clean name, not _2."""
         import bridge_mcp_ghidra as bridge
 
-        schema = bridge._parse_schema(
-            {"tools": [{"path": "/debugger/status", "method": "GET", "params": []}]}
-        )
+        schema = bridge._parse_schema({"tools": [{"path": "/debugger/status", "method": "GET", "params": []}]})
         self.assertEqual(schema[0]["name"], "debugger_status")
         self.assertFalse(schema[0]["name_collided"])
 

--- a/tests/unit/test_endpoint_catalog.py
+++ b/tests/unit/test_endpoint_catalog.py
@@ -72,9 +72,7 @@ class TestAnnotatedEndpoints(unittest.TestCase):
     def test_has_annotated_endpoints(self):
         """Services should have @McpTool annotations."""
         count = count_mcptool_annotations()
-        self.assertGreater(
-            count, 100, f"Expected >100 annotated endpoints, found {count}"
-        )
+        self.assertGreater(count, 100, f"Expected >100 annotated endpoints, found {count}")
 
     def test_all_paths_start_with_slash(self):
         """All @McpTool paths should start with /."""
@@ -126,9 +124,7 @@ class TestEndpointsJson(unittest.TestCase):
     def test_no_duplicate_paths(self):
         data = json.loads(ENDPOINTS_JSON.read_text())
         paths = [ep["path"] for ep in data.get("endpoints", [])]
-        self.assertEqual(
-            len(paths), len(set(paths)), "Duplicate paths in endpoints.json"
-        )
+        self.assertEqual(len(paths), len(set(paths)), "Duplicate paths in endpoints.json")
 
     @unittest.skipUnless(ENDPOINTS_JSON.exists(), "endpoints.json not found")
     def test_endpoints_have_required_fields(self):
@@ -154,8 +150,7 @@ class TestEndpointsJson(unittest.TestCase):
             ]
         }
         invalid = [
-            tool["name"] for tool in _parse_schema(raw_schema)
-            if not re.fullmatch(r"^[a-zA-Z0-9_-]+$", tool["name"])
+            tool["name"] for tool in _parse_schema(raw_schema) if not re.fullmatch(r"^[a-zA-Z0-9_-]+$", tool["name"])
         ]
         self.assertEqual(invalid, [])
 
@@ -174,20 +169,20 @@ class TestBridgeIsDynamic(unittest.TestCase):
         import bridge_mcp_ghidra as bridge
 
         content = _bridge_source_text()
-        mgmt_count = len(re.findall(r"@mcp\.tool\(\)", content))
+        mgmt_count = len(re.findall(r"@mcp\.tool\([^\n]*\)", content))
         debugger_count = len(re.findall(r"@_debugger_tool\(\)", content))
         tool_count = mgmt_count + debugger_count
         self.assertEqual(
             tool_count,
             len(bridge._ALL_STATIC_TOOL_NAMES),
-            f"Bridge has {mgmt_count} @mcp.tool() + {debugger_count} "
+            f"Bridge has {mgmt_count} @mcp.tool(...) + {debugger_count} "
             f"@_debugger_tool() decorators ({tool_count}) but "
             f"{len(bridge._ALL_STATIC_TOOL_NAMES)} static tool names",
         )
         self.assertEqual(
             mgmt_count,
             len(bridge.MANAGEMENT_TOOL_NAMES),
-            "management @mcp.tool() decorators should match MANAGEMENT_TOOL_NAMES",
+            "management @mcp.tool(...) decorators should match MANAGEMENT_TOOL_NAMES",
         )
         self.assertEqual(
             debugger_count,

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -6,14 +6,17 @@ verifying that dynamically generated functions correctly dispatch
 GET/POST requests with proper parameter handling.
 """
 
+import asyncio
 import json
 import inspect
 import os
+import threading
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 import sys
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 
@@ -29,6 +32,7 @@ def setUpModule():
     TestProgramRequired manages its own state via setUp/tearDown.
     """
     import bridge_mcp_ghidra
+
     bridge_mcp_ghidra.state._require_selectors = False
 
 
@@ -38,6 +42,7 @@ class TestGetToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_get_with_required_param(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = '{"result": "ok"}'
 
         schema = {
@@ -47,14 +52,13 @@ class TestGetToolDispatch(unittest.TestCase):
         fn = _build_tool_function("/decompile_function", "GET", schema)
         result = fn(address="0x401000")
 
-        mock_get.assert_called_once_with(
-            "/decompile_function", params={"address": "0x401000"}
-        )
+        mock_get.assert_called_once_with("/decompile_function", params={"address": "0x401000"})
         self.assertEqual(result, '{"result": "ok"}')
 
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_get_with_optional_param_none(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = '{"data": []}'
 
         schema = {
@@ -73,6 +77,7 @@ class TestGetToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_get_with_no_params(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = '{"version": "4.2.0"}'
 
         schema = {"properties": {}, "required": []}
@@ -88,6 +93,7 @@ class TestPostToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_post_with_json_body(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_post.return_value = '{"success": true}'
 
         schema = {
@@ -107,6 +113,7 @@ class TestPostToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_post_filters_none_values(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_post.return_value = '{"success": true}'
 
         schema = {
@@ -119,13 +126,12 @@ class TestPostToolDispatch(unittest.TestCase):
         fn = _build_tool_function("/rename_function", "POST", schema)
         fn(address="0x401000", program=None)
 
-        mock_post.assert_called_once_with(
-            "/rename_function", data={"address": "0x401000"}, query_params=None
-        )
+        mock_post.assert_called_once_with("/rename_function", data={"address": "0x401000"}, query_params=None)
 
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_post_integer_params(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_post.return_value = '{"data": []}'
 
         schema = {
@@ -144,6 +150,7 @@ class TestPostToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_post_synthetic_dry_run_only_for_true_values(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_post.return_value = '{"success": true}'
 
         schema = {
@@ -173,6 +180,7 @@ class TestPostToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_schema_declared_query_dry_run_does_not_duplicate_signature(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_post.return_value = '{"dry_run": true}'
 
         schema = {
@@ -201,6 +209,7 @@ class TestPostToolDispatch(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_schema_declared_body_dry_run_uses_body_source(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_post.return_value = '{"dry_run": true}'
 
         schema = {
@@ -233,6 +242,7 @@ class TestSchemaEdgeCases(unittest.TestCase):
 
     def test_unknown_type_defaults_to_string(self):
         from bridge_mcp_ghidra import _build_tool_function
+
         schema = {
             "properties": {"data": {"type": "unknown_type"}},
             "required": ["data"],
@@ -242,6 +252,7 @@ class TestSchemaEdgeCases(unittest.TestCase):
 
     def test_missing_type_defaults_to_string(self):
         from bridge_mcp_ghidra import _build_tool_function
+
         schema = {
             "properties": {"data": {}},
             "required": ["data"],
@@ -252,6 +263,7 @@ class TestSchemaEdgeCases(unittest.TestCase):
     def test_missing_required_field(self):
         """Schema without 'required' field should treat all as optional."""
         from bridge_mcp_ghidra import _build_tool_function
+
         schema = {
             "properties": {"data": {"type": "string"}},
         }
@@ -262,6 +274,7 @@ class TestSchemaEdgeCases(unittest.TestCase):
     def test_many_parameters(self):
         """Schema with many parameters should work."""
         from bridge_mcp_ghidra import _build_tool_function
+
         props = {f"param_{i}": {"type": "string"} for i in range(20)}
         schema = {"properties": props, "required": ["param_0"]}
         fn = _build_tool_function("/test", "POST", schema)
@@ -276,6 +289,7 @@ class TestToolRegistrationRoundTrip(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_full_roundtrip(self, mock_get):
         from bridge_mcp_ghidra import register_tools_from_schema, mcp
+
         mock_get.return_value = '{"functions": []}'
 
         schema = [
@@ -300,12 +314,62 @@ class TestToolRegistrationRoundTrip(unittest.TestCase):
         tools = mcp._tool_manager._tools
         self.assertIn("roundtrip_test_tool", tools)
 
+    @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
+    def test_registered_tool_offloads_blocking_dispatch(self, mock_get):
+        from bridge_mcp_ghidra import mcp, register_tools_from_schema
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_get(endpoint, params=None):
+            started.set()
+            if not release.wait(1):
+                raise AssertionError("blocking dispatch ran on the MCP event loop")
+            return '{"ok": true}'
+
+        mock_get.side_effect = blocking_get
+        schema = [
+            {
+                "name": "async_dispatch_test_tool",
+                "description": "Test worker offload",
+                "endpoint": "/async_dispatch_test",
+                "http_method": "GET",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"address": {"type": "string"}},
+                    "required": ["address"],
+                },
+            }
+        ]
+
+        try:
+            register_tools_from_schema(schema)
+            tool = mcp._tool_manager._tools["async_dispatch_test_tool"]
+            self.assertTrue(tool.is_async)
+            self.assertTrue(inspect.iscoroutinefunction(tool.fn))
+
+            async def run_tool():
+                task = asyncio.create_task(tool.fn(address="0x401000"))
+                for _ in range(100):
+                    if started.is_set():
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertTrue(started.is_set())
+                release.set()
+                return await task
+
+            self.assertEqual(asyncio.run(run_tool()), '{"ok": true}')
+        finally:
+            release.set()
+            register_tools_from_schema([])
+
 
 class TestProgramRequired(unittest.TestCase):
     """GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS: refuse calls missing a program selector."""
 
     def setUp(self):
         import bridge_mcp_ghidra as bridge
+
         self.bridge = bridge
         self._saved = bridge.state._require_selectors
 
@@ -323,6 +387,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_get_refuses_when_program_omitted(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         self.bridge.state._require_selectors = True
 
         fn = _build_tool_function("/decompile_function", "GET", self._OPTIONAL_PROGRAM_TOOL)
@@ -337,6 +402,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_get_allows_explicit_program(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = "{}"
         self.bridge.state._require_selectors = True
 
@@ -351,19 +417,19 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_pass_through_when_strict_mode_disabled(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = "{}"
         self.bridge.state._require_selectors = False
 
         fn = _build_tool_function("/decompile_function", "GET", self._OPTIONAL_PROGRAM_TOOL)
         fn(address="0x401000")
 
-        mock_get.assert_called_once_with(
-            "/decompile_function", params={"address": "0x401000"}
-        )
+        mock_get.assert_called_once_with("/decompile_function", params={"address": "0x401000"})
 
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_no_refusal_for_tools_without_program_param(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = "{}"
         self.bridge.state._require_selectors = True
 
@@ -377,6 +443,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_empty_program_counts_as_omitted(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         self.bridge.state._require_selectors = True
 
         # An empty string is filtered upstream of the strict check, so the
@@ -416,6 +483,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_multi_program_refuses_when_both_selectors_empty(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         self.bridge.state._require_selectors = True
 
         fn = _build_tool_function("/bulk_fuzzy_match", "GET", self._FUZZY_SCHEMA)
@@ -429,6 +497,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_multi_program_refuses_when_one_selector_empty(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         self.bridge.state._require_selectors = True
 
         fn = _build_tool_function("/bulk_fuzzy_match", "GET", self._FUZZY_SCHEMA)
@@ -443,6 +512,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_get")
     def test_multi_program_allows_when_all_present(self, mock_get):
         from bridge_mcp_ghidra import _build_tool_function
+
         mock_get.return_value = "{}"
         self.bridge.state._require_selectors = True
 
@@ -461,6 +531,7 @@ class TestProgramRequired(unittest.TestCase):
     @patch("bridge_mcp_ghidra.dispatch.dispatch_post")
     def test_program_a_b_pattern_enforced(self, mock_post):
         from bridge_mcp_ghidra import _build_tool_function
+
         self.bridge.state._require_selectors = True
 
         fn = _build_tool_function("/diff_functions", "POST", self._DIFF_SCHEMA)
@@ -479,9 +550,7 @@ class TestProgramRequired(unittest.TestCase):
                 # of test output) and doubles as an assertion that it fires.
                 with self.assertLogs("bridge_mcp_ghidra", level="INFO"):
                     self.bridge.state._init_require_selectors()
-            self.assertTrue(
-                self.bridge.state._require_selectors, f"{val!r} should enable strict mode"
-            )
+            self.assertTrue(self.bridge.state._require_selectors, f"{val!r} should enable strict mode")
 
     def test_init_non_1_values_leave_strict_mode_off(self):
         # Only "1" enables; other spellings (true/yes/on) and falsy values don't.
@@ -489,9 +558,7 @@ class TestProgramRequired(unittest.TestCase):
             self.bridge.state._require_selectors = True
             with patch.dict("os.environ", {"GHIDRA_MCP_REQUIRE_PROGRAM_SELECTORS": val}):
                 self.bridge.state._init_require_selectors()
-            self.assertFalse(
-                self.bridge.state._require_selectors, f"{val!r} should not enable strict mode"
-            )
+            self.assertFalse(self.bridge.state._require_selectors, f"{val!r} should not enable strict mode")
 
     def test_init_unset_env_leaves_strict_mode_off(self):
         self.bridge.state._require_selectors = True

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -191,9 +191,7 @@ class TestToolGroupManagement(unittest.TestCase):
             self.assertEqual(loaded, ["issue_212_lazy_valid_after"])
             self.assertIn("grp_beta", bridge.state._loaded_groups)
             self.assertIn("issue_212_lazy_valid_after", bridge.state._dynamic_tool_names)
-            self.assertNotIn(
-                "issue_212_lazy_bad_signature", bridge.state._dynamic_tool_names
-            )
+            self.assertNotIn("issue_212_lazy_bad_signature", bridge.state._dynamic_tool_names)
             message = mock_stderr.write.call_args.args[0]
             self.assertIn("1 tool(s) failed to register", message)
             self.assertIn("issue_212_lazy_bad_signature", message)
@@ -242,20 +240,19 @@ class TestConnectInstance(unittest.TestCase):
 
         try:
             bridge.state._lazy_mode = False
-            with mock.patch.object(
-                bridge.discovery,
-                "discover_instances",
-                return_value=[
-                    {"project": "TestProject", "socket": "/tmp/test.sock", "pid": 42}
-                ],
-            ), mock.patch.object(
-                bridge.transport,
-                "do_request",
-                return_value=(json.dumps(schema), 200),
+            with (
+                mock.patch.object(
+                    bridge.discovery,
+                    "discover_instances",
+                    return_value=[{"project": "TestProject", "socket": "/tmp/test.sock", "pid": 42}],
+                ),
+                mock.patch.object(
+                    bridge.transport,
+                    "do_request",
+                    return_value=(json.dumps(schema), 200),
+                ),
             ):
-                result = json.loads(
-                    asyncio.run(bridge.connect_instance("TestProject", ctx=ctx))
-                )
+                result = json.loads(asyncio.run(bridge.connect_instance("TestProject", ctx=ctx)))
 
             self.assertTrue(result["connected"])
             self.assertEqual(result["tools_registered"], 2)
@@ -275,6 +272,38 @@ class TestConnectInstance(unittest.TestCase):
             bridge.state._active_tcp = old_active_tcp
             bridge.state._transport_mode = old_transport_mode
             bridge.state._connected_project = old_connected_project
+
+
+class TestToolsChangedFanout(unittest.TestCase):
+    def test_worker_notification_fans_out_to_all_sessions(self):
+        import bridge_mcp_ghidra as bridge
+
+        session1 = SimpleNamespace(send_tool_list_changed=mock.AsyncMock())
+        session2 = SimpleNamespace(send_tool_list_changed=mock.AsyncMock())
+
+        async def scenario():
+            ctx1 = SimpleNamespace(
+                _request_context=object(),
+                request_context=SimpleNamespace(session=session1),
+            )
+            ctx2 = SimpleNamespace(
+                _request_context=object(),
+                request_context=SimpleNamespace(session=session2),
+            )
+            bridge.state.remember_tools_changed_context(ctx1)
+            bridge.state.remember_tools_changed_context(ctx2)
+            bridge.state.notify_tools_changed_from_worker()
+            await asyncio.sleep(0)
+
+        old_targets = list(bridge.state._tools_changed_targets)
+        try:
+            bridge.state._tools_changed_targets.clear()
+            asyncio.run(scenario())
+        finally:
+            bridge.state._tools_changed_targets[:] = old_targets
+
+        session1.send_tool_list_changed.assert_awaited_once()
+        session2.send_tool_list_changed.assert_awaited_once()
 
 
 class TestEndpointTimeouts(unittest.TestCase):

--- a/tests/unit/test_static_tools.py
+++ b/tests/unit/test_static_tools.py
@@ -128,10 +128,10 @@ class TestListInstances(unittest.TestCase):
     annotate each discovered instance with a correct `connected` flag."""
 
     def test_no_instances_returns_note(self):
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[]
-        ), patch.object(
-            bridge.discovery, "discover_active_tcp_instance", return_value=None
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[]),
+            patch.object(bridge.discovery, "discover_active_tcp_instance", return_value=None),
         ):
             data = json.loads(bridge.list_instances())
 
@@ -145,10 +145,10 @@ class TestListInstances(unittest.TestCase):
         active = {"transport": "tcp", "url": "http://127.0.0.1:8089", "project": "A"}
         other = {"transport": "tcp", "url": "http://127.0.0.1:8090", "project": "B"}
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[dict(other)]
-        ), patch.object(
-            bridge.discovery, "discover_active_tcp_instance", return_value=dict(active)
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[dict(other)]),
+            patch.object(bridge.discovery, "discover_active_tcp_instance", return_value=dict(active)),
         ):
             bridge.state._transport_mode = "tcp"
             bridge.state._active_tcp = "http://127.0.0.1:8089"
@@ -163,10 +163,10 @@ class TestListInstances(unittest.TestCase):
         uds = {"socket": "/tmp/ghidra-1.sock", "pid": 1, "project": "A"}
         uds2 = {"socket": "/tmp/ghidra-2.sock", "pid": 2, "project": "B"}
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[dict(uds), dict(uds2)]
-        ), patch.object(
-            bridge.discovery, "discover_active_tcp_instance", return_value=None
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[dict(uds), dict(uds2)]),
+            patch.object(bridge.discovery, "discover_active_tcp_instance", return_value=None),
         ):
             bridge.state._transport_mode = "uds"
             bridge.state._active_socket = "/tmp/ghidra-1.sock"
@@ -189,10 +189,10 @@ class TestListInstances(unittest.TestCase):
             "url": "http://127.0.0.1:8089",
         }
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[dict(uds)]
-        ), patch.object(
-            bridge.discovery, "discover_active_tcp_instance", return_value=None
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[dict(uds)]),
+            patch.object(bridge.discovery, "discover_active_tcp_instance", return_value=None),
         ):
             bridge.state._transport_mode = "tcp"
             bridge.state._active_tcp = "http://127.0.0.1:8089"
@@ -216,14 +216,15 @@ class TestConnectInstanceFailures(unittest.TestCase):
     def test_uds_schema_fetch_failure_reports_socket(self):
         one = [{"project": "diablo2", "socket": "/tmp/d2.sock", "pid": 42}]
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=one
-        ), patch.object(
-            bridge.transport, "uds_supported", return_value=True
-        ), patch.object(
-            bridge.registry,
-            "_fetch_and_register_schema",
-            side_effect=RuntimeError("HTTP 503"),
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=True),
+            patch.object(
+                bridge.registry,
+                "_fetch_schema",
+                side_effect=RuntimeError("HTTP 503"),
+            ),
         ):
             data = json.loads(asyncio.run(bridge.connect_instance("diablo2")))
 
@@ -237,12 +238,12 @@ class TestConnectInstanceFailures(unittest.TestCase):
         exact pass misses, so it needs its own case."""
         one = [{"project": "diablo2", "socket": "/tmp/d2.sock", "pid": 42}]
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=one
-        ), patch.object(
-            bridge.transport, "uds_supported", return_value=True
-        ), patch.object(
-            bridge.registry, "_fetch_and_register_schema", return_value=3
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=3),
         ):
             bridge.state._full_schema = []
             data = json.loads(asyncio.run(bridge.connect_instance("diablo")))
@@ -267,16 +268,14 @@ class TestConnectInstanceFailures(unittest.TestCase):
         ]
         env = {k: v for k, v in os.environ.items() if k != "GHIDRA_MCP_URL"}
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=one
-        ), patch.object(
-            bridge.transport, "uds_supported", return_value=False
-        ), patch.object(
-            bridge.discovery, "_scan_tcp_for_project"
-        ) as scan, patch.object(
-            bridge.registry, "_fetch_and_register_schema", return_value=5
-        ), patch.dict(
-            os.environ, env, clear=True
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(bridge.discovery, "_scan_tcp_for_project") as scan,
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=5),
+            patch.dict(os.environ, env, clear=True),
         ):
             bridge.state._full_schema = []
             data = json.loads(asyncio.run(bridge.connect_instance("diablo2")))
@@ -294,12 +293,11 @@ class TestConnectInstanceFailures(unittest.TestCase):
         """GHIDRA_MCP_URL wins over discovery, so it is also the one place a
         remote/hostile URL can enter. validate_server_url must refuse it before
         any schema fetch happens."""
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[]
-        ), patch.object(
-            bridge.registry, "_fetch_and_register_schema"
-        ) as fetch, patch.dict(
-            os.environ, {"GHIDRA_MCP_URL": "http://evil.example.com:8089"}
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[]),
+            patch.object(bridge.registry, "_fetch_schema") as fetch,
+            patch.dict(os.environ, {"GHIDRA_MCP_URL": "http://evil.example.com:8089"}),
         ):
             data = json.loads(asyncio.run(bridge.connect_instance("anything")))
 
@@ -313,16 +311,16 @@ class TestConnectInstanceFailures(unittest.TestCase):
         to a dead endpoint instead of reconnecting."""
         env = {k: v for k, v in os.environ.items() if k != "GHIDRA_MCP_URL"}
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[]
-        ), patch.object(
-            bridge.discovery, "_scan_tcp_for_project", return_value=None
-        ), patch.object(
-            bridge.registry,
-            "_fetch_and_register_schema",
-            side_effect=ConnectionRefusedError("connection refused"),
-        ), patch.dict(
-            os.environ, env, clear=True
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[]),
+            patch.object(bridge.discovery, "_scan_tcp_for_project", return_value=None),
+            patch.object(
+                bridge.registry,
+                "_fetch_schema",
+                side_effect=ConnectionRefusedError("connection refused"),
+            ),
+            patch.dict(os.environ, env, clear=True),
         ):
             bridge.state._transport_mode = "none"
             data = json.loads(asyncio.run(bridge.connect_instance("diablo2")))
@@ -392,9 +390,7 @@ class TestLoadToolGroup(unittest.TestCase):
         with isolated_bridge() as bridge:
             bridge.state._default_groups = set()
             seed_schema(bridge, defs, loaded_groups=set())
-            data = json.loads(
-                asyncio.run(bridge.load_tool_group("stg_beta", ctx=ctx))
-            )
+            data = json.loads(asyncio.run(bridge.load_tool_group("stg_beta", ctx=ctx)))
             # The tool must be genuinely callable now, not merely reported.
             registered = "stg_load_b" in bridge.mcp._tool_manager._tools
             unrelated = "stg_load_a" in bridge.mcp._tool_manager._tools
@@ -493,9 +489,7 @@ class TestUnloadToolGroup(unittest.TestCase):
         with isolated_bridge() as bridge:
             bridge.state._default_groups = set()
             seed_schema(bridge, defs, loaded_groups={"stg_alpha", "stg_beta"})
-            data = json.loads(
-                asyncio.run(bridge.unload_tool_group("stg_beta", ctx=ctx))
-            )
+            data = json.loads(asyncio.run(bridge.unload_tool_group("stg_beta", ctx=ctx)))
             still_registered = "stg_unload_b" in bridge.mcp._tool_manager._tools
             sibling_kept = "stg_unload_a" in bridge.mcp._tool_manager._tools
 
@@ -512,9 +506,7 @@ class TestUnloadToolGroup(unittest.TestCase):
         with isolated_bridge() as bridge:
             bridge.state._default_groups = set()
             seed_schema(bridge, [tool_def("stg_idle_a", "stg_alpha")], loaded_groups=set())
-            data = json.loads(
-                asyncio.run(bridge.unload_tool_group("stg_alpha", ctx=ctx))
-            )
+            data = json.loads(asyncio.run(bridge.unload_tool_group("stg_alpha", ctx=ctx)))
 
         self.assertIn("not loaded", data["message"])
         self.assertNotIn("error", data)
@@ -547,10 +539,7 @@ class TestCheckTools(unittest.TestCase):
             seed_schema(bridge, defs, loaded_groups={"stg_alpha"})
             data = json.loads(
                 asyncio.run(
-                    bridge.check_tools(
-                        " list_instances , stg_check_loaded ,"
-                        "stg_check_unloaded,stg_check_missing"
-                    )
+                    bridge.check_tools(" list_instances , stg_check_loaded ," "stg_check_unloaded,stg_check_missing")
                 )
             )
 
@@ -563,9 +552,7 @@ class TestCheckTools(unittest.TestCase):
         self.assertEqual(results["stg_check_loaded"]["group"], "stg_alpha")
         # A known tool whose group is not loaded gets the exact fix-up call.
         self.assertEqual(results["stg_check_unloaded"]["status"], "not_loaded")
-        self.assertEqual(
-            results["stg_check_unloaded"]["fix"], 'load_tool_group("stg_beta")'
-        )
+        self.assertEqual(results["stg_check_unloaded"]["fix"], 'load_tool_group("stg_beta")')
         # An unknown name is not_found -- no group, no fix.
         self.assertEqual(results["stg_check_missing"], {"status": "not_found"})
         self.assertEqual(data["summary"], "2/4 callable")
@@ -619,9 +606,7 @@ class TestSearchTools(unittest.TestCase):
         self.assertEqual(by_name["stg_rename_function"]["status"], "callable")
         self.assertNotIn("fix", by_name["stg_rename_function"])
         self.assertEqual(by_name["stg_list_globals"]["status"], "not_loaded")
-        self.assertEqual(
-            by_name["stg_list_globals"]["fix"], 'load_tool_group("stg_globals")'
-        )
+        self.assertEqual(by_name["stg_list_globals"]["fix"], 'load_tool_group("stg_globals")')
 
     def test_limit_caps_results_but_match_count_stays_honest(self):
         with isolated_bridge() as bridge:
@@ -649,9 +634,7 @@ class TestSearchTools(unittest.TestCase):
         long_desc = "rename " + ("x" * 400)
         with isolated_bridge() as bridge:
             bridge.state._default_groups = set()
-            seed_schema(
-                bridge, [tool_def("stg_long", "stg_misc", long_desc)], loaded_groups=set()
-            )
+            seed_schema(bridge, [tool_def("stg_long", "stg_misc", long_desc)], loaded_groups=set())
             data = json.loads(asyncio.run(bridge.search_tools("rename")))
 
         self.assertEqual(len(data["matches"][0]["description"]), 160)
@@ -695,9 +678,10 @@ class TestImportFile(unittest.TestCase):
     def test_payload_omits_unset_language_and_compiler_spec(self):
         """Ghidra auto-detects the format when `language` is absent; sending
         an explicit null would defeat that, so the keys must be omitted."""
-        with isolated_bridge() as bridge, patch.object(
-            bridge.dispatch, "dispatch_post", return_value='{"data": {}}'
-        ) as post:
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.dispatch, "dispatch_post", return_value='{"data": {}}') as post,
+        ):
             asyncio.run(bridge.import_file(r"C:\bins\game.exe"))
 
         post.assert_called_once_with(
@@ -710,9 +694,10 @@ class TestImportFile(unittest.TestCase):
         )
 
     def test_raw_binary_payload_includes_language_and_compiler_spec(self):
-        with isolated_bridge() as bridge, patch.object(
-            bridge.dispatch, "dispatch_post", return_value='{"data": {}}'
-        ) as post:
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.dispatch, "dispatch_post", return_value='{"data": {}}') as post,
+        ):
             asyncio.run(
                 bridge.import_file(
                     "/fw/image.bin",
@@ -737,8 +722,9 @@ class TestImportFile(unittest.TestCase):
     def test_non_json_response_is_returned_verbatim(self):
         """The Ghidra server can answer with a plain-text error; import_file
         must pass it through instead of raising a JSONDecodeError."""
-        with isolated_bridge() as bridge, patch.object(
-            bridge.dispatch, "dispatch_post", return_value="Import failed: no such file"
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.dispatch, "dispatch_post", return_value="Import failed: no such file"),
         ):
             result = asyncio.run(bridge.import_file("/nope.bin"))
 
@@ -746,12 +732,14 @@ class TestImportFile(unittest.TestCase):
 
     def test_no_poll_task_when_analysis_not_started(self):
         fake = FakeAsyncio()
-        with isolated_bridge() as bridge, patch.object(
-            bridge.static_tools, "asyncio", fake
-        ), patch.object(
-            bridge.dispatch,
-            "dispatch_post",
-            return_value=json.dumps({"data": {"analyzing": False, "name": "x.exe"}}),
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.static_tools, "asyncio", fake),
+            patch.object(
+                bridge.dispatch,
+                "dispatch_post",
+                return_value=json.dumps({"data": {"analyzing": False, "name": "x.exe"}}),
+            ),
         ):
             asyncio.run(bridge.import_file("/x.exe", ctx=make_ctx()))
 
@@ -761,12 +749,14 @@ class TestImportFile(unittest.TestCase):
         """Without a ctx there is no session to notify, so spawning a 30-minute
         poll loop would just burn requests forever."""
         fake = FakeAsyncio()
-        with isolated_bridge() as bridge, patch.object(
-            bridge.static_tools, "asyncio", fake
-        ), patch.object(
-            bridge.dispatch,
-            "dispatch_post",
-            return_value=json.dumps({"data": {"analyzing": True, "name": "x.exe"}}),
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.static_tools, "asyncio", fake),
+            patch.object(
+                bridge.dispatch,
+                "dispatch_post",
+                return_value=json.dumps({"data": {"analyzing": True, "name": "x.exe"}}),
+            ),
         ):
             asyncio.run(bridge.import_file("/x.exe"))
 
@@ -783,15 +773,16 @@ class TestImportFile(unittest.TestCase):
             await fake.tasks[0]  # drive the poll loop to completion
             return result
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.static_tools, "asyncio", fake
-        ), patch.object(
-            bridge.dispatch,
-            "dispatch_post",
-            return_value=json.dumps({"data": {"analyzing": True, "name": "game.exe"}}),
-        ), patch.object(
-            bridge.dispatch, "dispatch_get", return_value=status
-        ) as status_get:
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.static_tools, "asyncio", fake),
+            patch.object(
+                bridge.dispatch,
+                "dispatch_post",
+                return_value=json.dumps({"data": {"analyzing": True, "name": "game.exe"}}),
+            ),
+            patch.object(bridge.dispatch, "dispatch_get", return_value=status) as status_get,
+        ):
             asyncio.run(scenario(bridge))
 
         status_get.assert_called_with("/analysis_status", {"program": "game.exe"})
@@ -812,17 +803,20 @@ class TestImportFile(unittest.TestCase):
             await bridge.import_file("/x.exe", ctx=ctx)
             await fake.tasks[0]
 
-        with isolated_bridge() as bridge, patch.object(
-            bridge.static_tools, "asyncio", fake
-        ), patch.object(
-            bridge.dispatch,
-            "dispatch_post",
-            return_value=json.dumps({"data": {"analyzing": True, "name": "game.exe"}}),
-        ), patch.object(
-            bridge.dispatch,
-            "dispatch_get",
-            side_effect=[ConnectionError("boom"), "not json at all", done],
-        ) as status_get:
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.static_tools, "asyncio", fake),
+            patch.object(
+                bridge.dispatch,
+                "dispatch_post",
+                return_value=json.dumps({"data": {"analyzing": True, "name": "game.exe"}}),
+            ),
+            patch.object(
+                bridge.dispatch,
+                "dispatch_get",
+                side_effect=[ConnectionError("boom"), "not json at all", done],
+            ) as status_get,
+        ):
             asyncio.run(scenario(bridge))
 
         self.assertEqual(status_get.call_count, 3)
@@ -866,13 +860,12 @@ class TestAutoConnect(unittest.TestCase):
         bridge = self._bridge
         one = [{"socket": "/tmp/d2.sock", "pid": 42, "project": "diablo2"}]
 
-        with patch.object(
-            bridge.discovery, "discover_instances", return_value=one
-        ), patch.object(
-            bridge.transport, "uds_supported", return_value=True
-        ), patch.object(
-            bridge.registry, "_fetch_and_register_schema", return_value=271
-        ) as fetch:
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=True),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=271) as fetch,
+        ):
             bridge._auto_connect()
 
         fetch.assert_called_once()
@@ -886,16 +879,15 @@ class TestAutoConnect(unittest.TestCase):
         bridge = self._bridge
         one = [{"socket": "/tmp/d2.sock", "pid": 42, "project": "diablo2"}]
 
-        with patch.object(
-            bridge.discovery, "discover_instances", return_value=one
-        ), patch.object(
-            bridge.transport, "uds_supported", return_value=True
-        ), patch.object(
-            bridge.registry,
-            "_fetch_and_register_schema",
-            side_effect=RuntimeError("HTTP 500"),
-        ), patch.dict(
-            os.environ, {"GHIDRA_MCP_URL": "http://evil.example.com:8089"}
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=True),
+            patch.object(
+                bridge.registry,
+                "_fetch_schema",
+                side_effect=RuntimeError("HTTP 500"),
+            ),
+            patch.dict(os.environ, {"GHIDRA_MCP_URL": "http://evil.example.com:8089"}),
         ):
             bridge._auto_connect()
 
@@ -919,16 +911,15 @@ class TestAutoConnect(unittest.TestCase):
         ]
         env = {k: v for k, v in os.environ.items() if k != "GHIDRA_MCP_URL"}
 
-        with patch.object(
-            bridge.discovery, "discover_instances", return_value=one
-        ), patch.object(
-            bridge.transport, "uds_supported", return_value=False
-        ), patch.object(
-            bridge.registry,
-            "_fetch_and_register_schema",
-            side_effect=ConnectionRefusedError("nope"),
-        ), patch.dict(
-            os.environ, env, clear=True
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=one),
+            patch.object(bridge.transport, "uds_supported", return_value=False),
+            patch.object(
+                bridge.registry,
+                "_fetch_schema",
+                side_effect=ConnectionRefusedError("nope"),
+            ),
+            patch.dict(os.environ, env, clear=True),
         ):
             bridge._auto_connect()
 
@@ -939,12 +930,11 @@ class TestAutoConnect(unittest.TestCase):
         bridge = self._bridge
         env = {k: v for k, v in os.environ.items() if k != "GHIDRA_MCP_URL"}
 
-        with patch.object(
-            bridge.discovery, "discover_instances", return_value=[]
-        ), patch.object(
-            bridge.registry, "_fetch_and_register_schema", return_value=12
-        ), patch.dict(
-            os.environ, env, clear=True
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[]),
+            patch.object(bridge.registry, "_fetch_schema", return_value=[]),
+            patch.object(bridge.registry, "register_tools_from_schema", return_value=12),
+            patch.dict(os.environ, env, clear=True),
         ):
             bridge._auto_connect()
 
@@ -955,14 +945,14 @@ class TestAutoConnect(unittest.TestCase):
         bridge = self._bridge
         env = {k: v for k, v in os.environ.items() if k != "GHIDRA_MCP_URL"}
 
-        with patch.object(
-            bridge.discovery, "discover_instances", return_value=[]
-        ), patch.object(
-            bridge.registry,
-            "_fetch_and_register_schema",
-            side_effect=ConnectionRefusedError("nope"),
-        ), patch.dict(
-            os.environ, env, clear=True
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[]),
+            patch.object(
+                bridge.registry,
+                "_fetch_schema",
+                side_effect=ConnectionRefusedError("nope"),
+            ),
+            patch.dict(os.environ, env, clear=True),
         ):
             bridge._auto_connect()
 
@@ -972,12 +962,10 @@ class TestAutoConnect(unittest.TestCase):
     def test_non_local_env_url_is_never_auto_connected(self):
         bridge = self._bridge
 
-        with patch.object(
-            bridge.discovery, "discover_instances", return_value=[]
-        ), patch.object(
-            bridge.registry, "_fetch_and_register_schema"
-        ) as fetch, patch.dict(
-            os.environ, {"GHIDRA_MCP_URL": "http://10.0.0.5:8089"}
+        with (
+            patch.object(bridge.discovery, "discover_instances", return_value=[]),
+            patch.object(bridge.registry, "_fetch_schema") as fetch,
+            patch.dict(os.environ, {"GHIDRA_MCP_URL": "http://10.0.0.5:8089"}),
         ):
             bridge._auto_connect()
 
@@ -1018,10 +1006,10 @@ class TestListInstancesPayloadSize(unittest.TestCase):
         }
 
     def _run(self, instance):
-        with isolated_bridge() as bridge, patch.object(
-            bridge.discovery, "discover_instances", return_value=[instance]
-        ), patch.object(
-            bridge.discovery, "discover_active_tcp_instance", return_value=None
+        with (
+            isolated_bridge() as bridge,
+            patch.object(bridge.discovery, "discover_instances", return_value=[instance]),
+            patch.object(bridge.discovery, "discover_active_tcp_instance", return_value=None),
         ):
             raw = bridge.list_instances()
         return raw, json.loads(raw)["instances"][0]
@@ -1096,17 +1084,13 @@ class TestCheckToolsWithoutSchema(unittest.TestCase):
             bridge.state._full_schema = []
             data = asyncio.run(bridge.check_tools("list_instances"))
 
-        self.assertEqual(
-            json.loads(data)["results"]["list_instances"]["status"], "callable"
-        )
+        self.assertEqual(json.loads(data)["results"]["list_instances"]["status"], "callable")
 
     def test_missing_tool_is_still_not_found_when_schema_present(self):
         """With a schema loaded the distinction must still be made — this is
         what keeps the fix from degrading into "everything is unknown"."""
         with isolated_bridge() as bridge:
-            bridge.state._full_schema = [
-                {"name": "rename_function_by_address", "category": "rename"}
-            ]
+            bridge.state._full_schema = [{"name": "rename_function_by_address", "category": "rename"}]
             bridge.state._dynamic_tool_names[:] = []
             data = asyncio.run(bridge.check_tools("no_such_tool"))
 

--- a/tests/unit/test_transport_network.py
+++ b/tests/unit/test_transport_network.py
@@ -18,8 +18,11 @@ import os
 import socket
 import socketserver
 import sys
+import asyncio
+import concurrent.futures
 import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import patch
 
@@ -62,11 +65,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0))
         raw = self.rfile.read(length).decode("utf-8") if length else ""
         if self.path.startswith("/echo"):
-            self._reply(200, {
-                "content_type": self.headers.get("Content-Type"),
-                "received": json.loads(raw) if raw else None,
-                "path": self.path,
-            })
+            self._reply(
+                200,
+                {
+                    "content_type": self.headers.get("Content-Type"),
+                    "received": json.loads(raw) if raw else None,
+                    "path": self.path,
+                },
+            )
         elif self.path.startswith("/boom"):
             self._reply(500, {"error": "write failed"})
         else:
@@ -116,9 +122,7 @@ class TestTcpRequest(_TcpServerMixin, unittest.TestCase):
         self.assertTrue(json.loads(text)["ok"])
 
     def test_get_encodes_query_params(self):
-        text, _ = transport.tcp_request(
-            self.base_url, "GET", "ok", params={"program": "D2Common.dll", "n": 5}
-        )
+        text, _ = transport.tcp_request(self.base_url, "GET", "ok", params={"program": "D2Common.dll", "n": 5})
         path = json.loads(text)["path"]
         self.assertIn("program=D2Common.dll", path)
         self.assertIn("n=5", path)
@@ -127,9 +131,7 @@ class TestTcpRequest(_TcpServerMixin, unittest.TestCase):
 
     def test_post_sends_json_content_type_and_body(self):
         payload = {"address": "0x6fd50000", "name": "GetUnitPosition"}
-        text, status = transport.tcp_request(
-            self.base_url, "POST", "/echo", json_data=payload
-        )
+        text, status = transport.tcp_request(self.base_url, "POST", "/echo", json_data=payload)
         self.assertEqual(status, 200)
         data = json.loads(text)
         self.assertEqual(data["content_type"], "application/json")
@@ -142,7 +144,7 @@ class TestTcpRequest(_TcpServerMixin, unittest.TestCase):
 
     def test_connection_refused_raises(self):
         dead_url = f"http://127.0.0.1:{_free_port()}"
-        with self.assertRaises(OSError):
+        with self.assertRaises(transport.RequestNotSentError):
             transport.tcp_request(dead_url, "GET", "/ok", timeout=2)
 
 
@@ -164,6 +166,52 @@ class TestDoRequestRouting(_TcpServerMixin, unittest.TestCase):
         state._transport_mode = "none"
         with self.assertRaises(ConnectionError):
             transport.do_request("GET", "/ok")
+
+    def test_parallel_requests_are_not_globally_serialized(self):
+        state._transport_mode = "tcp"
+        state._active_tcp = self.base_url
+        barrier = threading.Barrier(2)
+
+        def concurrent_request(*args, **kwargs):
+            barrier.wait(timeout=1)
+            return '{"ok": true}', 200
+
+        with patch.object(transport, "tcp_request", side_effect=concurrent_request):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [pool.submit(transport.do_request, "GET", "/ok") for _ in range(2)]
+                self.assertEqual([future.result(timeout=2)[1] for future in futures], [200, 200])
+
+    def test_abort_during_connect_prevents_send(self):
+        handle = state.RequestCancelHandle()
+        token = state._request_cancel_handle.set(handle)
+
+        class FakeConn:
+            def __init__(self):
+                self.requested = False
+                self.closed = False
+                self.timeout = 1
+
+            def connect(self):
+                handle.abort()
+
+            def request(self, *args, **kwargs):
+                self.requested = True
+
+            def getresponse(self):
+                raise AssertionError("getresponse should not run")
+
+            def close(self):
+                self.closed = True
+
+        conn = FakeConn()
+        try:
+            with self.assertRaises(transport.RequestOutcomeUnknownError):
+                transport._request_over_connection(conn, "GET", "/ok", None, {})
+        finally:
+            state._request_cancel_handle.reset(token)
+
+        self.assertFalse(conn.requested)
+        self.assertTrue(conn.closed)
 
 
 class TestDispatchAgainstLiveServer(_TcpServerMixin, unittest.TestCase):
@@ -203,6 +251,166 @@ class TestDispatchAgainstLiveServer(_TcpServerMixin, unittest.TestCase):
         self.assertIn("HTTP 404", json.loads(text)["error"])
         self.assertEqual(self.server.hits["/missing"], 1)
 
+    def test_get_unknown_outcome_is_never_retried(self):
+        error = transport.RequestOutcomeUnknownError("response timed out")
+        with (
+            patch.object(transport, "do_request", side_effect=error) as request,
+            patch.object(dispatch, "_try_reconnect") as reconnect,
+        ):
+            text = dispatch.dispatch_get("/ok", retries=3)
+
+        self.assertEqual(request.call_count, 1)
+        reconnect.assert_not_called()
+        self.assertIn("was not retried", json.loads(text)["error"])
+
+    def test_get_reconnects_once_when_request_was_not_sent(self):
+        with (
+            patch.object(
+                transport,
+                "do_request",
+                side_effect=[
+                    transport.RequestNotSentError("connection refused"),
+                    ('{"ok": true}', 200),
+                ],
+            ) as request,
+            patch.object(dispatch, "_try_reconnect", return_value=True) as reconnect,
+        ):
+            text = dispatch.dispatch_get("/ok", retries=3)
+
+        self.assertTrue(json.loads(text)["ok"])
+        self.assertEqual(request.call_count, 2)
+        reconnect.assert_called_once()
+
+    def test_get_retries_known_unsent_failure_without_reconnect(self):
+        with (
+            patch.object(
+                transport,
+                "do_request",
+                side_effect=[
+                    transport.RequestNotSentError("connection refused"),
+                    ('{"ok": true}', 200),
+                ],
+            ) as request,
+            patch.object(dispatch, "_try_reconnect", return_value=False) as reconnect,
+            patch.object(dispatch.time, "sleep"),
+        ):
+            text = dispatch.dispatch_get("/ok", retries=3)
+
+        self.assertTrue(json.loads(text)["ok"])
+        self.assertEqual(request.call_count, 2)
+        reconnect.assert_called_once()
+
+
+class TestAsyncRequestAdmission(_TcpServerMixin, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        state._transport_mode = "tcp"
+        state._active_tcp = self.base_url
+        state._connected_project = None
+
+    def tearDown(self):
+        state._active_tcp = None
+        state._transport_mode = "none"
+        state._connected_project = None
+
+    def test_cancelled_waiter_never_executes(self):
+        call_count = 0
+
+        async def scenario():
+            nonlocal call_count
+            release = threading.Event()
+            started = threading.Event()
+            old_executor = state._ghidra_executor
+            state._ghidra_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="GhidraMCP-Test",
+            )
+
+            def blocking_call(tag):
+                nonlocal call_count
+                call_count += 1
+                if tag == "first":
+                    started.set()
+                    release.wait(1)
+                return tag
+
+            try:
+                first = asyncio.create_task(state.run_blocking_ghidra_call(blocking_call, "first"))
+                for _ in range(100):
+                    if started.is_set():
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertTrue(started.is_set())
+
+                second = asyncio.create_task(state.run_blocking_ghidra_call(blocking_call, "second"))
+                await asyncio.sleep(0)
+                second.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await second
+
+                release.set()
+                self.assertEqual(await first, "first")
+            finally:
+                release.set()
+                state._ghidra_executor.shutdown(wait=True, cancel_futures=False)
+                state._ghidra_executor = old_executor
+
+        asyncio.run(scenario())
+        self.assertEqual(call_count, 1)
+
+    def test_queued_request_keeps_original_connection_snapshot(self):
+        seen_connections = []
+
+        async def scenario():
+            old_executor = state._ghidra_executor
+            state._ghidra_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="GhidraMCP-Test",
+            )
+            release = threading.Event()
+            started = threading.Event()
+
+            def blocking_call():
+                started.set()
+                release.wait(1)
+                return "released"
+
+            try:
+                state.set_connection_snapshot(
+                    "tcp",
+                    active_tcp="http://target-a:8089",
+                    connected_project="A",
+                )
+                first = asyncio.create_task(state.run_blocking_ghidra_call(blocking_call))
+                for _ in range(100):
+                    if started.is_set():
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertTrue(started.is_set())
+
+                with patch.object(transport, "do_request") as request:
+                    request.side_effect = lambda *args, **kwargs: (
+                        seen_connections.append(kwargs["connection"].active_tcp) or '{"ok": true}',
+                        200,
+                    )
+                    second = asyncio.create_task(state.run_blocking_ghidra_call(dispatch.dispatch_get, "/ok"))
+                    await asyncio.sleep(0)
+                    state.set_connection_snapshot(
+                        "tcp",
+                        active_tcp="http://target-b:8089",
+                        connected_project="B",
+                    )
+                    release.set()
+                    self.assertEqual(await first, "released")
+                    self.assertTrue(json.loads(await second)["ok"])
+            finally:
+                release.set()
+                state._ghidra_executor.shutdown(wait=True, cancel_futures=False)
+                state._ghidra_executor = old_executor
+
+        asyncio.run(scenario())
+        self.assertEqual(seen_connections, ["http://target-a:8089"])
+
     def test_post_success(self):
         text = dispatch.dispatch_post("/echo", {"k": "v"})
         self.assertEqual(json.loads(text)["received"], {"k": "v"})
@@ -217,9 +425,7 @@ class TestDispatchAgainstLiveServer(_TcpServerMixin, unittest.TestCase):
     def test_post_sends_query_params_separately_from_body(self):
         # The @Param(value="program") QUERY convention: program rides the
         # URL, never the JSON body.
-        text = dispatch.dispatch_post(
-            "/echo", {"name": "x"}, query_params={"program": "D2Game.dll"}
-        )
+        text = dispatch.dispatch_post("/echo", {"name": "x"}, query_params={"program": "D2Game.dll"})
         data = json.loads(text)
         self.assertIn("program=D2Game.dll", data["path"])
         self.assertEqual(data["received"], {"name": "x"})
@@ -267,17 +473,13 @@ class TestUdsRequest(unittest.TestCase):
         self.assertTrue(json.loads(text)["ok"])
 
     def test_post_json_round_trip(self):
-        text, status = transport.uds_request(
-            self.socket_path, "POST", "/echo", json_data={"a": 1}
-        )
+        text, status = transport.uds_request(self.socket_path, "POST", "/echo", json_data={"a": 1})
         self.assertEqual(status, 200)
         self.assertEqual(json.loads(text)["received"], {"a": 1})
 
     def test_missing_socket_raises(self):
         with self.assertRaises(OSError):
-            transport.uds_request(
-                str(Path(self._tmpdir.name) / "nope.sock"), "GET", "/ok", timeout=2
-            )
+            transport.uds_request(str(Path(self._tmpdir.name) / "nope.sock"), "GET", "/ok", timeout=2)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -616,7 +616,7 @@ wheels = [
 
 [[package]]
 name = "ghidra-mcp-bridge"
-version = "5.17.0"
+version = "6.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Close the race where a cancelled request could close an HTTPConnection between connect() and request(), allowing http.client to reconnect and send a side-effecting request anyway.

Add RequestCancelHandle.hold_send_window() and use it around request() submission for Ghidra UDS/TCP transport, debugger proxy requests, and TCP instance discovery. Abort now either prevents the send or waits until the send operation has crossed the non-interruptible boundary.

Run load_tool_group() and unload_tool_group() notifications from the underlying worker Future completion callback. This preserves tools/list_changed delivery when the initiating MCP coroutine is cancelled after the worker has started and changed the dynamic registry.

Also fan out worker-originated tools/list_changed notifications to every remembered live MCP session instead of only the last session, and include TCP port scanning in the request cancellation handle.