### PR TITLE
fix(params): keep empty nullable Boolean defaults unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Complete version history for the Ghidra MCP Server project.
 
 ## v7.0.0 (unreleased) — major: tool consolidation, JSON response contract, MCP conformance suite, documentation-correctness linting
 
+### Parameter coercion fixes
+
+- Omitted nullable `Boolean` parameters whose annotation uses `defaultValue = ""`
+  now resolve to `null` for both query-string and JSON-body inputs. Previously,
+  the empty string was coerced to `false`, silently activating tri-state filters
+  such as `has_custom_name`, `is_thunk`, and `is_external`.
+
 ### Tool consolidation (breaking) — 272 → 251 tools
 
 Redundant tools were folded into "one-or-many" survivors. **No capability was
@@ -4059,3 +4066,4 @@ code = decompile_function(address='0x401000', offset=100, limit=100)
 ---
 
 For older release details, see the [docs/releases/](docs/releases/) directory.
+

--- a/src/main/java/com/xebyte/core/AnnotationScanner.java
+++ b/src/main/java/com/xebyte/core/AnnotationScanner.java
@@ -300,7 +300,11 @@ public class AnnotationScanner {
 
         } else if (type == Boolean.class) {
             if (value == null || value.isEmpty()) {
-                return hasDef ? Boolean.valueOf(def) : null;
+                // An EMPTY defaultValue means "no default" for a nullable tri-state
+                // filter, exactly as the String/Integer branches above treat it.
+                // Boolean.valueOf("") is false, so returning it here would turn an
+                // OMITTED filter into an active "== false" filter.
+                return (hasDef && !def.isEmpty()) ? Boolean.valueOf(def) : null;
             }
             return Boolean.parseBoolean(value);
 
@@ -369,7 +373,9 @@ public class AnnotationScanner {
 
         } else if (type == Boolean.class) {
             if (raw == null) {
-                return hasDef ? Boolean.valueOf(def) : null;
+                // See the note in the query-string coercion above: an empty
+                // defaultValue means "unset", not "false".
+                return (hasDef && !def.isEmpty()) ? Boolean.valueOf(def) : null;
             }
             if (raw instanceof Boolean b) return b;
             return Boolean.parseBoolean(String.valueOf(raw));
@@ -543,3 +549,4 @@ public class AnnotationScanner {
         }
     }
 }
+

--- a/src/test/java/com/xebyte/offline/AnnotationScannerOfflineTest.java
+++ b/src/test/java/com/xebyte/offline/AnnotationScannerOfflineTest.java
@@ -235,6 +235,108 @@ public class AnnotationScannerOfflineTest extends TestCase {
     }
 
     /**
+     * Regression test: a boxed param declared with an EMPTY {@code defaultValue}
+     * must resolve to {@code null} ("unset"), not to a concrete value.
+     *
+     * <p>This is the counterpart to the H13 fix above, which overcorrected. H13
+     * changed the boxed branches to {@code hasDef ? Boolean.valueOf(def) : null},
+     * but {@code hasDef} is true for {@code defaultValue = ""} (it only tests
+     * against the {@code NO_DEFAULT} sentinel), and {@code Boolean.valueOf("")}
+     * is {@code false}. Every nullable tri-state filter in the codebase is
+     * declared exactly that way — e.g. {@code has_custom_name}, {@code is_thunk},
+     * {@code is_external} on {@code /search_functions_enhanced}. The effect was
+     * that OMITTING such a filter silently applied it as {@code == false}:
+     * {@code search_functions_enhanced} with a name_pattern and no other args
+     * returned zero results for every user-named function, reporting a
+     * well-formed empty list rather than an error.
+     *
+     * <p>{@code Integer} was unaffected only by accident — {@code Integer.valueOf("")}
+     * throws {@code NumberFormatException}, which that branch already catches and
+     * turns into {@code null}. {@code Boolean.valueOf} never throws, so the Boolean
+     * branch failed silently. Both are asserted here so the behaviour is pinned
+     * explicitly rather than resting on a parse failure.
+     */
+    public void testBoxedParamWithEmptyDefaultResolvesToNull() throws Exception {
+        BoxedDefaultFixture fixture = new BoxedDefaultFixture();
+        AnnotationScanner fixtureScanner = new AnnotationScanner(fixture);
+
+        EndpointDef getEndpoint = null;
+        EndpointDef postEndpoint = null;
+        for (EndpointDef ep : fixtureScanner.getEndpoints()) {
+            if ("/test_empty_default_query".equals(ep.path())) getEndpoint = ep;
+            if ("/test_empty_default_body".equals(ep.path()))  postEndpoint = ep;
+        }
+        assertNotNull("GET empty-default fixture endpoint not found", getEndpoint);
+        assertNotNull("POST empty-default fixture endpoint not found", postEndpoint);
+
+        Map<String, String> emptyQuery = Collections.emptyMap();
+        Map<String, Object> emptyBody  = Collections.emptyMap();
+
+        fixture.lastOptFilter = Boolean.TRUE;   // poison, so a no-op write is visible
+        fixture.lastOptCount  = Integer.valueOf(-1);
+        getEndpoint.handler().handle(emptyQuery, emptyBody);
+        assertNull("QUERY: boxed Boolean with defaultValue=\"\" and absent value must be null (unset), "
+            + "not false — otherwise an omitted tri-state filter is applied as '== false'",
+            fixture.lastOptFilter);
+        assertNull("QUERY: boxed Integer with defaultValue=\"\" and absent value must be null",
+            fixture.lastOptCount);
+
+        fixture.lastBodyOptFilter = Boolean.TRUE;
+        fixture.lastBodyOptCount  = Integer.valueOf(-1);
+        postEndpoint.handler().handle(emptyQuery, emptyBody);
+        assertNull("BODY: boxed Boolean with defaultValue=\"\" and absent value must be null (unset), not false",
+            fixture.lastBodyOptFilter);
+        assertNull("BODY: boxed Integer with defaultValue=\"\" and absent value must be null",
+            fixture.lastBodyOptCount);
+    }
+
+    /**
+     * An EXPLICIT value must still win over the empty default, in both directions —
+     * the fix must not make these params unsettable.
+     */
+    public void testBoxedParamWithEmptyDefaultStillHonorsExplicitValue() throws Exception {
+        BoxedDefaultFixture fixture = new BoxedDefaultFixture();
+        AnnotationScanner fixtureScanner = new AnnotationScanner(fixture);
+
+        EndpointDef getEndpoint = null;
+        EndpointDef postEndpoint = null;
+        for (EndpointDef ep : fixtureScanner.getEndpoints()) {
+            if ("/test_empty_default_query".equals(ep.path())) getEndpoint = ep;
+            if ("/test_empty_default_body".equals(ep.path())) postEndpoint = ep;
+        }
+        assertNotNull("GET empty-default fixture endpoint not found", getEndpoint);
+        assertNotNull("POST empty-default fixture endpoint not found", postEndpoint);
+
+        Map<String, String> query = new HashMap<>();
+        query.put("opt_filter", "true");
+        query.put("opt_count", "7");
+        getEndpoint.handler().handle(query, Collections.emptyMap());
+        assertEquals("Explicit true must survive the empty default",
+            Boolean.TRUE, fixture.lastOptFilter);
+        assertEquals("Explicit 7 must survive the empty default",
+            Integer.valueOf(7), fixture.lastOptCount);
+
+        query.put("opt_filter", "false");
+        getEndpoint.handler().handle(query, Collections.emptyMap());
+        assertEquals("Explicit false must be distinguishable from unset",
+            Boolean.FALSE, fixture.lastOptFilter);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("opt_filter", Boolean.TRUE);
+        body.put("opt_count", Integer.valueOf(9));
+        postEndpoint.handler().handle(Collections.emptyMap(), body);
+        assertEquals("BODY: explicit true must survive the empty default",
+            Boolean.TRUE, fixture.lastBodyOptFilter);
+        assertEquals("BODY: explicit 9 must survive the empty default",
+            Integer.valueOf(9), fixture.lastBodyOptCount);
+
+        body.put("opt_filter", Boolean.FALSE);
+        postEndpoint.handler().handle(Collections.emptyMap(), body);
+        assertEquals("BODY: explicit false must be distinguishable from unset",
+            Boolean.FALSE, fixture.lastBodyOptFilter);
+    }
+
+    /**
      * Tiny fixture service scanned by {@link #testBoxedParamHonorsDefaultValue}.
      * The two {@code @McpTool} methods capture their resolved arguments so the test
      * can assert the values without needing to parse the Response JSON.
@@ -256,6 +358,32 @@ public class AnnotationScannerOfflineTest extends TestCase {
                 @Param(value = "strict", defaultValue = "true") Boolean strict) {
             lastLength = length;
             lastStrict = strict;
+            return Response.ok("ok");
+        }
+
+        // Captured by the empty-default handlers
+        volatile Boolean lastOptFilter;
+        volatile Integer lastOptCount;
+        volatile Boolean lastBodyOptFilter;
+        volatile Integer lastBodyOptCount;
+
+        @McpTool(path = "/test_empty_default_query", method = "GET",
+                 description = "Fixture: boxed params with an EMPTY defaultValue via QUERY source")
+        public Response queryEmptyDefault(
+                @Param(value = "opt_filter", defaultValue = "") Boolean optFilter,
+                @Param(value = "opt_count", defaultValue = "") Integer optCount) {
+            lastOptFilter = optFilter;
+            lastOptCount = optCount;
+            return Response.ok("ok");
+        }
+
+        @McpTool(path = "/test_empty_default_body", method = "POST",
+                 description = "Fixture: boxed params with an EMPTY defaultValue via BODY source")
+        public Response bodyEmptyDefault(
+                @Param(value = "opt_filter", source = ParamSource.BODY, defaultValue = "") Boolean optFilter,
+                @Param(value = "opt_count", source = ParamSource.BODY, defaultValue = "") Integer optCount) {
+            lastBodyOptFilter = optFilter;
+            lastBodyOptCount = optCount;
             return Response.ok("ok");
         }
 
@@ -342,3 +470,4 @@ public class AnnotationScannerOfflineTest extends TestCase {
         }
     }
 }
+


### PR DESCRIPTION
## Summary

- Treat `@Param(defaultValue = "")` on boxed `Boolean` values as unset (`null`) for both query-string and request-body coercion.
- Preserve the distinction between omitted, explicitly `true`, and explicitly `false` tri-state filters.
- Add regression coverage for empty defaults and explicit values across both parameter sources.
- Document the fix in the v7.0.0 changelog.

## Why

Nullable filters such as `has_custom_name`, `is_thunk`, and `is_external` on `/search_functions_enhanced` are declared with an empty default. `Boolean.valueOf("")` evaluates to `false`, so omitting one of these filters silently applied an active `== false` filter. In particular, omitted `has_custom_name` could hide user-renamed functions while returning a well-formed empty result.

## Testing

- The regression tests cover omitted, explicit `true`, and explicit `false` values for both query and body paths.
- Claude's source run recorded 507 tests with 2 failures confirmed pre-existing in `HardeningWiringTest` / `RunGhidraScriptProgramPropagationTest`.
- A fresh targeted Gradle run in the current environment was blocked before test execution because `GHIDRA_INSTALL_DIR` and the required Ghidra jars are unavailable here.

The fork branch was read back after publication and all three changed files match the prepared local patch byte-for-byte after newline normalization.