### PR TITLE
fun-doc: the dashboard was reporting green over three things that could not work

### DIFF
--- a/fun-doc/conformance_dashboard.py
+++ b/fun-doc/conformance_dashboard.py
@@ -126,9 +126,17 @@ def summary(program: str = None) -> dict:
 
 def matrix(program: str = None) -> dict:
     """The DOC_ x CONF_ joint counts, plus marginals and the never-evaluated cell.
-    Rows = CONF (best->worst then none); cols = DOC (none->best). Cheap set math."""
-    conf_sets = {r: _tag_addrs(r, program) for r in CONF_RUNGS}
-    doc_sets = {r: _tag_addrs(r, program) for r in DOC_RUNGS}
+    Rows = CONF (best->worst then none); cols = DOC (none->best). Cheap set math.
+
+    Library/stub functions are subtracted, exactly as `bands()` does, because
+    the dashboard divides these counts by `in_scope` -- which already excludes
+    them. Without the subtraction the numerator covers a WIDER population than
+    the denominator and the bars read over 100%: measured 105.3% on D2Common
+    and 172.6% on PD2_EXT before this, with the leading `untagged`/`none`
+    segment clamped to zero so the bar looked merely full instead of wrong."""
+    excl = set().union(*(_tag_addrs(t, program) for t in EXCLUDE_TAGS))
+    conf_sets = {r: _tag_addrs(r, program) - excl for r in CONF_RUNGS}
+    doc_sets = {r: _tag_addrs(r, program) - excl for r in DOC_RUNGS}
     conf_tagged = set().union(*conf_sets.values()) if conf_sets else set()
     doc_tagged = set().union(*doc_sets.values()) if doc_sets else set()
 

--- a/fun-doc/redeploy-dashboard.ps1
+++ b/fun-doc/redeploy-dashboard.ps1
@@ -132,6 +132,25 @@ function Wait-Healthy([int]$Seconds) {
     return $false
 }
 
+# Wait for the LISTENER PID to actually change, then for the new one to answer.
+#
+# A fixed sleep is not enough and gave a false negative that made things worse:
+# /api/admin/restart stops the workers FIRST (stop_timeout 45s), so with a few
+# port workers running the old process is still up and perfectly healthy five
+# seconds later. The old flow slept 5s, saw a healthy dashboard on the SAME
+# pid, declared "the PID did not change", and fell through to the scheduled
+# task -- firing a second restart on top of one already in flight, and
+# reporting a version that had not been deployed yet.
+function Wait-PidChange([int]$Seconds, $OldPid) {
+    $deadline = (Get-Date).AddSeconds($Seconds)
+    while ((Get-Date) -lt $deadline) {
+        $now = Get-ListenerPid
+        if ($now -and $now -ne $OldPid) { return $now }
+        Start-Sleep -Seconds 2
+    }
+    return $null
+}
+
 $before = Get-ListenerPid
 
 if ($InstallTask) { $Force = $true }   # task registration needs elevation anyway
@@ -156,18 +175,17 @@ if (-not $Force) {
         $resp = Invoke-RestMethod -Uri "$Base/api/admin/restart" -Method Post -TimeoutSec 15
         if ($resp.ok) {
             Write-Host "Self-restart accepted (no elevation needed). Waiting..."
-            # It stops workers first, so allow for that before it drops the port.
-            Start-Sleep -Seconds 5
-            if (Wait-Healthy $TimeoutSec) {
-                $after = Get-ListenerPid
-                if ($after -and $after -ne $before) {
+            # It stops workers first (stop_timeout 45s), so the handover can be
+            # well over a minute with a busy fleet. Watch the PID, not the clock.
+            $after = Wait-PidChange ($TimeoutSec + 60) $before
+            if ($after) {
+                if (Wait-Healthy $TimeoutSec) {
                     Write-Host "Dashboard restarted (PID $before -> $after)."
                     exit 0
                 }
-                # Same PID means it never actually went down.
-                Write-Warning "Dashboard answered but the PID did not change ($after)."
+                Write-Warning "New dashboard (PID $after) bound the port but never answered."
             } else {
-                Write-Warning "Dashboard did not come back within ${TimeoutSec}s."
+                Write-Warning "Dashboard never released the port; PID is still $before."
             }
         }
     } catch {
@@ -181,10 +199,19 @@ $task = Get-ScheduledTask -TaskName 'FunDoc Dashboard' -ErrorAction SilentlyCont
 if ($task -and -not $Force) {
     try {
         Write-Host "Trying the scheduled task..."
+        $beforeTask = Get-ListenerPid
         Stop-ScheduledTask  -TaskName 'FunDoc Dashboard' -ErrorAction Stop
         Start-Sleep -Seconds 3
         Start-ScheduledTask -TaskName 'FunDoc Dashboard' -ErrorAction Stop
-        if (Wait-Healthy $TimeoutSec) { Write-Host "Dashboard restarted via scheduled task." ; exit 0 }
+        # Same trap as path 1: "it answers" is not "it restarted". This path
+        # used to report success purely on Wait-Healthy, so a task that failed
+        # to take over the port announced a deploy that had not happened.
+        $afterTask = Wait-PidChange $TimeoutSec $beforeTask
+        if ($afterTask -and (Wait-Healthy $TimeoutSec)) {
+            Write-Host "Dashboard restarted via scheduled task (PID $beforeTask -> $afterTask)."
+            exit 0
+        }
+        Write-Warning "Scheduled task did not take over the port (PID still $beforeTask)."
     } catch {
         Write-Warning "Scheduled-task restart failed ($($_.Exception.Message))."
     }

--- a/fun-doc/templates/pipeline.html
+++ b/fun-doc/templates/pipeline.html
@@ -92,6 +92,14 @@
     border-bottom:1px solid transparent; padding:0 1rem;
     transition:max-height .2s ease, border-color .2s ease; }
   .roster-bar.active { max-height:52px; padding:.5rem 1rem; border-bottom-color:#7896c7; }
+  /* ---- fleet pause bar (deliberate parking, not a fault -- amber, not red) ---- */
+  .pause-bar { max-height:0; overflow:hidden; display:flex; align-items:center; gap:.6rem;
+    background:linear-gradient(90deg,rgba(199,179,119,.18),rgba(199,179,119,.04));
+    border-bottom:1px solid transparent; padding:0 1rem;
+    transition:max-height .2s ease, border-color .2s ease; }
+  .pause-bar.active { max-height:52px; padding:.5rem 1rem; border-bottom-color:var(--gold,#c7b377); }
+  .pause-bar .tb-icon { font-size:.9rem; color:var(--gold,#c7b377); letter-spacing:-2px; }
+  .pause-bar .tb-msg { flex:1; font-size:.72rem; color:var(--text-secondary); }
   .header .spacer { flex:1; }
   .header-info { color:var(--text-muted); font-size:.72rem; font-family:var(--font-mono); }
 
@@ -144,6 +152,11 @@
   .worker-pane.stopping { border-color:var(--rare); }
   .worker-pane.finished { border-color:var(--text-muted); opacity:.8; }
   .worker-pane.quota_paused { border-color:var(--rare); }
+  /* Operator pause is not a fault and not progress. It had no class at all, so
+     `paused` fell through to `running`: three parked workers drew green
+     "running" borders under a hint that read "0 running / 3 total". */
+  .worker-pane.paused { border-color:var(--text-muted); opacity:.85; }
+  .worker-pane-header .wp-parked { font-family:var(--font-mono); font-size:.55rem; font-weight:700; letter-spacing:.5px; color:var(--crafted); border:1px solid var(--crafted); border-radius:3px; padding:0 4px; }
   .worker-pane-header { padding:.25rem .5rem; background:linear-gradient(180deg,var(--bg-light),var(--bg-medium)); border-bottom:1px solid var(--border-dark); border-radius:6px 6px 0 0; display:flex; align-items:center; gap:.4rem; flex-wrap:wrap; font-size:.65rem; }
   .worker-pane-header .wp-title { font-family:var(--font-mono); color:var(--text-primary); font-weight:600; white-space:nowrap; display:flex; align-items:center; gap:.3rem; }
   .worker-pane-header .wp-title .wp-binary { color:var(--text-primary); font-weight:700; }
@@ -484,6 +497,19 @@
     <button class="tb-dismiss" title="Dismiss (forgets the roster)" onclick="dismissRoster()">&times;</button>
   </div>
 
+  <!-- FLEET PAUSE slide-out. /api/health/all has always carried `paused` and
+       `pause_reason` at the top level -- the server comment even says it is
+       surfaced "at the top level, not as a sixth dot" -- but nothing on this
+       page read either field. A paused fleet was therefore invisible: five
+       green dots, worker panes drawn in the running colour, and no cause on
+       screen for why nothing was progressing. No dismiss button: a pause is a
+       standing condition, and dismissing it would recreate the invisibility. -->
+  <div class="pause-bar" id="pauseBar">
+    <span class="tb-icon">&#10073;&#10073;</span>
+    <span class="tb-msg" id="pauseBarMsg">&nbsp;</span>
+    <button class="btn go tb-btn" id="pauseBarBtn" onclick="resumeFleet()">Resume</button>
+  </div>
+
   <!-- SETTINGS slide-out (queue config: good@, cold, debug, handoff, audit, provider models) -->
   <div class="settings-popout" id="settingsPopout">
     <div class="settings-popout-inner">
@@ -597,7 +623,8 @@
          adds the scan + queue-maintenance actions that only the classic page had. -->
     <div class="panel">
       <div class="panel-header"><h2>Steering</h2>
-        <span class="hint" title="Scan refreshes the workflow store from Ghidra. Pins jump the line for Doc + Prove workers.">scan &amp; queue</span></div>
+        <span class="hint" title="Scan refreshes the workflow store from Ghidra. Pins jump the line for Doc + Prove workers.">scan &amp; queue</span>
+        <span class="hint" id="lastSync" title="When sync_conformance_to_ghidra.py last wrote the summary option this dashboard reads."></span></div>
       <div class="panel-content">
         <div class="steer-row">
           <span class="steer-lab">Scan</span>
@@ -828,11 +855,15 @@
 
   // A bar lists ALL rungs in progression order (low->high); untagged/none is the FIRST
   // (leftmost) segment. Legend always lists every rung, even at 0. Bar span drawn only when >0.
+  // Labels are PLAIN TEXT. The legend is built with insertAdjacentHTML so it
+  // escapes here; the segment title is a property assignment and must not be
+  // pre-escaped. Passing "&lt;80" satisfied the legend and left the tooltip on
+  // the completeness bars' first segment reading a literal "&lt;80".
   function seg(bar,legend,parts,total){
     bar.innerHTML=""; legend.innerHTML="";
     parts.forEach(p=>{
       if(p.n>0){ const s=document.createElement("span"); s.style.background=p.c; s.style.width=(100*p.n/Math.max(1,total))+"%"; s.title=`${p.label} ${p.n}`; bar.appendChild(s); }
-      legend.insertAdjacentHTML("beforeend",`<span class="lg"><span class="sw" style="background:${p.c}"></span>${p.label} ${p.n}</span>`);
+      legend.insertAdjacentHTML("beforeend",`<span class="lg"><span class="sw" style="background:${p.c}"></span>${escHtml(p.label)} ${p.n}</span>`);
     });
   }
   function renderBars(s,m){
@@ -888,7 +919,7 @@
     const pct=inscope>0?`${(100*done/inscope).toFixed(1)}%`:"&mdash;";
     document.getElementById("bandPct").innerHTML=`<b>${pct}</b> at target (${target}+)`;
     seg(document.getElementById("bandBar"),document.getElementById("bandLegend"),[
-      {label:"&lt;80",n:Math.max(0,inscope-(c80+c90+c95+c100)),c:"var(--text-muted)"},
+      {label:"<80",n:Math.max(0,inscope-(c80+c90+c95+c100)),c:"var(--text-muted)"},
       {label:"80+",n:c80,c:"var(--crafted)"},
       {label:"90+",n:c90,c:"var(--magic)"},
       {label:"95+",n:c95,c:"var(--set)"},
@@ -922,7 +953,7 @@
     document.getElementById("globBandPct").innerHTML=
       `<b>${pct}</b> at target (${target}+) <span class="revchip" title="Confirmed by an independent review pass — set by the globals audit provider, or by hand from the inventory row. 0 is honest: review is off unless config.globals_audit_provider is set.">&#10003; ${rev.toLocaleString()} reviewed</span>`;
     seg(document.getElementById("globBandBar"),document.getElementById("globBandLegend"),[
-      {label:"&lt;80",n:Math.max(0,inscope-(c80+c90+c95+c100)),c:"var(--text-muted)"},
+      {label:"<80",n:Math.max(0,inscope-(c80+c90+c95+c100)),c:"var(--text-muted)"},
       {label:"80+",n:c80,c:"var(--crafted)"},
       {label:"90+",n:c90,c:"var(--magic)"},
       {label:"95+",n:c95,c:"var(--set)"},
@@ -1194,7 +1225,13 @@
     const ik=await api("/intake")||SAMPLE.intake;
     renderBars(s,m);
     document.getElementById("intakeN").innerHTML=`${(ik.untriaged||0).toLocaleString()} <small>/ ${(ik.in_scope||0).toLocaleString()} in scope &middot; ${ik.excluded_lib||0} excluded</small>`;
-    document.getElementById("workerHint").textContent=`last sync ${s.last_sync||'-'}`;
+    // NOT #workerHint. That is the Active Workers panel header, owned by
+    // renderWorkers(), and writing here clobbered "3 running / 3 total" with
+    // an unrelated sync date on every refresh pass -- so half the time the
+    // operator could not see how many workers were running, and the number
+    // only came back on the next worker_status socket push.
+    const ls=document.getElementById("lastSync");
+    if(ls) ls.textContent=`last sync ${s.last_sync||'-'}`;
     loadPins(); loadInv(); loadGlobals();
     checkTypes();
   }
@@ -1307,8 +1344,34 @@
     try{
       const r = await fetch("/api/health/all");
       if(!r.ok) return;
-      renderHealthStrip(await r.json());
+      const h = await r.json();
+      renderHealthStrip(h);
+      renderPauseBar(h);
     }catch(e){ /* transient; the socket dot already reports a dead link */ }
+  }
+
+  // A paused fleet is deliberate parking, so it is NOT a red dot -- but it is
+  // the single most important thing on the page when it is true, because every
+  // other indicator is green and nothing is moving. `paused`/`pause_reason`
+  // ride at the top level of /api/health/all for exactly this.
+  function renderPauseBar(h){
+    const bar = document.getElementById("pauseBar");
+    if(!bar) return;
+    if(!h || !h.paused){ bar.classList.remove("active"); return; }
+    const reason = h.pause_reason ? escHtml(h.pause_reason) : "no reason recorded";
+    document.getElementById("pauseBarMsg").innerHTML =
+      `<b>Fleet paused</b> &mdash; ${reason}. Workers stay alive and parked at their `
+      + `next candidate boundary; oracle auto-recovery is stood down.`;
+    bar.classList.add("active");
+  }
+  async function resumeFleet(){
+    const btn = document.getElementById("pauseBarBtn");
+    if(btn) btn.disabled = true;
+    try{
+      await fetch("/api/worker/resume", {method:"POST"});
+      flash("resuming fleet");
+    }catch(e){ flash("resume failed"); }
+    finally{ if(btn) btn.disabled = false; refreshHealth(); }
   }
 
   // Clicking the oracle dot when it is not green triggers the same relaunch
@@ -1391,6 +1454,33 @@
       msg.textContent = h.game_running
         ? "D2Debugger oracle (:8790) is unreachable, but Game.exe is still running — the embedded oracle likely crashed. Close Game.exe manually, then relaunch."
         : "D2Debugger oracle (:8790) is unreachable and Game.exe is not running. Live-prove and shadow-promote are paused until it's back.";
+      return;
+    }
+    // Two fault shapes answer HTTP perfectly and used to fall straight through
+    // to "healthy -> bar stays hidden": FROZEN (alive, oracle replying, drawing
+    // nothing) and IDLE (parked at a menu). oracle_health.py detects both and
+    // puts game_frozen / game_idle in this very payload; nothing read them, so
+    // a fleet that could not do a single unit of work sat behind a hidden bar
+    // and a green dot. That is the 2026-07-31 incident, not a hypothetical.
+    if(h.game_frozen){
+      bar.classList.remove("ok"); bar.classList.add("active");
+      btn.disabled=false; btn.textContent="Relaunch";
+      const rate = (h.present_rate!=null) ? ` (${h.present_rate} fps)` : "";
+      msg.textContent =
+        `Game.exe is FROZEN${rate} — the oracle still answers and the process is alive, `
+        + `but the game is drawing nothing. A stalled render thread raises no exception, `
+        + `so /crash stays null. Recover it like a wedged game: close Game.exe, then relaunch.`;
+      return;
+    }
+    if(h.game_idle){
+      // No relaunch button: the game is HEALTHY, just parked. Navigation is the
+      // cure; relaunching a healthy game is what oracle_health warns against.
+      bar.classList.remove("ok"); bar.classList.add("active");
+      btn.disabled=true; btn.textContent="Navigating…";
+      msg.textContent =
+        "Game is parked at a menu — every liveness probe reads healthy, but proving "
+        + "needs a world, so the Prove lane cannot make progress. Auto-recovery is "
+        + "navigating in and loading a character.";
       return;
     }
     bar.classList.remove("active","busy","ok");   // healthy -> bar stays hidden
@@ -1538,12 +1628,19 @@
     Object.keys(workerPanes).forEach(id=>{ if(!ids.has(String(id)) && !syntheticPanes.has(String(id))){ workerPanes[id].element.remove(); delete workerPanes[id]; if(_focusedWorkerId===id)_focusedWorkerId=null; } });
     if(!w.length){ if(!grid.querySelector(".worker-empty")) grid.innerHTML='<div class="worker-empty">No workers running. Pick a lane and Start.</div>'; if(hint) hint.textContent='0 workers'; return; }
     const running = w.filter(x=>['starting','running','stopping'].includes(x.status)).length;
-    if(hint) hint.textContent = `${running} running / ${w.length} total`;
+    // Parked workers are neither running nor finished. Counting them nowhere
+    // produced a hint that read "0 running / 3 total" beside three panes drawn
+    // in the running colour -- the page contradicting itself on its own screen.
+    const parked = w.filter(x=>['paused','quota_paused'].includes(x.status)).length;
+    if(hint) hint.textContent = parked
+      ? `${running} running / ${parked} paused / ${w.length} total`
+      : `${running} running / ${w.length} total`;
     w.forEach(x=>{
       const p = getOrCreatePane(x.id, x.provider, x.binary, x.mode);
       const titleEl = document.getElementById(`wp-title-${x.id}`); if(titleEl) titleEl.innerHTML = paneTitleHTML(x.binary, x.mode, x.provider, x.id);
       if(['finished','stopped'].includes(x.status)){ markPaneFinished(x.id, x.status); return; }
-      const cls = x.status==='stopping' ? 'stopping' : x.status==='quota_paused' ? 'quota_paused' : 'running';
+      const cls = x.status==='stopping' ? 'stopping' : x.status==='quota_paused' ? 'quota_paused'
+                : x.status==='paused' ? 'paused' : 'running';
       p.element.className = 'worker-pane ' + cls + (_focusedWorkerId===String(x.id)||_focusedWorkerId===x.id?' focused':'') + (p.element.classList.contains('timeout')?' timeout':'');
       setPaneAlert(x.id, x.last_alert);
       renderWorkerConfig(x.id, x.config_snapshot);
@@ -1555,7 +1652,12 @@
         const skip = pr.skipped>0 ? ` ${pr.skipped}skip` : '';
         const to = x.timeout_count>0 ? ` | ${x.timeout_count} timeout${x.timeout_count>1?'s':''}` : '';
         let cur=''; if(pr.current) cur = typeof pr.current==='string' ? pr.current : (pr.current.name || pr.current.address || '');
-        stt.innerHTML = esc(`${cnt} | ${pr.completed||0}ok ${pr.failed||0}fail${skip}${to}`) + (cur ? ` | <span class="wp-current">${esc(cur)}</span>` : '');
+        // A parked worker keeps `progress.current` from the function it finished
+        // last, which reads exactly like a function in flight. Say PARKED first
+        // so the line cannot be mistaken for work happening right now.
+        const park = x.status==='paused' ? `<span class="wp-parked">PARKED</span> ` :
+                     x.status==='quota_paused' ? `<span class="wp-parked">QUOTA</span> ` : '';
+        stt.innerHTML = park + esc(`${cnt} | ${pr.completed||0}ok ${pr.failed||0}fail${skip}${to}`) + (cur ? ` | <span class="wp-current">${esc(cur)}</span>` : '');
       }
     });
     maybeToggleTypesBarForWorkers(w);

--- a/fun-doc/web.py
+++ b/fun-doc/web.py
@@ -346,7 +346,29 @@ class WorkerManager:
                     "detail": "health check failed (see server log)",
                     "endpoint": None, "action": None}
         if s.get("reachable"):
-            state, detail = self._OK, "live-prove enabled"
+            # `reachable` alone is NOT health. oracle_health.py detects FOUR
+            # fault shapes and two of them answer HTTP perfectly: FROZEN (alive,
+            # oracle replying, drawing nothing) and IDLE (parked at a menu, no
+            # world to prove against). Both were being reported as
+            # "live-prove enabled" -- a green dot over a fleet that cannot do
+            # any work, which is the precise symptom of the 2026-07-31 incident
+            # where a deploy restart left the game at the main menu and workers
+            # sat idle behind a green banner for 70 minutes.
+            if s.get("game_frozen"):
+                state = self._DOWN
+                rate = s.get("present_rate")
+                detail = "Game.exe FROZEN — answering but drawing nothing"
+                if rate is not None:
+                    detail += f" ({rate:g} fps)"
+            elif s.get("game_idle"):
+                # Deliberately NOT `down`, and deliberately no relaunch action:
+                # the game is healthy, it is just parked at a menu. Recovery is
+                # to NAVIGATE (_navigate_and_load_character); relaunching a
+                # healthy game is the exact thing oracle_health warns against.
+                state = self._DEGRADED
+                detail = "game parked at a menu — proving needs a world"
+            else:
+                state, detail = self._OK, "live-prove enabled"
         elif s.get("reachable") is None:
             state, detail = self._UNKNOWN, "not probed yet"
         else:
@@ -369,8 +391,19 @@ class WorkerManager:
         return {
             "state": state, "label": "Oracle + Game", "detail": detail,
             "endpoint": _oracle_endpoint(),
-            "action": "relaunch_oracle" if state != self._OK else None,
+            # No relaunch affordance for IDLE: the game is healthy and parked,
+            # and a one-click relaunch of a healthy game is the mistake
+            # oracle_health.py exists to prevent. Auto-recovery navigates.
+            "action": (
+                None
+                if state == self._OK or s.get("game_idle")
+                else "relaunch_oracle"
+            ),
             "degraded": bool(s.get("recovery_degraded")),
+            # Surfaced so the UI can distinguish the two answering-but-useless
+            # shapes from a plain outage without re-deriving them.
+            "game_frozen": bool(s.get("game_frozen")),
+            "game_idle": bool(s.get("game_idle")),
         }
 
     def _health_provider(self):
@@ -3918,6 +3951,14 @@ def create_app(state_file, event_bus=None, dashboard_port=5000):
         try:
             worker_mgr.stop_worker(wid)
             return jsonify({"ok": True, "worker_id": wid})
+        except ValueError as e:
+            # "Unknown worker: <id>" is a CLIENT error, not a server fault. The
+            # socket handler has always reported it as such; the HTTP twin
+            # returned a 500 with a generic message, so an operator's script
+            # stopping an already-finished worker got an alarming "internal
+            # error -- see dashboard server log" and nothing in the log.
+            # Message is built from fixed literals plus the caller's own id.
+            return jsonify({"ok": False, "error": str(e)}), 404  # codeql[py/stack-trace-exposure]
         except Exception:  # noqa: BLE001
             app.logger.exception("HTTP worker stop failed for %r", wid)
             return jsonify({"ok": False, "error": "internal error -- see dashboard server log"}), 500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ markers = [
     "requires_program: mark test as requiring a loaded program",
     "requires_server: mark test as requiring server connection",
     "write: mark test as performing write operations",
+    "e2e: browser-driven tests against a live fun-doc dashboard (tests/e2e)",
+    "destructive: e2e tests that start workers or write config (revert themselves)",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,105 @@
+# fun-doc dashboard — browser end-to-end suite
+
+Playwright tests that drive the real pipeline dashboard in a real browser
+and cross-check what the page **renders** against what the server's own
+JSON APIs **report**.
+
+That pairing is the point. Every dashboard bug this project has actually
+shipped left the API perfectly correct and the test suite green:
+
+| Bug | What the API said | What the operator saw |
+| --- | --- | --- |
+| `in_scope \|\| 1` denominator | correct counts | `326700%` on the completeness bar |
+| same class, globals bar | correct counts | `228600%` |
+| 7.0.0 envelope unwrap | correct rows | both inventories empty, for days |
+| `ghidra_health` lost its emitter | nothing | a green dot for a dead Ghidra |
+| context switch via `save_state()` | correct | a ~50 s freeze on every binary switch |
+
+None of those are visible from a request/response assertion. They are
+visible from the DOM.
+
+## Running
+
+```bash
+# read-only — safe against a live, working fleet
+python -m pytest tests/e2e -m "not destructive" --no-cov
+
+# starts and stops real workers, writes and reverts config
+python -m pytest tests/e2e -m destructive --no-cov
+
+# everything
+python -m pytest tests/e2e --no-cov
+
+# headed, so you can watch it drive the page
+python -m pytest tests/e2e --no-cov --headed --slowmo 250
+
+# against a dashboard somewhere else
+python -m pytest tests/e2e --no-cov --dashboard-url http://127.0.0.1:5001
+```
+
+Prerequisites: `pytest-playwright` plus `python -m playwright install
+chromium`, and a dashboard answering on `--dashboard-url` (default
+`http://127.0.0.1:5000`). Without one the whole suite **skips** — it
+never fails for the dashboard being down.
+
+**Runtime: expect 20–35 minutes for the full suite.** Each test loads a
+fresh page and waits for all four bars to hydrate against a live
+Ghidra-backed dashboard. That isolation is deliberate — shared page state
+between tests is how a suite starts passing for the wrong reasons — but
+it is why this is not a tier you run on every edit. Narrow it while
+iterating (`tests/e2e/test_bars.py`, `-k legend`).
+
+Run it with `python -u -m pytest ... > out.txt`, not `| tail`: `tail`
+buffers the entire stream to EOF, so a piped run shows you nothing at all
+until it finishes.
+
+Use `python -m pytest`, not `uv run pytest`: `uv` re-syncs the venv on
+every invocation and cannot replace `Scripts/bridge-mcp-ghidra.exe` while
+an MCP bridge is running, which fails the run before pytest starts.
+
+## Why `destructive` is safe here
+
+`--allow-unpaused` exists because the destructive worker tests **require
+a paused fleet** by default. That is a safety property, not a
+limitation: `WorkerManager._park_if_paused` is called at the *top* of
+each lane loop, before a function is selected and before any provider
+call, so a worker started against a paused fleet parks immediately. The
+full start → render → stop lifecycle gets exercised for **zero tokens
+and zero documentation changes**.
+
+`worker_guard` stops anything the suite started even when a test fails
+midway, and every config write is reverted in a `finally`.
+
+## Files
+
+| File | Covers |
+| --- | --- |
+| `test_smoke.py` | page loads, all steering controls present, console clean, `/pipeline` alias, theme persistence |
+| `test_health_strip.py` | the five dependency dots vs `/api/health/all`; tooltips; `.bad` class; socket-loss precedence |
+| `test_bars.py` | all four segmented bars: legend vs API, widths fit the track, widths match their share, headline arithmetic, target follows config |
+| `test_workers.py` | pane set vs manager roster, titles, status lines, stale rendering; **destructive**: UI start → park → UI stop, launch rejections |
+| `test_settings.py` | popout reflects `/api/queue/config`; **destructive**: Target round-trip that asserts no neighbouring key moved |
+| `test_inventory.py` | both inventories vs API, search filtering, untyped/reviewed markers, function drawer |
+| `test_binary_picker.py` | focus button, picker, `/api/context`; **destructive**: switch repoints every panel, context switch stays under an 8 s budget |
+| `test_regressions.py` | named guards for the bugs in the table above |
+
+## Shared helpers (`conftest.py`)
+
+- `dashboard` — loads the page, waits for real hydration (not
+  `networkidle`, which never settles on a page that polls), returns
+  `(page, errors)` with console/pageerror/4xx collection attached.
+- `read_legend(page, id)` → `{label: count}`. Anchors on the last integer
+  because labels contain digits (`80+`, `<80`, `100`).
+- `read_segments(page, id)` → `[(title, width_pct)]` for the spans that
+  are actually drawn — a zero-count segment isn't rendered, so this is
+  the bar as the operator sees it.
+- `wait_for(predicate, ...)` — polls a *server-side* condition;
+  Playwright's `expect()` can only see the DOM.
+
+## Adding a test
+
+Assert against the API, not a constant. The corpus changes every time a
+worker runs; a test that hardcodes `2196` is a test that fails on
+Tuesday. If a check can be made without a browser (a data-contract
+invariant like `evaluated <= in_scope`), write it without one — it will
+be faster and the failure will point at the right layer.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -37,6 +37,18 @@ from typing import Any
 import pytest
 import requests
 
+# Self-skip the whole directory when the browser stack is absent. These are
+# the only tests in the repo that need pytest-playwright, and it is not a
+# declared dependency -- CI runs tests/unit and tests/performance, never
+# tests/. Without this, a plain `pytest tests/` anywhere without playwright
+# installed dies with an ImportError at COLLECTION, taking every other tier
+# down with it rather than skipping the one tier that cannot run.
+try:  # noqa: SIM105
+    import playwright.sync_api  # noqa: F401
+except ImportError:  # pragma: no cover - depends on the environment
+    collect_ignore_glob = ["test_*.py"]
+
+
 DEFAULT_BASE_URL = "http://127.0.0.1:5000"
 
 # Wall-clock budget for the page's first full hydration (bars fetch

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,377 @@
+"""Playwright end-to-end suite for the fun-doc pipeline dashboard.
+
+These tests drive the REAL dashboard in a real browser at ``--base-url``
+(default ``http://127.0.0.1:5000``) and cross-check what the page RENDERS
+against what the server's own JSON APIs REPORT. That pairing is the whole
+point: every historical dashboard bug in this repo was a rendering /
+denominator bug that left the API perfectly correct and the suite green
+(the ``326700%`` band bar, the two inventories silently returning 0 rows).
+A test that only calls the API cannot see those.
+
+Tiers
+-----
+``-m "not destructive"``   read-only: page loads, health strip, bars,
+                           inventories, settings round-trip is reverted.
+``-m destructive``         starts and stops REAL workers.
+
+Worker safety
+-------------
+``start_worker`` parks a new worker at the TOP of its lane loop when the
+fleet is paused (``WorkerManager._park_if_paused``), i.e. before selecting
+a function and before any provider call — so on a paused dashboard the
+lifecycle test costs zero tokens. ``require_paused_fleet`` enforces that
+precondition rather than assuming it, and ``worker_guard`` stops anything
+this suite started even if a test fails midway.
+
+Run:
+    uv run pytest tests/e2e -m "not destructive" --no-cov
+    uv run pytest tests/e2e -m destructive --no-cov
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+import pytest
+import requests
+
+DEFAULT_BASE_URL = "http://127.0.0.1:5000"
+
+# Wall-clock budget for the page's first full hydration (bars fetch
+# /matrix + /bands + /glob_bands + /summary serially on a large corpus).
+HYDRATE_TIMEOUT_MS = 45_000
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("fun-doc e2e")
+    group.addoption(
+        "--dashboard-url",
+        action="store",
+        default=None,
+        help=f"fun-doc dashboard base URL (default {DEFAULT_BASE_URL})",
+    )
+    group.addoption(
+        "--allow-unpaused",
+        action="store_true",
+        default=False,
+        help="Permit destructive worker tests against an UNPAUSED fleet "
+        "(a started worker will then do real, token-spending work).",
+    )
+
+
+# --------------------------------------------------------------------------
+# server-side fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def base_url(request) -> str:
+    return (request.config.getoption("--dashboard-url") or DEFAULT_BASE_URL).rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def live_dashboard(base_url: str) -> str:
+    """Skip the whole suite unless a dashboard is answering."""
+    try:
+        r = requests.get(f"{base_url}/api/health/all", timeout=10)
+        r.raise_for_status()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"no fun-doc dashboard at {base_url} ({exc})")
+    return base_url
+
+
+class Api:
+    """Thin JSON client against the dashboard under test.
+
+    ``/api/conformance/*`` reads are automatically scoped to the binary the
+    PAGE is focused on. This is not convenience — it is correctness. Those
+    endpoints fall back to ``conformance_dashboard.PROGRAM`` (a module
+    constant from ``FUNDOC_GHIDRA_PROGRAM``) when no ``program`` is given,
+    while the page passes its own ``PROGRAM`` on every call. Forget the
+    param in one test and you compare D2Client's DOM against D2Common's
+    numbers and get a failure that looks like a rendering bug.
+
+    Pass ``program=`` explicitly to override; pass ``program=None`` to
+    deliberately exercise the server's default.
+    """
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+        self.session = requests.Session()
+        self.program: str | None = None
+
+    def get(self, path: str, **params) -> Any:
+        if (
+            path.startswith("/api/conformance/")
+            and "program" not in params
+            and self.program
+            # these two are whole-project, not per-binary
+            and not path.startswith("/api/conformance/binaries")
+        ):
+            params["program"] = self.program
+        params = {k: v for k, v in params.items() if v is not None}
+        r = self.session.get(f"{self.base_url}{path}", params=params or None, timeout=120)
+        r.raise_for_status()
+        return r.json()
+
+    def post(self, path: str, json: dict | None = None) -> requests.Response:
+        return self.session.post(f"{self.base_url}{path}", json=json or {}, timeout=120)
+
+
+@pytest.fixture(scope="session")
+def api_client(live_dashboard: str) -> Api:
+    client = Api(live_dashboard)
+    try:
+        client.program = client.get("/api/conformance/binaries/progress").get("active")
+    except Exception:  # noqa: BLE001 — leave unscoped; per-test skips will explain
+        client.program = None
+    return client
+
+
+@pytest.fixture
+def api(api_client: Api) -> Api:
+    """The API client, re-pointed at the currently-focused binary.
+
+    Function-scoped so a test that doesn't take `dashboard` still sees the
+    live focus rather than the session-start snapshot.
+    """
+    try:
+        active = api_client.get("/api/conformance/binaries/progress").get("active")
+        if active:
+            api_client.program = active
+    except Exception:  # noqa: BLE001
+        pass
+    return api_client
+
+
+@pytest.fixture
+def health(api: Api) -> dict:
+    return api.get("/api/health/all")
+
+
+@pytest.fixture
+def active_program(api: Api) -> str:
+    """The binary the PAGE is focused on — every count on it is per-binary.
+
+    Sourced from ``/api/conformance/binaries/progress``, which is what
+    ``loadBinaries()`` assigns to ``PROGRAM`` — NOT from
+    ``/api/conformance/binaries``, whose ``active`` is still the
+    process-start default (``FUNDOC_GHIDRA_PROGRAM``) and disagrees with
+    it. Comparing rendered counts against the wrong binary produces
+    failures that look like rendering bugs and aren't.
+    """
+    if not api.program:
+        pytest.skip("dashboard reports no active binary")
+    return api.program
+
+
+# --------------------------------------------------------------------------
+# browser-side fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args: dict) -> dict:
+    return {**browser_context_args, "viewport": {"width": 1680, "height": 1050}}
+
+
+class PageErrors:
+    """Console errors + failed responses collected while a page is open."""
+
+    def __init__(self):
+        self.console: list[str] = []
+        self.pageerrors: list[str] = []
+        self.bad_responses: list[str] = []
+
+    @property
+    def all(self) -> list[str]:
+        return self.console + self.pageerrors + self.bad_responses
+
+
+@pytest.fixture
+def dashboard(page, live_dashboard: str, api_client: "Api"):
+    """Load the dashboard and wait for the bars to hydrate.
+
+    Returns ``(page, errors)``. Errors are collected for the page's whole
+    lifetime so any test can assert the console stayed clean.
+    """
+    errors = PageErrors()
+    page.on(
+        "console",
+        lambda m: errors.console.append(f"console.{m.type}: {m.text}")
+        if m.type == "error"
+        else None,
+    )
+    page.on("pageerror", lambda e: errors.pageerrors.append(f"pageerror: {e}"))
+    page.on(
+        "response",
+        lambda r: errors.bad_responses.append(f"HTTP {r.status} {r.url}")
+        if r.status >= 400
+        else None,
+    )
+
+    page.goto(live_dashboard, wait_until="domcontentloaded")
+    # Hydration means ALL FOUR bars, not just the first one. `renderBandBar`
+    # and `renderGlobBandBar` are async and each makes two further round trips
+    # (`/bands` + `/api/queue/config`) AFTER renderBars has already filled the
+    # doc and conformance bars — so waiting on `#docPct` alone returns a page
+    # whose completeness bars are still showing their "-" placeholder, and
+    # every assertion against them reads an empty legend.
+    page.wait_for_function(
+        """() => ['docLegend','bandLegend','confLegend','globBandLegend']
+                  .every(id => document.querySelectorAll('#' + id + ' .lg').length > 0)""",
+        timeout=HYDRATE_TIMEOUT_MS,
+    )
+    page.wait_for_function(
+        """() => ['docPct','bandPct','confPct','globBandPct']
+                  .every(id => (document.getElementById(id).textContent || '').trim() !== '-')""",
+        timeout=HYDRATE_TIMEOUT_MS,
+    )
+    # Bind the API client to the binary THIS page ended up focused on, rather
+    # than the one that was focused when the session started. Focus is server
+    # state that several tests legitimately change, so a session-scoped
+    # snapshot goes stale mid-run and later tests then compare one binary's
+    # DOM against another's counts (seen: intake read 21 on screen, 76 from
+    # the API, with nothing wrong on either side).
+    try:
+        program = page.evaluate("() => (typeof PROGRAM !== 'undefined') ? PROGRAM : null")
+        if program:
+            api_client.program = program
+    except Exception:  # noqa: BLE001
+        pass
+
+    page.errors = errors  # type: ignore[attr-defined]
+    return page, errors
+
+
+# --------------------------------------------------------------------------
+# destructive-test guards
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def require_paused_fleet(api: Api, request):
+    """Destructive worker tests require a PAUSED fleet unless overridden.
+
+    Paused is not a limitation here, it is the safety property: a worker
+    started against a paused fleet parks before it selects a function, so
+    the lifecycle is exercised end to end without spending a token or
+    mutating a single function's documentation.
+    """
+    state = api.get("/api/worker/pause_state")
+    if not state.get("paused") and not request.config.getoption("--allow-unpaused"):
+        pytest.skip(
+            "fleet is not paused — a started worker would do real work. "
+            "Pause the fleet, or pass --allow-unpaused to accept that."
+        )
+    return state
+
+
+@pytest.fixture(scope="session", autouse=True)
+def restore_server_context(live_dashboard: str):
+    """Put the operator's binary focus back, whatever the tests did to it.
+
+    Several tests legitimately switch focus, and each restores its own. That
+    is not enough: a test that fails between the switch and its `finally`,
+    or an interrupted run, leaves the operator's dashboard pointing at a
+    binary they did not choose — and every count on it is per-binary, so the
+    next thing they read is quietly about the wrong program. This is the
+    session-level backstop.
+    """
+    session = requests.Session()
+    try:
+        before = session.get(f"{live_dashboard}/api/context", timeout=60).json().get(
+            "active_binary"
+        )
+    except Exception:  # noqa: BLE001
+        before = None
+    yield before
+    if not before:
+        return
+    try:
+        after = session.get(f"{live_dashboard}/api/context", timeout=60).json().get(
+            "active_binary"
+        )
+        if after != before:
+            session.post(
+                f"{live_dashboard}/api/context/binary", json={"binary": before}, timeout=60
+            )
+            print(f"\n[e2e] restored dashboard focus: {after} -> {before}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"\n[e2e] WARNING: could not restore dashboard focus to {before}: {exc}")
+
+
+@pytest.fixture
+def worker_guard(api: Api):
+    """Stop every worker this test started, even if it failed midway."""
+    before = {w["id"] for w in api.get("/api/worker/status").get("workers", [])}
+    yield before
+    after = api.get("/api/worker/status").get("workers", [])
+    for w in after:
+        if w["id"] not in before and w.get("status") in (
+            "starting",
+            "running",
+            "stopping",
+            "paused",
+            "quota_paused",
+        ):
+            api.post("/api/worker/stop", {"worker_id": w["id"]})
+
+
+# --------------------------------------------------------------------------
+# shared DOM helpers
+# --------------------------------------------------------------------------
+
+_LEGEND_RE = re.compile(r"^(?P<label>.*?)\s+(?P<n>[\d,]+)$")
+
+
+def read_legend(page, legend_id: str) -> dict[str, int]:
+    """Parse a ``.seg-legend`` into ``{label: count}``.
+
+    Entries render as ``<swatch>LABEL N`` — the label may itself contain
+    digits (``80+``, ``<80``, ``100``), so anchor on the LAST whitespace-
+    separated integer rather than splitting greedily.
+    """
+    out: dict[str, int] = {}
+    for text in page.locator(f"#{legend_id} .lg").all_inner_texts():
+        m = _LEGEND_RE.match(text.strip())
+        assert m, f"unparseable legend entry {text!r} in #{legend_id}"
+        out[m.group("label").strip()] = int(m.group("n").replace(",", ""))
+    return out
+
+
+def read_segments(page, bar_id: str) -> list[tuple[str, float]]:
+    """Return ``[(title, width_pct)]`` for a segmented bar's drawn spans.
+
+    Only segments with n > 0 are drawn, so this is the bar as the operator
+    actually SEES it — which is what a width-overflow bug shows up in.
+    """
+    return page.evaluate(
+        """(id) => Array.from(document.querySelectorAll('#' + id + ' > span'))
+              .map(s => [s.title, parseFloat(s.style.width) || 0])""",
+        bar_id,
+    )
+
+
+def pct_from_label(text: str) -> float | None:
+    """Extract the leading percentage from a bar's ``.p`` label.
+
+    Returns None for the em-dash the renderers print when the denominator
+    is unknown — that is a legitimate, deliberate state, not a parse error.
+    """
+    m = re.search(r"(-?[\d.]+)\s*%", text)
+    return float(m.group(1)) if m else None
+
+
+def wait_for(predicate, timeout: float = 30.0, interval: float = 0.5, what: str = "condition"):
+    """Poll a server-side predicate. Playwright's expect() cannot see the API."""
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval)
+    raise AssertionError(f"timed out after {timeout}s waiting for {what} (last={last!r})")

--- a/tests/e2e/test_bars.py
+++ b/tests/e2e/test_bars.py
@@ -1,0 +1,295 @@
+"""The four segmented completion bars.
+
+Every bar is `count / denominator`, and every bar bug this project has
+had was a DENOMINATOR bug that the API never saw: `in_scope || 1` turned
+3,267 tagged functions into "326700%", and the same class produced
+"228600%" on the globals bar. Both were found by eye, in production.
+
+So the invariants under test are structural, not cosmetic:
+
+  1. legend counts == the API's counts (the bar isn't inventing numbers)
+  2. drawn segment widths sum to ~100% (the bar fits its track)
+  3. the headline percentage is arithmetically consistent with the legend
+  4. the numerator's population is the same population as the denominator
+
+(4) is the one that catches a scope mismatch: if the counts come from a
+wider set than the denominator counts, the bar reads over 100% and the
+leading "untagged/none" segment silently collapses to zero.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import pct_from_label, read_legend, read_segments
+
+pytestmark = pytest.mark.e2e
+
+# A bar is drawn from integer counts over an integer denominator, so the
+# only slack needed is float/rounding noise in the CSS percentages.
+WIDTH_TOLERANCE = 0.75
+PCT_TOLERANCE = 0.15
+
+
+BARS = {
+    "documentation": ("docBar", "docLegend", "docPct"),
+    "function_completeness": ("bandBar", "bandLegend", "bandPct"),
+    "conformance": ("confBar", "confLegend", "confPct"),
+    "globals": ("globBandBar", "globBandLegend", "globBandPct"),
+}
+
+
+@pytest.fixture
+def matrix(api):
+    """Function-scoped on purpose: `api` re-points at whatever binary the
+    dashboard is focused on right now, and focus is server state that other
+    tests change. A module-scoped cache here would pin one binary's matrix
+    across a focus switch."""
+    return api.get("/api/conformance/matrix")
+
+
+def _col(matrix: dict, col: str) -> int:
+    return sum(matrix["cell"].get(r, {}).get(col, 0) for r in matrix["rows"])
+
+
+def _row(matrix: dict, row: str) -> int:
+    return sum(matrix["cell"].get(row, {}).get(c, 0) for c in matrix["cols"])
+
+
+# ---------------------------------------------------------------------------
+# structural invariants — apply to every bar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", list(BARS))
+def test_bar_is_drawn(dashboard, name):
+    page, _ = dashboard
+    bar_id, legend_id, _ = BARS[name]
+    page.wait_for_function(
+        "(id) => document.querySelectorAll('#' + id + ' .lg').length > 0",
+        arg=legend_id,
+        timeout=30_000,
+    )
+    assert read_legend(page, legend_id), f"{name} legend is empty"
+    assert read_segments(page, bar_id), f"{name} bar drew no segments"
+
+
+@pytest.mark.parametrize("name", list(BARS))
+def test_segments_fit_the_track(dashboard, name):
+    """Widths summing past 100% mean the bar has overflowed its own track:
+    the visual is wrong AND the numbers behind it are being divided by a
+    denominator that does not cover them."""
+    page, _ = dashboard
+    bar_id, _, _ = BARS[name]
+    segments = read_segments(page, bar_id)
+    total = sum(w for _, w in segments)
+    assert total <= 100 + WIDTH_TOLERANCE, (
+        f"{name} bar segments sum to {total:.2f}% — the bar overflows its track. "
+        f"Segments: {segments}"
+    )
+    assert total >= 100 - WIDTH_TOLERANCE, (
+        f"{name} bar segments sum to only {total:.2f}% — part of the population "
+        f"is unaccounted for. Segments: {segments}"
+    )
+
+
+@pytest.mark.parametrize("name", list(BARS))
+def test_headline_percentage_is_in_range(dashboard, name):
+    page, _ = dashboard
+    _, _, pct_id = BARS[name]
+    label = page.locator(f"#{pct_id}").inner_text()
+    pct = pct_from_label(label)
+    if pct is None:
+        assert "—" in label or "-" in label, f"{name} shows neither a % nor an em-dash: {label!r}"
+        return
+    assert 0.0 <= pct <= 100.0, f"{name} headline reads {pct}% ({label!r})"
+
+
+@pytest.mark.parametrize("name", list(BARS))
+def test_legend_and_segments_agree(dashboard, name):
+    """Every drawn segment must correspond to a legend entry with the same
+    count — the legend is the only place the operator can read an actual
+    number, so a legend that disagrees with the bar is worse than no bar."""
+    page, _ = dashboard
+    bar_id, legend_id, _ = BARS[name]
+    legend = read_legend(page, legend_id)
+    for title, _width in read_segments(page, bar_id):
+        seg_label, _, seg_n = title.rpartition(" ")
+        assert seg_label in legend, f"{name}: segment {seg_label!r} has no legend entry"
+        assert legend[seg_label] == int(seg_n), (
+            f"{name}: segment {seg_label!r} says {seg_n} but the legend says {legend[seg_label]}"
+        )
+
+
+@pytest.mark.parametrize("name", list(BARS))
+def test_segment_widths_match_their_share(dashboard, name):
+    """A width must be the segment's share of the total the legend sums to.
+    This is what catches a bar whose numbers are right but whose geometry
+    is computed against a different denominator."""
+    page, _ = dashboard
+    bar_id, legend_id, _ = BARS[name]
+    legend = read_legend(page, legend_id)
+    total = sum(legend.values())
+    if total <= 0:
+        pytest.skip(f"{name} has an empty population")
+    for title, width in read_segments(page, bar_id):
+        label, _, n = title.rpartition(" ")
+        expected = 100.0 * int(n) / total
+        assert abs(width - expected) <= WIDTH_TOLERANCE, (
+            f"{name}: segment {label!r} is drawn {width:.2f}% wide but is "
+            f"{n}/{total} = {expected:.2f}% of the bar"
+        )
+
+
+# ---------------------------------------------------------------------------
+# per-bar: does the page agree with the server?
+# ---------------------------------------------------------------------------
+
+
+def test_documentation_bar_matches_matrix(dashboard, matrix):
+    page, _ = dashboard
+    legend = read_legend(page, "docLegend")
+    in_scope = matrix["in_scope"]
+    dd, dr, dv = (_col(matrix, c) for c in ("DOC_DRAFT", "DOC_REVIEWED", "DOC_VERIFIED"))
+
+    assert legend["DRAFT"] == dd
+    assert legend["REVIEWED"] == dr
+    assert legend["VERIFIED"] == dv
+    assert legend["untagged"] == max(0, in_scope - (dd + dr + dv))
+
+    pct = pct_from_label(page.locator("#docPct").inner_text())
+    if pct is not None:
+        assert abs(pct - 100.0 * dv / in_scope) <= PCT_TOLERANCE
+
+
+def test_documentation_population_fits_its_denominator(matrix):
+    """The doc bar divides matrix tag counts by `in_scope`. `matrix()` does
+    not subtract EXCLUDE_TAGS (library/stub) the way `bands()` does, so its
+    counts can cover a WIDER population than the denominator — at which
+    point the "% any" reading exceeds 100 and the `untagged` segment is
+    clamped to zero, hiding the inconsistency. Server-side check, no
+    browser needed: the bug is in the data contract, not the rendering."""
+    tagged = sum(_col(matrix, c) for c in ("DOC_DRAFT", "DOC_REVIEWED", "DOC_VERIFIED"))
+    assert tagged <= matrix["in_scope"], (
+        f"{tagged} DOC-tagged functions vs in_scope={matrix['in_scope']} "
+        f"(evaluated={matrix.get('evaluated')}, excluded_lib={matrix.get('excluded_lib')}): "
+        "matrix() counts library-excluded functions that in_scope does not, so the "
+        "documentation bar reads over 100%."
+    )
+
+
+def test_conformance_bar_matches_matrix(dashboard, matrix):
+    page, _ = dashboard
+    legend = read_legend(page, "confLegend")
+    in_scope = matrix["in_scope"]
+    rungs = {
+        "DRAFT": "CONF_DRAFT",
+        "VECTORS": "CONF_VECTORS",
+        "LIVE": "CONF_LIVE",
+        "BATTLETESTED": "CONF_BATTLETESTED",
+        "REGRESSION": "CONF_REGRESSION",
+    }
+    proven = 0
+    for label, rung in rungs.items():
+        n = _row(matrix, rung)
+        assert legend[label] == n, f"conformance {label}: page {legend[label]} vs API {n}"
+        proven += n
+    assert legend["none"] == max(0, in_scope - proven)
+
+    pct = pct_from_label(page.locator("#confPct").inner_text())
+    if pct is not None:
+        assert abs(pct - 100.0 * proven / in_scope) <= PCT_TOLERANCE
+
+
+def test_conformance_none_segment_agrees_with_the_matrix_cell(matrix):
+    """The bar computes `none` as in_scope - proven; the matrix reports its
+    own `none` row. They are the same quantity and must not diverge."""
+    proven = sum(
+        _row(matrix, r)
+        for r in ("CONF_DRAFT", "CONF_VECTORS", "CONF_LIVE", "CONF_BATTLETESTED", "CONF_REGRESSION")
+    )
+    rendered_none = max(0, matrix["in_scope"] - proven)
+    matrix_none = _row(matrix, "none")
+    assert rendered_none == matrix_none, (
+        f"conformance bar draws none={rendered_none} while the matrix row says "
+        f"{matrix_none} — the bar and the matrix are counting different populations"
+    )
+
+
+def test_function_completeness_bar_matches_bands(dashboard, api):
+    page, _ = dashboard
+    b = api.get("/api/conformance/bands")
+    legend = read_legend(page, "bandLegend")
+    bands = b["bands"]
+    in_scope = b["in_scope"]
+
+    assert legend["80+"] == bands.get("COMPLETE_80", 0)
+    assert legend["90+"] == bands.get("COMPLETE_90", 0)
+    assert legend["95+"] == bands.get("COMPLETE_95", 0)
+    assert legend["100"] == bands.get("COMPLETE_100", 0)
+    tagged = sum(bands.get(f"COMPLETE_{t}", 0) for t in (80, 90, 95, 100))
+    assert legend["<80"] == max(0, in_scope - tagged)
+
+
+def test_function_completeness_target_follows_config(dashboard, api):
+    """The "at target" reading must follow `good_enough_score`, not a
+    hardcoded 90 — the Target picker is how an operator changes what
+    "done" means, and a frozen headline makes that setting a lie."""
+    page, _ = dashboard
+    cfg = api.get("/api/queue/config")
+    target = int((cfg.get("config") or cfg).get("good_enough_score") or 90)
+    label = page.locator("#bandPct").inner_text()
+    assert f"({target}+)" in label, f"band headline {label!r} does not reflect target {target}"
+
+    b = api.get("/api/conformance/bands")
+    bands, in_scope = b["bands"], b["in_scope"]
+    at_level = {
+        80: sum(bands.get(f"COMPLETE_{t}", 0) for t in (80, 90, 95, 100)),
+        90: sum(bands.get(f"COMPLETE_{t}", 0) for t in (90, 95, 100)),
+        95: sum(bands.get(f"COMPLETE_{t}", 0) for t in (95, 100)),
+        100: bands.get("COMPLETE_100", 0),
+    }
+    pct = pct_from_label(label)
+    if pct is not None and in_scope:
+        assert abs(pct - 100.0 * at_level[target] / in_scope) <= PCT_TOLERANCE
+
+
+def test_globals_bar_matches_glob_bands(dashboard, api):
+    page, _ = dashboard
+    b = api.get("/api/conformance/glob_bands")
+    legend = read_legend(page, "globBandLegend")
+    bands, in_scope = b["bands"], b["in_scope"]
+
+    assert legend["80+"] == bands.get("COMPLETE_80", 0)
+    assert legend["90+"] == bands.get("COMPLETE_90", 0)
+    assert legend["95+"] == bands.get("COMPLETE_95", 0)
+    assert legend["100"] == bands.get("COMPLETE_100", 0)
+    tagged = sum(bands.get(f"COMPLETE_{t}", 0) for t in (80, 90, 95, 100))
+    assert legend["<80"] == max(0, in_scope - tagged)
+
+
+def test_globals_reviewed_chip_is_not_folded_into_the_bar(dashboard, api):
+    """`reviewed` is a trust bit, orthogonal to completeness — it rides as
+    a chip in the label and must never become a band segment (that
+    conflation is exactly why the DOC rung ladder was retired)."""
+    page, _ = dashboard
+    reviewed = api.get("/api/conformance/glob_bands").get("reviewed", 0)
+    label = page.locator("#globBandPct").inner_text()
+    assert "reviewed" in label
+    assert f"{reviewed:,}" in label or str(reviewed) in label
+    assert "reviewed" not in read_legend(page, "globBandLegend")
+
+
+def test_bars_survive_a_refresh(dashboard):
+    """The refresh button re-runs the same render path; a bar that only
+    renders on first paint leaves stale numbers on screen indefinitely."""
+    page, _ = dashboard
+    before = read_legend(page, "docLegend")
+    page.locator("header button[title='Refresh']").click()
+    page.wait_for_timeout(4000)
+    page.wait_for_function(
+        """() => ['docLegend','bandLegend','confLegend','globBandLegend']
+                  .every(id => document.querySelectorAll('#' + id + ' .lg').length > 0)""",
+        timeout=45_000,
+    )
+    assert read_legend(page, "docLegend") == before

--- a/tests/e2e/test_binary_picker.py
+++ b/tests/e2e/test_binary_picker.py
@@ -1,0 +1,149 @@
+"""The binary focus picker.
+
+Everything on this dashboard is per-binary — tags, bands, inventories,
+the queue the workers pull from. Focus is therefore the single most
+consequential control on the page, and it has a history: switching
+context used to route through `save_state()`, which bulk-upserted all
+~62K workflow rows and stalled the dashboard for ~50 seconds. Context
+switches must stay meta-only, so this file times one.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+# Meta-only context write. A regression back to save_state() would put
+# this in the tens of seconds; anything past a few seconds means the
+# switch is doing more than stamping two meta keys.
+CONTEXT_SWITCH_BUDGET_SEC = 8.0
+
+
+def test_focus_button_shows_the_active_binary(dashboard, active_program):
+    page, _ = dashboard
+    name = active_program.replace("\\", "/").split("/")[-1]
+    expect(page.locator("#fbName")).to_have_text(name)
+
+
+def test_picker_opens_and_lists_binaries(dashboard):
+    page, _ = dashboard
+    page.locator("#focusBtn").click()
+    expect(page.locator("#picker")).to_have_class("picker open", timeout=15_000)
+    page.wait_for_function(
+        "() => document.querySelectorAll('#pickerBody .bcard, #pickerBody .worker-empty').length > 0",
+        timeout=30_000,
+    )
+    assert page.locator("#pickerBody").inner_text().strip()
+    page.keyboard.press("Escape")
+    expect(page.locator("#picker")).not_to_have_class("picker open")
+
+
+def test_picker_closes_on_click_away(dashboard):
+    page, _ = dashboard
+    page.locator("#focusBtn").click()
+    expect(page.locator("#picker")).to_have_class("picker open")
+    page.locator("#intakeN").click()
+    expect(page.locator("#picker")).not_to_have_class("picker open")
+
+
+def test_picker_lists_binaries_the_server_knows_about(dashboard, api):
+    page, _ = dashboard
+    page.locator("#focusBtn").click()
+    page.wait_for_function(
+        "() => document.querySelectorAll('#pickerBody .bcard').length > 0", timeout=30_000
+    )
+    listed = page.locator("#pickerBody").inner_text()
+    served = api.get("/api/conformance/binaries")
+    names = served if isinstance(served, list) else served.get("binaries", [])
+    if not names:
+        pytest.skip("no binaries reported")
+    shown = [
+        n
+        for n in (
+            (b if isinstance(b, str) else b.get("name") or b.get("path", "")) for b in names
+        )
+        if n
+    ]
+    hits = sum(1 for n in shown if n.replace("\\", "/").split("/")[-1] in listed)
+    assert hits > 0, "the picker listed none of the binaries the server reports"
+    page.keyboard.press("Escape")
+
+
+def test_context_endpoint_reports_a_binary_and_folder(api):
+    ctx = api.get("/api/context")
+    assert ctx.get("active_binary"), "no active_binary in /api/context"
+    assert ctx.get("project_folder"), "no project_folder in /api/context"
+    assert ctx.get("available_binaries"), "no available_binaries in /api/context"
+
+
+@pytest.mark.destructive
+def test_context_switch_is_meta_only_and_fast(api):
+    """Set the active binary to what it already is and time it. Even the
+    identity write goes down the same path, so a regression to a bulk
+    upsert shows up here without changing any state."""
+    ctx = api.get("/api/context")
+    active = ctx["active_binary"]
+    start = time.time()
+    r = api.post("/api/context/binary", {"binary": active})
+    elapsed = time.time() - start
+    assert r.status_code < 400, f"{r.status_code}: {r.text}"
+    assert elapsed < CONTEXT_SWITCH_BUDGET_SEC, (
+        f"a context switch took {elapsed:.1f}s (budget {CONTEXT_SWITCH_BUDGET_SEC}s) — "
+        "context switches must stay meta-only, not route through save_state()"
+    )
+    assert api.get("/api/context")["active_binary"] == active
+
+
+@pytest.mark.destructive
+def test_switching_binary_repoints_every_panel(dashboard, api, active_program):
+    """Switching focus must move the bars AND both inventories. A panel
+    that keeps the old binary's numbers next to the new binary's name is
+    the worst possible outcome: it looks correct."""
+    page, _ = dashboard
+    original_context = api.get("/api/context")["active_binary"]
+    listed = api.get("/api/conformance/binaries")["binaries"]
+    candidates = [b["path"] for b in listed if b["path"] != active_program]
+    if not candidates:
+        pytest.skip("only one binary available")
+
+    # pick one that actually has functions, else the assertion is vacuous
+    target = None
+    for path in candidates:
+        try:
+            if api.get("/api/conformance/inventory", program=path, limit=1)["total"] > 0:
+                target = path
+                break
+        except Exception:  # noqa: BLE001, PERF203
+            continue
+    if not target:
+        pytest.skip("no alternative binary with functions")
+
+    before_inv = page.locator("#invHint").inner_text()
+    try:
+        page.locator("#focusBtn").click()
+        page.wait_for_function(
+            "() => document.querySelectorAll('#pickerBody .bcard').length > 0", timeout=30_000
+        )
+        page.evaluate("(p) => pickBinary(p)", target)
+        page.wait_for_function(
+            "(n) => (document.getElementById('fbName').textContent || '').includes(n)",
+            arg=target.split("/")[-1],
+            timeout=30_000,
+        )
+        page.wait_for_function(
+            "(before) => document.getElementById('invHint').textContent !== before",
+            arg=before_inv,
+            timeout=60_000,
+        )
+        assert api.get("/api/context")["active_binary"] == target
+
+        served = api.get("/api/conformance/inventory", program=target, q="", limit=6000)
+        assert page.locator("#invHint").inner_text().strip() == (
+            f"{served['shown']} of {served['total']}"
+        )
+    finally:
+        api.post("/api/context/binary", {"binary": original_context})

--- a/tests/e2e/test_health_strip.py
+++ b/tests/e2e/test_health_strip.py
@@ -1,0 +1,134 @@
+"""The five-dot dependency health strip.
+
+Each dot is a claim about a subsystem the fleet cannot work without. The
+failure mode that matters is not "a dot is red" — it's a dot that is GREEN
+while the subsystem is dead, which is exactly what happened when
+`ghidra_health` stopped emitting and `ghidra_offline_sustained` silently
+went dead. So every assertion here compares the RENDERED dot against
+`/api/health/all`, and the socket-precedence rule gets its own test:
+a page with no socket must not show four reassuring green dots.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+SUBSYSTEMS = {
+    "hs-dashboard": ("dashboard", "Dashboard"),
+    "hs-ghidra": ("ghidra", "Ghidra"),
+    "hs-oracle": ("oracle", "Oracle + Game"),
+    "hs-provider": ("provider", "Provider"),
+    "hs-store": ("store", "Store"),
+}
+
+VALID_STATES = {"ok", "degraded", "down", "unknown"}
+
+
+def _dot_state(page, item_id: str) -> str:
+    cls = page.locator(f"#{item_id} .hs-dot").get_attribute("class") or ""
+    states = [c for c in cls.split() if c in VALID_STATES]
+    assert len(states) == 1, f"#{item_id} dot has ambiguous state classes: {cls!r}"
+    return states[0]
+
+
+def test_strip_has_all_five_dots(dashboard):
+    page, _ = dashboard
+    expect(page.locator("#healthStrip .hs-item")).to_have_count(5)
+    for item_id in SUBSYSTEMS:
+        expect(page.locator(f"#{item_id}")).to_be_visible()
+
+
+def test_no_dot_is_stuck_unknown(dashboard):
+    """`unknown` is the pre-hydration placeholder. Still showing it after
+    the page has hydrated means that subsystem's render path never ran."""
+    page, _ = dashboard
+    page.wait_for_timeout(2000)
+    stuck = [i for i in SUBSYSTEMS if _dot_state(page, i) == "unknown"]
+    assert not stuck, f"dots never left the placeholder state: {stuck}"
+
+
+@pytest.mark.parametrize("item_id", list(SUBSYSTEMS))
+def test_dot_state_matches_api(dashboard, api, item_id):
+    page, _ = dashboard
+    key, _label = SUBSYSTEMS[item_id]
+    served = api.get("/api/health/all")["subsystems"][key]
+    expected = served.get("state", "unknown")
+    rendered = _dot_state(page, item_id)
+    assert rendered == expected, (
+        f"{key}: strip shows '{rendered}' but /api/health/all says '{expected}' "
+        f"({served.get('detail')})"
+    )
+
+
+@pytest.mark.parametrize("item_id", list(SUBSYSTEMS))
+def test_dot_tooltip_carries_title_and_detail(dashboard, api, item_id):
+    """The dot is 8px wide; the tooltip is the entire diagnosis. An empty
+    detail is a dot that tells the operator a colour and nothing else."""
+    page, _ = dashboard
+    key, label = SUBSYSTEMS[item_id]
+    served = api.get("/api/health/all")["subsystems"][key]
+    tip = page.locator(f"#{item_id} .hs-tip")
+    assert tip.locator(".t").inner_text().strip() == label
+    detail = tip.locator(".d").inner_text().strip()
+    assert detail, f"{key} tooltip has no detail line"
+    if served.get("detail"):
+        assert detail == served["detail"].strip()
+    if served.get("endpoint"):
+        assert tip.locator(".e").inner_text().strip() == served["endpoint"]
+
+
+@pytest.mark.parametrize("item_id", list(SUBSYSTEMS))
+def test_bad_class_tracks_unhealthy_state(dashboard, api, item_id):
+    """`.bad` is what makes a dot legible at a glance; it must be set for
+    exactly down+degraded and for nothing else."""
+    page, _ = dashboard
+    key, _ = SUBSYSTEMS[item_id]
+    state = api.get("/api/health/all")["subsystems"][key].get("state")
+    classes = page.locator(f"#{item_id}").get_attribute("class") or ""
+    should_be_bad = state in ("down", "degraded")
+    assert ("bad" in classes.split()) == should_be_bad, (
+        f"{key} state={state} but .bad={'bad' in classes.split()}"
+    )
+
+
+def test_socket_loss_downgrades_the_dashboard_dot(dashboard, page):
+    """Server-owned dots are stale the moment the socket dies. The
+    dashboard dot must go `down` and say so, rather than leaving a page
+    that is talking to nothing looking healthy."""
+    _page, _ = dashboard
+    assert _dot_state(page, "hs-dashboard") in ("ok", "degraded")
+
+    page.evaluate("() => { window.socket && window.socket.disconnect(); }")
+    # The template holds `socket` in a closure, not on window; fall back to
+    # cutting the transport at the network layer if the handle isn't exposed.
+    if _dot_state(page, "hs-dashboard") != "down":
+        page.context.set_offline(True)
+        try:
+            page.wait_for_function(
+                "() => (document.querySelector('#hs-dashboard .hs-dot').className || '')"
+                ".includes('down')",
+                timeout=30_000,
+            )
+            detail = page.locator("#hs-dashboard .hs-tip .d").inner_text()
+            assert "socket" in detail.lower(), (
+                f"dashboard dot went down but the tooltip does not explain why: {detail!r}"
+            )
+        finally:
+            page.context.set_offline(False)
+
+
+def test_paused_fleet_is_surfaced(dashboard, api):
+    """A paused fleet is deliberate parking, not a fault — it must not be
+    a red dot, but it MUST be visible somewhere or an operator will spend
+    an hour wondering why nothing is progressing."""
+    page, _ = dashboard
+    state = api.get("/api/worker/pause_state")
+    if not state.get("paused"):
+        pytest.skip("fleet is not paused")
+    body = page.locator("body").inner_text().lower()
+    assert "pause" in body or "resume" in body, (
+        "fleet is paused but the word never appears on the page"
+    )

--- a/tests/e2e/test_inventory.py
+++ b/tests/e2e/test_inventory.py
@@ -1,0 +1,207 @@
+"""The function and globals inventories, and the function drawer.
+
+Both inventories are read through `conformance_dashboard`, which reads
+7.0.0 envelopes from `/list_functions`, `/list_globals` and
+`/list_segments`. When that module was blanket-exempted from the
+response-contract guard, BOTH inventories silently returned zero rows for
+days while the whole suite stayed green — the operator saw an empty table
+and the tests saw nothing at all. That is the specific failure these
+tests exist to make impossible, so "renders a non-zero number of rows
+that agrees with the API" is the headline assertion, not a detail.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+
+def _rows(page, tbody: str) -> int:
+    return page.locator(f"#{tbody} tr").count()
+
+
+def _wait_rows(page, tbody: str, timeout: int = 45_000):
+    page.wait_for_function(
+        "(id) => document.querySelectorAll('#' + id + ' tr').length > 0",
+        arg=tbody,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# function inventory
+# ---------------------------------------------------------------------------
+
+
+def test_function_inventory_renders_rows(dashboard, api):
+    page, _ = dashboard
+    total = api.get("/api/conformance/inventory", limit=1)["total"]
+    if not total:
+        pytest.skip("no functions in scope for the focused binary")
+    _wait_rows(page, "invBody")
+    assert _rows(page, "invBody") > 0, (
+        "the function inventory rendered zero rows while the API reports "
+        f"{total} — this is the envelope-unwrap regression"
+    )
+
+
+def test_function_inventory_hint_matches_api(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "invBody")
+    hint = page.locator("#invHint").inner_text().strip()
+    served = api.get("/api/conformance/inventory", q="", limit=6000)
+    assert hint == f"{served['shown']} of {served['total']}", (
+        f"inventory hint {hint!r} vs API shown={served['shown']} total={served['total']}"
+    )
+    assert _rows(page, "invBody") == served["shown"]
+
+
+def test_function_inventory_row_content_matches_api(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "invBody")
+    served = api.get("/api/conformance/inventory", q="", limit=6000)
+    if not served["rows"]:
+        pytest.skip("empty inventory")
+    first = served["rows"][0]
+    row = page.locator("#invBody tr").first
+    assert first["name"] in row.inner_text()
+    assert first["address"] in row.inner_text()
+
+
+def test_function_inventory_search_filters(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "invBody")
+    served = api.get("/api/conformance/inventory", q="", limit=6000)
+    if not served["rows"]:
+        pytest.skip("empty inventory")
+    needle = served["rows"][0]["name"][:6]
+    before = _rows(page, "invBody")
+
+    page.locator("#invSearch").fill(needle)
+    page.wait_for_timeout(2000)  # debouncedInv()
+    filtered = api.get("/api/conformance/inventory", q=needle, limit=6000)
+    page.wait_for_function(
+        "(n) => document.querySelectorAll('#invBody tr').length === n",
+        arg=filtered["shown"],
+        timeout=30_000,
+    )
+    assert _rows(page, "invBody") <= before
+
+    page.locator("#invSearch").fill("")
+    page.wait_for_timeout(2000)
+
+
+def test_function_inventory_search_with_no_matches_is_empty_not_stale(dashboard):
+    """A search that matches nothing must clear the table. Leaving the
+    previous result set on screen reads as "these matched"."""
+    page, _ = dashboard
+    _wait_rows(page, "invBody")
+    try:
+        page.locator("#invSearch").fill("zzz_no_such_function_zzz")
+        page.wait_for_function(
+            "() => document.querySelectorAll('#invBody tr').length === 0", timeout=30_000
+        )
+        assert page.locator("#invHint").inner_text().strip().startswith("0 of")
+    finally:
+        page.locator("#invSearch").fill("")
+        page.wait_for_timeout(2000)
+
+
+def test_function_drawer_opens_and_closes(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "invBody")
+    served = api.get("/api/conformance/inventory", q="", limit=1)
+    if not served["rows"]:
+        pytest.skip("empty inventory")
+    expected = served["rows"][0]
+
+    page.locator("#invBody tr").first.click()
+    expect(page.locator("#drawer")).to_have_class("drawer open", timeout=30_000)
+    expect(page.locator("#drAddr")).to_have_text(expected["address"])
+    assert page.locator("#drName").inner_text().strip()
+    assert page.locator("#drBadges").inner_text().strip()
+
+    page.keyboard.press("Escape")
+    expect(page.locator("#drawer")).not_to_have_class("drawer open")
+
+
+# ---------------------------------------------------------------------------
+# globals inventory
+# ---------------------------------------------------------------------------
+
+
+def test_globals_inventory_renders_rows(dashboard, api):
+    page, _ = dashboard
+    total = api.get("/api/conformance/globals", limit=1)["total"]
+    if not total:
+        pytest.skip("no globals in scope for the focused binary")
+    _wait_rows(page, "globBody")
+    assert _rows(page, "globBody") > 0, (
+        f"the globals inventory rendered zero rows while the API reports {total}"
+    )
+
+
+def test_globals_inventory_hint_matches_api(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "globBody")
+    hint = page.locator("#globHint").inner_text().strip()
+    served = api.get("/api/conformance/globals", q="", limit=200)
+    assert hint == f"{served['shown']} of {served['total']}"
+    assert _rows(page, "globBody") == served["shown"]
+
+
+def test_globals_untyped_rows_are_marked(dashboard, api):
+    """An untyped global is hard-capped below COMPLETE_80 — the type cell
+    carries the `untyped` class so the operator can see the backlog
+    without reading every band badge."""
+    page, _ = dashboard
+    _wait_rows(page, "globBody")
+    served = api.get("/api/conformance/globals", q="", limit=200)
+    untyped_api = sum(1 for r in served["rows"] if not r.get("typed"))
+    untyped_dom = page.locator("#globBody td.gtype.untyped").count()
+    assert untyped_dom == untyped_api, (
+        f"{untyped_dom} rows marked untyped in the DOM vs {untyped_api} from the API"
+    )
+
+
+def test_globals_reviewed_flag_matches_api(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "globBody")
+    served = api.get("/api/conformance/globals", q="", limit=200)
+    reviewed_api = sum(1 for r in served["rows"] if r.get("reviewed"))
+    reviewed_dom = page.locator("#globBody button.pin-btn.pinned").count()
+    assert reviewed_dom == reviewed_api
+
+
+def test_globals_search_filters(dashboard, api):
+    page, _ = dashboard
+    _wait_rows(page, "globBody")
+    served = api.get("/api/conformance/globals", q="", limit=200)
+    if not served["rows"]:
+        pytest.skip("empty globals inventory")
+    needle = served["rows"][0]["name"][:5]
+    try:
+        page.locator("#globSearch").fill(needle)
+        page.wait_for_timeout(2000)
+        filtered = api.get("/api/conformance/globals", q=needle, limit=200)
+        page.wait_for_function(
+            "(n) => document.querySelectorAll('#globBody tr').length === n",
+            arg=filtered["shown"],
+            timeout=30_000,
+        )
+    finally:
+        page.locator("#globSearch").fill("")
+        page.wait_for_timeout(2000)
+
+
+def test_globals_summary_agrees_with_the_bar(api):
+    """`/globals` carries its own summary block; the bar reads
+    `/glob_bands`. Two sources for one number is two chances to be wrong,
+    so they must at least agree."""
+    inv = api.get("/api/conformance/globals", limit=1)["summary"]
+    bands = api.get("/api/conformance/glob_bands")
+    assert inv["bands"] == bands["bands"]
+    assert inv["reviewed"] == bands["reviewed"]
+    assert inv["scope"] == bands["in_scope"]

--- a/tests/e2e/test_oracle.py
+++ b/tests/e2e/test_oracle.py
@@ -1,0 +1,185 @@
+"""The Oracle + Game dot and the oracle slide-out bar.
+
+`oracle_health.py` distinguishes FOUR fault shapes, and the two that matter
+most are the ones that answer HTTP perfectly:
+
+  WEDGED  process up, oracle dead        -> reachable False, game_wedged
+  DEAD    process gone                   -> reachable False, game_dead
+  IDLE    oracle fine, parked at a menu  -> reachable TRUE,  game_idle
+  FROZEN  oracle fine, drawing nothing   -> reachable TRUE,  game_frozen
+
+IDLE and FROZEN were reported as `ok` / "live-prove enabled" with the bar
+hidden, because both the dot and the bar keyed on `reachable` alone. That is
+not a hypothetical: on 2026-07-31 a deploy restart left the game at the main
+menu and the fleet sat idle behind a green banner for 70 minutes.
+
+The two reachable-but-useless shapes cannot be produced on demand against a
+live game, so those tests drive the page's own renderer with a synthetic
+payload — the same function `checkOracleStatus()` calls. That tests the
+rendering contract, which is exactly where the bug was.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+HEALTHY = {
+    "reachable": True, "game_running": True, "game_wedged": False,
+    "game_dead": False, "game_idle": False, "game_frozen": False,
+    "relaunching": False, "relaunch_stage": None, "relaunch_error": None,
+    "present_rate": 25.0,
+}
+
+
+def _bar_classes(page) -> list[str]:
+    return (page.locator("#oracleBar").get_attribute("class") or "").split()
+
+
+def _render(page, **overrides) -> None:
+    """Drive the page's own oracle renderer with a synthetic payload."""
+    page.evaluate("(h) => renderOracleBar(h)", {**HEALTHY, **overrides})
+
+
+# ---------------------------------------------------------------------------
+# live state
+# ---------------------------------------------------------------------------
+
+
+def test_oracle_dot_matches_oracle_status(dashboard, api):
+    """The dot must agree with `/api/oracle/status`, including for the two
+    shapes where `reachable` is True but the game is useless."""
+    page, _ = dashboard
+    page.wait_for_timeout(2000)
+    s = api.get("/api/oracle/status")
+    dot = page.locator("#hs-oracle .hs-dot").get_attribute("class") or ""
+
+    if s.get("reachable") and not s.get("game_frozen") and not s.get("game_idle"):
+        assert "ok" in dot.split(), f"healthy oracle but dot is {dot!r}"
+    elif s.get("game_frozen"):
+        assert "down" in dot.split(), f"game is FROZEN but dot is {dot!r}"
+    elif s.get("game_idle"):
+        assert "degraded" in dot.split(), f"game is IDLE but dot is {dot!r}"
+    elif s.get("reachable") is False:
+        assert dot.split() and dot.split()[-1] in ("down", "degraded"), (
+            f"oracle unreachable but dot is {dot!r}"
+        )
+
+
+def test_oracle_bar_hidden_only_when_genuinely_healthy(dashboard, api):
+    page, _ = dashboard
+    page.wait_for_timeout(2000)
+    s = api.get("/api/oracle/status")
+    healthy = (
+        s.get("reachable")
+        and not s.get("game_frozen")
+        and not s.get("game_idle")
+        and not s.get("relaunching")
+    )
+    if healthy:
+        assert "active" not in _bar_classes(page), (
+            "oracle is healthy but the warning bar is showing"
+        )
+
+
+def test_health_payload_exposes_the_reachable_but_useless_flags(api):
+    """The UI cannot distinguish FROZEN/IDLE from a plain outage unless the
+    health payload carries them."""
+    oracle = api.get("/api/health/all")["subsystems"]["oracle"]
+    assert "game_frozen" in oracle, "health payload drops game_frozen"
+    assert "game_idle" in oracle, "health payload drops game_idle"
+
+
+# ---------------------------------------------------------------------------
+# the four fault shapes, driven through the page's own renderer
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_hides_the_bar(dashboard):
+    page, _ = dashboard
+    _render(page)
+    assert "active" not in _bar_classes(page)
+
+
+def test_frozen_game_raises_the_bar_and_offers_relaunch(dashboard):
+    """A hang raises no exception, so /crash stays null and every other probe
+    is green. The frame counter is the only tell — say so on screen."""
+    page, _ = dashboard
+    _render(page, game_frozen=True, present_rate=0)
+    assert "active" in _bar_classes(page), "FROZEN game did not raise the oracle bar"
+    msg = page.locator("#oracleBarMsg").inner_text()
+    assert "frozen" in msg.lower()
+    assert page.locator("#oracleBarBtn").is_enabled(), (
+        "FROZEN recovers on the wedged path, so a relaunch must be offered"
+    )
+
+
+def test_idle_game_raises_the_bar_but_offers_no_relaunch(dashboard):
+    """IDLE passes every liveness check while proving is stalled. It must be
+    visible — but relaunching a HEALTHY game is the mistake oracle_health
+    exists to prevent, so no relaunch affordance."""
+    page, _ = dashboard
+    _render(page, game_idle=True)
+    assert "active" in _bar_classes(page), "IDLE game did not raise the oracle bar"
+    msg = page.locator("#oracleBarMsg").inner_text().lower()
+    assert "menu" in msg or "parked" in msg
+    assert not page.locator("#oracleBarBtn").is_enabled(), (
+        "an IDLE game must not offer a one-click relaunch of a healthy game"
+    )
+
+
+def test_wedged_game_tells_you_to_close_the_corpse_first(dashboard):
+    """D2 Halt leaves Game.exe alive and Responding, which blocks a relaunch."""
+    page, _ = dashboard
+    _render(page, reachable=False, game_running=True, game_wedged=True)
+    assert "active" in _bar_classes(page)
+    msg = page.locator("#oracleBarMsg").inner_text().lower()
+    assert "still running" in msg or "close game.exe" in msg
+
+
+def test_dead_game_says_the_process_is_gone(dashboard):
+    page, _ = dashboard
+    _render(page, reachable=False, game_running=False, game_dead=True)
+    assert "active" in _bar_classes(page)
+    assert "not running" in page.locator("#oracleBarMsg").inner_text().lower()
+
+
+def test_relaunch_in_progress_disables_the_button(dashboard):
+    """A second click mid-relaunch is how you get two games."""
+    page, _ = dashboard
+    _render(page, reachable=False, relaunching=True, relaunch_stage="launching")
+    assert "busy" in _bar_classes(page)
+    assert not page.locator("#oracleBarBtn").is_enabled()
+    assert "launching" in page.locator("#oracleBarMsg").inner_text().lower()
+
+
+def test_relaunch_failure_offers_a_retry_with_the_error(dashboard):
+    page, _ = dashboard
+    _render(
+        page,
+        reachable=False,
+        relaunch_stage="failed",
+        relaunch_error="UAC prompt timed out",
+    )
+    assert "active" in _bar_classes(page)
+    msg = page.locator("#oracleBarMsg").inner_text()
+    assert "UAC prompt timed out" in msg, f"relaunch error not surfaced: {msg!r}"
+    assert page.locator("#oracleBarBtn").is_enabled()
+
+
+def test_oracle_dot_is_clickable_only_when_it_can_act(dashboard, api):
+    """The dot doubles as the relaunch trigger when there is something to
+    relaunch — and must NOT when the right recovery is navigation."""
+    page, _ = dashboard
+    page.wait_for_timeout(2000)
+    oracle = api.get("/api/health/all")["subsystems"]["oracle"]
+    actionable = "actionable" in (
+        page.locator("#hs-oracle").get_attribute("class") or ""
+    ).split()
+    assert actionable == (oracle.get("action") == "relaunch_oracle"), (
+        f"dot actionable={actionable} but health action={oracle.get('action')}"
+    )
+    if oracle.get("game_idle"):
+        assert not actionable, "an IDLE game must not offer click-to-relaunch"

--- a/tests/e2e/test_regressions.py
+++ b/tests/e2e/test_regressions.py
@@ -1,0 +1,250 @@
+"""Named guards for dashboard bugs that actually shipped.
+
+Each test here corresponds to a specific failure that reached the
+operator's screen. They are separated from the feature tests on purpose:
+when one of these goes red it is not "a test broke", it is "a bug we have
+already paid for is back".
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+# `326700%` on the completeness bar, `228600%` on the globals bar — both
+# from `in_scope || 1` folding a legitimate zero into a denominator of 1.
+IMPLAUSIBLE_PCT = 100.5
+
+_PCT_RE = re.compile(r"(-?\d[\d,]*\.?\d*)\s*%")
+
+
+def test_no_percentage_on_the_page_exceeds_100(dashboard):
+    """The `|| 1` denominator class of bug, caught wherever it surfaces."""
+    page, _ = dashboard
+    page.wait_for_timeout(4000)
+    offenders = []
+    for pct_id in ("docPct", "bandPct", "confPct", "globBandPct"):
+        text = page.locator(f"#{pct_id}").inner_text()
+        for raw in _PCT_RE.findall(text):
+            value = float(raw.replace(",", ""))
+            if value > IMPLAUSIBLE_PCT or value < 0:
+                offenders.append(f"#{pct_id}: {value}% (in {text!r})")
+    assert not offenders, "implausible percentages rendered:\n  " + "\n  ".join(offenders)
+
+
+def test_health_payload_carries_no_store_credentials(api):
+    """`_health_store` must report `config.backend`, never `config.url` —
+    a Postgres URL carries credentials and this payload renders in a
+    browser and lands in anyone's devtools."""
+    store = api.get("/api/health/all")["subsystems"]["store"]
+    blob = " ".join(str(v) for v in store.values() if v is not None).lower()
+    for leak in ("://", "password", "postgresql:", "@localhost", "user="):
+        assert leak not in blob, f"store health detail looks like a connection string: {store}"
+
+
+def test_both_inventories_are_non_zero(api):
+    """`conformance_dashboard` reads 7.0.0 envelopes; when its unwrap
+    broke, both inventories returned 0 rows for days behind a green
+    suite. Zero from a binary with functions is the tell."""
+    summary = api.get("/api/conformance/summary")
+    if not summary.get("local_defined"):
+        pytest.skip("focused binary has no defined functions")
+    assert api.get("/api/conformance/inventory", limit=1)["total"] > 0, (
+        "function inventory returned 0 rows for a binary with defined functions"
+    )
+    assert api.get("/api/conformance/globals", limit=1)["total"] > 0, (
+        "globals inventory returned 0 rows for a binary with defined functions"
+    )
+
+
+def test_worker_roster_is_offered_not_auto_restored(api):
+    """Auto-restore is retired at the call site on purpose: a restart used
+    to silently relaunch a fleet the operator had deliberately stopped.
+    The roster may be OFFERED, never applied."""
+    roster = api.get("/api/worker/roster")
+    assert "offer" in roster, f"roster payload has no offer field: {roster}"
+    offer = roster.get("offer")
+    if not offer:
+        return
+    running = {w["id"] for w in api.get("/api/worker/status")["workers"]}
+    offered = {w.get("id") for w in offer.get("workers", [])}
+    assert not (offered & running), (
+        "workers from the persisted roster are already running — "
+        f"auto-restore appears to have fired: {offered & running}"
+    )
+
+
+def test_pause_state_reports_worker_count_and_reason(api):
+    """A paused fleet must say WHY and HOW MANY. `paused: true` with no
+    reason is indistinguishable from a bug that stopped the fleet."""
+    state = api.get("/api/worker/pause_state")
+    assert "paused" in state
+    if state.get("paused"):
+        assert state.get("reason"), "fleet is paused with no reason recorded"
+        assert isinstance(state.get("workers"), int)
+
+
+def test_matrix_and_summary_count_the_same_population(api):
+    """`summary()` filters library-excluded functions; `matrix()` does
+    not. When the two disagree, every bar built from the matrix is
+    divided by the summary's denominator and reads high."""
+    m = api.get("/api/conformance/matrix")
+    s = api.get("/api/conformance/summary")
+    # `summary.in_scope` comes from a stored Ghidra option that only the sync
+    # tool writes, so it is absent for any binary that never went through
+    # conformance intake; matrix() then computes defined-minus-library itself.
+    # Only compare when the authoritative value actually exists.
+    if s.get("in_scope") is not None:
+        assert m["in_scope"] == s["in_scope"], (
+            f"matrix in_scope={m['in_scope']} but summary in_scope={s['in_scope']}"
+        )
+    assert m["evaluated"] <= m["in_scope"], (
+        f"matrix evaluated={m['evaluated']} exceeds in_scope={m['in_scope']} "
+        f"(excluded_lib={m.get('excluded_lib')}) — the matrix is counting functions "
+        "the denominator excludes, so the doc/conformance bars read high"
+    )
+
+
+def test_summary_declares_how_stale_it_is(dashboard, api):
+    """`summary` is a SNAPSHOT; `matrix` is LIVE.
+
+    The conformance bar takes its denominator from the stored summary option
+    (written only by `sync_conformance_to_ghidra.py`) and its numerators from
+    a live Ghidra read, so the two legitimately disagree — measured
+    CONF_LIVE 162 live vs 149 in a snapshot three weeks old. That is by
+    design and cannot be asserted away.
+
+    What CAN go wrong is an operator reading a stale percentage without
+    knowing it is stale, so the guard is that `last_sync` exists AND is on
+    the page. (It used to be rendered into `#workerHint`, the Active Workers
+    header, where it clobbered the worker count and told you nothing about
+    the bars it actually qualifies.)
+    """
+    page, _ = dashboard
+    s = api.get("/api/conformance/summary")
+    if not s.get("last_sync"):
+        pytest.skip("focused binary has never been synced")
+    shown = page.locator("#lastSync").inner_text()
+    assert s["last_sync"] in shown, (
+        f"summary is a {s['last_sync']} snapshot but the page shows {shown!r}"
+    )
+    assert "last sync" not in page.locator("#workerHint").inner_text().lower(), (
+        "the sync date is being written into the Active Workers header again"
+    )
+
+
+@pytest.mark.slow
+def test_no_binary_in_the_project_overflows_its_denominator(api):
+    """Sweep every binary, not just the focused one.
+
+    The per-binary guards above only fire for whatever is in focus, and
+    the overflow is corpus-shaped: when this was found, 32 of 34 binaries
+    were fine and D2Common (105.3%) and PD2_EXT (172.6%) were not. A
+    guard that only checks the focused binary would have been green on
+    31 of 34 workdays.
+    """
+    listed = api.get("/api/conformance/binaries")["binaries"]
+    offenders = []
+    for b in listed:
+        try:
+            m = api.get("/api/conformance/matrix", program=b["path"])
+        except Exception as exc:  # noqa: BLE001, PERF203
+            offenders.append(f"{b['name']}: matrix failed ({exc})")
+            continue
+        in_scope = m.get("in_scope") or 0
+        if not in_scope:
+            continue
+        tagged = sum(
+            sum(m["cell"].get(r, {}).get(c, 0) for r in m["rows"])
+            for c in ("DOC_DRAFT", "DOC_REVIEWED", "DOC_VERIFIED")
+        )
+        if tagged > in_scope:
+            offenders.append(
+                f"{b['name']}: {tagged} DOC-tagged / {in_scope} in scope "
+                f"= {100.0 * tagged / in_scope:.1f}%"
+            )
+        elif m.get("evaluated", 0) > in_scope:
+            offenders.append(
+                f"{b['name']}: evaluated={m['evaluated']} > in_scope={in_scope}"
+            )
+    assert not offenders, "binaries whose bars divide by too small a denominator:\n  " + "\n  ".join(
+        offenders
+    )
+
+
+def test_bands_never_exceed_in_scope(api):
+    """`bands()` DOES subtract EXCLUDE_TAGS. This is the control that
+    proves the matrix failure above is a real asymmetry and not just how
+    the corpus is shaped."""
+    for endpoint in ("/api/conformance/bands", "/api/conformance/glob_bands"):
+        b = api.get(endpoint)
+        tagged = sum(b["bands"].values())
+        assert tagged <= b["in_scope"], (
+            f"{endpoint}: {tagged} band-tagged vs in_scope={b['in_scope']}"
+        )
+
+
+def test_page_focus_and_server_context_agree(api):
+    """The binary the header names must be the binary the fleet works.
+
+    `loadBinaries()` seeds `PROGRAM` from
+    `/api/conformance/binaries/progress`, whose route deliberately
+    overrides `conformance_dashboard.PROGRAM` (a module constant from
+    `FUNDOC_GHIDRA_PROGRAM`) with the persisted `active_binary` meta —
+    the value `pickBinary -> syncServerContext` writes. Drop that
+    override and focus silently reverts to the default binary on every
+    reload while the workers keep running against the chosen one.
+
+    Note `/api/conformance/binaries` (no `/progress`) still reports the
+    unpatched constant; it is not what the page reads.
+    """
+    page_focus = api.get("/api/conformance/binaries/progress").get("active")
+    server_context = api.get("/api/context").get("active_binary")
+    assert page_focus == server_context, (
+        f"the dashboard header focuses {page_focus} but the server context "
+        f"(globals worker / queue refresh / worker default) is {server_context}"
+    )
+
+
+@pytest.mark.destructive
+def test_binary_focus_survives_a_reload(dashboard, api):
+    """Picking a binary writes the server context but the boot path never
+    reads it back, so focus silently resets on every refresh."""
+    page, _ = dashboard
+    listed = api.get("/api/conformance/binaries")
+    original = listed.get("active")
+    candidates = [b["path"] for b in listed["binaries"] if b["path"] != original]
+    if not candidates:
+        pytest.skip("only one binary available")
+    target = candidates[0]
+    try:
+        page.evaluate("(p) => pickBinary(p)", target)
+        page.wait_for_function(
+            "(n) => (document.getElementById('fbName').textContent || '') === n",
+            arg=target.split("/")[-1],
+            timeout=30_000,
+        )
+        page.reload(wait_until="domcontentloaded")
+        page.wait_for_function(
+            "() => (document.getElementById('fbName').textContent || '') !== 'binary'",
+            timeout=45_000,
+        )
+        assert page.locator("#fbName").inner_text().strip() == target.split("/")[-1], (
+            "binary focus reset on reload — the picked binary was written to the "
+            "server context but the boot path re-reads the hardcoded default"
+        )
+    finally:
+        if original:
+            api.post("/api/context/binary", {"binary": original})
+
+
+def test_dashboard_does_not_error_when_a_panel_endpoint_is_slow(dashboard):
+    """Panels fetch independently; one slow endpoint must degrade that
+    panel, not throw and abort the rest of the render pass."""
+    page, errors = dashboard
+    page.wait_for_timeout(5000)
+    fatal = [e for e in errors.pageerrors if "TypeError" in e or "undefined" in e]
+    assert not fatal, "unhandled render errors:\n  " + "\n  ".join(fatal)

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -1,0 +1,164 @@
+"""The settings popout — the only UI for `priority_queue.json -> config`.
+
+Two things matter here. First, the popout must SHOW what the server has:
+a control rendering a default while the server holds something else is a
+control that lies about what the fleet is doing. Second, saving must not
+clobber neighbouring keys — `save_priority_queue` does a 3-way merge
+inside the write lock precisely because whole-file replace silently
+reverted `globals_audit_provider` twice in one session, and the popout
+posts a whole form on every change.
+
+Every write here is reverted in a `finally`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def settings_open(dashboard):
+    page, _ = dashboard
+    page.locator("#btnToggleSettings").click()
+    expect(page.locator("#settingsPopout")).to_have_class("settings-popout active")
+    page.wait_for_timeout(1500)  # loadQueueConfig()
+    yield page
+    if "active" in (page.locator("#settingsPopout").get_attribute("class") or ""):
+        page.locator("#btnToggleSettings").click()
+
+
+def _cfg(api) -> dict:
+    j = api.get("/api/queue/config")
+    return j.get("config") or j
+
+
+def test_popout_toggles(dashboard):
+    page, _ = dashboard
+    popout = page.locator("#settingsPopout")
+    expect(popout).not_to_have_class("settings-popout active")
+    page.locator("#btnToggleSettings").click()
+    expect(popout).to_have_class("settings-popout active")
+    page.locator("#btnToggleSettings").click()
+    expect(popout).not_to_have_class("settings-popout active")
+
+
+@pytest.mark.parametrize(
+    "control,key,default",
+    [
+        ("#goodEnoughInput", "good_enough_score", 80),
+        ("#handoffMaxInput", "complexity_handoff_max", 0),
+        ("#auditMinDeltaInput", "audit_min_delta", 5),
+    ],
+)
+def test_numeric_control_shows_server_value(settings_open, api, control, key, default):
+    cfg = _cfg(api)
+    expected = cfg.get(key, default)
+    assert settings_open.locator(control).input_value() == str(expected)
+
+
+@pytest.mark.parametrize(
+    "control,key",
+    [
+        ("#requireScoredInput", "require_scored"),
+        ("#debugModeInput", "debug_mode"),
+        ("#plateScaffoldInput", "plate_scaffold"),
+    ],
+)
+def test_checkbox_shows_server_value(settings_open, api, control, key):
+    assert settings_open.locator(control).is_checked() == bool(_cfg(api).get(key))
+
+
+@pytest.mark.parametrize(
+    "control,key",
+    [
+        ("#handoffProviderInput", "complexity_handoff_provider"),
+        ("#auditProviderInput", "audit_provider"),
+        ("#globAuditProviderInput", "globals_audit_provider"),
+    ],
+)
+def test_provider_select_shows_server_value(settings_open, api, control, key):
+    expected = _cfg(api).get(key) or "off"
+    assert settings_open.locator(control).input_value() == expected
+
+
+def test_provider_model_grid_matches_config(settings_open, api):
+    """The model table is what the workers actually run; a grid that shows
+    a different model than the fleet uses makes every quality comparison
+    unreproducible."""
+    cfg = _cfg(api)
+    models = cfg.get("provider_models") or {}
+    turns = cfg.get("provider_max_turns") or {}
+    if not models:
+        pytest.skip("no provider_models configured")
+    # each cell is an <input>, so assert on VALUES — inner_text() sees none of
+    # them and would pass on a grid of entirely empty boxes
+    for provider, tiers in models.items():
+        for tier, model in tiers.items():
+            cell = settings_open.locator(f"#model-{provider}-{tier}")
+            if cell.count() == 0:
+                pytest.fail(f"no grid cell for {provider}/{tier} (config has {model})")
+            assert cell.input_value() == model, (
+                f"{provider}/{tier}: grid shows {cell.input_value()!r}, config has {model!r}"
+            )
+    for provider, n in turns.items():
+        cell = settings_open.locator(f"#turns-{provider}")
+        if cell.count():
+            assert cell.input_value() == str(n)
+
+
+@pytest.mark.destructive
+def test_target_round_trips_and_leaves_neighbours_alone(settings_open, api):
+    """Change Target through the UI, confirm the server took it AND that
+    nothing else in config moved. Reverted unconditionally."""
+    page = settings_open
+    before = _cfg(api)
+    original = str(before.get("good_enough_score", 80))
+    new = "90" if original != "90" else "95"
+    try:
+        page.locator("#goodEnoughInput").select_option(new)
+        page.wait_for_timeout(2500)
+        after = _cfg(api)
+        assert str(after.get("good_enough_score")) == new
+
+        moved = {
+            k: (before.get(k), after.get(k))
+            for k in set(before) | set(after)
+            if k != "good_enough_score" and before.get(k) != after.get(k)
+        }
+        assert not moved, f"saving Target also changed unrelated config keys: {moved}"
+
+        # The completeness headline follows the target. It re-renders on the
+        # next refresh pass, not on the save, so allow a full cycle — and skip
+        # rather than fail if the bar never hydrated (a binary with no
+        # in-scope functions legitimately renders "-" forever).
+        if page.locator("#bandPct").inner_text().strip() not in ("-", "—", ""):
+            page.wait_for_function(
+                "(t) => (document.getElementById('bandPct').textContent || '')"
+                ".includes('(' + t + '+)')",
+                arg=new,
+                timeout=90_000,
+            )
+    finally:
+        page.locator("#goodEnoughInput").select_option(original)
+        page.wait_for_timeout(2500)
+        assert str(_cfg(api).get("good_enough_score")) == original
+
+
+def test_config_rejects_a_bad_provider(api):
+    """A typo must be a 400, not a silently-accepted provider name that
+    makes every audit pass fail at call time."""
+    r = api.post("/api/queue/config", {"audit_provider": "not-a-provider"})
+    assert r.status_code == 400
+    assert "audit_provider" in (r.json().get("error") or "")
+
+
+def test_config_rejects_an_out_of_range_target(api):
+    """Out-of-range is clamped rather than rejected; either way it must
+    never persist a nonsense band."""
+    before = _cfg(api).get("good_enough_score")
+    r = api.post("/api/queue/config", {"good_enough_score": "not-a-number"})
+    assert r.status_code == 400
+    assert _cfg(api).get("good_enough_score") == before

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,0 +1,89 @@
+"""Does the page load at all, and does it load clean?
+
+The dashboard is one 1,700-line template with no build step and no unit
+tests behind it, so a typo in a renderer is caught by exactly nothing
+today. These checks are the floor: the shell renders, every panel the
+operator steers from is present, and the browser reported no errors.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+
+def test_page_loads_with_title(dashboard):
+    page, _ = dashboard
+    expect(page).to_have_title("Fun-Doc Command Center")
+
+
+def test_no_console_errors_on_load(dashboard):
+    page, errors = dashboard
+    page.wait_for_timeout(3000)  # let the deferred fetch fan-out settle
+    assert not errors.all, "browser reported errors on load:\n  " + "\n  ".join(errors.all)
+
+
+@pytest.mark.parametrize(
+    "selector,what",
+    [
+        ("#healthStrip", "dependency health strip"),
+        ("#focusBtn", "binary focus button"),
+        ("#lane", "lane picker"),
+        ("#provider", "provider picker"),
+        ("#count", "count input"),
+        ("#docBar", "documentation bar"),
+        ("#bandBar", "function completeness bar"),
+        ("#confBar", "conformance bar"),
+        ("#globBandBar", "globals completeness bar"),
+        ("#workerCards", "worker panes"),
+        ("#intakeN", "intake counter"),
+        ("#invBody", "function inventory"),
+        ("#globBody", "globals inventory"),
+        ("#settingsPopout", "settings popout"),
+    ],
+)
+def test_core_controls_present(dashboard, selector, what):
+    page, _ = dashboard
+    assert page.locator(selector).count() == 1, f"missing {what} ({selector})"
+
+
+def test_start_button_is_reachable(dashboard):
+    page, _ = dashboard
+    expect(page.locator("header button.go[onclick='startLane()']")).to_be_visible()
+
+
+def test_pipeline_alias_serves_the_same_page(page, live_dashboard):
+    """`/pipeline` is kept as an alias for bookmarks and specs that predate
+    the root swap; a redirect loop or 404 here breaks those silently."""
+    resp = page.goto(f"{live_dashboard}/pipeline", wait_until="domcontentloaded")
+    assert resp is not None and resp.status == 200
+    expect(page.locator("#docBar")).to_have_count(1)
+
+
+def test_theme_switch_persists(dashboard):
+    """Theme is stored per-operator; a broken setter leaves a light-theme
+    user on a dark dashboard after every refresh."""
+    page, _ = dashboard
+    original = page.locator("#themeSel").input_value()
+    other = "neutral-light" if original != "neutral-light" else "d2-dark"
+    try:
+        page.locator("#themeSel").select_option(other)
+        expect(page.locator("html")).to_have_attribute("data-theme", other)
+        page.reload(wait_until="domcontentloaded")
+        expect(page.locator("#themeSel")).to_have_value(other)
+    finally:
+        page.locator("#themeSel").select_option(original)
+
+
+def test_intake_count_matches_api(dashboard, api, active_program):
+    """The intake tile renders `untriaged / in_scope in scope · N excluded`."""
+    page, _ = dashboard
+    shown = page.locator("#intakeN").inner_text().strip()
+    if shown in ("-", "—", ""):
+        pytest.skip("intake counter not populated")
+    served = api.get("/api/conformance/intake", program=active_program)
+    assert shown.split()[0].replace(",", "") == str(served["untriaged"])
+    assert f"{served['in_scope']:,}" in shown
+    assert str(served["excluded_lib"]) in shown

--- a/tests/e2e/test_workers.py
+++ b/tests/e2e/test_workers.py
@@ -1,0 +1,340 @@
+"""Worker start / stop, driven through the UI the operator actually uses.
+
+The read-only half checks that the pane the page renders describes the
+worker the server reports — a pane that says "running" for a worker the
+manager has forgotten is how four deadlocked workers went unnoticed for
+half an hour.
+
+The destructive half starts a REAL worker via the Start button and stops
+it via the pane's stop button. It requires a paused fleet (see
+`require_paused_fleet`): a worker started against a paused fleet parks at
+the top of its lane loop, before it selects a function and before any
+provider call, so the whole lifecycle is exercised for zero tokens and
+zero documentation changes.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from playwright.sync_api import expect
+
+from conftest import wait_for
+
+pytestmark = pytest.mark.e2e
+
+LIVE_STATES = {"starting", "running", "stopping", "paused", "quota_paused"}
+
+
+def _panes(page) -> dict[str, str]:
+    """Rendered worker panes: {worker_id: pane class}."""
+    return page.evaluate(
+        """() => Object.fromEntries(
+             Array.from(document.querySelectorAll('.worker-pane'))
+                  .map(p => [p.id.replace(/^wp-/, ''), p.className]))"""
+    )
+
+
+# ---------------------------------------------------------------------------
+# read-only: does the roster on screen match the roster in the manager?
+# ---------------------------------------------------------------------------
+
+
+def test_pane_set_matches_worker_roster(dashboard, api):
+    page, _ = dashboard
+    page.wait_for_timeout(3000)  # first worker_status push
+    workers = api.get("/api/worker/status")["workers"]
+    rendered = set(_panes(page))
+    expected = {w["id"] for w in workers}
+    assert rendered == expected, (
+        f"panes on screen {sorted(rendered)} vs manager roster {sorted(expected)}"
+    )
+
+
+def test_worker_hint_counts_running_and_total(dashboard, api):
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    workers = api.get("/api/worker/status")["workers"]
+    hint = page.locator("#workerHint").inner_text().strip()
+    if not workers:
+        assert hint == "0 workers", hint
+        expect(page.locator(".worker-empty")).to_be_visible()
+        return
+    running = sum(1 for w in workers if w.get("status") in ("starting", "running", "stopping"))
+    parked = sum(1 for w in workers if w.get("status") in ("paused", "quota_paused"))
+    expected = (
+        f"{running} running / {parked} paused / {len(workers)} total"
+        if parked
+        else f"{running} running / {len(workers)} total"
+    )
+    assert hint == expected, f"hint {hint!r} vs {expected!r}"
+
+
+def test_pane_titles_carry_binary_mode_and_provider(dashboard, api):
+    """Six panes across three binaries and three lanes look identical
+    without these three facts; picking the wrong one to stop is a real
+    and expensive mistake."""
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    workers = api.get("/api/worker/status")["workers"]
+    if not workers:
+        pytest.skip("no workers running")
+    labels = {"functions": "Doc", "port": "Prove", "globals": "Globals"}
+    for w in workers:
+        # the mode chip is CSS-uppercased, so inner_text() yields "PROVE"
+        title = page.locator(f"#wp-title-{w['id']}").inner_text().lower()
+        if w.get("binary"):
+            assert w["binary"].replace("\\", "/").split("/")[-1].lower() in title
+        assert labels.get(w.get("mode"), w.get("mode", "")).lower() in title
+        assert (w.get("provider") or "worker").lower() in title
+        assert f"#{w['id']}".lower() in title
+
+
+def test_pane_class_reflects_worker_status(dashboard, api):
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    workers = {w["id"]: w for w in api.get("/api/worker/status")["workers"]}
+    if not workers:
+        pytest.skip("no workers running")
+    for wid, cls in _panes(page).items():
+        status = workers[wid].get("status")
+        if status in ("finished", "stopped"):
+            assert "finished" in cls
+        elif status == "stopping":
+            assert "stopping" in cls
+        elif status == "quota_paused":
+            assert "quota_paused" in cls
+        elif status == "paused":
+            assert "paused" in cls.split(), f"worker {wid} is paused but pane class is {cls!r}"
+        else:
+            assert "running" in cls, f"worker {wid} is {status} but pane class is {cls!r}"
+
+
+def test_pane_progress_line_matches_worker_progress(dashboard, api):
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    workers = api.get("/api/worker/status")["workers"]
+    live = [w for w in workers if w.get("status") not in ("finished", "stopped")]
+    if not live:
+        pytest.skip("no live workers")
+    for w in live:
+        text = page.locator(f"#wp-status-{w['id']}").inner_text()
+        pr = w.get("progress") or {}
+        assert f"{pr.get('completed', 0)}ok" in text
+        assert f"{pr.get('failed', 0)}fail" in text
+        # a parked worker's line is prefixed PARKED/QUOTA so it cannot be read
+        # as work in flight; strip that before checking the counter itself
+        text = re.sub(r"^(PARKED|QUOTA)\s+", "", text)
+        if w.get("continuous"):
+            assert text.startswith("auto")
+        else:
+            done = (pr.get("completed", 0)) + (pr.get("skipped", 0)) + (pr.get("failed", 0))
+            assert f"{done}/{w.get('count')}" in text
+
+
+def test_paused_workers_are_not_drawn_as_running(dashboard, api):
+    """`paused` had no branch in the pane class map, so it fell through to
+    `running`: three parked workers drew the green running border while
+    the hint above them read "0 running / 3 total"."""
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    paused = [w for w in api.get("/api/worker/status")["workers"] if w.get("status") == "paused"]
+    if not paused:
+        pytest.skip("no paused workers")
+    for w in paused:
+        cls = page.locator(f"#wp-{w['id']}").get_attribute("class") or ""
+        assert "paused" in cls.split(), (
+            f"worker {w['id']} is paused but its pane class is {cls!r}"
+        )
+        assert "running" not in cls.split()
+
+
+def test_paused_worker_status_line_says_so(dashboard, api):
+    """A parked worker keeps `progress.current` from the function it
+    finished last, which reads exactly like work in flight."""
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    paused = [w for w in api.get("/api/worker/status")["workers"] if w.get("status") == "paused"]
+    if not paused:
+        pytest.skip("no paused workers")
+    for w in paused:
+        text = page.locator(f"#wp-status-{w['id']}").inner_text().upper()
+        assert "PARKED" in text, (
+            f"worker {w['id']} is parked but its status line reads {text!r}"
+        )
+
+
+def test_hint_counts_paused_workers(dashboard, api):
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    workers = api.get("/api/worker/status")["workers"]
+    parked = sum(1 for w in workers if w.get("status") in ("paused", "quota_paused"))
+    if not parked:
+        pytest.skip("no parked workers")
+    hint = page.locator("#workerHint").inner_text()
+    assert f"{parked} paused" in hint, f"{parked} parked workers but the hint reads {hint!r}"
+
+
+def test_fleet_pause_bar_is_shown_when_paused(dashboard, api):
+    """`/api/health/all` has always carried `paused` + `pause_reason` at
+    the top level; nothing on the page read either, so a paused fleet was
+    invisible behind five green dots."""
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    health = api.get("/api/health/all")
+    bar = page.locator("#pauseBar")
+    if not health.get("paused"):
+        assert "active" not in (bar.get_attribute("class") or "").split()
+        return
+    assert "active" in (bar.get_attribute("class") or "").split(), (
+        "fleet is paused but the pause bar is not shown"
+    )
+    msg = page.locator("#pauseBarMsg").inner_text()
+    assert "paused" in msg.lower()
+    if health.get("pause_reason"):
+        assert health["pause_reason"] in msg, (
+            f"pause bar does not carry the reason: {msg!r}"
+        )
+
+
+def test_stale_worker_is_not_shown_as_healthy(dashboard, api):
+    """A worker the manager has flagged stale must not render as a plain
+    running pane — a frozen non-terminal status also burns a MAX_WORKERS
+    slot, so it has to be visible."""
+    page, _ = dashboard
+    page.wait_for_timeout(3000)
+    stale = [w for w in api.get("/api/worker/status")["workers"] if w.get("is_stale")]
+    if not stale:
+        pytest.skip("no stale workers")
+    for w in stale:
+        pane = page.locator(f"#wp-{w['id']}")
+        text = pane.inner_text().lower()
+        cls = pane.get_attribute("class") or ""
+        assert "stale" in text or "stale" in cls or "timeout" in cls, (
+            f"worker {w['id']} is stale but its pane looks healthy"
+        )
+
+
+# ---------------------------------------------------------------------------
+# destructive: start and stop a real worker through the UI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.destructive
+def test_start_and_stop_a_worker_through_the_ui(
+    dashboard, api, require_paused_fleet, worker_guard, active_program
+):
+    page, _ = dashboard
+    before = worker_guard
+
+    page.locator("#lane").select_option("document")
+    page.locator("#provider").select_option("minimax")
+    if page.locator("#allFns").is_checked():
+        page.locator("#allFns").uncheck()
+    page.locator("#count").fill("1")
+    page.locator("header button.go[onclick='startLane()']").click()
+
+    # 1. the manager registered a new worker
+    new = wait_for(
+        lambda: next(
+            (
+                w
+                for w in api.get("/api/worker/status")["workers"]
+                if w["id"] not in before and w.get("status") in LIVE_STATES
+            ),
+            None,
+        ),
+        timeout=60,
+        what="a newly started worker in the roster",
+    )
+    assert new["mode"] == "functions"
+    assert new["provider"] == "minimax"
+    assert new["count"] == 1
+
+    # 2. the page grew a pane for it, with a working stop button
+    wid = new["id"]
+    expect(page.locator(f"#wp-{wid}")).to_be_visible(timeout=30_000)
+    expect(page.locator(f"#wp-stop-{wid}")).to_be_visible()
+    expect(page.locator(f"#wp-title-{wid}")).to_contain_text("Doc")
+    expect(page.locator(f"#wp-title-{wid}")).to_contain_text("minimax")
+
+    # 3. On a PAUSED fleet the worker must park before it selects a function —
+    #    that is the property that makes this test free to run. Under
+    #    --allow-unpaused there is nothing to park against and the worker
+    #    correctly goes to work instead, so only assert this when it applies.
+    if require_paused_fleet.get("paused"):
+        parked = wait_for(
+            lambda: next(
+                (w for w in api.get("/api/worker/status")["workers"] if w["id"] == wid),
+                {},
+            ).get("status")
+            == "paused",
+            timeout=90,
+            what="the new worker to park on the paused fleet",
+        )
+        assert parked
+
+    # 4. the stop button actually stops it
+    page.locator(f"#wp-stop-{wid}").click()
+    wait_for(
+        lambda: next(
+            (w for w in api.get("/api/worker/status")["workers"] if w["id"] == wid),
+            {"status": "gone"},
+        ).get("status")
+        in ("stopped", "finished", "gone"),
+        timeout=120,
+        what="the worker to reach a terminal status after Stop",
+    )
+
+    # 5. and the pane reflects that, with the stop button retired
+    page.wait_for_function(
+        "(id) => { const p = document.getElementById('wp-' + id);"
+        " return !p || p.className.includes('finished'); }",
+        arg=wid,
+        timeout=60_000,
+    )
+
+
+@pytest.mark.destructive
+def test_globals_lane_without_a_binary_is_refused(api, require_paused_fleet, worker_guard):
+    """`start_worker` refuses a globals worker with no binary rather than
+    launching one that can never pick a target. The HTTP twin must return
+    that as a 409 with the reason, not a 500."""
+    r = api.post("/api/worker/start", {"mode": "globals", "provider": "minimax", "binary": None})
+    assert r.status_code == 409, f"expected a controlled rejection, got {r.status_code}: {r.text}"
+    body = r.json()
+    assert body.get("ok") is False
+    assert "binary" in (body.get("error") or "").lower()
+
+
+@pytest.mark.destructive
+def test_disabled_provider_is_refused(api, require_paused_fleet, worker_guard):
+    """Routing a worker at a provider the operator disabled (gemini has
+    been dead since Google retired the individual tier) must fail at the
+    launch, not on every function."""
+    cfg = api.get("/api/queue/config")
+    disabled = (cfg.get("config") or cfg).get("disabled_providers") or []
+    if not disabled:
+        pytest.skip("no disabled providers configured")
+    r = api.post(
+        "/api/worker/start",
+        {"mode": "functions", "provider": disabled[0], "count": 1},
+    )
+    assert r.status_code == 409, f"expected 409, got {r.status_code}: {r.text}"
+    assert "disabled" in (r.json().get("error") or "").lower()
+
+
+def test_stop_of_an_unknown_worker_is_a_404_not_a_500(api):
+    """Stopping an already-finished worker is a client mistake, not a
+    server fault. It returned a 500 with "internal error -- see dashboard
+    server log", and nothing in the log."""
+    r = api.post("/api/worker/stop", {"worker_id": "definitely-not-a-worker"})
+    assert r.status_code == 404, f"unknown worker id produced {r.status_code}: {r.text}"
+    assert "unknown worker" in (r.json().get("error") or "").lower()
+
+
+def test_stop_without_a_worker_id_is_a_400(api):
+    r = api.post("/api/worker/stop", {})
+    assert r.status_code == 400
+    assert r.json().get("ok") is False

--- a/tests/performance/test_dependency_monitoring.py
+++ b/tests/performance/test_dependency_monitoring.py
@@ -529,3 +529,93 @@ def test_restart_endpoint_is_loopback_only():
     body = text[idx:idx + 900]
     assert "127.0.0.1" in body
     assert "403" in body
+
+
+# ====================================================== oracle health dot ===
+#
+# The dashboard's Oracle + Game dot keyed on `reachable` alone, so of
+# oracle_health.py's FOUR fault shapes the two that answer HTTP perfectly --
+# FROZEN (alive, oracle replying, drawing nothing) and IDLE (parked at a menu,
+# no world to prove against) -- both rendered as a green "live-prove enabled".
+# That is the 2026-07-31 incident verbatim: a deploy restart left the game at
+# the main menu and the fleet sat idle behind a green banner for 70 minutes.
+#
+# Detection was never the problem; `game_frozen` / `game_idle` were already in
+# the payload. Nothing consumed them. These tests pin the mapping so it cannot
+# silently revert to "reachable == healthy".
+
+
+class _FakeOracleMonitor:
+    def __init__(self, **state):
+        base = {
+            "reachable": True, "game_running": True, "game_wedged": False,
+            "game_dead": False, "game_idle": False, "game_frozen": False,
+            "relaunching": False, "relaunch_stage": None, "relaunch_error": None,
+            "recover_attempts": 0, "next_retry_in": None,
+            "recovery_degraded": False, "present_rate": 25.0,
+        }
+        base.update(state)
+        self._state = base
+
+    def get_state(self):
+        return self._state
+
+
+def _oracle_dot(**state):
+    """Call WorkerManager._health_oracle against a fake monitor."""
+    import web
+
+    mgr = web.WorkerManager.__new__(web.WorkerManager)
+    mgr._oracle_monitor = _FakeOracleMonitor(**state)
+    return web.WorkerManager._health_oracle(mgr)
+
+
+def test_healthy_oracle_is_ok_with_no_action():
+    dot = _oracle_dot()
+    assert dot["state"] == "ok"
+    assert dot["action"] is None
+
+
+def test_frozen_game_is_not_reported_as_healthy():
+    """A stalled render thread raises no exception, so /crash stays null and
+    every probe but the frame counter reads fine."""
+    dot = _oracle_dot(game_frozen=True, present_rate=0)
+    assert dot["state"] == "down", f"FROZEN game reported as {dot['state']}"
+    assert "frozen" in dot["detail"].lower()
+    assert dot["action"] == "relaunch_oracle", (
+        "FROZEN recovers on the WEDGED path, so a relaunch must be offered"
+    )
+
+
+def test_idle_game_is_degraded_and_offers_no_relaunch():
+    """IDLE passes every liveness check while proving is stalled. It must be
+    visible -- but the cure is navigation, and offering a one-click relaunch
+    of a HEALTHY game is the mistake oracle_health.py exists to prevent."""
+    dot = _oracle_dot(game_idle=True)
+    assert dot["state"] == "degraded", f"IDLE game reported as {dot['state']}"
+    assert "menu" in dot["detail"].lower() or "parked" in dot["detail"].lower()
+    assert dot["action"] is None, (
+        "an IDLE game must not offer a one-click relaunch of a healthy game"
+    )
+
+
+def test_frozen_outranks_idle_when_both_are_set():
+    """Both flags can ride together; the worse one has to win, because a
+    frozen game cannot be cured by navigating it."""
+    dot = _oracle_dot(game_frozen=True, game_idle=True)
+    assert dot["state"] == "down"
+    assert "frozen" in dot["detail"].lower()
+
+
+def test_flags_are_exposed_so_the_ui_need_not_re_derive_them():
+    for key in ("game_frozen", "game_idle"):
+        assert key in _oracle_dot(), f"health payload drops {key}"
+
+
+def test_unreachable_shapes_are_unchanged():
+    wedged = _oracle_dot(reachable=False, game_wedged=True)
+    assert wedged["state"] == "down" and "wedged" in wedged["detail"].lower()
+    dead = _oracle_dot(reachable=False, game_dead=True)
+    assert dead["state"] == "down" and "not running" in dead["detail"].lower()
+    unprobed = _oracle_dot(reachable=None)
+    assert unprobed["state"] == "unknown"


### PR DESCRIPTION
Manual + browser testing of the pipeline dashboard, plus the harness that
found the bugs and the fixes for them.

Every bug here has the same shape: **the API was correct, the page was not,
and the test suite was green throughout.** That is why `tests/e2e/` drives a
real browser and compares the *rendered* value against the API's — an
API-only assertion cannot see any of these. It is also this repo's history:
the `326700%` band bar and the two inventories that silently returned zero
rows for days were both found by eye, in production.

## The three that mattered

**1. A bar that read 172%.** `matrix()` never subtracted `EXCLUDE_TAGS`,
unlike `bands()` and `summary()`, so it counted library/stub functions and
then divided by an `in_scope` that excludes them. The Documentation bar read
**105.3% on D2Common** and **172.6% on PD2_EXT** — and because the leading
`untagged` segment clamps at zero, an overflowing bar renders as a *full*
one rather than a visibly broken one. Every binary was affected, not only
the two that crossed 100 (D2Client 98.8% → 96.9%).

**2. A green oracle dot for a game that cannot do any work.**
`_health_oracle` short-circuited on `reachable`, and `renderOracleBar` fell
through to "healthy → bar hidden". So of `oracle_health.py`'s four fault
shapes, the two that answer HTTP perfectly — **FROZEN** (alive, oracle
replying, drawing nothing) and **IDLE** (parked at a menu, no world to prove
against) — both reported `ok` / "live-prove enabled".

Detection had already shipped: `game_frozen` and `game_idle` were sitting in
the payload and *nothing read them*. This is the 2026-07-31 incident
verbatim — a deploy restart left the game at the main menu and the fleet
idled 70 minutes behind a green banner.

FROZEN is now `down` + bar + relaunch. IDLE is `degraded` + bar with **no
relaunch affordance**, because the cure is navigation and one-click
relaunching a healthy game is precisely the mistake that module exists to
prevent.

**3. Paused workers drawn as running.** `paused` had no branch in the pane
class map and fell through to `running`, so three parked workers drew green
running borders under a hint reading "0 running / 3 total", beside a
progress line still naming the last function — indistinguishable from work
in flight. And nothing on the page read the fleet pause at all, though
`/api/health/all` has always carried `paused` + `pause_reason` at the top
level. Now: a `paused` pane class, a `PARKED` badge, a parked count in the
hint, and a pause bar carrying the operator's own reason.

## Three smaller ones found on the way

- `refreshAll()` wrote `last sync <date>` into `#workerHint` — the **Active
  Workers** header — clobbering the worker count on every refresh pass. It
  has its own `#lastSync` span now, beside the scan controls it qualifies.
- `/api/worker/stop` on an unknown id returned **500** "internal error — see
  dashboard server log", with nothing in the log. The socket handler always
  treated it as the client error it is; the HTTP twin now 404s with cause.
- A `&lt;80` label literal satisfied the legend (`insertAdjacentHTML`) but
  left the completeness bars' first segment tooltip rendering the raw entity.

## Tooling

`redeploy-dashboard.ps1` **reported deploys that had not happened**, which is
how two of the above nearly went unverified. `/api/admin/restart` stops
workers first (`stop_timeout` 45 s), so with port workers running the old
process is still healthy after the script's fixed 5 s sleep; it read an
unchanged PID, declared failure, and fired the scheduled task *on top of a
restart already in flight* — which then announced success on `Wait-Healthy`
alone, never checking the PID either. Both paths now wait for the listener
PID to actually change.

## The suite

`tests/e2e/` — 139 Playwright tests across 10 files, two tiers.

```
python -m pytest tests/e2e -m "not destructive" --no-cov   # safe
python -m pytest tests/e2e -m destructive --no-cov         # starts real workers
```

The destructive tier **requires a paused fleet by default**, which is a
safety property rather than a limitation: `_park_if_paused` runs at the top
of each lane loop, so a worker started against a paused fleet parks before
selecting a function and before any provider call — the full start → render
→ stop lifecycle for zero tokens and zero documentation changes.
`--allow-unpaused` overrides.

Covers: page load / console-clean, the five dependency dots, all four
segmented bars (legend vs API, widths fit the track, widths match their
share, headline arithmetic), worker lifecycle, settings round-trip (asserting
no neighbouring config key moved), both inventories + drawer, binary picker
(including an 8 s budget on a context switch, since that path once bulk-
upserted ~62 K rows), the oracle's four fault shapes, and named guards for
bugs that already shipped.

**Result: 133 passed / 6 skipped / 0 failed** against a live dashboard.

The FROZEN/IDLE mapping additionally gets six offline tests in
`test_dependency_monitoring.py`, so it cannot regress without a browser.

Uses `python -m pytest`, not `uv run pytest` — `uv` re-syncs the venv on
every invocation and cannot replace `Scripts/bridge-mcp-ghidra.exe` while an
MCP bridge is running, which fails the run before pytest starts. Documented
in `tests/e2e/README.md`.

## Still open — deliberately not fixed here

**Pausing the fleet empties the worker restore roster.**
`_persist_active_workers` filters to `status in ("starting","running")` and a
parked worker is neither, while the sticky peak copy only updates `if live:`.
So pausing for a deploy — the exact scenario the roster feature exists for —
is what erases it. Confirmed both ways: paused workers gave `offer: null`,
and the same workers running gave an offer of 4. That code carries heavy
warnings in CLAUDE.md and deserves its own change.

Also observed once and **not** reproducible: the fleet pause itself did not
restore on one restart. A clean retry with the same file restored it
correctly, so the persistence path works; that observation stands
unexplained and the pre-restart file is unrecoverable (`priority_queue.json`
is untracked).

Minor: `/api/conformance/binaries` still reports a stale `active` (the
`FUNDOC_GHIDRA_PROGRAM` constant) that disagrees with
`/api/conformance/binaries/progress`. Harmless today because the page reads
the latter, but a trap for anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
