### PR TITLE
fix(options): a CUSTOM_TYPE option silently lost its `value` key

### DIFF
--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -341,8 +341,14 @@ public class ProgramScriptService {
                 entry.put("name", name);
                 OptionType type = opts.getType(name);
                 entry.put("type", type != null ? type.name() : "NO_TYPE");
-                entry.put("value", opts.getValueAsString(name));
-                entry.put("default_value", opts.getDefaultValueAsString(name));
+                // getValueAsString returns null for CUSTOM_TYPE options (e.g.
+                // "Analysis Times.Times"), and the JSON writer drops null-valued
+                // keys -- so the entry silently lost `value` entirely for that
+                // one type while every other entry carried it. A key the shape
+                // promises must always be present, so fall back to the stored
+                // object's own rendering before giving up on an empty string.
+                entry.put("value", optionValueString(opts, name, false));
+                entry.put("default_value", optionValueString(opts, name, true));
                 entry.put("is_default", opts.isDefaultValue(name));
                 entry.put("registered", opts.isRegistered(name));
                 String desc = opts.getDescription(name);
@@ -359,6 +365,35 @@ public class ProgramScriptService {
         } catch (Exception e) {
             return Response.err(e.getMessage());
         }
+    }
+
+    /**
+     * Render an option's value (or default) as a string that is never null.
+     *
+     * <p>{@link Options#getValueAsString} and {@link Options#getDefaultValueAsString}
+     * both return null for option types they cannot stringify -- CUSTOM_TYPE in
+     * practice. Because the JSON writer omits null-valued keys, that turned into
+     * an entry missing {@code value} altogether while its siblings had one, so a
+     * caller iterating options had to special-case a key the shape promises.
+     * Falling back to the stored object's own {@code toString} keeps the key
+     * present and usually carries real information; empty string is the last
+     * resort, meaning "present but not representable".
+     */
+    private static String optionValueString(Options opts, String name, boolean wantDefault) {
+        String value = wantDefault ? opts.getDefaultValueAsString(name) : opts.getValueAsString(name);
+        if (value != null) {
+            return value;
+        }
+        try {
+            Object raw = wantDefault ? opts.getDefaultValue(name) : opts.getObject(name, null);
+            if (raw != null) {
+                return String.valueOf(raw);
+            }
+        } catch (Exception ignored) {
+            // A custom option whose accessor throws is still an option we must
+            // list; degrade to empty rather than failing the whole group.
+        }
+        return "";
     }
 
     /**


### PR DESCRIPTION
Found during the **first live verification of 7.0.0** — no offline tier could have caught it.

## The bug

`get_program_options` promises every entry carries `value`. One option type did not:

```json
{"name": "Analysis Times.Times", "type": "CUSTOM_TYPE",
 "is_default": true, "registered": true, "description": "Cumulative analysis task times"}
```

No `value`, no `default_value` — while the other **14 entries in the same response** had both.

`Options.getValueAsString()` returns null for types it cannot stringify (CUSTOM_TYPE in
practice), and the JSON writer omits null-valued keys, so the key vanished entirely rather
than coming back null. A caller iterating options had to special-case a key the shape
guarantees — exactly the inconsistency the 7.0.0 response contract exists to remove.

## The fix

`optionValueString()` falls back to the stored object's own `toString` before degrading to
`""` (present, but not representable), and applies the same rule to `default_value`. A custom
accessor that throws is caught: a weird option is still an option that must be listed, and it
must not fail the whole group.

## Why offline testing missed it

The option only exists once analysis has run and recorded Analysis Times against a real
program. It is invisible to unit tests, the offline Java tier, and the offline Python tier —
it needs a live Ghidra with an analyzed binary. `tests/integration/test_program_storage_endpoints.py::TestProgramOptions::test_get_program_options`
already asserted the invariant; nothing had ever run it against a program in this state.

## Verification

On a live 7.0.0 deploy (`plugin 7.0.0`, built `20260803-042355`):

- Entries missing `value`: **1 → 0**
- `pytest tests/ -m safe_write` — **1 failure → 0**
- `pytest tests/ -m readonly` — **0 failures**
- Offline Java — 409 tests, 0 failures
- Release regression tier — passed

The one remaining Java error under `mvn test`
(`FunctionServiceClearFlowAndRepairGhidraTest.initializeGhidra`, `application.properties was
not found`) is pre-existing and unrelated — confirmed by reproducing it identically with this
change stashed.
