### PR TITLE
Fix unauthenticated non-loopback MCP bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,6 +475,11 @@ trains you to ignore the number that is supposed to mean something.
 
 ### Security (pre-release hardening)
 
+- **Authenticated non-loopback MCP bridge.** When the bridge has
+  `GHIDRA_MCP_AUTH_TOKEN` and exposes its HTTP/SSE transport beyond loopback,
+  clients must present the same bearer token. This prevents the bridge from
+  acting as an unauthenticated confused deputy for its protected Ghidra server.
+
 - **Anti-CSRF / DNS-rebinding guard on the HTTP servers.** Loopback binding
   does not stop a web page the operator visits from issuing a cross-origin
   `fetch()` to `127.0.0.1` (responses are `text/plain` and bodies parse as JSON

--- a/docs/prompts/TOOL_USAGE_GUIDE.md
+++ b/docs/prompts/TOOL_USAGE_GUIDE.md
@@ -501,7 +501,7 @@ GhidraMCP defaults to localhost-unauthenticated — safe on a single-user dev bo
 
 The headless server refuses to start on a non-loopback bind address (`0.0.0.0`, explicit external IP) unless `GHIDRA_MCP_AUTH_TOKEN` is set.
 
-**The MCP bridge reads the same `GHIDRA_MCP_AUTH_TOKEN`** and attaches `Authorization: Bearer <token>` to every outbound call (UDS and TCP). Export the same token in the bridge's environment — otherwise it will hit `401 Unauthorized` on every tool call to an auth-enabled server. Unset = no header (matches the localhost default).
+**The MCP bridge reads the same `GHIDRA_MCP_AUTH_TOKEN`** and attaches `Authorization: Bearer <token>` to every outbound call (UDS and TCP). Export the same token in the bridge's environment — otherwise it will hit `401 Unauthorized` on every tool call to an auth-enabled server. When an HTTP/SSE bridge binds beyond loopback, clients must also send that bearer token to the bridge; unauthenticated requests receive `401 Unauthorized`. Unset = no header (matches the localhost default).
 
 ### Worked example — exposing to a private LAN with auth
 

--- a/python/bridge_mcp_ghidra/cli.py
+++ b/python/bridge_mcp_ghidra/cli.py
@@ -1,6 +1,7 @@
 """Command-line entry point for the GhidraMCP bridge."""
 
 import argparse
+import hmac
 import os
 import re
 import socket
@@ -10,7 +11,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from starlette.middleware.cors import CORSMiddleware
 
 from . import state
-from .config import logger
+from .config import AUTH_TOKEN, logger
 from .server import mcp
 from .static_tools import _auto_connect, _start_auto_connect_retry
 
@@ -77,6 +78,35 @@ def _cors_origin_regex(bind_host: str) -> str:
     return rf"^https?://({alternatives})(:\d+)?$"
 
 
+class _BearerAuthMiddleware:
+    """Require the backend bearer token from clients of an exposed bridge."""
+
+    def __init__(self, app, token: str):
+        self.app = app
+        self.expected = f"Bearer {token}".encode("utf-8")
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope.get("method") != "OPTIONS":
+            headers = dict(scope.get("headers", ()))
+            supplied = headers.get(b"authorization", b"")
+            if not hmac.compare_digest(supplied, self.expected):
+                body = b"Unauthorized"
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 401,
+                        "headers": [
+                            (b"content-type", b"text/plain; charset=utf-8"),
+                            (b"content-length", str(len(body)).encode("ascii")),
+                            (b"www-authenticate", b"Bearer"),
+                        ],
+                    }
+                )
+                await send({"type": "http.response.body", "body": body})
+                return
+        await self.app(scope, receive, send)
+
+
 def _build_http_app(transport: str, bind_host: str):
     """Return the transport's Starlette app wrapped in CORS middleware.
 
@@ -96,6 +126,10 @@ def _build_http_app(transport: str, bind_host: str):
         expose_headers=["mcp-session-id", "mcp-protocol-version"],
         max_age=3600,
     )
+    if AUTH_TOKEN and bind_host not in {"127.0.0.1", "localhost", "::1"}:
+        # The bridge reuses this credential for its backend requests.  Do not
+        # let an unauthenticated network client turn it into a confused deputy.
+        app = _BearerAuthMiddleware(app, AUTH_TOKEN)
     return app
 
 

--- a/tests/unit/test_bridge_cli.py
+++ b/tests/unit/test_bridge_cli.py
@@ -254,6 +254,50 @@ class TestHttpAppPreflight(unittest.TestCase):
         self.assertIn("mcp-session-id", cors[0].kwargs["expose_headers"])
 
 
+class TestBridgeBearerAuth(unittest.TestCase):
+    """An exposed bridge must not replay its backend token for strangers."""
+
+    def setUp(self):
+        from starlette.applications import Starlette
+        from starlette.responses import PlainTextResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        async def endpoint(_request):
+            return PlainTextResponse("proxied")
+
+        app = Starlette(routes=[Route("/mcp", endpoint, methods=["POST", "OPTIONS"])])
+        self.client = TestClient(cli._BearerAuthMiddleware(app, "bridge-secret"))
+
+    def test_missing_token_is_rejected(self):
+        response = self.client.post("/mcp")
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers["www-authenticate"], "Bearer")
+
+    def test_wrong_token_is_rejected(self):
+        response = self.client.post("/mcp", headers={"Authorization": "Bearer wrong"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_matching_token_reaches_bridge(self):
+        response = self.client.post("/mcp", headers={"Authorization": "Bearer bridge-secret"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "proxied")
+
+    def test_cors_preflight_does_not_require_credentials(self):
+        response = self.client.options("/mcp")
+        self.assertNotEqual(response.status_code, 401)
+
+    def test_remote_http_app_is_wrapped_when_backend_token_is_set(self):
+        with patch.object(cli, "AUTH_TOKEN", "bridge-secret"):
+            app = cli._build_http_app("streamable-http", "0.0.0.0")
+        self.assertIsInstance(app, cli._BearerAuthMiddleware)
+
+    def test_loopback_http_app_preserves_local_unauthenticated_access(self):
+        with patch.object(cli, "AUTH_TOKEN", "bridge-secret"):
+            app = cli._build_http_app("streamable-http", "127.0.0.1")
+        self.assertNotIsInstance(app, cli._BearerAuthMiddleware)
+
+
 class TestWildcardAllowedHosts(unittest.TestCase):
     def test_includes_loopbacks_with_port_wildcards(self):
         hosts = cli._wildcard_allowed_hosts()


### PR DESCRIPTION
### Motivation

- Close a confused-deputy vulnerability where the bridge forwarded `GHIDRA_MCP_AUTH_TOKEN` to the Ghidra server while accepting unauthenticated requests on non-loopback HTTP/SSE transports.

### Description

- Add a `_BearerAuthMiddleware` that requires `Authorization: Bearer <token>` from clients and uses `hmac.compare_digest` for a constant-time comparison.
- Wire the middleware into the HTTP/SSE app in `cli.py` when `AUTH_TOKEN` is set and the bridge binds beyond loopback, while allowing `OPTIONS` preflight requests.
- Add regression tests in `tests/unit/test_bridge_cli.py` to cover missing, wrong, and valid tokens, CORS preflight behavior, remote wrapping, and preserved loopback behavior.
- Update `docs/prompts/TOOL_USAGE_GUIDE.md` and `CHANGELOG.md` to document the inbound-bridge authentication requirement.

### Testing

- `pytest tests/unit/ -v --no-cov` — full unit suite passed with `567 passed, 7 skipped`.
- `pytest tests/unit/test_bridge_cli.py -v --no-cov` — bridge CLI tests passed with `29 passed`.
- `black --check` on the changed files passed after formatting adjustments.
- `mvn clean compile -q` was attempted but failed to resolve local Ghidra artifacts in this environment (Maven dependency resolution failure).