### PR TITLE
fix: land the program-param, lazy-loading (#440) and variable-storage (#446) backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ Complete version history for the Ghidra MCP Server project.
 
 ## v7.0.0 (unreleased) — major: tool consolidation, JSON response contract, MCP conformance suite, documentation-correctness linting
 
+### Fixed — `program` in a POST body was silently ignored, sending writes to the wrong program
+
+`@Param.source()` defaults to `ParamSource.QUERY`. On a POST tool that declares
+its other parameters as `BODY`, any parameter left at that default was looked
+for in the query string only — so a caller following this project's own "POST
+params go in the body" convention had it dropped. **192 `program` declarations
+across 103 POST tools** have that shape.
+
+For `program` the consequence was not a missing argument but a wrong target:
+resolution fell through to `getProgramOrError(provider, "")`, i.e. the *current*
+program. A `set_bookmark`, `set_comment` or rename addressed to one program
+landed in whichever program happened to be active, and the response said
+`success` — with no `program` field to reveal where it actually went.
+
+Observed in the field: **16,442 bookmarks describing one DLL were written into
+another**, across two separate publishing runs, without a single error. The
+callers were correct; every one named its target program in the body.
+
+`resolveParam` now falls back to the other source when the declared one does not
+carry the parameter at all. The declared source still wins when it has a value,
+so the Python bridge's synthesized query params are unaffected. This generalises
+what `isDryRunRequested` already did by hand for `dry_run` — same root cause,
+found earlier, where a query-only check meant a dry run performed a real write.
+`resolveProgramForDryRun` was reading `query.get("program")` only and is fixed
+the same way.
+
+Covered by `AnnotationScannerParamSourceTest`, which fails against the previous
+behaviour (`expected:<D2Common.dll> but was:<null>`).
+
 ### Tool consolidation (breaking) — 272 → 251 tools
 
 Redundant tools were folded into "one-or-many" survivors. **No capability was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,81 @@ Complete version history for the Ghidra MCP Server project.
 
 ## v7.0.0 (unreleased) — major: tool consolidation, JSON response contract, MCP conformance suite, documentation-correctness linting
 
+### Fixed — `set_variable_storage` reported storage instead of setting it ([#446](https://github.com/bethington/ghidra-mcp/issues/446))
+
+`/set_variable_storage` was a no-op. It looked the variable up, read its
+*current* storage, logged the request, and returned HTTP 200 with
+`"status": "unsupported"`. Nothing was ever written. The stated reason was
+wrong: `Variable.setDataType(type, storage, force, source)` together with
+`Function.setCustomVariableStorage(boolean)` has been public Ghidra API for many
+versions.
+
+Returning success for a write that never happened is worse than refusing it,
+because the caller cannot tell the difference — and this is the one case where
+the caller has no alternative. An argument layout that assigns registers in a
+fixed ordered run (`R0`+`R2`, a lone `R28` — a NEC V60 target in the report)
+cannot be expressed by **any** calling convention, so adding one to the `.cspec`
+does not help. Custom storage is the only route.
+
+The endpoint now:
+
+- parses the shapes Ghidra itself prints, so storage read back from
+  `get_function_variables` can be handed straight in: `EAX`, `EAX:4`,
+  `R0:4,R2:4` (one value split across registers) and `Stack[-0x10]:4`. Size
+  defaults to the variable's data-type length.
+- switches the function to custom variable storage when the target is a
+  **parameter**, whose storage is otherwise re-derived from the `.cspec`, and
+  reports that as `custom_storage_enabled` because it pins every other
+  parameter too.
+- **reads the storage back off the variable** and compares it to what was asked
+  for, instead of echoing the request. Echoing is what let the stub look like it
+  worked.
+- returns genuine errors — unknown register (naming the language), a size larger
+  than the register, an unparseable offset, an overlap that did not take.
+- leaves nothing behind when it refuses: the spec is parsed *before* the
+  function-wide storage mode is touched, and any failure after that point puts
+  the mode back. A mistyped register name previously answered
+  `Unknown register 'R99'` having already detached the function's whole
+  parameter list from its calling convention.
+
+Reported by drojaazu. Covered by `VariableStorageWriteTest`.
+
+### Fixed — lazy tool loading is now the default, unbreaking the Gemini API ([#440](https://github.com/bethington/ghidra-mcp/issues/440))
+
+Eager loading put every endpoint into a single `tools/list`. For Gemini that is
+not merely expensive, it is over a hard limit: the API compiles function
+declarations into a constrained-decoding state machine and rejects the whole
+request before any tool is ever called.
+
+```text
+400 INVALID_ARGUMENT
+The specified schema produces a constraint that has too many states for serving
+```
+
+So the old default did not degrade those clients, it broke them outright, and no
+client-side configuration could work around a server that only ever offered the
+full set. The bridge now loads `listing,function,program` (57 endpoints plus the
+8 static tools) on connect and registers the rest on demand. This is also the
+concrete half of the "too many tools for agents" complaint in
+[#307](https://github.com/bethington/ghidra-mcp/issues/307) /
+[#245](https://github.com/bethington/ghidra-mcp/issues/245) /
+[#267](https://github.com/bethington/ghidra-mcp/issues/267): the capability is
+unchanged, only what is advertised by default.
+
+Eager only ever existed for clients that ignore `tools/list_changed` and would
+therefore never see a later `load_tool_group()` registration. **Those clients
+keep an escape hatch, by either route:**
+
+```bash
+uv run bridge-mcp-ghidra --no-lazy   # when you control the command line
+export GHIDRA_MCP_LAZY=0             # when you don't (Docker, uvx, some client configs)
+```
+
+`GHIDRA_MCP_LAZY` is new here — `--no-lazy` alone is not an escape hatch for a
+container `ENTRYPOINT` or a client config that gives the user no way to add a
+flag. An explicit flag beats the variable; an unrecognised value is ignored with
+a warning rather than guessed at. Startup logs which mode is in effect.
+
 ### Fixed — `program` in a POST body was silently ignored, sending writes to the wrong program
 
 `@Param.source()` defaults to `ParamSource.QUERY`. On a POST tool that declares

--- a/README.md
+++ b/README.md
@@ -345,9 +345,38 @@ uv run bridge-mcp-ghidra --transport sse --mcp-host 127.0.0.1 --mcp-port 8081
 | `--transport` | `stdio` | `stdio` (AI tools), `streamable-http` (web clients), `sse` (deprecated) |
 | `--mcp-host` | `127.0.0.1` | Bind host for HTTP transports |
 | `--mcp-port` | — | Port for HTTP transports |
-| `--lazy` | off | Load only the default tool groups on connect. Faster startup, but MCP clients that don't support `tools/list_changed` will see an incomplete tool list. Not recommended for Claude Code. |
-| `--no-lazy` | (default) | Load all tool groups immediately on connect. Required for most AI clients. |
-| `--default-groups` | `listing,function,program` | Comma-separated groups loaded on connect when `--lazy` is set. |
+| `--lazy` | (default) | Load only the default tool groups on connect, and let the model pull in the rest with `search_tools`/`load_tool_group`. |
+| `--no-lazy` | off | Load all tool groups immediately on connect. Needed only by MCP clients that ignore `tools/list_changed`; **rejected outright by the Gemini API** (see below). |
+| `--default-groups` | `listing,function,program` | Comma-separated groups loaded on connect under `--lazy`. |
+
+#### Lazy tool loading is the default (issue #440)
+
+Advertising all ~250 endpoints in a single `tools/list` is over a hard limit for
+at least one major provider. Gemini compiles function declarations into a
+constrained-decoding state machine and rejects the whole request before any tool
+is ever called:
+
+```text
+400 INVALID_ARGUMENT
+The specified schema produces a constraint that has too many states for serving
+```
+
+That is not a degradation, it is an outright break, and no client-side setting
+could work around a server that only ever offered the full set. So the bridge
+now loads `listing,function,program` (57 endpoints plus the 8 static tools) on
+connect and registers the rest on demand.
+
+**If your client ignores `tools/list_changed`** it will not notice tools that
+are registered later, and should turn lazy loading off:
+
+```bash
+uv run bridge-mcp-ghidra --no-lazy          # when you control the command line
+export GHIDRA_MCP_LAZY=0                    # when you don't (Docker, uvx, some client configs)
+```
+
+`GHIDRA_MCP_LAZY` accepts `0/false/no/off` and `1/true/yes/on`; an explicit
+`--lazy`/`--no-lazy` on the command line wins over it. Startup logs which mode
+is in effect.
 
 #### Strict program routing (multi-program safety)
 
@@ -378,9 +407,9 @@ Off by default: with the variable unset the bridge sends calls unchanged.
 
 #### Reducing tool-context overhead
 
-The bridge exposes a large catalog. To keep the model's tool surface small, run
-with `--lazy` (loads only `listing,function,program` on connect) and let the
-model **discover** the rest on demand instead of registering everything:
+The bridge exposes a large catalog, so it loads only `listing,function,program`
+on connect (see above) and lets the model **discover** the rest on demand
+instead of registering everything:
 
 - `search_tools("rename function")` — keyword-search the **entire** catalog,
   including tools whose group isn't loaded. Each result says whether it's
@@ -391,7 +420,7 @@ model **discover** the rest on demand instead of registering everything:
 - `check_tools("rename_symbol,batch_set_comments")` — confirm specific tools
   are callable right now.
 
-`search_tools` works in both eager and `--lazy` modes, so agents that honor
+`search_tools` works in both lazy and `--no-lazy` modes, so agents that honor
 `tools/list_changed` get full discovery without the upfront context cost.
 
 #### Optional: Connect a standalone debugger server

--- a/python/bridge_mcp_ghidra/cli.py
+++ b/python/bridge_mcp_ghidra/cli.py
@@ -120,7 +120,7 @@ def main():
     parser.add_argument(
         "--lazy",
         action="store_true",
-        default=True,
+        default=None,
         help="Only load default tool groups on connect (default). Keeps the "
         "advertised tool set small enough for providers that cap function "
         "declarations; use search_tools/load_tool_group to pull in more.",
@@ -131,7 +131,8 @@ def main():
         action="store_false",
         help="Load all tool groups on connect. Needed only by clients that "
         "ignore tools/list_changed; rejected outright by the Gemini API "
-        "(400 INVALID_ARGUMENT, too many states for serving).",
+        "(400 INVALID_ARGUMENT, too many states for serving). "
+        "GHIDRA_MCP_LAZY=0 does the same where argv is not yours to set.",
     )
     parser.add_argument(
         "--default-groups",
@@ -141,7 +142,12 @@ def main():
     )
     args = parser.parse_args()
 
-    state._lazy_mode = args.lazy
+    # An explicit --lazy/--no-lazy wins; otherwise GHIDRA_MCP_LAZY decides, and
+    # only then the built-in default. Argparse leaves args.lazy as None when
+    # neither flag was given, which is what makes the three levels separable —
+    # a store_true default of True would make "not passed" and "passed --lazy"
+    # indistinguishable and swallow the env var.
+    state._lazy_mode = args.lazy if args.lazy is not None else state.lazy_mode_from_env()
     if args.default_groups is not None:
         state._default_groups = {g.strip() for g in args.default_groups.split(",") if g.strip()}
 
@@ -151,7 +157,7 @@ def main():
         logger.info(
             "Lazy tool loading: only %s on connect. "
             "Call search_tools()/load_tool_group() for the rest, or pass "
-            "--no-lazy to advertise every group up front.",
+            "--no-lazy (or set GHIDRA_MCP_LAZY=0) to advertise every group up front.",
             ",".join(sorted(state._default_groups)),
         )
     if not _auto_connect():

--- a/python/bridge_mcp_ghidra/cli.py
+++ b/python/bridge_mcp_ghidra/cli.py
@@ -120,14 +120,18 @@ def main():
     parser.add_argument(
         "--lazy",
         action="store_true",
-        default=False,
-        help="Only load default tool groups on connect (not recommended for Claude Code)",
+        default=True,
+        help="Only load default tool groups on connect (default). Keeps the "
+        "advertised tool set small enough for providers that cap function "
+        "declarations; use search_tools/load_tool_group to pull in more.",
     )
     parser.add_argument(
         "--no-lazy",
         dest="lazy",
         action="store_false",
-        help="Load all tool groups on connect (default)",
+        help="Load all tool groups on connect. Needed only by clients that "
+        "ignore tools/list_changed; rejected outright by the Gemini API "
+        "(400 INVALID_ARGUMENT, too many states for serving).",
     )
     parser.add_argument(
         "--default-groups",
@@ -143,6 +147,13 @@ def main():
 
     if not state._lazy_mode:
         logger.info("Loading all tool groups on startup (clients that don't support tools/list_changed need this)")
+    else:
+        logger.info(
+            "Lazy tool loading: only %s on connect. "
+            "Call search_tools()/load_tool_group() for the rest, or pass "
+            "--no-lazy to advertise every group up front.",
+            ",".join(sorted(state._default_groups)),
+        )
     if not _auto_connect():
         # Ghidra may simply not be up yet. Keep looking in the background so a
         # bridge that wins the startup race still gets its tools, instead of

--- a/python/bridge_mcp_ghidra/state.py
+++ b/python/bridge_mcp_ghidra/state.py
@@ -410,6 +410,28 @@ _dynamic_tool_names: list[str] = []
 _full_schema: list[dict] = []  # Complete parsed schema
 _loaded_groups: set[str] = set()
 
-# CLI-configurable: --lazy keeps only default groups, otherwise load all
-_lazy_mode = False  # default: eager (load all groups on connect)
+# CLI-configurable: --lazy keeps only default groups, --no-lazy loads all.
+#
+# DEFAULT IS LAZY (#440). Eager was the default until 2026-08-25 and made the
+# bridge advertise all 253 endpoints in one tools/list. That is not merely
+# expensive -- it is over a hard limit for at least one major provider. Gemini
+# compiles function declarations into a constrained-decoding state machine and
+# rejects the whole request before any tool is ever called:
+#
+#     400 INVALID_ARGUMENT
+#     "The specified schema produces a constraint that has too many states
+#      for serving"
+#
+# So the eager default did not degrade Gemini clients, it broke them outright,
+# and no amount of client-side configuration could work around a server that
+# only ever offered the full set. CORE_GROUPS (listing/function/program) is 57
+# endpoints + 8 static tools, which fits.
+#
+# Eager only ever existed for clients that ignore tools/list_changed and would
+# therefore never see a later load_tool_group() registration. That notification
+# actually works as of a7f5936, and the always-present static tools
+# (search_tools / check_tools) hand the model the exact load_tool_group(...)
+# call it needs, so discovery no longer depends on advertising everything up
+# front. Clients that still want the old behaviour pass --no-lazy.
+_lazy_mode = True  # default: lazy (CORE_GROUPS only; --no-lazy loads all)
 _default_groups: set[str] = set(CORE_GROUPS)

--- a/python/bridge_mcp_ghidra/state.py
+++ b/python/bridge_mcp_ghidra/state.py
@@ -432,6 +432,40 @@ _loaded_groups: set[str] = set()
 # actually works as of a7f5936, and the always-present static tools
 # (search_tools / check_tools) hand the model the exact load_tool_group(...)
 # call it needs, so discovery no longer depends on advertising everything up
-# front. Clients that still want the old behaviour pass --no-lazy.
+# front. Clients that still want the old behaviour pass --no-lazy, or set
+# GHIDRA_MCP_LAZY=0 where the client's config gives no way to pass argv (a
+# container ENTRYPOINT, an `uvx` invocation, a registry-installed server entry).
 _lazy_mode = True  # default: lazy (CORE_GROUPS only; --no-lazy loads all)
 _default_groups: set[str] = set(CORE_GROUPS)
+
+_TRUTHY_LAZY = {"1", "true", "yes", "on"}
+_FALSEY_LAZY = {"0", "false", "no", "off"}
+
+
+def lazy_mode_from_env(default: bool = True) -> bool:
+    """Resolve lazy mode from GHIDRA_MCP_LAZY, falling back to the default.
+
+    The escape hatch for a client that ignores ``tools/list_changed`` is
+    ``--no-lazy``, but a CLI flag is only reachable when the caller controls
+    argv. Docker ENTRYPOINTs, ``uvx`` one-liners and some MCP client configs
+    do not, and telling those users "pass a flag you cannot pass" is not an
+    escape hatch. GHIDRA_MCP_LAZY=0 is the same switch by another route.
+
+    An unrecognised value is ignored (and warned about) rather than guessed at,
+    because guessing here silently picks one of the two client families this
+    setting exists to keep working.
+    """
+    raw = (os.getenv("GHIDRA_MCP_LAZY") or "").strip().lower()
+    if not raw:
+        return default
+    if raw in _FALSEY_LAZY:
+        return False
+    if raw in _TRUTHY_LAZY:
+        return True
+    logger.warning(
+        "Ignoring GHIDRA_MCP_LAZY=%r: expected one of %s. Leaving lazy tool loading %s.",
+        raw,
+        ",".join(sorted(_TRUTHY_LAZY | _FALSEY_LAZY)),
+        "on" if default else "off",
+    )
+    return default

--- a/src/main/java/com/xebyte/core/AnnotationScanner.java
+++ b/src/main/java/com/xebyte/core/AnnotationScanner.java
@@ -179,7 +179,7 @@ public class AnnotationScanner {
                 // method.invoke(...) unguarded. Confirmed live 2026-08-09 on /batch_set_comments
                 // (see reference_dry_run_silently_writes.md).
                 if (isWrite && isDryRunRequested(query, body) && programProvider != null) {
-                    Program program = resolveProgramForDryRun(bindings, query);
+                    Program program = resolveProgramForDryRun(bindings, query, body);
                     if (program != null) {
                         int tx = program.startTransaction("[DRY RUN] " + tool.path());
                         try {
@@ -221,11 +221,19 @@ public class AnnotationScanner {
     /**
      * Resolve the Program for dry-run wrapping by finding the "program" param binding.
      */
-    private Program resolveProgramForDryRun(ParamBinding[] bindings, Map<String, String> query) {
+    private Program resolveProgramForDryRun(ParamBinding[] bindings, Map<String, String> query,
+            Map<String, Object> body) {
         // Look for a @Param(value = "program") binding
         for (ParamBinding binding : bindings) {
             if (binding != null && "program".equals(binding.param.value())) {
+                // Query first, then body -- a POST caller following this project's
+                // "POST params go in the body" convention puts it there, and reading
+                // only the query made a dry run preview the wrong program.
                 String programName = query.get("program");
+                if (programName == null || programName.isEmpty()) {
+                    Object raw = body != null ? body.get("program") : null;
+                    if (raw != null) programName = String.valueOf(raw);
+                }
                 if (programName != null && !programName.isEmpty()) {
                     return programProvider.getProgram(programName);
                 }
@@ -252,13 +260,55 @@ public class AnnotationScanner {
     // Parameter resolution
     // ==================================================================
 
-    private static Object resolveParam(ParamBinding binding, Map<String, String> query,
+    /**
+     * Resolve a parameter from its declared source, falling back to the other one
+     * when the declared source does not carry it at all.
+     *
+     * {@link Param#source()} defaults to {@link ParamSource#QUERY}. On a POST tool
+     * that declares its other parameters as BODY, any parameter left at the default
+     * -- {@code program} on 192 declarations across 103 POST tools -- is therefore
+     * looked for in the query string and silently missed when the caller puts it in
+     * the JSON body alongside everything else. For {@code program} the consequence
+     * is not a missing argument but a WRONG TARGET: resolution falls through to the
+     * current program, so a bookmark, comment or rename addressed to one program
+     * lands in whichever program happens to be active, and the response says
+     * success. That is how 16442 bookmarks describing D2Common were written into
+     * D2Game without a single error.
+     *
+     * This generalises what {@code isDryRunRequested} already does by hand for
+     * {@code dry_run}, and for the same reason it gives: the Python bridge
+     * synthesizes query params while a direct-HTTP caller follows this project's
+     * own "POST params go in the body" convention. Both are legitimate; a parameter
+     * should be found wherever the caller put it.
+     *
+     * The declared source still wins when it has a value, so nothing that works
+     * today changes meaning.
+     */
+    static Object resolveParam(ParamBinding binding, Map<String, String> query,
             Map<String, Object> body) {
-        if (binding.param.source() == ParamSource.QUERY) {
-            return resolveQueryParam(binding, query);
-        } else {
-            return resolveBodyParam(binding, body);
+        boolean declaredQuery = binding.param.source() == ParamSource.QUERY;
+        boolean inDeclared = declaredQuery ? presentIn(binding, query) : presentIn(binding, body);
+        if (!inDeclared) {
+            boolean inOther = declaredQuery ? presentIn(binding, body) : presentIn(binding, query);
+            if (inOther) {
+                return declaredQuery ? resolveBodyParam(binding, body)
+                                     : resolveQueryParam(binding, query);
+            }
         }
+        return declaredQuery ? resolveQueryParam(binding, query)
+                             : resolveBodyParam(binding, body);
+    }
+
+    /** Whether a map actually carries this parameter, under its name or any alias. */
+    static boolean presentIn(ParamBinding binding, Map<String, ?> values) {
+        if (values == null || values.isEmpty()) return false;
+        if (values.containsKey(binding.param.value())) return true;
+        if (binding.aliases != null) {
+            for (String alias : binding.aliases) {
+                if (values.containsKey(alias)) return true;
+            }
+        }
+        return false;
     }
 
     private static Object resolveQueryParam(ParamBinding binding, Map<String, String> query) {
@@ -537,7 +587,8 @@ public class AnnotationScanner {
     // Internal binding record
     // ==================================================================
 
-    private record ParamBinding(Param param, Class<?> javaType, String[] aliases) {
+    /** Package-private so AnnotationScannerParamSourceTest can build one directly. */
+    record ParamBinding(Param param, Class<?> javaType, String[] aliases) {
         ParamBinding(Param param, Class<?> javaType) {
             this(param, javaType, param.aliases());
         }

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -2216,6 +2216,24 @@ public class FunctionService {
                 boolean isParam = targetVar instanceof Parameter;
                 variableKind.set(isParam ? "parameter" : "local");
 
+                // PARSE BEFORE TOUCHING THE FUNCTION'S STORAGE MODE. Enabling
+                // custom storage is a FUNCTION-WIDE change -- it pins every
+                // other parameter at its current location too -- so it must
+                // never survive behind an error response. Parsing after
+                // enabling it meant the most ordinary mistake there is, a
+                // mistyped register name, answered "Unknown register 'R99'"
+                // having already detached the whole parameter list from the
+                // calling convention, with nothing in the response to say so.
+                DataType currentType = targetVar.getDataType();
+                int defaultSize = currentType != null ? currentType.getLength() : targetVar.getLength();
+                VariableStorage newStorage;
+                try {
+                    newStorage = parseStorageSpec(program, storageSpec, defaultSize);
+                } catch (InvalidInputException e) {
+                    errorMessage.set(e.getMessage());
+                    return null;
+                }
+
                 // A parameter's storage is owned by the calling convention until
                 // custom storage is switched on; without this the assignment
                 // below is silently re-derived from the .cspec and the caller
@@ -2235,18 +2253,10 @@ public class FunctionService {
                     if (targetVar == null) {
                         errorMessage.set("Variable '" + variableName + "' disappeared when custom storage was "
                                 + "enabled on " + func.getName() + "; storage was not changed.");
+                        revertCustomStorage(func, enabledCustom);
                         return null;
                     }
-                }
-
-                DataType currentType = targetVar.getDataType();
-                int defaultSize = currentType != null ? currentType.getLength() : targetVar.getLength();
-                VariableStorage newStorage;
-                try {
-                    newStorage = parseStorageSpec(program, storageSpec, defaultSize);
-                } catch (InvalidInputException e) {
-                    errorMessage.set(e.getMessage());
-                    return null;
+                    currentType = targetVar.getDataType();
                 }
 
                 try {
@@ -2258,6 +2268,7 @@ public class FunctionService {
                     // this one catch covers both.
                     errorMessage.set("Ghidra rejected storage '" + storageSpec + "' for '" + variableName
                             + "': " + e.getMessage());
+                    revertCustomStorage(func, enabledCustom);
                     return null;
                 }
 
@@ -2274,6 +2285,7 @@ public class FunctionService {
                 }
                 if (readBack == null) {
                     errorMessage.set("Variable '" + variableName + "' could not be read back after the write");
+                    revertCustomStorage(func, enabledCustom);
                     return null;
                 }
                 VariableStorage actual = readBack.getVariableStorage();
@@ -2282,6 +2294,7 @@ public class FunctionService {
                     errorMessage.set("Storage did not take: requested " + newStorage
                             + " but the variable now reads " + actual
                             + ". This usually means the location overlaps another variable's storage.");
+                    revertCustomStorage(func, enabledCustom);
                     return null;
                 }
 
@@ -2325,6 +2338,30 @@ public class FunctionService {
     // ========================================================================
     // Variable storage (#446)
     // ========================================================================
+
+    /**
+     * Undo a custom-variable-storage mode change THIS call made, so a refused
+     * request never leaves the function's whole parameter list detached from its
+     * calling convention. Only ever called when this call is the one that turned
+     * it on -- a function that already had custom storage is left alone.
+     *
+     * This is load-bearing because the endpoint's error paths set a message and
+     * return NORMALLY, so the surrounding transaction commits. Without it, a
+     * request that was refused would still have permanently changed the
+     * function, which is the mirror image of the bug #446 was filed for.
+     */
+    private static void revertCustomStorage(Function func, AtomicBoolean enabledHere) {
+        if (!enabledHere.get()) {
+            return;
+        }
+        try {
+            func.setCustomVariableStorage(false);
+            enabledHere.set(false);
+        } catch (Exception e) {
+            Msg.warn(FunctionService.class, "Could not restore convention-derived storage on "
+                    + func.getName() + " after a refused set_variable_storage: " + e.getMessage());
+        }
+    }
 
     /**
      * Parse a signed integer that may be written in hex ("-0x10", "0x1c") or

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -16,6 +16,9 @@ import ghidra.program.model.data.Pointer;
 import ghidra.program.model.data.Structure;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.lang.InjectPayload;
+import ghidra.program.model.lang.Register;
+import ghidra.program.model.pcode.Varnode;
+import ghidra.util.exception.InvalidInputException;
 import ghidra.program.model.symbol.Namespace;
 import ghidra.program.model.pcode.HighFunction;
 import ghidra.program.model.pcode.HighFunctionDBUtil;
@@ -2129,15 +2132,29 @@ public class FunctionService {
     /**
      * Set custom storage for a local variable or parameter (v1.7.0).
      *
-     * This allows overriding Ghidra's automatic variable storage detection.
-     * Useful for cases where registers are reused or compiler optimizations confuse the decompiler.
+     * This overrides Ghidra's automatic variable storage detection, which is
+     * the only way to express an argument layout no calling convention can
+     * describe -- a prototype that assigns registers in a fixed ordered run,
+     * say, so a function takes its arguments in R0+R2 or in a lone R28. Adding
+     * a convention to the .cspec cannot express those; custom storage can.
+     *
+     * Until 2026-08-25 this method was a NO-OP: it read the current storage,
+     * logged the request and returned HTTP 200. The stated reason (Ghidra's
+     * storage API being "limited") was wrong -- Variable.setDataType(type,
+     * storage, force, source) together with Function.setCustomVariableStorage
+     * has been public API for many versions. Reporting success for a write
+     * that never happened is worse than refusing it, because a caller cannot
+     * tell the difference (#446).
      *
      * @param functionAddrStr Function address containing the variable
      * @param variableName Name of the variable to modify
-     * @param storageSpec Storage specification (e.g., "Stack[-0x10]:4", "EBP:4", "EAX:4")
-     * @return Success or error message
+     * @param storageSpec Storage specification: "EAX", "EAX:4", "R0:4,R2:4",
+     *                    "Stack[-0x10]:4". Size defaults to the variable's
+     *                    current data-type length when omitted.
+     * @return The storage read back off the variable, or an error explaining
+     *         why the requested location was refused
      */
-    @McpTool(path = "/set_variable_storage", method = "POST", description = "Set variable storage location. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution.", category = "function")
+    @McpTool(path = "/set_variable_storage", method = "POST", description = "Set a parameter's or local's storage location to a register, register pair, or stack slot. Accepts 'EAX', 'EAX:4', 'R0:4,R2:4' or 'Stack[-0x10]:4'; size defaults to the variable's data-type length. Use this when the argument layout cannot be expressed by any calling convention. Setting a PARAMETER's storage switches the whole function to custom variable storage (reported as custom_storage_enabled). The storage is read back after the write and returned in 'storage'. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution.", category = "function")
     public Response setVariableStorage(
             @Param(value = "function_address", paramType = "address", source = ParamSource.BODY,
                    description = "Address in the program. Accepts 0x<hex> (default space) or <space>:<hex> "
@@ -2170,6 +2187,9 @@ public class FunctionService {
         final AtomicReference<String> errorMessage = new AtomicReference<>();
         final AtomicReference<String> functionName = new AtomicReference<>();
         final AtomicReference<String> oldStorageRef = new AtomicReference<>();
+        final AtomicReference<String> newStorageRef = new AtomicReference<>();
+        final AtomicBoolean enabledCustom = new AtomicBoolean(false);
+        final AtomicReference<String> variableKind = new AtomicReference<>();
 
         try {
             threadingStrategy.executeWrite(program, "Set variable storage", () -> {
@@ -2179,8 +2199,8 @@ public class FunctionService {
                     errorMessage.set("No function found at address " + functionAddrStr);
                     return null;
                 }
+                functionName.set(func.getName());
 
-                // Find the variable
                 Variable targetVar = null;
                 for (Variable var : func.getAllVariables()) {
                     if (var.getName().equals(variableName)) {
@@ -2188,45 +2208,218 @@ public class FunctionService {
                         break;
                     }
                 }
-
                 if (targetVar == null) {
                     errorMessage.set("Variable '" + variableName + "' not found in function " + func.getName());
                     return null;
                 }
+                oldStorageRef.set(targetVar.getVariableStorage().toString());
+                boolean isParam = targetVar instanceof Parameter;
+                variableKind.set(isParam ? "parameter" : "local");
 
-                String oldStorage = targetVar.getVariableStorage().toString();
-                functionName.set(func.getName());
-                oldStorageRef.set(oldStorage);
+                // A parameter's storage is owned by the calling convention until
+                // custom storage is switched on; without this the assignment
+                // below is silently re-derived from the .cspec and the caller
+                // sees the convention's answer, not theirs. Enabling it REBUILDS
+                // the parameter objects, so the old handle is stale and the
+                // variable must be looked up again afterwards.
+                if (isParam && !func.hasCustomVariableStorage()) {
+                    func.setCustomVariableStorage(true);
+                    enabledCustom.set(true);
+                    targetVar = null;
+                    for (Variable var : func.getAllVariables()) {
+                        if (var.getName().equals(variableName)) {
+                            targetVar = var;
+                            break;
+                        }
+                    }
+                    if (targetVar == null) {
+                        errorMessage.set("Variable '" + variableName + "' disappeared when custom storage was "
+                                + "enabled on " + func.getName() + "; storage was not changed.");
+                        return null;
+                    }
+                }
 
-                // Ghidra's variable storage API has limited programmatic access;
-                // this call reports the current/requested storage rather than
-                // actually changing it -- see the manual workaround in the
-                // response's "message"/"see_also" fields.
+                DataType currentType = targetVar.getDataType();
+                int defaultSize = currentType != null ? currentType.getLength() : targetVar.getLength();
+                VariableStorage newStorage;
+                try {
+                    newStorage = parseStorageSpec(program, storageSpec, defaultSize);
+                } catch (InvalidInputException e) {
+                    errorMessage.set(e.getMessage());
+                    return null;
+                }
+
+                try {
+                    // force=true so a size difference retypes rather than
+                    // refusing; an invalid request still throws and is reported.
+                    targetVar.setDataType(currentType, newStorage, true, SourceType.USER_DEFINED);
+                } catch (InvalidInputException e) {
+                    // VariableSizeException extends InvalidInputException, so
+                    // this one catch covers both.
+                    errorMessage.set("Ghidra rejected storage '" + storageSpec + "' for '" + variableName
+                            + "': " + e.getMessage());
+                    return null;
+                }
+
+                // Read the storage back off the variable rather than echoing the
+                // request. Ghidra normalises (and can coalesce) what it stores,
+                // so the request is not evidence that the write took -- which is
+                // exactly the failure this endpoint used to ship.
+                Variable readBack = null;
+                for (Variable var : func.getAllVariables()) {
+                    if (var.getName().equals(variableName)) {
+                        readBack = var;
+                        break;
+                    }
+                }
+                if (readBack == null) {
+                    errorMessage.set("Variable '" + variableName + "' could not be read back after the write");
+                    return null;
+                }
+                VariableStorage actual = readBack.getVariableStorage();
+                newStorageRef.set(actual.toString());
+                if (actual.compareTo(newStorage) != 0) {
+                    errorMessage.set("Storage did not take: requested " + newStorage
+                            + " but the variable now reads " + actual
+                            + ". This usually means the location overlaps another variable's storage.");
+                    return null;
+                }
+
                 success.set(true);
-                Msg.info(this, "Variable storage query for: " + variableName + " in " + func.getName() +
-                         " (current: " + oldStorage + ", requested: " + storageSpec + ")");
+                Msg.info(this, "Set variable storage for " + variableName + " in " + func.getName()
+                        + ": " + oldStorageRef.get() + " -> " + actual);
                 return null;
             });
         } catch (Exception e) {
-            errorMessage.set("Failed to execute on Swing thread: " + e.getMessage());
-            Msg.error(this, "Failed to execute set variable storage on Swing thread", e);
+            errorMessage.set("Failed to set variable storage: " + e.getMessage());
+            Msg.error(this, "Failed to execute set variable storage", e);
         }
 
         if (!success.get()) {
             return Response.err(errorMessage.get() != null ? errorMessage.get() : "Unknown failure");
         }
         Map<String, Object> out = new LinkedHashMap<>();
-        out.put("status", "unsupported");
+        out.put("status", "success");
         out.put("variable", variableName);
+        out.put("variable_kind", variableKind.get());
         out.put("function", functionName.get());
         out.put("address", functionAddrStr);
-        out.put("current_storage", oldStorageRef.get());
+        out.put("previous_storage", oldStorageRef.get());
+        out.put("storage", newStorageRef.get());
         out.put("requested_storage", storageSpec);
-        out.put("message", "Programmatic variable storage control is limited in Ghidra; use the Decompiler UI "
-                + "(right-click the variable > Edit Data Type/Retype Variable) or run_ghidra_script with the "
-                + "high-level Pcode/HighVariable API.");
-        out.put("see_also", "FixEBPRegisterReuse.java");
+        if (enabledCustom.get()) {
+            // Say it: this is a function-wide mode change, not a per-variable
+            // one. Every other parameter is now pinned at whatever the calling
+            // convention had assigned it, and will no longer track a later
+            // change of convention.
+            out.put("custom_storage_enabled", true);
+            out.put("note", "Custom variable storage was switched on for " + functionName.get()
+                    + " so this parameter's storage could be set. All of the function's parameters are "
+                    + "now held at their current locations instead of being derived from its calling "
+                    + "convention.");
+        }
         return Response.ok(out);
+    }
+
+
+    // ========================================================================
+    // Variable storage (#446)
+    // ========================================================================
+
+    /**
+     * Parse a signed integer that may be written in hex ("-0x10", "0x1c") or
+     * decimal ("-16"). Long.decode handles the sign for both bases; parseInt
+     * does not understand "0x" at all, which is the form Ghidra itself prints.
+     */
+    private static int parseSignedInt(String text) throws InvalidInputException {
+        try {
+            return Long.decode(text.trim()).intValue();
+        } catch (NumberFormatException e) {
+            throw new InvalidInputException("not an integer: '" + text + "'");
+        }
+    }
+
+    /**
+     * Turn a storage spec into a {@link VariableStorage}.
+     *
+     * Accepts the same shapes Ghidra prints in the Decompiler and that
+     * get_function_variables already returns, so a caller can read storage from
+     * one endpoint and hand it straight back to this one:
+     *
+     *   EAX                  register, sized from the variable's data type
+     *   EAX:4                register, explicit size
+     *   R0:4,R2:4            multi-piece (one value split across registers)
+     *   Stack[-0x10]:4       stack slot at a signed offset
+     *   Stack[-0x10]         stack slot, sized from the variable's data type
+     *
+     * defaultSize is the variable's current data-type length and is used for
+     * any piece that does not carry an explicit ":size".
+     */
+    private static VariableStorage parseStorageSpec(Program program, String spec, int defaultSize)
+            throws InvalidInputException {
+        if (spec == null || spec.trim().isEmpty()) {
+            throw new InvalidInputException("Storage specification is empty");
+        }
+        List<Varnode> varnodes = new ArrayList<>();
+        for (String rawPiece : spec.split(",")) {
+            String piece = rawPiece.trim();
+            if (piece.isEmpty()) continue;
+
+            // Split a trailing ":<size>". The size colon is always the LAST
+            // colon and always after any ']', which keeps "Stack[-0x10]:4"
+            // from being cut inside its brackets.
+            int size = -1;
+            String location = piece;
+            int bracket = piece.lastIndexOf(']');
+            int colon = piece.lastIndexOf(':');
+            if (colon > bracket && colon > 0 && colon < piece.length() - 1) {
+                String tail = piece.substring(colon + 1).trim();
+                if (tail.matches("\\d+")) {
+                    size = Integer.parseInt(tail);
+                    location = piece.substring(0, colon).trim();
+                }
+            }
+            if (size == 0) {
+                throw new InvalidInputException("Storage size must be greater than zero: '" + piece + "'");
+            }
+
+            if (location.toLowerCase(Locale.ROOT).startsWith("stack[")) {
+                int close = location.indexOf(']');
+                if (close < 0) {
+                    throw new InvalidInputException("Unterminated stack offset in '" + piece + "' (expected Stack[-0x10]:4)");
+                }
+                int stackOffset = parseSignedInt(location.substring("stack[".length(), close));
+                int stackSize = size > 0 ? size : defaultSize;
+                if (stackSize <= 0) {
+                    throw new InvalidInputException(
+                            "Cannot infer a size for '" + piece + "'; give one explicitly (e.g. Stack[-0x10]:4)");
+                }
+                Address stackAddr = program.getAddressFactory().getStackSpace().getAddress(stackOffset);
+                varnodes.add(new Varnode(stackAddr, stackSize));
+                continue;
+            }
+
+            Register register = program.getRegister(location);
+            if (register == null) {
+                throw new InvalidInputException(
+                        "Unknown register '" + location + "' for language "
+                                + program.getLanguage().getLanguageID()
+                                + ". Use a register name from this processor, or the "
+                                + "Stack[-0x10]:4 form for a stack slot.");
+            }
+            int regSize = size > 0 ? size : (defaultSize > 0 ? defaultSize : register.getMinimumByteSize());
+            if (regSize > register.getMinimumByteSize()) {
+                throw new InvalidInputException(
+                        "Requested size " + regSize + " exceeds register " + register.getName()
+                                + " (" + register.getMinimumByteSize() + " bytes). Split the value across "
+                                + "registers with a comma, e.g. \"" + register.getName() + ":4,<other>:4\".");
+            }
+            varnodes.add(new Varnode(register.getAddress(), regSize));
+        }
+        if (varnodes.isEmpty()) {
+            throw new InvalidInputException("Storage specification '" + spec + "' named no locations");
+        }
+        return new VariableStorage(program, varnodes.toArray(new Varnode[0]));
     }
 
     public Response setVariableStorage(String functionAddrStr, String variableName, String storageSpec) {

--- a/src/test/java/com/xebyte/core/AnnotationScannerParamSourceTest.java
+++ b/src/test/java/com/xebyte/core/AnnotationScannerParamSourceTest.java
@@ -1,0 +1,104 @@
+package com.xebyte.core;
+
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * A parameter must be found wherever the caller actually put it.
+ *
+ * {@link Param#source()} defaults to {@link ParamSource#QUERY}. On a POST tool that
+ * declares its other parameters as BODY, any parameter left at that default is
+ * looked for in the query string only -- so a caller following this project's own
+ * "POST params go in the body" convention has it silently dropped.
+ *
+ * For {@code program} the result is not a missing argument but a WRONG TARGET:
+ * resolution falls through to the current program, and a write addressed to one
+ * program lands in whichever happens to be active while the response still says
+ * success. That is not hypothetical -- it put 16442 bookmarks describing one DLL
+ * into another, with no error at any point.
+ *
+ * The same class of bug was already found and patched by hand for {@code dry_run},
+ * where the query-only check meant a dry run performed a real write.
+ */
+public class AnnotationScannerParamSourceTest {
+
+    /** Stands in for a POST tool: body-sourced work params, `program` left at the default. */
+    @SuppressWarnings("unused")
+    private void postLikeTool(
+            @Param(value = "address", source = ParamSource.BODY) String address,
+            @Param(value = "program", defaultValue = "") String program) {
+    }
+
+    private static AnnotationScanner.ParamBinding bindingFor(String name) throws Exception {
+        Method m = AnnotationScannerParamSourceTest.class
+                .getDeclaredMethod("postLikeTool", String.class, String.class);
+        Annotation[][] anns = m.getParameterAnnotations();
+        for (int i = 0; i < anns.length; i++) {
+            for (Annotation a : anns[i]) {
+                if (a instanceof Param p && p.value().equals(name)) {
+                    return new AnnotationScanner.ParamBinding(p, m.getParameterTypes()[i]);
+                }
+            }
+        }
+        throw new IllegalArgumentException("no binding for " + name);
+    }
+
+    private static Map<String, String> query(String... kv) {
+        Map<String, String> m = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) m.put(kv[i], kv[i + 1]);
+        return m;
+    }
+
+    private static Map<String, Object> body(String... kv) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) m.put(kv[i], kv[i + 1]);
+        return m;
+    }
+
+    /** The regression: `program` in the JSON body must be seen, not silently dropped. */
+    @Test
+    public void queryDeclaredParamIsFoundInTheBody() throws Exception {
+        Object resolved = AnnotationScanner.resolveParam(
+                bindingFor("program"), query(), body("address", "0x1000", "program", "D2Common.dll"));
+        assertEquals("a program named in the body must not fall through to the current program",
+                "D2Common.dll", resolved);
+    }
+
+    /** The Python bridge synthesizes query params; that path must keep working. */
+    @Test
+    public void queryStillWins() throws Exception {
+        Object resolved = AnnotationScanner.resolveParam(
+                bindingFor("program"), query("program", "FromQuery.dll"), body("program", "FromBody.dll"));
+        assertEquals("the declared source wins when it has a value",
+                "FromQuery.dll", resolved);
+    }
+
+    /** Absent everywhere still means absent -- the fallback must not invent a value. */
+    @Test
+    public void missingEverywhereStaysNull() throws Exception {
+        assertNull(AnnotationScanner.resolveParam(
+                bindingFor("program"), query(), body("address", "0x1000")));
+    }
+
+    /** And the reverse direction: a BODY-declared param passed on the query string. */
+    @Test
+    public void bodyDeclaredParamIsFoundInTheQuery() throws Exception {
+        Object resolved = AnnotationScanner.resolveParam(
+                bindingFor("address"), query("address", "0x2000"), body());
+        assertEquals("0x2000", resolved);
+    }
+
+    @Test
+    public void presentInSeesNameAndNulls() throws Exception {
+        AnnotationScanner.ParamBinding b = bindingFor("program");
+        assertTrue(AnnotationScanner.presentIn(b, body("program", "X.dll")));
+        assertFalse(AnnotationScanner.presentIn(b, body("other", "X.dll")));
+        assertFalse(AnnotationScanner.presentIn(b, null));
+    }
+}

--- a/src/test/java/com/xebyte/offline/VariableStorageWriteTest.java
+++ b/src/test/java/com/xebyte/offline/VariableStorageWriteTest.java
@@ -1,0 +1,132 @@
+package com.xebyte.offline;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Regression tests for /set_variable_storage (#446).
+ *
+ * The endpoint shipped for several versions as a NO-OP: it read the current
+ * storage, logged the request, set success = true and returned HTTP 200 with
+ * {@code "status": "unsupported"}. A caller could not distinguish that from a
+ * write that landed, which is the whole defect -- silently reporting success
+ * for work never done is strictly worse than refusing.
+ *
+ * Applying storage needs a live Program (registers, stack space, a function
+ * with variables), which does not stand up cheaply in CI, so the wiring half
+ * of this uses the same source-assertion idiom as {@link HardeningWiringTest}.
+ * The parsing half is exercised directly by reflection.
+ */
+public class VariableStorageWriteTest extends TestCase {
+
+    private static String functionServiceSource() throws IOException {
+        Path p = Paths.get("src", "main", "java", "com", "xebyte", "core", "FunctionService.java");
+        return new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+    }
+
+    /** Extract just the setVariableStorage(4-arg) method body. */
+    private static String setVariableStorageBody() throws IOException {
+        String src = functionServiceSource();
+        int start = src.indexOf("public Response setVariableStorage(");
+        assertTrue("setVariableStorage(...) not found", start > 0);
+        int end = src.indexOf("public Response setVariableStorage(String functionAddrStr", start + 1);
+        assertTrue("the 3-arg overload should follow the annotated method", end > start);
+        return src.substring(start, end);
+    }
+
+    // ---------------------------------------------------------------- wiring
+
+    /**
+     * The stub's tell was returning ok() with status "unsupported". If that
+     * string comes back to this method, the no-op came back with it.
+     */
+    public void testDoesNotReportUnsupported() throws IOException {
+        String body = setVariableStorageBody();
+        assertFalse("set_variable_storage must not answer ok(status=unsupported); "
+                        + "it either performs the write or returns an error",
+                body.contains("\"unsupported\""));
+    }
+
+    /** The write itself: storage is applied through Variable.setDataType. */
+    public void testAppliesStorageThroughSetDataType() throws IOException {
+        String body = setVariableStorageBody();
+        assertTrue("must apply storage via setDataType(type, storage, force, source)",
+                body.contains("setDataType(currentType, newStorage, true, SourceType.USER_DEFINED)"));
+    }
+
+    /**
+     * A parameter's storage is owned by the calling convention until custom
+     * storage is enabled; without this the assignment is re-derived from the
+     * .cspec and the caller gets the convention's answer, not theirs.
+     */
+    public void testEnablesCustomStorageForParameters() throws IOException {
+        String body = setVariableStorageBody();
+        assertTrue("must switch the function to custom variable storage for a parameter",
+                body.contains("setCustomVariableStorage(true)"));
+        assertTrue("must tell the caller the function-wide mode changed",
+                body.contains("custom_storage_enabled"));
+    }
+
+    /**
+     * The response must quote storage read back off the variable, not the
+     * request echoed. Echoing the request is what made the stub look like it
+     * worked.
+     */
+    public void testReadsStorageBackAfterWriting() throws IOException {
+        String body = setVariableStorageBody();
+        assertTrue("must re-read the variable after writing",
+                body.contains("could not be read back after the write"));
+        assertTrue("must compare what landed against what was asked for",
+                body.contains("Storage did not take"));
+    }
+
+    /** Enabling custom storage rebuilds parameters, invalidating the handle. */
+    public void testRefetchesVariableAfterEnablingCustomStorage() throws IOException {
+        String body = setVariableStorageBody();
+        int enable = body.indexOf("setCustomVariableStorage(true)");
+        int refetch = body.indexOf("getAllVariables()", enable);
+        assertTrue("must look the variable up again after enabling custom storage, "
+                        + "because enabling it rebuilds the parameter objects",
+                enable > 0 && refetch > enable);
+    }
+
+    // --------------------------------------------------------------- parsing
+
+    private static int parseSignedInt(String text) throws Exception {
+        Class<?> cls = Class.forName("com.xebyte.core.FunctionService");
+        Method m = cls.getDeclaredMethod("parseSignedInt", String.class);
+        m.setAccessible(true);
+        return (Integer) m.invoke(null, text);
+    }
+
+    /**
+     * Stack offsets are negative and Ghidra prints them in hex ("Stack[-0x10]").
+     * Integer.parseInt cannot read "0x10" at all, so the naive parse would
+     * reject the exact form this endpoint's own sibling emits.
+     */
+    public void testParsesNegativeHexStackOffsets() throws Exception {
+        assertEquals(-16, parseSignedInt("-0x10"));
+        assertEquals(-16, parseSignedInt("-16"));
+        assertEquals(28, parseSignedInt("0x1c"));
+        assertEquals(0, parseSignedInt("0"));
+        assertEquals(-4, parseSignedInt("  -0x4  "));
+    }
+
+    /** A bad offset must raise, not silently resolve to zero. */
+    public void testRejectsNonNumericOffset() throws Exception {
+        try {
+            parseSignedInt("ebp");
+            fail("expected InvalidInputException for a non-numeric offset");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            assertTrue("should name the offending text, got: " + cause.getMessage(),
+                    String.valueOf(cause.getMessage()).contains("ebp"));
+        }
+    }
+}

--- a/tests/unit/test_bridge_cli.py
+++ b/tests/unit/test_bridge_cli.py
@@ -47,13 +47,20 @@ class _CliHarness(unittest.TestCase):
             patch.object(cli.uvicorn, "run"),
             patch.object(cli, "_build_http_app"),
         ]
-        if env:
-            import os
+        # os.environ is patched unconditionally (patch.dict restores the whole
+        # mapping on stop) so a test that does not name GHIDRA_MCP_LAZY can
+        # clear it below. That var now feeds the lazy default, so a developer
+        # who happens to export it would otherwise flip the assertions of every
+        # test that says nothing about it.
+        import os
 
-            patches.append(patch.dict(os.environ, env))
+        effective_env = dict(env or {})
+        patches.append(patch.dict(os.environ, effective_env))
         started = []
         for p in patches:
             started.append(p.start())
+        if "GHIDRA_MCP_LAZY" not in effective_env:
+            os.environ.pop("GHIDRA_MCP_LAZY", None)
         try:
             cli.main()
             return {
@@ -90,6 +97,36 @@ class TestCliArguments(_CliHarness):
         # tools/list_changed does not actually exist.
         self.run_main("--no-lazy")
         self.assertFalse(state._lazy_mode)
+
+    def test_env_var_disables_lazy_without_argv(self):
+        # The second half of the #440 escape hatch. A Docker ENTRYPOINT, a uvx
+        # one-liner or a registry-installed server entry may give the user no
+        # way to add a flag, and an escape hatch you cannot reach is not one.
+        self.run_main(env={"GHIDRA_MCP_LAZY": "0"})
+        self.assertFalse(state._lazy_mode)
+
+    def test_env_var_accepts_word_forms(self):
+        for value in ("false", "FALSE", "no", "off"):
+            with self.subTest(value=value):
+                self.run_main(env={"GHIDRA_MCP_LAZY": value})
+                self.assertFalse(state._lazy_mode)
+        for value in ("1", "true", "yes", "on"):
+            with self.subTest(value=value):
+                self.run_main(env={"GHIDRA_MCP_LAZY": value})
+                self.assertTrue(state._lazy_mode)
+
+    def test_explicit_flag_beats_env_var(self):
+        # Both directions: whoever typed the flag meant it.
+        self.run_main("--no-lazy", env={"GHIDRA_MCP_LAZY": "1"})
+        self.assertFalse(state._lazy_mode)
+        self.run_main("--lazy", env={"GHIDRA_MCP_LAZY": "0"})
+        self.assertTrue(state._lazy_mode)
+
+    def test_unparseable_env_var_keeps_the_default(self):
+        # Guessing here silently picks one of the two client families this
+        # setting exists to keep working, so an unknown value is ignored.
+        self.run_main(env={"GHIDRA_MCP_LAZY": "maybe"})
+        self.assertTrue(state._lazy_mode)
 
     def test_default_groups_parsed_and_stripped(self):
         self.run_main("--default-groups", " function , datatype ,")

--- a/tests/unit/test_bridge_cli.py
+++ b/tests/unit/test_bridge_cli.py
@@ -67,11 +67,14 @@ class _CliHarness(unittest.TestCase):
 
 
 class TestCliArguments(_CliHarness):
-    def test_defaults_stdio_and_eager_loading(self):
+    def test_defaults_stdio_and_lazy_loading(self):
+        # Lazy is the DEFAULT as of #440: eager advertised all 253 endpoints in
+        # one tools/list, which the Gemini API rejects with 400
+        # INVALID_ARGUMENT before any tool is called.
         mocks = self.run_main()
         mocks["mcp_run"].assert_called_once_with(transport="stdio")
         mocks["uvicorn_run"].assert_not_called()
-        self.assertFalse(state._lazy_mode)
+        self.assertTrue(state._lazy_mode)
 
     def test_lazy_flag_sets_lazy_mode(self):
         self.run_main("--lazy")
@@ -79,6 +82,13 @@ class TestCliArguments(_CliHarness):
 
     def test_no_lazy_overrides_lazy(self):
         self.run_main("--lazy", "--no-lazy")
+        self.assertFalse(state._lazy_mode)
+
+    def test_no_lazy_alone_disables_lazy(self):
+        # --no-lazy must win over the new default without needing --lazy first,
+        # otherwise the documented escape hatch for clients that ignore
+        # tools/list_changed does not actually exist.
+        self.run_main("--no-lazy")
         self.assertFalse(state._lazy_mode)
 
     def test_default_groups_parsed_and_stripped(self):

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -71,10 +71,12 @@ class TestStaticTools(unittest.TestCase):
 class TestToolGroupManagement(unittest.TestCase):
     """Test tool group management tools."""
 
-    def test_lazy_loading_disabled_by_default(self):
+    def test_lazy_loading_enabled_by_default(self):
+        # See state._lazy_mode (#440). Eager loading put every endpoint in a
+        # single tools/list, over Gemini's function-declaration limit.
         import bridge_mcp_ghidra as bridge
 
-        self.assertFalse(bridge.state._lazy_mode)
+        self.assertTrue(bridge.state._lazy_mode)
 
     def test_list_tool_groups_registered(self):
         import bridge_mcp_ghidra as bridge


### PR DESCRIPTION
Lands three fixes that were finished but never pushed, plus the escape hatches and error-path fixes found while verifying them.

## `fix: find program wherever the caller put it`

`@Param(value = "program")` defaults to `ParamSource.QUERY`, so a POST that put `program` in the JSON body silently got no program. This falls back to the other source when the declared one has no value at all.

Verified backward compatible: `registry.py` routes each parameter to exactly one map and drops empty values, so every call from the Python bridge takes the unchanged "declared source wins" path. The fallback only fires when the declared source lacks the key entirely. `AnnotationScannerParamSourceTest` was re-run against the pre-fix `resolveParam` and fails in both directions, so it is not a vacuous test.

## `fix(bridge): load tool groups lazily by default` (#440)

Gemini rejects the full tool set with `400 INVALID_ARGUMENT / "too many states for serving"` - it compiles function declarations into a constrained-decoding state machine and ~239 tools exceed its limit. Advertising fewer tools up front fixes it.

Two gaps found and closed while verifying:

- The README table still documented the old default after the change landed. It literally read `--no-lazy | (default) | Required for most AI clients`, so an Open WebUI or Cline user reading it would have concluded the bridge was broken. Corrected.
- `--no-lazy` was unreachable for Docker `ENTRYPOINT`, `uvx`, and client configs with nowhere to put a flag - which is exactly where the users in #399 and #307 are. Added `GHIDRA_MCP_LAZY`; an explicit flag still wins, an unknown value is ignored with a warning.

This was landed rather than held back because #440 is a hard break with no client-side workaround, while the regression risk is a configurable degradation with two now-reachable fixes.

## `fix(function): actually set variable storage instead of reporting it` (#446)

The endpoint read the current storage, logged the request and returned `success: true`. The comment blamed a Ghidra API limitation, which was not true.

Register storage genuinely works now: `getRegister` to `Varnode`, comma-splitting gives multiple varnodes for `R0:4,R2:4`, and a lone `R28` takes the single-varnode path - the NEC V60 cases from the report.

One bug found during verification and fixed here: error paths returned normally, so the transaction committed anyway, and `setCustomVariableStorage(true)` ran before the storage spec was parsed. A mistyped register name answered `Unknown register 'R99'` having already detached the function's entire parameter list from its calling convention. Now the spec is parsed first, and the failures only detectable afterwards revert the custom-storage mode.

## Tests

| Run | Result |
| --- | --- |
| Offline Java, clean `e4d293c` | 444, 0 failures |
| Offline Java, after | 451, 0 failures |
| plus `AnnotationScannerParamSourceTest` | 456, 0 failures |
| `pytest tests/unit/` | 565 passed, 8 skipped |
| coverage gate | 57.37%, floor 55, passes |

Note for anyone who has seen otherwise: `HardeningWiringTest` and `RunGhidraScriptProgramPropagationTest` are **not** pre-existing failures. Both pass on clean `dev`. They read Java sources through a path relative to the working directory, so they only fail when Maven runs from somewhere other than the repo root.

`AnnotationScannerParamSourceTest` lives in `com.xebyte.core`, so the `com.xebyte.offline.*Test` glob misses it - name it explicitly.

## Follow-up

`CLAUDE.md` still carries the now-false rule that POST endpoints must send `program` as a URL query parameter. It needs softening to a preference.
