### PR TITLE
ci: pay off the coverage debt and raise the floor to 67

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,27 +177,37 @@ jobs:
         # points below the measured baseline to absorb platform/version skew;
         # raise it as coverage improves, never lower it.
         #
-        # Lowered 63.6% -> 58 -> 55 on 2026-08-25. The drop is NOT a test
-        # regression: commit 6f7e7e8 (2026-08-12, one day after the 63.6%
-        # baseline was recorded) dissolved scripts/ into tools/, and tools/ is
-        # a coverage source while scripts/ was not. That moved 533 uncovered
-        # statements into the DENOMINATOR in one commit:
-        # upgrade_project_language.py (530 stmts / 343 missed),
-        # build_reference_index.py (147 / 147) and
-        # ghidra_server_health_check.py (43 / 43), taking the measured total
-        # to 57-58%. Nothing got less tested; the measured scope grew.
+        # History, so the next person does not re-derive it:
+        #   63.6% (2026-08-11) — baseline after the debugger package moved to
+        #     d2-game-exe and left the denominator. Floor 58.
+        #   57-58% (2026-08-12) — commit 6f7e7e8 dissolved scripts/ into
+        #     tools/, and tools/ is a coverage source while scripts/ was not.
+        #     That moved 533 uncovered statements into the DENOMINATOR in one
+        #     commit: upgrade_project_language.py (530 stmts / 343 missed),
+        #     build_reference_index.py (147/147) and
+        #     ghidra_server_health_check.py (43/43). Nothing got less tested;
+        #     the measured scope grew. With the floor still at 58 the gate sat
+        #     exactly on the knife-edge and failed PRs that touch no Python at
+        #     all — #442 is two .md files and reported Build Status=FAILURE,
+        #     and 6 of 8 open dependabot PRs were red for the same reason. The
+        #     floor was dropped to 55 to unblock the queue. That was a
+        #     stopgap, not a fix.
+        #   69.2% (2026-08-30) — the debt is paid: those three operator
+        #     scripts are now COVERED, not scoped out. They reach 99%, 99% and
+        #     98% respectively (the only missed line in each is the
+        #     `sys.exit(main())` under `if __name__ == "__main__"`, which
+        #     cannot execute under import). tests/unit/ gained
+        #     test_ghidra_server_health_check.py,
+        #     test_build_reference_index.py and
+        #     test_upgrade_project_language_main.py; no module was added to
+        #     [tool.coverage.run] omit.
         #
-        # Leaving the floor at 58 with the real number at 57-58 put the gate
-        # exactly on the knife-edge, so it failed PRs that touch no Python at
-        # all: #442 is two .md files and reported Build Status=FAILURE, and 6
-        # of 8 open dependabot PRs were red for the same reason. A ratchet
-        # that blocks a docs-only change is measuring the wrong thing.
-        #
-        # The honest way back up is to cover those three operator scripts, or
-        # scope them out of the coverage sources -- not to re-raise this
-        # number and re-block the queue.
+        # Floor 67 against a measured 69.22% — a ~2pt margin, not the ~0.5pt
+        # knife-edge that caused the outage above. That is ~98 statements of
+        # headroom for platform skew between this ubuntu matrix and the
+        # Windows leg where the baseline was measured.
         uv run --python ${{ matrix.python-version }} --group test \
-          pytest tests/unit/ -v --tb=short --cov-fail-under=55
+          pytest tests/unit/ -v --tb=short --cov-fail-under=67
 
     - name: Upload coverage
       if: ${{ always() && hashFiles('coverage.xml', 'tests/coverage.xml') != '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,51 @@ had been passing on tools that returned the wrong thing — one baseline case
 asserted `nonempty` against `"Search pattern is required"`, so it passed while
 testing nothing.
 
+### CI: the Python coverage ratchet, paid off instead of lowered
+
+The unit-test coverage gate had been red-lining pull requests that touch no
+Python at all — #442 is two `.md` files and reported Build Status=FAILURE, and 6
+of 8 open dependabot PRs were red for the same reason. The whole contributor
+queue looked stalled on review when it was blocked on a number.
+
+Nothing had got less tested. Commit `6f7e7e8` dissolved `scripts/` into
+`tools/`, and `tools/` is a coverage source while `scripts/` was not, so 533
+uncovered statements entered the DENOMINATOR in a single commit —
+`upgrade_project_language.py` (530 stmts / 343 missed),
+`build_reference_index.py` (147/147) and `ghidra_server_health_check.py`
+(43/43). The measured total fell to 57%, the floor was 58, and the gate sat on a
+knife-edge. Dropping it to 55 unblocked the queue but left the debt.
+
+The debt is now paid rather than hidden: those three operator scripts are
+**covered, not scoped out**. No module was added to `[tool.coverage.run] omit`.
+
+| Module | Before | After |
+| --- | --- | --- |
+| `tools/upgrade_project_language.py` | 35% (343 missed) | **99%** (1 missed) |
+| `tools/build_reference_index.py` | 0% (147 missed) | **99%** (1 missed) |
+| `tools/ghidra_server_health_check.py` | 0% (43 missed) | **98%** (1 missed) |
+| **total** | **57.24%** | **69.22%** |
+
+The one missed line in each is the `sys.exit(main())` under
+`if __name__ == "__main__"`, which cannot execute under import.
+
+Three new suites, ~150 tests, pinning behaviour rather than touching lines —
+`tests/unit/test_ghidra_server_health_check.py`,
+`tests/unit/test_build_reference_index.py` and
+`tests/unit/test_upgrade_project_language_main.py`. They cover the traps these
+scripts were built around: the 24h refusal on a repeat whole-project `--apply`
+(the tool is not idempotent and must not be used as its own verification), the
+MSYS `--folder` mangling that turns a run into a silent no-op, the reconciliation
+that catches a planned program which was never attempted, the checkout-leak
+bookkeeping, "saved" being distinct from "committed" on a shared project, the
+`bsim` password reaching each child on stdin and never argv, and `add_binary`
+verifying its ARTIFACT because `analyzeHeadless` exits 0 when a script throws.
+
+`--cov-fail-under` goes **55 → 67** against a measured 69.22% — a ~2 point
+margin, deliberately not the ~0.5 point knife-edge that caused the outage. The
+comment block in `.github/workflows/tests.yml` now records the whole history so
+the number is not re-derived from scratch next time.
+
 ### Fixed
 
 - **`close_program` and auto-analysis could freeze the MCP server.** Both paths

--- a/tests/unit/test_build_reference_index.py
+++ b/tests/unit/test_build_reference_index.py
@@ -1,0 +1,603 @@
+"""Unit tests for tools/build_reference_index.py.
+
+Pure Python. Every Ghidra invocation goes through `subprocess.run`, which is the
+single seam these tests replace -- no `bsim`, no `analyzeHeadless`, no BSim
+database is touched.
+
+The behaviours pinned here are the ones the module's own docstrings say cost
+real debugging time:
+
+* `analyzeHeadless` EXITS 0 WHEN A SCRIPT THROWS, so every step verifies its
+  ARTIFACT (the .mv.db file, a "Writing signatures" line) rather than a return
+  code. A refactor that trusts `returncode` would make this script report a
+  successfully built index that is empty.
+* the failure-line filter is ANCHORED on purpose: a bare `Exception` also
+  matches the analyzer literally named "Windows x86 PE Exception Handling",
+  which fires in every single run.
+* a remote backend must survive VERBATIM. `os.path.abspath` on a
+  `postgresql://` URL turns it into a nonsense path relative to the cwd.
+* the password comes from an ENV VAR and is fed on stdin, because argv is
+  readable by every other process on the box -- and because the `bsim` prompt
+  reads stdin per-child, so a shell pipe reaches the first child and nothing
+  after it.
+* a binary already in the index is SKIPPED: BSim keys executables by md5, and
+  committing one twice grows duplicate functions that tie with each other and
+  abstain forever.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from tools import build_reference_index as bri
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _isolated_module_globals(monkeypatch):
+    """`GHIDRA_HOME` and `BSIM_PASSWORD` are module-level state that `main()`
+    writes. Leaking either between tests makes results order-dependent."""
+    monkeypatch.setattr(bri, "GHIDRA_HOME", "")
+    monkeypatch.setattr(bri, "BSIM_PASSWORD", None)
+    monkeypatch.delenv("GHIDRA_INSTALL_DIR", raising=False)
+    monkeypatch.delenv("BSIM_PASSWORD", raising=False)
+
+
+def _fake_ghidra(root: Path) -> Path:
+    """A directory that passes the `support/bsim.bat` existence check."""
+    support = root / "support"
+    support.mkdir(parents=True, exist_ok=True)
+    (support / "bsim.bat").touch()
+    (support / "analyzeHeadless.bat").touch()
+    return root
+
+
+class _Completed:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _record_runs(monkeypatch, script=None):
+    """Replace subprocess.run; return the list it records calls into.
+
+    `script` maps a substring of the joined command to the output to return.
+    """
+    calls: list[dict] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append({"cmd": list(cmd), "input": kwargs.get("input"),
+                      "timeout": kwargs.get("timeout")})
+        joined = " ".join(cmd)
+        for needle, outcome in (script or {}).items():
+            if needle in joined:
+                return outcome if isinstance(outcome, _Completed) else _Completed(outcome)
+        return _Completed()
+
+    monkeypatch.setattr(bri.subprocess, "run", fake_run)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# find_ghidra_home -- VERIFY the install, never trust a name
+# --------------------------------------------------------------------------- #
+
+
+def test_explicit_home_is_accepted_only_when_the_tool_actually_exists(tmp_path):
+    good = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+
+    assert bri.find_ghidra_home(str(good)) == str(good)
+
+
+def test_a_stale_env_var_is_rejected_rather_than_trusted(tmp_path, monkeypatch):
+    """GHIDRA_INSTALL_DIR is stale on at least one box in this project -- it
+    names a version that is not installed. Trusting it fails deep inside a
+    subprocess with a confusing error."""
+    monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path / "ghidra_9.0_PUBLIC"))
+    monkeypatch.setattr(bri, "_SEARCH_ROOTS", (str(tmp_path),))
+
+    real = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+
+    assert bri.find_ghidra_home("") == str(real), "the scan must win over a name that does not exist"
+
+
+def test_a_valid_env_var_short_circuits_the_disk_scan(tmp_path, monkeypatch):
+    home = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+    monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(home))
+    monkeypatch.setattr(bri, "_SEARCH_ROOTS", ("/nonexistent-root",))
+
+    assert bri.find_ghidra_home("") == str(home)
+
+
+def test_newest_install_wins_by_NUMERIC_version_not_string_order(tmp_path, monkeypatch, capsys):
+    """String ordering puts ghidra_9.2 above ghidra_12.1.2, which would pick a
+    three-major-versions-old install to write an index with."""
+    monkeypatch.setattr(bri, "_SEARCH_ROOTS", (str(tmp_path),))
+    _fake_ghidra(tmp_path / "ghidra_9.2_PUBLIC")
+    _fake_ghidra(tmp_path / "ghidra_12.1_PUBLIC")
+    newest = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+
+    assert bri.find_ghidra_home("") == str(newest)
+    assert "several Ghidra installs found" in capsys.readouterr().out
+
+
+def test_a_ghidra_dir_without_bsim_is_not_a_candidate(tmp_path, monkeypatch):
+    monkeypatch.setattr(bri, "_SEARCH_ROOTS", (str(tmp_path),))
+    (tmp_path / "ghidra_12.1.2_PUBLIC").mkdir()  # no support/bsim.bat
+
+    with pytest.raises(SystemExit) as excinfo:
+        bri.find_ghidra_home("")
+    assert "no Ghidra install found" in str(excinfo.value)
+
+
+def test_unreadable_and_missing_search_roots_are_skipped_not_fatal(tmp_path, monkeypatch):
+    """`os.listdir` on a root that exists but denies access raises OSError. A
+    reference-index build must not die because some drive is locked."""
+    monkeypatch.setattr(bri, "_SEARCH_ROOTS", (str(tmp_path / "gone"), str(tmp_path)))
+    real = os.listdir
+
+    def picky_listdir(path):
+        if str(path) == str(tmp_path):
+            raise PermissionError("denied")
+        return real(path)
+
+    monkeypatch.setattr(bri.os, "listdir", picky_listdir)
+
+    with pytest.raises(SystemExit):
+        bri.find_ghidra_home("")
+
+
+def test_ghidra_tool_refuses_a_missing_helper_by_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+
+    assert bri.ghidra_tool("bsim.bat").endswith(os.path.join("support", "bsim.bat"))
+    with pytest.raises(SystemExit, match="not found"):
+        bri.ghidra_tool("nope.bat")
+
+
+# --------------------------------------------------------------------------- #
+# URL vs path -- a remote backend must survive verbatim
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("index", [
+    "postgresql://u@h:5432/bsim_ref",
+    "elastic://h:9200/idx",
+    "https://h/bsim",
+    "file:/C:/bsim/refindex",
+])
+def test_every_bsim_scheme_is_recognised_as_a_url(index):
+    assert bri.is_url(index) is True
+    assert bri.bsim_url(index) == index, "a URL must pass through untouched"
+
+
+@pytest.mark.parametrize("index", ["C:/bsim/refindex", "refindex", "/var/lib/refindex"])
+def test_a_plain_path_is_not_a_url(index):
+    assert bri.is_url(index) is False
+
+
+def test_a_local_path_is_wrapped_as_a_file_url_with_forward_slashes():
+    """An H2 path that reaches the `bsim` CLI unwrapped fails with an
+    unhelpful error, and native separators are not valid in the URL."""
+    native = os.sep.join(["C:", "bsim", "refindex"])
+
+    assert bri.bsim_url(native) == "file:/C:/bsim/refindex"
+
+
+# --------------------------------------------------------------------------- #
+# run() -- loud, but not crying wolf
+# --------------------------------------------------------------------------- #
+
+
+def test_run_surfaces_real_failures(monkeypatch, capsys):
+    monkeypatch.setattr(bri.subprocess, "run", lambda cmd, **kw: _Completed(
+        stdout="INFO fine\nSCRIPT ERROR: boom\n",
+        stderr="java.lang.NullPointerException\n",
+        returncode=3,
+    ))
+
+    out = bri.run(["bsim.bat", "x"], "doing a thing")
+
+    printed = capsys.readouterr().out
+    assert "$ doing a thing" in printed
+    assert "SCRIPT ERROR: boom" in printed
+    assert "exit 3" in printed
+    assert "SCRIPT ERROR" in out, "the full output is returned for the caller to verify"
+
+
+def test_the_pe_exception_handling_ANALYZER_is_not_reported_as_a_failure(monkeypatch, capsys):
+    """A bare `Exception` match hits the analyzer named "Windows x86 PE
+    Exception Handling" in every single run. A failure channel that cries wolf
+    every time is one you stop reading."""
+    monkeypatch.setattr(bri.subprocess, "run", lambda cmd, **kw: _Completed(
+        stdout="INFO  Windows x86 PE Exception Handling   0.100 secs\n"
+               "INFO  Windows x86 PE RTTI Analyzer        0.050 secs\n",
+    ))
+
+    bri.run(["analyzeHeadless.bat"], "import")
+
+    assert "!" not in capsys.readouterr().out.replace("$ import", "")
+
+
+def test_the_password_is_fed_on_stdin_to_bsim_and_to_nothing_else(monkeypatch):
+    """Remote backends prompt on EVERY `bsim` invocation, and the prompt reads
+    stdin -- which a subprocess does not inherit usefully, so a shell-level
+    pipe reaches the first child and nothing after it."""
+    monkeypatch.setattr(bri, "BSIM_PASSWORD", "hunter2")
+    calls = _record_runs(monkeypatch)
+
+    bri.run([os.path.join("s", "bsim.bat"), "listexes"], "bsim")
+    bri.run([os.path.join("s", "analyzeHeadless.bat"), "proj"], "analyze")
+
+    assert calls[0]["input"] == "hunter2\n"
+    assert calls[1]["input"] is None, "only the bsim CLI prompts"
+    assert not any("hunter2" in " ".join(c["cmd"]) for c in calls), "argv is world-readable"
+
+
+def test_no_stdin_is_supplied_when_no_password_is_configured(monkeypatch):
+    calls = _record_runs(monkeypatch)
+
+    bri.run([os.path.join("s", "bsim.bat"), "listexes"], "bsim")
+
+    assert calls[0]["input"] is None
+
+
+# --------------------------------------------------------------------------- #
+# md5 + index_exists
+# --------------------------------------------------------------------------- #
+
+
+def test_md5_streams_a_file_larger_than_one_chunk(tmp_path):
+    """The read loop uses 1 MiB chunks; a file that spans several must hash
+    identically to the whole-buffer digest."""
+    payload = (b"D2Common" * 4096) * 64  # 2 MiB
+    binary = tmp_path / "big.dll"
+    binary.write_bytes(payload)
+
+    assert bri.md5(str(binary)) == hashlib.md5(payload).hexdigest()
+
+
+def test_index_exists_is_a_FILE_test_for_h2(tmp_path, monkeypatch):
+    calls = _record_runs(monkeypatch)
+    index = str(tmp_path / "refindex")
+
+    assert bri.index_exists(index) is False
+    (tmp_path / "refindex.mv.db").touch()
+    assert bri.index_exists(index) is True
+    assert calls == [], "an H2 probe must not shell out"
+
+
+def test_index_exists_ASKS_THE_SERVER_for_a_remote_backend(tmp_path, monkeypatch):
+    """There is nothing on the local disk to look at, and `getmetadata`
+    succeeds only against an initialised BSim database."""
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    calls = _record_runs(monkeypatch, {"getmetadata": "BSim metadata for medium_32"})
+
+    assert bri.index_exists("postgresql://u@h/db") is True
+    assert "getmetadata" in calls[0]["cmd"]
+    assert calls[0]["timeout"] == 300
+
+
+def test_a_remote_probe_that_says_nothing_useful_is_not_an_index(tmp_path, monkeypatch):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    _record_runs(monkeypatch, {"getmetadata": "The server does not support SSL"})
+
+    assert bri.index_exists("postgresql://u@h/db") is False
+
+
+# --------------------------------------------------------------------------- #
+# create_index -- verify the ARTIFACT, never the exit code
+# --------------------------------------------------------------------------- #
+
+
+def test_create_index_verifies_the_file_appeared(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    index = str(tmp_path / "nested" / "refindex")
+
+    def creating_run(cmd, **kw):
+        if "createdatabase" in cmd:
+            Path(index + ".mv.db").touch()
+        return _Completed()
+
+    monkeypatch.setattr(bri.subprocess, "run", creating_run)
+
+    bri.create_index(index, "bsim_reference_index")
+
+    assert Path(index + ".mv.db").exists()
+    assert "creating index" in capsys.readouterr().out
+
+
+def test_a_createdatabase_that_exits_zero_but_creates_nothing_is_a_failure(tmp_path, monkeypatch):
+    """These tools report success far too readily; the exit code is not
+    evidence of anything."""
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    _record_runs(monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        bri.create_index(str(tmp_path / "refindex"), "n")
+    assert ".mv.db" in str(excinfo.value)
+
+
+def test_a_failed_remote_create_names_ssl_and_the_password_prompt(tmp_path, monkeypatch):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    _record_runs(monkeypatch)  # getmetadata returns nothing -> not created
+
+    with pytest.raises(SystemExit) as excinfo:
+        bri.create_index("postgresql://u@h/db", "n")
+    message = str(excinfo.value)
+    assert "SSL" in message and "password" in message
+    assert ".mv.db" not in message, "a remote backend has no such file"
+
+
+def test_the_template_is_medium_32(tmp_path, monkeypatch):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    index = str(tmp_path / "refindex")
+    calls = _record_runs(monkeypatch)
+    monkeypatch.setattr(bri, "index_exists", lambda i: True)
+
+    bri.create_index(index, "myname")
+
+    assert bri.TEMPLATE == "medium_32"
+    assert "medium_32" in calls[0]["cmd"]
+    assert calls[0]["cmd"][-2:] == ["--name", "myname"]
+
+
+# --------------------------------------------------------------------------- #
+# listed_md5s + add_binary
+# --------------------------------------------------------------------------- #
+
+
+def test_listed_md5s_extracts_only_line_leading_digests(tmp_path, monkeypatch):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    listing = (
+        "d41d8cd98f00b204e9800998ecf8427e libcrypto-1_1.dll\n"
+        "0123456789abcdef0123456789abcdef BH.dll\n"
+        "  indented deadbeefdeadbeefdeadbeefdeadbeef not-a-record\n"
+    )
+    _record_runs(monkeypatch, {"listexes": listing})
+
+    assert bri.listed_md5s("idx") == {
+        "d41d8cd98f00b204e9800998ecf8427e",
+        "0123456789abcdef0123456789abcdef",
+    }
+
+
+def test_a_missing_binary_is_skipped_loudly_and_counted_as_not_added(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    _record_runs(monkeypatch)
+
+    added = bri.add_binary("idx", str(tmp_path / "absent.dll"), str(tmp_path), force=False)
+
+    assert added is False
+    assert "SKIP (missing)" in capsys.readouterr().out
+
+
+def test_a_binary_already_in_the_index_is_skipped_unless_forced(tmp_path, monkeypatch, capsys):
+    """BSim keys executables by md5; committing the same one twice grows
+    duplicate functions that then tie with each other and abstain forever."""
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    binary = tmp_path / "BH.dll"
+    binary.write_bytes(b"MZ...")
+    digest = bri.md5(str(binary))
+    _record_runs(monkeypatch, {
+        "listexes": f"{digest} BH.dll\n",
+        "generatesigs": "Writing signatures\n",
+    })
+
+    assert bri.add_binary("idx", str(binary), str(tmp_path), force=False) is False
+    assert f"SKIP (already indexed, md5 {digest[:8]})" in capsys.readouterr().out
+
+    assert bri.add_binary("idx", str(binary), str(tmp_path), force=True) is True
+
+
+def test_add_binary_reports_whether_a_pdb_sits_beside_the_dll(tmp_path, monkeypatch, capsys):
+    """Without the PDB the names are weak, and an index of weak names is worse
+    than no index -- the operator has to be told which they got."""
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    binary = tmp_path / "libcrypto-1_1.dll"
+    binary.write_bytes(b"MZ")
+    _record_runs(monkeypatch, {"generatesigs": "Writing signatures\n"})
+
+    bri.add_binary("idx", str(binary), str(tmp_path), force=True)
+    assert "NO PDB - names will be weak" in capsys.readouterr().out
+
+    (tmp_path / "libcrypto-1_1.pdb").write_bytes(b"pdb")
+    bri.add_binary("idx", str(binary), str(tmp_path), force=True)
+    assert "+PDB" in capsys.readouterr().out
+
+
+def test_no_signatures_written_is_a_failure_even_though_bsim_exited_zero(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    binary = tmp_path / "d2common.dll"
+    binary.write_bytes(b"MZ")
+    _record_runs(monkeypatch, {"generatesigs": "Nothing to do.\n"})
+
+    assert bri.add_binary("idx", str(binary), str(tmp_path), force=True) is False
+    assert "no signatures were written" in capsys.readouterr().out
+
+
+def test_each_binary_gets_its_own_throwaway_project_keyed_on_its_md5(tmp_path, monkeypatch):
+    """A shared project accumulates state across runs and makes a re-run
+    non-reproducible."""
+    monkeypatch.setattr(bri, "GHIDRA_HOME", str(_fake_ghidra(tmp_path)))
+    binary = tmp_path / "d2client.dll"
+    binary.write_bytes(b"MZ")
+    calls = _record_runs(monkeypatch, {"generatesigs": "Writing signatures\n"})
+
+    bri.add_binary("idx", str(binary), str(tmp_path), force=True)
+
+    project = f"ref_{bri.md5(str(binary))[:8]}"
+    analyze = next(c for c in calls if "analyzeHeadless.bat" in c["cmd"][0])
+    assert analyze["cmd"][2] == project
+    assert "-import" in analyze["cmd"]
+    sigs = next(c for c in calls if "generatesigs" in c["cmd"])
+    assert sigs["cmd"][2].startswith("ghidra:/")
+    assert "\\" not in sigs["cmd"][2], "a ghidra:/ URL takes forward slashes"
+
+
+# --------------------------------------------------------------------------- #
+# main()
+# --------------------------------------------------------------------------- #
+
+
+def _main(monkeypatch, argv, ghidra_home):
+    monkeypatch.setattr(bri.sys, "argv", ["build_reference_index.py",
+                                          "--ghidra-home", str(ghidra_home), *argv])
+    return bri.main()
+
+
+def test_list_on_an_absent_index_returns_one_rather_than_an_empty_success(tmp_path, monkeypatch, capsys):
+    home = _fake_ghidra(tmp_path / "gh")
+    _record_runs(monkeypatch)
+
+    code = _main(monkeypatch, ["--index", str(tmp_path / "refindex"), "--list"], home)
+
+    assert code == 1
+    assert "no BSim index at" in capsys.readouterr().out
+
+
+def test_list_prints_the_indexed_executables(tmp_path, monkeypatch, capsys):
+    home = _fake_ghidra(tmp_path / "gh")
+    index = tmp_path / "refindex"
+    (tmp_path / "refindex.mv.db").touch()
+    _record_runs(monkeypatch, {"listexes": "d41d8cd98f00b204e9800998ecf8427e BH.dll\n"})
+
+    code = _main(monkeypatch, ["--index", str(index), "--list"], home)
+
+    assert code == 0
+    assert "BH.dll" in capsys.readouterr().out
+
+
+def test_nothing_to_do_is_an_argparse_error_not_a_silent_success(tmp_path, monkeypatch):
+    home = _fake_ghidra(tmp_path / "gh")
+    _record_runs(monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _main(monkeypatch, ["--index", str(tmp_path / "refindex")], home)
+    assert excinfo.value.code == 2
+
+
+def test_main_creates_the_index_then_adds_each_binary(tmp_path, monkeypatch, capsys):
+    home = _fake_ghidra(tmp_path / "gh")
+    index = tmp_path / "refindex"
+    for name in ("BH.dll", "ddraw.dll"):
+        (tmp_path / name).write_bytes(b"MZ" + name.encode())
+
+    def creating_run(cmd, **kw):
+        if "createdatabase" in cmd:
+            Path(str(index) + ".mv.db").touch()
+            return _Completed()
+        if "generatesigs" in cmd:
+            return _Completed("Writing signatures\n")
+        return _Completed()
+
+    monkeypatch.setattr(bri.subprocess, "run", creating_run)
+
+    code = _main(monkeypatch, [
+        "--index", str(index),
+        "--add", str(tmp_path / "BH.dll"),
+        "--add", str(tmp_path / "ddraw.dll"),
+    ], home)
+
+    assert code == 0
+    assert "indexed 2 of 2 binaries" in capsys.readouterr().out
+
+
+def test_an_owned_temp_project_dir_is_cleaned_up_even_when_a_binary_fails(tmp_path, monkeypatch):
+    """The temp dir holds a full Ghidra project per binary; leaking it fills
+    the disk over a corpus-sized run."""
+    home = _fake_ghidra(tmp_path / "gh")
+    (tmp_path / "refindex.mv.db").touch()
+    (tmp_path / "BH.dll").write_bytes(b"MZ")
+    made: list[str] = []
+
+    monkeypatch.setattr(bri.tempfile, "mkdtemp",
+                        lambda prefix: made.append(str(tmp_path / "tmpproj")) or str(tmp_path / "tmpproj"))
+    removed: list[str] = []
+    monkeypatch.setattr(bri.shutil, "rmtree", lambda p, ignore_errors=False: removed.append(str(p)))
+    _record_runs(monkeypatch, {"generatesigs": "nothing\n"})
+
+    code = _main(monkeypatch, ["--index", str(tmp_path / "refindex"),
+                               "--add", str(tmp_path / "BH.dll")], home)
+
+    assert code == 0
+    assert removed == made, "the temp project dir this run created must be removed"
+
+
+def test_an_operator_supplied_project_dir_is_NOT_deleted(tmp_path, monkeypatch):
+    home = _fake_ghidra(tmp_path / "gh")
+    (tmp_path / "refindex.mv.db").touch()
+    (tmp_path / "BH.dll").write_bytes(b"MZ")
+    keep = tmp_path / "keepme"
+    keep.mkdir()
+    removed: list[str] = []
+    monkeypatch.setattr(bri.shutil, "rmtree", lambda p, ignore_errors=False: removed.append(str(p)))
+    _record_runs(monkeypatch, {"generatesigs": "Writing signatures\n"})
+
+    _main(monkeypatch, ["--index", str(tmp_path / "refindex"),
+                        "--add", str(tmp_path / "BH.dll"),
+                        "--project-dir", str(keep)], home)
+
+    assert removed == [], "only a temp dir this run created may be removed"
+    assert keep.is_dir()
+
+
+def test_a_postgres_index_is_never_run_through_abspath(tmp_path, monkeypatch, capsys):
+    """abspath would turn postgresql://host/db into a nonsense path relative to
+    the cwd, and the resulting URL reaches `bsim` as garbage."""
+    home = _fake_ghidra(tmp_path / "gh")
+    url = "postgresql://u@h:5432/bsim_ref"
+    calls = _record_runs(monkeypatch, {"getmetadata": "BSim metadata\n",
+                                       "listexes": "\n"})
+
+    code = _main(monkeypatch, ["--index", url, "--list"], home)
+
+    assert code == 0
+    assert any(url in c["cmd"] for c in calls), "the URL must reach bsim character-for-character"
+    assert not any(os.path.abspath(url) in c["cmd"] for c in calls)
+
+
+def test_a_remote_backend_reads_its_password_from_the_named_env_var(tmp_path, monkeypatch):
+    home = _fake_ghidra(tmp_path / "gh")
+    monkeypatch.setenv("MY_BSIM_PW", "s3cret")
+    calls = _record_runs(monkeypatch, {"getmetadata": "BSim metadata\n", "listexes": "\n"})
+
+    _main(monkeypatch, ["--index", "postgresql://u@h/db", "--list",
+                        "--password-env", "MY_BSIM_PW"], home)
+
+    assert bri.BSIM_PASSWORD == "s3cret"
+    assert all(c["input"] == "s3cret\n" for c in calls), "every bsim child needs its own copy"
+    assert not any("s3cret" in " ".join(c["cmd"]) for c in calls)
+
+
+def test_an_unset_password_var_warns_instead_of_failing(tmp_path, monkeypatch, capsys):
+    """`bsim` will prompt interactively; that is workable for a human and only
+    awkward unattended, so warn rather than refuse."""
+    home = _fake_ghidra(tmp_path / "gh")
+    _record_runs(monkeypatch, {"getmetadata": "BSim metadata\n", "listexes": "\n"})
+
+    _main(monkeypatch, ["--index", "postgresql://u@h/db", "--list"], home)
+
+    assert "$BSIM_PASSWORD is unset" in capsys.readouterr().err
+    assert bri.BSIM_PASSWORD is None
+
+
+def test_no_password_is_read_for_a_local_h2_index(tmp_path, monkeypatch):
+    home = _fake_ghidra(tmp_path / "gh")
+    monkeypatch.setenv("BSIM_PASSWORD", "should-not-be-used")
+    (tmp_path / "refindex.mv.db").touch()
+    calls = _record_runs(monkeypatch, {"listexes": "\n"})
+
+    _main(monkeypatch, ["--index", str(tmp_path / "refindex"), "--list"], home)
+
+    assert bri.BSIM_PASSWORD is None
+    assert all(c["input"] is None for c in calls)

--- a/tests/unit/test_ghidra_server_health_check.py
+++ b/tests/unit/test_ghidra_server_health_check.py
@@ -1,0 +1,228 @@
+"""Unit tests for tools/ghidra_server_health_check.py.
+
+Pure Python -- the one network call (`_probe`) is the seam every test replaces.
+Nothing here opens a socket or sleeps for real.
+
+This probe is what deploy/startup tasks gate on, so the behaviours that matter
+are the ones that decide an exit code: a 200 is success even when the body is
+not JSON, a non-200 is a *retryable* failure rather than an immediate verdict,
+and running out of retries must return 1 rather than falling off the end of the
+loop with a 0.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import ghidra_server_health_check as health
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleeping(monkeypatch):
+    """Retry delays default to 2s; a unit test must never actually wait."""
+    slept: list[float] = []
+    monkeypatch.setattr(health.time, "sleep", slept.append)
+    return slept
+
+
+def _run(monkeypatch, argv, responses):
+    """Drive main() with a scripted sequence of `_probe` outcomes.
+
+    Each entry in `responses` is either a `(status, body)` tuple to return or an
+    exception instance to raise.
+    """
+    calls: list[tuple[str, float]] = []
+    queue = list(responses)
+
+    def fake_probe(url, timeout):
+        calls.append((url, timeout))
+        outcome = queue.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(health, "_probe", fake_probe)
+    monkeypatch.setattr(health.sys, "argv", ["ghidra_server_health_check.py", *argv])
+    return health.main(), calls
+
+
+# --------------------------------------------------------------------------- #
+# Success paths
+# --------------------------------------------------------------------------- #
+
+
+def test_healthy_server_returns_zero_and_reports_the_status_field(monkeypatch, capsys):
+    body = json.dumps({"status": "connected", "port": 8089})
+    code, calls = _run(monkeypatch, [], [(200, body)])
+
+    assert code == 0
+    assert len(calls) == 1, "a healthy first attempt must not retry"
+    out = capsys.readouterr().out
+    assert "STATUS=200" in out
+    assert "HEALTH=connected" in out
+
+
+def test_message_field_is_used_when_status_is_absent(monkeypatch, capsys):
+    """The Ghidra endpoint has spelled this both ways across versions."""
+    code, _ = _run(monkeypatch, [], [(200, json.dumps({"message": "alive"}))])
+
+    assert code == 0
+    assert "HEALTH=alive" in capsys.readouterr().out
+
+
+def test_json_object_without_either_field_still_reports_ok(monkeypatch, capsys):
+    code, _ = _run(monkeypatch, [], [(200, json.dumps({"unrelated": 1}))])
+
+    assert code == 0
+    assert "HEALTH=ok" in capsys.readouterr().out
+
+
+def test_non_json_body_on_a_200_is_still_healthy(monkeypatch, capsys):
+    """A 200 is the verdict. An unparseable body must not turn success into
+    failure -- the endpoint has returned bare text, and treating that as a
+    fault would make deploy gate on the response *format*."""
+    code, _ = _run(monkeypatch, [], [(200, "OK")])
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "STATUS=200" in out
+    assert "HEALTH=" not in out
+
+
+def test_json_scalar_body_is_not_treated_as_a_dict(monkeypatch, capsys):
+    """`json.loads("7")` succeeds and returns an int; calling .get() on it
+    would raise straight out of a health probe."""
+    code, _ = _run(monkeypatch, [], [(200, "7")])
+
+    assert code == 0
+    assert "HEALTH=" not in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Retry behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_transient_connection_error_is_retried_until_it_succeeds(monkeypatch, capsys, _no_real_sleeping):
+    import urllib.error
+
+    code, calls = _run(
+        monkeypatch,
+        ["--retries", "3", "--retry-delay", "0.25"],
+        [urllib.error.URLError("refused"), (200, "{}")],
+    )
+
+    assert code == 0
+    assert len(calls) == 2
+    assert _no_real_sleeping == [0.25], "the configured delay must be honoured"
+    assert "Attempt 1/3 failed" in capsys.readouterr().out
+
+
+def test_unexpected_status_is_retried_not_immediately_fatal(monkeypatch, capsys):
+    """A 503 during startup is the normal case, not a verdict."""
+    code, calls = _run(monkeypatch, ["--retries", "2"], [(503, "starting"), (200, "{}")])
+
+    assert code == 0
+    assert len(calls) == 2
+    assert "Unexpected HTTP status 503" in capsys.readouterr().out
+
+
+def test_exhausting_retries_returns_one_and_names_the_last_error(monkeypatch, capsys):
+    code, calls = _run(
+        monkeypatch,
+        ["--retries", "3"],
+        [OSError("boom-1"), OSError("boom-2"), OSError("boom-final")],
+    )
+
+    assert code == 1
+    assert len(calls) == 3
+    assert "ERROR=boom-final" in capsys.readouterr().out
+
+
+def test_no_sleep_after_the_final_attempt(monkeypatch, _no_real_sleeping):
+    """Sleeping after the last try just adds latency to a run that has already
+    decided it failed."""
+    code, _ = _run(monkeypatch, ["--retries", "2"], [OSError("a"), OSError("b")])
+
+    assert code == 1
+    assert len(_no_real_sleeping) == 1, "one delay between two attempts, none after"
+
+
+def test_timeout_error_is_caught_like_any_other_transport_failure(monkeypatch):
+    code, _ = _run(monkeypatch, ["--retries", "1"], [TimeoutError("slow")])
+
+    assert code == 1
+
+
+def test_persistent_bad_status_exhausts_retries_and_fails(monkeypatch, capsys):
+    code, calls = _run(monkeypatch, ["--retries", "2"], [(500, "err"), (500, "err")])
+
+    assert code == 1
+    assert len(calls) == 2
+    assert "ERROR=Unexpected HTTP status 500" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Argument handling
+# --------------------------------------------------------------------------- #
+
+
+def test_defaults_target_the_loopback_mcp_port(monkeypatch):
+    """127.0.0.1, not `localhost`: on Windows the dual-stack resolution tries
+    IPv6 first and Ghidra's HTTP server binds IPv4 only."""
+    _, calls = _run(monkeypatch, [], [(200, "{}")])
+
+    assert calls == [("http://127.0.0.1:8089/check_connection", 5.0)]
+
+
+def test_url_and_timeout_flags_reach_the_probe(monkeypatch):
+    _, calls = _run(
+        monkeypatch,
+        ["--url", "http://10.0.0.5:9000/check_connection", "--timeout", "1.5"],
+        [(200, "{}")],
+    )
+
+    assert calls == [("http://10.0.0.5:9000/check_connection", 1.5)]
+
+
+# --------------------------------------------------------------------------- #
+# The transport seam itself
+# --------------------------------------------------------------------------- #
+
+
+def test_probe_returns_status_and_a_bounded_decoded_body(monkeypatch):
+    """`_probe` caps the read at 4 KiB and decodes with ``errors="replace"``.
+
+    Both matter: the endpoint can return a large listing, and a health probe
+    that raises UnicodeDecodeError on a stray byte reports the server dead when
+    it is in fact answering fine.
+    """
+    seen: dict[str, object] = {}
+
+    class FakeResponse:
+        status = 200
+
+        def read(self, size):
+            seen["size"] = size
+            return b"hello \xff world"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(url, timeout):
+        seen["url"] = url
+        seen["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(health.urllib.request, "urlopen", fake_urlopen)
+
+    status, body = health._probe("http://h/check_connection", 3.0)
+
+    assert status == 200
+    assert body == "hello � world", "an undecodable byte must not raise"
+    assert seen == {"size": 4096, "url": "http://h/check_connection", "timeout": 3.0}

--- a/tests/unit/test_upgrade_project_language_main.py
+++ b/tests/unit/test_upgrade_project_language_main.py
@@ -1203,41 +1203,77 @@ def test_the_filesystem_scan_takes_the_last_install_by_name(tmp_path, monkeypatc
     assert upl.resolve_ghidra_dir(None) == (new, "filesystem scan")
 
 
+#: A synthetic WINDOWS install path for the running-install probe.
+#:
+#: `running_ghidra_dir` parses drive-letter paths out of a Windows process
+#: listing (`([A-Za-z]:\\...ghidra_...)\\`), so a real `tmp_path` cannot stand in
+#: for the install: on Linux it is `/tmp/...`, the regex matches nothing, and the
+#: probe returns None having exercised none of the parse-and-select logic. That
+#: is not a platform gate in the function -- the body is fully reachable once
+#: `sys.platform` and `subprocess.run` are stubbed -- so these tests use a
+#: literal `C:\` path and stub the `<candidate>/support` probe instead. Both
+#: platforms then execute the same code, which matters because CI's ratchet runs
+#: on ubuntu and a test skipped there verifies nothing.
+WIN_INSTALL = "C:\\Ghidra\\ghidra_12.1.2_PUBLIC"
+
+
+def _windows_process_listing(monkeypatch, stdout, *, installed=(WIN_INSTALL,)):
+    """Drive `running_ghidra_dir` against a canned Windows process listing.
+
+    `installed` names the paths whose `support/` subdirectory exists; anything
+    else the listing mentions is a candidate the probe must reject.
+    """
+    class Done:
+        stderr = ""
+        returncode = 0
+
+    Done.stdout = stdout
+    supports = {Path(p) / "support" for p in installed}
+
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+    monkeypatch.setattr(upl.subprocess, "run", lambda cmd, **kw: Done())
+    monkeypatch.setattr(upl.Path, "is_dir", lambda self: self in supports)
+
+
 def test_the_running_install_probe_is_windows_only(monkeypatch):
     monkeypatch.setattr(upl.sys, "platform", "linux")
 
     assert upl.running_ghidra_dir() is None
 
 
-def test_the_running_install_comes_from_the_class_loader_line(tmp_path, monkeypatch):
+def test_the_running_install_comes_from_the_class_loader_line(monkeypatch):
     """Keyed on `ghidra.GhidraClassLoader`, never a bare `*ghidra*` glob: this
     repo's own VSCode Java language server carries the workspace path
     `ghidra-mcp` on its command line and would match one."""
-    real = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
-    listing = (
-        f'"C:\\jdk\\java.exe" -cp X;{real}\\support\\lib -Dfoo '
+    _windows_process_listing(monkeypatch, (
+        f'"C:\\jdk\\java.exe" -cp X;{WIN_INSTALL}\\support\\lib -Dfoo '
         'com.example.LanguageServer C:\\src\\ghidra-mcp\n'
-        f'"C:\\jdk\\java.exe" -cp {real}\\Ghidra\\lib;q ghidra.GhidraClassLoader '
-        'ghidra.GhidraRun\n'
+        f'"C:\\jdk\\java.exe" -cp {WIN_INSTALL}\\Ghidra\\lib;q '
+        'ghidra.GhidraClassLoader ghidra.GhidraRun\n'
+    ))
+
+    assert upl.running_ghidra_dir() == Path(WIN_INSTALL)
+
+
+def test_a_java_process_that_is_not_ghidra_is_never_matched(monkeypatch):
+    """The decoy above must be rejected on its own, not merely outranked: with
+    only the language server running, the probe must find nothing rather than
+    return this repo's workspace."""
+    _windows_process_listing(monkeypatch, (
+        f'"C:\\jdk\\java.exe" -cp X;{WIN_INSTALL}\\support\\lib -Dfoo '
+        'com.example.LanguageServer C:\\src\\ghidra-mcp\n'
+    ))
+
+    assert upl.running_ghidra_dir() is None
+
+
+def test_a_class_loader_line_naming_a_dir_without_support_is_rejected(monkeypatch):
+    _windows_process_listing(
+        monkeypatch,
+        '"java.exe" -cp C:\\nope\\ghidra_12.1.2_PUBLIC\\lib;q '
+        'ghidra.GhidraClassLoader ghidra.GhidraRun\n',
+        installed=(),
     )
-
-    class Done:
-        stdout, stderr, returncode = listing, "", 0
-
-    monkeypatch.setattr(upl.sys, "platform", "win32")
-    monkeypatch.setattr(upl.subprocess, "run", lambda cmd, **kw: Done())
-
-    assert upl.running_ghidra_dir() == Path(str(real))
-
-
-def test_a_class_loader_line_naming_a_dir_without_support_is_rejected(tmp_path, monkeypatch):
-    class Done:
-        stdout = ('"java.exe" -cp C:\\nope\\ghidra_12.1.2_PUBLIC\\lib;q '
-                  'ghidra.GhidraClassLoader ghidra.GhidraRun\n')
-        stderr, returncode = "", 0
-
-    monkeypatch.setattr(upl.sys, "platform", "win32")
-    monkeypatch.setattr(upl.subprocess, "run", lambda cmd, **kw: Done())
 
     assert upl.running_ghidra_dir() is None
 

--- a/tests/unit/test_upgrade_project_language_main.py
+++ b/tests/unit/test_upgrade_project_language_main.py
@@ -1,0 +1,1377 @@
+"""Unit tests for the DRIVER half of tools/upgrade_project_language.py.
+
+``test_upgrade_project_language.py`` covers the leaf helpers -- credentials, the
+log-line regexes, headless command construction. This file covers everything
+that decides whether the tool *runs*: ``main()``'s refusals, the checkout
+lifecycle, the report reconciliation, and the MCP transport helpers.
+
+No Ghidra, no server, no subprocess. ``subprocess.run``, ``urllib.request`` and
+the module's own MCP helpers are the seams.
+
+Every refusal pinned here exists because its absence produced a run that
+completed cleanly having done nothing (or having done something unrecoverable):
+
+* ``--apply`` is NOT idempotent -- HeadlessAnalyzer does ``if canSave() save()``
+  then commits unconditionally, and ``canSave()`` is true for any checked-out
+  file regardless of changes, so every pass writes a new server version for
+  every file it touches. A whole-project re-run within 24h is refused.
+* Git Bash/MSYS rewrites ``--folder /Vanilla/1.01`` into
+  ``C:/Program Files/Git/Vanilla/1.01``, which matches nothing.
+* a requested folder that matches nothing must abort the whole run, not be
+  quietly dropped from the plan and reported as success.
+* a private (unversioned) file is UNREACHABLE through a ``ghidra://`` URL. It is
+  not "skipped" -- counting it as covered overstates what the pass did.
+* every planned program must be reconciled as opened or blocked; one that is
+  neither was never attempted.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "tools" / "upgrade_project_language.py"
+
+
+def _load():
+    """Reuse the already-imported module when the sibling test file loaded it,
+    so both files monkeypatch the same globals."""
+    existing = sys.modules.get("upgrade_project_language")
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location("upgrade_project_language", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+upl = _load()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _program(path: str, versioned: bool = True) -> dict:
+    return {"name": path.rsplit("/", 1)[-1], "path": path,
+            "content_type": "Program", "is_versioned": versioned}
+
+
+CORPUS = [
+    _program("/Vanilla/1.01/D2Game.dll"),
+    _program("/Vanilla/1.01/Diablo II.exe"),
+    _program("/Vanilla/1.02/D2Win.dll"),
+]
+
+
+def _fake_ghidra(root: Path) -> Path:
+    support = root / "support"
+    support.mkdir(parents=True, exist_ok=True)
+    (support / "analyzeHeadless.bat").touch()
+    (support / "analyzeHeadless").touch()
+    return root
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """A fully stubbed environment for main(): a Ghidra dir, a resolved server,
+    a known inventory, no checkouts, and a cwd it can write reports into."""
+    ghidra = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(upl, "resolve_ghidra_dir", lambda explicit: (ghidra, "test"))
+    monkeypatch.setattr(upl, "resolve_server_and_repo",
+                        lambda *a, **k: ("ghidra-host:13100", "diablo2", "test"))
+    monkeypatch.setattr(upl, "walk_project", lambda base, root="/": list(CORPUS))
+    monkeypatch.setattr(upl, "checkout_census", lambda base: {})
+    monkeypatch.setattr(upl, "resolve_password", lambda d: ("pw", "test:GHIDRA_SERVER_PASSWORD"))
+    monkeypatch.setattr(upl, "resolve_user", lambda d: "benam")
+    return {"ghidra": ghidra, "cwd": tmp_path}
+
+
+def _main(monkeypatch, *argv) -> int:
+    monkeypatch.setattr(upl.sys, "argv", ["upgrade_project_language.py", *argv])
+    return upl.main()
+
+
+def _result(folder, **kwargs):
+    return upl.FolderResult(folder=folder, returncode=0, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Preconditions -- refuse rather than guess
+# --------------------------------------------------------------------------- #
+
+
+def test_a_missing_ghidra_install_is_reported_with_the_source_that_named_it(
+        tmp_path, monkeypatch, capsys):
+    """"not found" alone leaves the operator hunting; the SOURCE is what tells
+    them which stale variable to fix."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(upl, "resolve_ghidra_dir",
+                        lambda explicit: (tmp_path / "absent", "$GHIDRA_INSTALL_DIR"))
+
+    assert _main(monkeypatch) == 2
+    err = capsys.readouterr().err
+    assert "Ghidra install not found" in err
+    assert "$GHIDRA_INSTALL_DIR" in err
+
+
+def test_an_unresolvable_server_refuses_instead_of_guessing(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(upl, "resolve_ghidra_dir",
+                        lambda explicit: (_fake_ghidra(tmp_path / "g"), "test"))
+    monkeypatch.setattr(upl, "resolve_server_and_repo", lambda *a, **k: (None, None, "unresolved"))
+
+    assert _main(monkeypatch) == 2
+    assert "could not determine the Ghidra Server" in capsys.readouterr().err
+
+
+def test_a_failed_mcp_inventory_names_the_likely_cause(env, monkeypatch, capsys):
+    def boom(base, root="/"):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(upl, "walk_project", boom)
+
+    assert _main(monkeypatch) == 2
+    err = capsys.readouterr().err
+    assert "MCP inventory failed" in err
+    assert "8089" in err
+
+
+def test_an_empty_inventory_is_refused_not_treated_as_a_clean_project(env, monkeypatch, capsys):
+    """Zero programs means the walk failed or the wrong project is open. An
+    upgrade pass that reports success over an empty list has proved nothing."""
+    monkeypatch.setattr(upl, "walk_project", lambda base, root="/": [])
+
+    assert _main(monkeypatch) == 2
+    assert "refusing to proceed on an empty inventory" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Folder selection
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("folder", ["Vanilla/1.01", "C:/Program Files/Git/Vanilla", "/C:/Git/x"])
+def test_an_msys_mangled_folder_is_refused_and_explained(env, monkeypatch, capsys, folder):
+    """Git Bash rewrites a leading-slash argument into a Windows path, which
+    matches nothing and makes the whole run a silent no-op."""
+    assert _main(monkeypatch, "--folder", folder) == 2
+    err = capsys.readouterr().err
+    assert "do not look like project paths" in err
+    assert "MSYS2_ARG_CONV_EXCL" in err
+
+
+def test_a_requested_folder_that_matches_nothing_aborts_the_whole_run(env, monkeypatch, capsys):
+    """Processing the remainder would report success for work never
+    attempted."""
+    assert _main(monkeypatch, "--folder", "/Vanilla/1.01", "--folder", "/Vanilla/9.99") == 2
+    out = capsys.readouterr()
+    assert "no Programs found in /Vanilla/9.99" in out.out
+    assert "refusing to run" in out.err
+
+
+def test_more_folders_than_the_limit_is_refused_not_silently_truncated(env, monkeypatch, capsys):
+    assert _main(monkeypatch, "--limit", "1") == 2
+    assert "exceeds --limit 1" in capsys.readouterr().err
+
+
+def test_the_limit_permits_exactly_its_own_count(env, monkeypatch):
+    assert _main(monkeypatch, "--limit", "2") == 0, "2 folders under --limit 2 must run"
+
+
+# --------------------------------------------------------------------------- #
+# Dry run (the default)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_default_is_a_dry_run_that_writes_nothing(env, monkeypatch, capsys):
+    called: list[str] = []
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: called.append(kw["folder"]))
+
+    assert _main(monkeypatch) == 0
+    assert called == [], "a dry run must not invoke headless at all"
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "nothing will be written" in out
+    assert not list(env["cwd"].glob("reports/*.json"))
+
+
+def test_private_files_are_reported_as_UNREACHABLE_not_merely_skipped(env, monkeypatch, capsys):
+    """A ghidra:// URL exposes only VERSIONED files. Counting a private file in
+    the plan overstates what the pass covers."""
+    corpus = CORPUS + [_program("/Mods/PD2/PD2_EXT.dll", versioned=False)]
+    monkeypatch.setattr(upl, "walk_project", lambda base, root="/": list(corpus))
+
+    assert _main(monkeypatch) == 0
+    out = capsys.readouterr().out
+    assert "3 versioned (reachable), 1 private (NOT reachable via headless)" in out
+    assert "private: /Mods/PD2/PD2_EXT.dll" in out
+    assert "Total: 3 versioned" in out
+
+
+def test_files_already_checked_out_by_the_gui_are_named_as_blockers(env, monkeypatch, capsys):
+    """Headless runs as a SEPARATE project instance and cannot take an
+    exclusive checkout on these -- it will skip them."""
+    monkeypatch.setattr(upl, "checkout_census",
+                        lambda base: {"/Vanilla/1.01/D2Game.dll": {"path": "/Vanilla/1.01/D2Game.dll"}})
+
+    assert _main(monkeypatch) == 0
+    out = capsys.readouterr().out
+    assert "1 Programs already checked out by the GUI project" in out
+    assert "- /Vanilla/1.01/D2Game.dll" in out
+    assert "(1 blocked by existing checkout)" in out
+
+
+def test_a_long_blocker_list_is_truncated_with_a_count(env, monkeypatch, capsys):
+    many = [_program(f"/Big/{i}.dll") for i in range(15)]
+    monkeypatch.setattr(upl, "walk_project", lambda base, root="/": many)
+    monkeypatch.setattr(upl, "checkout_census", lambda base: {e["path"]: {} for e in many})
+
+    _main(monkeypatch)
+    out = capsys.readouterr().out
+    assert "15 Programs already checked out" in out
+    assert "... and 5 more" in out
+
+
+def test_a_failing_checkout_census_warns_and_continues(env, monkeypatch, capsys):
+    """The census is advisory. Aborting the plan because it failed would make a
+    read-only listing a hard dependency of a dry run."""
+    def boom(base):
+        raise OSError("census down")
+
+    monkeypatch.setattr(upl, "checkout_census", boom)
+
+    assert _main(monkeypatch) == 0
+    assert "[WARN] checkout census failed: census down" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# --apply
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_runs_every_folder_and_writes_a_report(env, monkeypatch, capsys):
+    seen: list[dict] = []
+
+    def fake_run_folder(**kw):
+        seen.append(kw)
+        return _result(kw["folder"],
+                       processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])],
+                       committed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])])
+
+    monkeypatch.setattr(upl, "run_folder", fake_run_folder)
+
+    assert _main(monkeypatch, "--apply") == 0
+
+    assert [k["folder"] for k in seen] == ["/Vanilla/1.01", "/Vanilla/1.02"]
+    assert all(k["apply_changes"] is True for k in seen)
+    assert all(k["password"] == "pw" for k in seen)
+
+    reports = list((env["cwd"] / "reports").glob("language_upgrade_*.json"))
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert report["mode"] == "APPLY"
+    assert report["totals"]["committed"] == 3
+    assert report["unaccounted"] == {}
+    assert report["repository"] == "ghidra://ghidra-host:13100/diablo2"
+    assert "Ghidra's project tree is now stale" in capsys.readouterr().out
+
+
+def test_a_planned_program_that_was_never_opened_is_reported_UNACCOUNTED(env, monkeypatch, capsys):
+    """Without this reconciliation the run prints a clean summary having
+    quietly missed a file."""
+    monkeypatch.setattr(upl, "run_folder",
+                        lambda **kw: _result(kw["folder"], processed=["/Vanilla/1.01/D2Game.dll"]))
+
+    assert _main(monkeypatch, "--apply") == 1, "an unaccounted file must fail the run"
+    out = capsys.readouterr().out
+    assert "UNACCOUNTED -- planned but neither opened nor reported blocked" in out
+    assert "/Vanilla/1.01/Diablo II.exe" in out
+
+    report = json.loads(next((env["cwd"] / "reports").glob("*.json")).read_text(encoding="utf-8"))
+    assert report["unaccounted"]["/Vanilla/1.01"] == ["/Vanilla/1.01/Diablo II.exe"]
+
+
+def test_a_checkout_blocked_file_counts_as_accounted_for(env, monkeypatch):
+    """It was attempted and refused, which is a known outcome -- not a miss."""
+    def fake(**kw):
+        paths = [e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]
+        return _result(kw["folder"], processed=paths[:1], no_exclusive_checkout=paths[1:])
+
+    monkeypatch.setattr(upl, "run_folder", fake)
+
+    assert _main(monkeypatch, "--apply") == 0
+
+
+def test_unauthorized_aborts_before_any_further_folder_is_attempted(env, monkeypatch, capsys):
+    attempts: list[str] = []
+
+    def fake(**kw):
+        attempts.append(kw["folder"])
+        result = _result(kw["folder"])
+        result.unauthorized = True
+        return result
+
+    monkeypatch.setattr(upl, "run_folder", fake)
+
+    assert _main(monkeypatch, "--apply") == 1
+    assert attempts == ["/Vanilla/1.01"], "the second folder must never be tried"
+    assert "the server rejected the credentials" in capsys.readouterr().err
+
+
+def test_save_errors_and_too_new_files_fail_the_run(env, monkeypatch):
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"],
+        processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])],
+        save_errors=["/Vanilla/1.01/D2Game.dll"],
+    ))
+
+    assert _main(monkeypatch, "--apply") == 1
+
+
+def test_a_nonzero_headless_returncode_fails_the_run(env, monkeypatch):
+    def fake(**kw):
+        result = _result(kw["folder"],
+                         processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])])
+        result.returncode = 1
+        return result
+
+    monkeypatch.setattr(upl, "run_folder", fake)
+
+    assert _main(monkeypatch, "--apply") == 1
+
+
+def test_a_timeout_returncode_of_None_is_not_treated_as_a_process_failure(env, monkeypatch):
+    """run_folder sets returncode=None on timeout and the log already carries
+    the *** TIMEOUT *** marker; the reconciliation is what catches the damage."""
+    def fake(**kw):
+        result = _result(kw["folder"],
+                         processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])])
+        result.returncode = None
+        return result
+
+    monkeypatch.setattr(upl, "run_folder", fake)
+
+    assert _main(monkeypatch, "--apply") == 0
+
+
+def test_saved_but_NOT_committed_is_called_out_in_the_progress_line(env, monkeypatch, capsys):
+    """On a shared project only the commit line means the work reached the
+    server. A folder that saved 3 files and committed none has changed nothing
+    anyone else can see, and must not read as a success."""
+    paths = {"/Vanilla/1.01": ["/Vanilla/1.01/D2Game.dll", "/Vanilla/1.01/Diablo II.exe"],
+             "/Vanilla/1.02": ["/Vanilla/1.02/D2Win.dll"]}
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"], processed=paths[kw["folder"]], saved=paths[kw["folder"]]))
+
+    assert _main(monkeypatch, "--apply") == 0
+    out = capsys.readouterr().out
+    assert "2 opened, 2 saved (NOT committed)" in out
+    assert "1 opened, 1 saved (NOT committed)" in out
+    assert "committed            0" in out, "the summary must not credit an uncommitted save"
+    assert "project tree is now stale" not in out, "nothing reached the server"
+
+
+def test_every_blocked_bucket_is_named_in_the_progress_line(env, monkeypatch, capsys):
+    """A folder that opened one file and refused four must say so on the line
+    the operator actually reads, not only in the JSON report."""
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"],
+        processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])],
+        committed=["/x.dll"],
+        needs_upgrade_blocked=["/a.dll"],
+        no_exclusive_checkout=["/b.dll"],
+        newer_than_ghidra=["/c.dll"],
+        save_errors=["/d.dll"],
+    ))
+
+    assert _main(monkeypatch, "--apply") == 1, "save errors and too-new files fail the run"
+    out = capsys.readouterr().out
+    for expected in ("1 committed", "1 UPGRADE-BLOCKED", "1 checkout-blocked",
+                     "1 TOO-NEW", "1 SAVE-ERRORS"):
+        assert expected in out
+
+
+def test_missing_credentials_refuse_the_apply_and_name_the_env_file(env, monkeypatch, capsys):
+    monkeypatch.setattr(upl, "resolve_password", lambda d: (None, "unset"))
+
+    assert _main(monkeypatch, "--apply") == 2
+    err = capsys.readouterr().err
+    assert "no server password" in err
+    assert "GHIDRA_SERVER_PASSWORD" in err
+    assert ".env" in err
+
+
+def test_cmd_metacharacters_are_stripped_from_the_checkin_comment(env, monkeypatch):
+    """A parenthesis in the comment kills analyzeHeadless.bat with `"" was
+    unexpected at this time` before the JVM is ever launched."""
+    seen: list[str] = []
+    monkeypatch.setattr(upl, "run_folder",
+                        lambda **kw: seen.append(kw["comment"]) or _result(kw["folder"]))
+
+    _main(monkeypatch, "--apply", "--force",
+          "--comment", 'Upgrade (12.1.2) & more <now> ^ 100% "quoted" | piped!')
+
+    assert seen[0] == "Upgrade 12.1.2  more now  100 quoted  piped"
+    assert not set(seen[0]) & set('()&|<>^%!"')
+
+
+def test_the_default_comment_names_the_ghidra_version_being_matched(env, monkeypatch):
+    seen: list[str] = []
+    monkeypatch.setattr(upl, "run_folder",
+                        lambda **kw: seen.append(kw["comment"]) or _result(kw["folder"]))
+
+    _main(monkeypatch, "--apply")
+
+    assert seen[0] == "Language upgrade to ghidra_12.1.2_PUBLIC"
+
+
+def test_the_folder_timeout_scales_with_the_program_count_above_a_floor(env, monkeypatch):
+    seen: list[float] = []
+    monkeypatch.setattr(upl, "run_folder",
+                        lambda **kw: seen.append(kw["timeout"]) or _result(kw["folder"]))
+
+    _main(monkeypatch, "--apply", "--timeout-per-file", "100", "--min-timeout", "150")
+
+    assert seen == [200.0, 150.0], "2 programs -> 200s; 1 program -> the 150s floor"
+
+
+# --------------------------------------------------------------------------- #
+# The 24h whole-project re-run guard
+# --------------------------------------------------------------------------- #
+
+
+def _prior_apply_report(cwd: Path, name="language_upgrade_20260825-120000.json", mode="APPLY"):
+    reports = cwd / "reports"
+    reports.mkdir(exist_ok=True)
+    path = reports / name
+    path.write_text(json.dumps({"mode": mode}), encoding="utf-8")
+    return path
+
+
+def test_a_second_whole_project_apply_within_24h_is_refused(env, monkeypatch, capsys):
+    """--apply is NOT idempotent and must not be used as its own verification:
+    canSave() is true for any checked-out file regardless of changes, so every
+    pass writes a new server version for every file it touches."""
+    _prior_apply_report(env["cwd"])
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(kw["folder"]))
+
+    assert _main(monkeypatch, "--apply") == 2
+    err = capsys.readouterr().err
+    assert "already ran within 24h" in err
+    assert "--verify" in err and "--force" in err
+
+
+def test_force_overrides_the_24h_guard(env, monkeypatch):
+    _prior_apply_report(env["cwd"])
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"], processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]))
+
+    assert _main(monkeypatch, "--apply", "--force") == 0
+
+
+def test_a_folder_scoped_apply_is_not_a_whole_project_rerun(env, monkeypatch):
+    """--folder is the sanctioned way to retry a genuine subset."""
+    _prior_apply_report(env["cwd"])
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"], processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]))
+
+    assert _main(monkeypatch, "--apply", "--folder", "/Vanilla/1.01") == 0
+
+
+def test_a_prior_PREFLIGHT_report_does_not_trip_the_apply_guard(env, monkeypatch):
+    """A preflight writes nothing to the server, so it is not the thing the
+    guard protects against."""
+    _prior_apply_report(env["cwd"], mode="PREFLIGHT (read-only)")
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"], processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]))
+
+    assert _main(monkeypatch, "--apply") == 0
+
+
+def test_an_apply_report_older_than_24h_does_not_block(env, monkeypatch):
+    path = _prior_apply_report(env["cwd"])
+    old = upl.time.time() - 200000
+    os.utime(path, (old, old))
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"], processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]))
+
+    assert _main(monkeypatch, "--apply") == 0
+
+
+# --------------------------------------------------------------------------- #
+# --preflight
+# --------------------------------------------------------------------------- #
+
+
+def test_preflight_runs_headless_READ_ONLY(env, monkeypatch, capsys):
+    seen: list[dict] = []
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: seen.append(kw) or _result(
+        kw["folder"], processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]))
+
+    assert _main(monkeypatch, "--preflight") == 0
+    assert all(k["apply_changes"] is False for k in seen)
+    out = capsys.readouterr().out
+    assert "PREFLIGHT (read-only)" in out
+    assert "Preflighting 2 folders" in out
+    assert "project tree is now stale" not in out, "nothing was committed"
+
+
+def test_a_report_path_can_be_directed_somewhere_explicit(env, monkeypatch):
+    target = env["cwd"] / "out" / "custom.json"
+    monkeypatch.setattr(upl, "run_folder", lambda **kw: _result(
+        kw["folder"], processed=[e["path"] for e in CORPUS if e["path"].startswith(kw["folder"])]))
+
+    _main(monkeypatch, "--preflight", "--report", str(target))
+
+    assert json.loads(target.read_text(encoding="utf-8"))["mode"] == "PREFLIGHT (read-only)"
+
+
+# --------------------------------------------------------------------------- #
+# --verify
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_samples_one_program_per_folder_by_default(env, monkeypatch, capsys):
+    """The probe leaks an exclusive checkout per program, so the sample must
+    stay small by default -- a 152-program probe stranded 140 checkouts."""
+    probed: list[str] = []
+
+    def fake_probe(base, path, leaked=None):
+        probed.append(path)
+        return "current", '{"success": true}'
+
+    monkeypatch.setattr(upl, "probe_language_state", fake_probe)
+
+    assert _main(monkeypatch, "--verify") == 0
+    assert probed == ["/Vanilla/1.01/D2Game.dll", "/Vanilla/1.02/D2Win.dll"]
+    assert "current: 2   stale: 0   unknown: 0" in capsys.readouterr().out
+
+
+def test_verify_sample_zero_probes_every_program(env, monkeypatch):
+    probed: list[str] = []
+    monkeypatch.setattr(upl, "probe_language_state",
+                        lambda b, p, leaked=None: probed.append(p) or ("current", "{}"))
+
+    _main(monkeypatch, "--verify", "--verify-sample", "0")
+
+    assert len(probed) == 3
+
+
+def test_a_stale_program_fails_verify_and_points_at_apply(env, monkeypatch, capsys):
+    monkeypatch.setattr(upl, "probe_language_state",
+                        lambda b, p, leaked=None: ("stale", "Minor language change 4.6 -> 4.7"))
+
+    assert _main(monkeypatch, "--verify") == 1
+    out = capsys.readouterr().out
+    assert "STALE   /Vanilla/1.01/D2Game.dll" in out
+    assert "re-run with --apply" in out
+
+
+def test_an_UNKNOWN_probe_is_not_reported_as_passed(env, monkeypatch, capsys):
+    """An unreadable probe must never certify anything -- otherwise the
+    verification step quietly certifies nothing at all."""
+    monkeypatch.setattr(upl, "probe_language_state",
+                        lambda b, p, leaked=None: ("unknown", "checkout failed"))
+
+    assert _main(monkeypatch, "--verify") == 1
+    assert "UNKNOWN /Vanilla/1.01/D2Game.dll" in capsys.readouterr().out
+
+
+def test_leaked_checkouts_are_recorded_and_warned_about_LOUDLY(env, monkeypatch, capsys):
+    """open_program registers a DomainObject consumer nothing releases, so the
+    checkout survives until Ghidra restarts. Leaving the project quietly worse
+    than we found it is the failure mode."""
+    def leaking(base, path, leaked=None):
+        leaked.append(path)
+        return "current", "{}"
+
+    monkeypatch.setattr(upl, "probe_language_state", leaking)
+
+    assert _main(monkeypatch, "--verify") == 1, "a leak alone must fail the run"
+    out = capsys.readouterr().out
+    assert "exclusive checkout(s) could NOT be released" in out
+    assert "restart Ghidra" in out
+    assert "--release-checkouts" in out
+
+    # NOTE: --verify always records to this fixed path; it does not honour
+    # --stray-file, which only --release-checkouts reads. Pinned as-is so a
+    # deliberate fix has to update this assertion rather than drift past it.
+    recorded = json.loads((env["cwd"] / "reports" / "verify_stray_checkouts.json")
+                          .read_text(encoding="utf-8"))
+    assert recorded == ["/Vanilla/1.01/D2Game.dll", "/Vanilla/1.02/D2Win.dll"]
+
+
+def test_newly_leaked_checkouts_are_merged_with_previously_recorded_ones(env, monkeypatch):
+    reports = env["cwd"] / "reports"
+    reports.mkdir()
+    (reports / "verify_stray_checkouts.json").write_text(
+        json.dumps(["/Older/leak.dll"]), encoding="utf-8")
+    monkeypatch.setattr(upl, "probe_language_state",
+                        lambda b, p, leaked=None: (leaked.append(p), ("current", "{}"))[1])
+
+    _main(monkeypatch, "--verify")
+
+    recorded = json.loads((reports / "verify_stray_checkouts.json").read_text(encoding="utf-8"))
+    assert "/Older/leak.dll" in recorded, "a prior run's leaks must not be dropped"
+    assert "/Vanilla/1.01/D2Game.dll" in recorded
+
+
+def test_a_corrupt_stray_file_is_replaced_rather_than_crashing_the_probe(env, monkeypatch):
+    reports = env["cwd"] / "reports"
+    reports.mkdir()
+    (reports / "verify_stray_checkouts.json").write_text("not json", encoding="utf-8")
+    monkeypatch.setattr(upl, "probe_language_state",
+                        lambda b, p, leaked=None: (leaked.append(p), ("current", "{}"))[1])
+
+    _main(monkeypatch, "--verify")
+
+    recorded = json.loads((reports / "verify_stray_checkouts.json").read_text(encoding="utf-8"))
+    assert recorded == ["/Vanilla/1.01/D2Game.dll", "/Vanilla/1.02/D2Win.dll"]
+
+
+# --------------------------------------------------------------------------- #
+# --release-checkouts
+# --------------------------------------------------------------------------- #
+
+
+def _stray_file(cwd: Path, paths) -> Path:
+    reports = cwd / "reports"
+    reports.mkdir(exist_ok=True)
+    path = reports / "verify_stray_checkouts.json"
+    path.write_text(json.dumps(list(paths)), encoding="utf-8")
+    return path
+
+
+def test_release_with_no_recorded_strays_is_a_clean_no_op(env, monkeypatch, capsys):
+    assert _main(monkeypatch, "--release-checkouts") == 0
+    assert "Nothing to do" in capsys.readouterr().out
+
+
+def _live_server(monkeypatch, checked_out, *, releasable=True):
+    """A census backed by mutable state, so the re-poll sees what undo did.
+
+    A call-counting stub cannot model this: main() reads the census once for
+    the plan and again for the release, and the whole point of the re-poll is
+    that it observes a DIFFERENT answer than the per-call results claimed.
+    """
+    live = {path: {} for path in checked_out}
+    undone: list[str] = []
+
+    def undo(base, path):
+        undone.append(path)
+        if not releasable:
+            return False, f"{path.rsplit('/', 1)[-1]} is in use"
+        live.pop(path, None)
+        return True, "released"
+
+    monkeypatch.setattr(upl, "checkout_census", lambda base: dict(live))
+    monkeypatch.setattr(upl, "undo_checkout", undo)
+    return undone, live
+
+
+def test_release_only_touches_checkouts_this_tool_recorded_creating(env, monkeypatch):
+    """Undoing an arbitrary checkout discards whatever local work it held."""
+    _stray_file(env["cwd"], ["/Vanilla/1.01/D2Game.dll"])
+    # /Vanilla/1.02/D2Win.dll is the operator's own -- it must be left alone.
+    undone, live = _live_server(
+        monkeypatch, ["/Vanilla/1.01/D2Game.dll", "/Vanilla/1.02/D2Win.dll"])
+
+    assert _main(monkeypatch, "--release-checkouts") == 0
+    assert undone == ["/Vanilla/1.01/D2Game.dll"]
+    assert "/Vanilla/1.02/D2Win.dll" in live
+
+
+def test_release_repolls_and_refuses_to_believe_its_own_success(env, monkeypatch, capsys):
+    """The census lags the server: "released 140, stuck 0" was reported while
+    two checkouts were still live. Silence there is what let that stand."""
+    _stray_file(env["cwd"], ["/Vanilla/1.01/D2Game.dll"])
+    monkeypatch.setattr(upl, "checkout_census", lambda base: {"/Vanilla/1.01/D2Game.dll": {}})
+    monkeypatch.setattr(upl, "undo_checkout", lambda base, path: (True, "released"))
+
+    assert _main(monkeypatch, "--release-checkouts") == 1, "still present on re-poll => failure"
+    out = capsys.readouterr().out
+    assert "STILL CHECKED OUT after re-poll: 1" in out
+    assert "run this again" in out
+
+
+def test_a_stuck_checkout_is_named_and_kept_in_the_stray_file(env, monkeypatch, capsys):
+    path = _stray_file(env["cwd"], ["/Vanilla/1.01/D2Game.dll"])
+    _live_server(monkeypatch, ["/Vanilla/1.01/D2Game.dll"], releasable=False)
+
+    assert _main(monkeypatch, "--release-checkouts") == 1
+    assert "STUCK /Vanilla/1.01/D2Game.dll: D2Game.dll is in use" in capsys.readouterr().out
+    assert json.loads(path.read_text(encoding="utf-8")) == ["/Vanilla/1.01/D2Game.dll"], \
+        "a stuck path must survive for the next attempt"
+
+
+def test_a_successfully_released_checkout_is_dropped_from_the_stray_file(env, monkeypatch):
+    path = _stray_file(env["cwd"], ["/Vanilla/1.01/D2Game.dll"])
+    _live_server(monkeypatch, ["/Vanilla/1.01/D2Game.dll"])
+
+    assert _main(monkeypatch, "--release-checkouts") == 0
+    assert json.loads(path.read_text(encoding="utf-8")) == []
+
+
+def test_a_baseline_report_widens_the_release_to_strays_the_census_missed(env, monkeypatch):
+    """/server/checkouts reads LOCAL project data that lags the server, so a
+    checkout created moments earlier can be absent from the census and never
+    recorded. Anything NOT in the baseline's preexisting set is ours."""
+    _stray_file(env["cwd"], [])
+    baseline = env["cwd"] / "baseline.json"
+    baseline.write_text(json.dumps({"preexisting_checkouts": ["/Theirs/x.dll"]}), encoding="utf-8")
+    undone, live = _live_server(monkeypatch, ["/Theirs/x.dll", "/Vanilla/1.01/D2Game.dll"])
+
+    assert _main(monkeypatch, "--release-checkouts", "--baseline", str(baseline)) == 0
+    assert undone == ["/Vanilla/1.01/D2Game.dll"], "the operator's own checkout is untouched"
+    assert "/Theirs/x.dll" in live
+
+
+# --------------------------------------------------------------------------- #
+# MCP transport helpers
+# --------------------------------------------------------------------------- #
+
+
+class _Resp:
+    def __init__(self, raw: bytes):
+        self._raw = raw
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _fake_urlopen(monkeypatch, raw: bytes, sink: dict | None = None):
+    def opener(url_or_request, timeout=None):
+        if sink is not None:
+            if hasattr(url_or_request, "full_url"):
+                sink["url"] = url_or_request.full_url
+                sink["body"] = url_or_request.data
+                sink["method"] = url_or_request.get_method()
+                sink["headers"] = url_or_request.headers
+            else:
+                sink["url"] = url_or_request
+            sink["timeout"] = timeout
+        return _Resp(raw)
+
+    monkeypatch.setattr(upl.urllib.request, "urlopen", opener)
+
+
+def test_mcp_get_returns_a_non_json_body_verbatim(monkeypatch):
+    _fake_urlopen(monkeypatch, b"plain text error")
+
+    assert upl.mcp_get("http://h:8089", "check_connection") == "plain text error"
+
+
+def test_mcp_get_passes_through_a_result_that_is_already_structured(monkeypatch):
+    _fake_urlopen(monkeypatch, json.dumps({"result": {"a": 1}}).encode())
+
+    assert upl.mcp_get("http://h:8089", "x") == {"a": 1}
+
+
+def test_mcp_get_returns_an_unwrappable_result_string_as_a_string(monkeypatch):
+    _fake_urlopen(monkeypatch, json.dumps({"result": "checked_out"}).encode())
+
+    assert upl.mcp_get("http://h:8089", "x") == "checked_out"
+
+
+def test_mcp_get_returns_an_unenveloped_payload_unchanged(monkeypatch):
+    _fake_urlopen(monkeypatch, json.dumps({"status": "ok"}).encode())
+
+    assert upl.mcp_get("http://h:8089", "x") == {"status": "ok"}
+
+
+def test_mcp_post_sends_a_JSON_BODY_not_a_query_string(monkeypatch):
+    """The version-control routes read their arguments with parseJsonParams; a
+    query string reaches them as `'path' parameter required`."""
+    sink: dict = {}
+    _fake_urlopen(monkeypatch, json.dumps({"result": '{"status": "checkout_undone"}'}).encode(), sink)
+
+    out = upl.mcp_post("http://h:8089/", "/server/version_control/undo_checkout",
+                       path="/Vanilla/1.01/D2Game.dll")
+
+    assert out == {"status": "checkout_undone"}
+    assert sink["method"] == "POST"
+    assert sink["url"] == "http://h:8089/server/version_control/undo_checkout"
+    assert json.loads(sink["body"]) == {"path": "/Vanilla/1.01/D2Game.dll"}
+    assert sink["headers"]["Content-type"] == "application/json"
+
+
+def test_mcp_post_survives_a_non_json_response(monkeypatch):
+    _fake_urlopen(monkeypatch, b"<html>500</html>")
+
+    assert upl.mcp_post("http://h:8089", "x") == "<html>500</html>"
+
+
+def test_mcp_post_unwraps_a_structured_result_and_an_unparseable_one(monkeypatch):
+    _fake_urlopen(monkeypatch, json.dumps({"result": {"ok": True}}).encode())
+    assert upl.mcp_post("http://h:8089", "x") == {"ok": True}
+
+    _fake_urlopen(monkeypatch, json.dumps({"result": "raw"}).encode())
+    assert upl.mcp_post("http://h:8089", "x") == "raw"
+
+    _fake_urlopen(monkeypatch, json.dumps({"other": 1}).encode())
+    assert upl.mcp_post("http://h:8089", "x") == {"other": 1}
+
+
+def test_walk_project_does_not_revisit_a_folder_or_loop_forever(monkeypatch, capsys):
+    """A project tree that names itself as its own child would otherwise spin."""
+    listings = {
+        "/": {"files": [], "folders": ["Vanilla"]},
+        "/Vanilla": {"files": [_program("/Vanilla/D2Game.dll")], "folders": ["Vanilla"]},
+    }
+    seen: list[str] = []
+
+    def fake_get(base, endpoint, timeout=60.0, **params):
+        seen.append(params["folder"])
+        return listings.get(params["folder"], {"files": [], "folders": []})
+
+    monkeypatch.setattr(upl, "mcp_get", fake_get)
+
+    found = upl.walk_project("http://h:8089")
+
+    assert [e["path"] for e in found] == ["/Vanilla/D2Game.dll"]
+    assert seen == ["/", "/Vanilla", "/Vanilla/Vanilla"]
+
+
+def test_a_folder_queued_twice_is_listed_only_once(monkeypatch):
+    """A duplicated child entry would otherwise double-count every Program
+    underneath it, and the plan's totals are what the operator reconciles the
+    run against."""
+    listings = {
+        "/": {"files": [], "folders": ["Vanilla", "Vanilla"]},
+        "/Vanilla": {"files": [_program("/Vanilla/D2Game.dll")], "folders": []},
+    }
+    visits: list[str] = []
+
+    def fake_get(base, endpoint, timeout=60.0, **params):
+        visits.append(params["folder"])
+        return listings[params["folder"]]
+
+    monkeypatch.setattr(upl, "mcp_get", fake_get)
+
+    found = upl.walk_project("http://h:8089")
+
+    assert [e["path"] for e in found] == ["/Vanilla/D2Game.dll"], "no duplicate Program"
+    assert visits == ["/", "/Vanilla"], "the second queue entry is dropped, not re-listed"
+
+
+def test_walk_project_ignores_a_folder_listing_that_is_not_a_mapping(monkeypatch):
+    monkeypatch.setattr(upl, "mcp_get", lambda base, endpoint, timeout=60.0, **p: "server error")
+
+    assert upl.walk_project("http://h:8089") == []
+
+
+# --------------------------------------------------------------------------- #
+# Checkout lifecycle
+# --------------------------------------------------------------------------- #
+
+
+def test_undo_checkout_closes_the_program_first_then_releases(monkeypatch):
+    posted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(upl, "mcp_post", lambda base, endpoint, **kw: (
+        posted.append((endpoint, kw)), {"status": "checkout_undone"})[1])
+
+    released, detail = upl.undo_checkout("http://h", "/Vanilla/1.01/D2Game.dll")
+
+    assert released is True and detail == "released"
+    assert [e for e, _ in posted] == ["close_program", "server/version_control/undo_checkout"]
+
+
+def test_undo_checkout_never_raises_when_close_program_fails(monkeypatch):
+    """close is best effort -- a failure there must not stop the release."""
+    def flaky(base, endpoint, **kw):
+        if endpoint == "close_program":
+            raise OSError("no such program")
+        return {"status": "checkout_undone"}
+
+    monkeypatch.setattr(upl, "mcp_post", flaky)
+
+    assert upl.undo_checkout("http://h", "/p") == (True, "released")
+
+
+def test_undo_checkout_reports_a_transport_failure_rather_than_raising(monkeypatch):
+    def boom(base, endpoint, **kw):
+        if endpoint == "close_program":
+            return {}
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(upl, "mcp_post", boom)
+    released, detail = upl.undo_checkout("http://h", "/p")
+
+    assert released is False and "connection reset" in detail
+
+
+def test_undo_checkout_reports_a_refusal_verbatim(monkeypatch):
+    monkeypatch.setattr(upl, "mcp_post",
+                        lambda base, endpoint, **kw: {"error": "D2Game.dll is in use"})
+
+    released, detail = upl.undo_checkout("http://h", "/p")
+
+    assert released is False
+    assert "is in use" in detail
+
+
+def test_undo_checkout_passes_a_plain_string_refusal_through(monkeypatch):
+    monkeypatch.setattr(upl, "mcp_post", lambda base, endpoint, **kw: "not checked out")
+
+    assert upl.undo_checkout("http://h", "/p") == (False, "not checked out")
+
+
+# --------------------------------------------------------------------------- #
+# probe_language_state -- the staleness oracle
+# --------------------------------------------------------------------------- #
+
+
+def _probe_env(monkeypatch, *, checkouts=(), checkout_ok=True, opened=None):
+    posted: list[str] = []
+
+    def fake_get(base, endpoint, timeout=60.0, **params):
+        if endpoint == "server/checkouts":
+            return {"checkouts": [{"path": p} for p in checkouts]}
+        return opened
+
+    def fake_post(base, endpoint, **params):
+        posted.append(endpoint)
+        if endpoint.endswith("checkout"):
+            return {"status": "checked_out"} if checkout_ok else {"status": "denied"}
+        return {"status": "checkout_undone"}
+
+    monkeypatch.setattr(upl, "mcp_get", fake_get)
+    monkeypatch.setattr(upl, "mcp_post", fake_post)
+    return posted
+
+
+def test_a_program_that_opens_read_write_is_current(monkeypatch):
+    posted = _probe_env(monkeypatch, opened={"success": True})
+
+    state, _ = upl.probe_language_state("http://h", "/p")
+
+    assert state == "current"
+    assert "server/version_control/checkout" in posted
+    assert "server/version_control/undo_checkout" in posted, "the probe must clean up after itself"
+
+
+def test_a_minor_language_change_is_reported_as_STALE(monkeypatch):
+    """FrontEndProgramProvider passes okToUpgrade=false, so a stale program
+    surfaces this message instead of being silently upgraded."""
+    _probe_env(monkeypatch, opened={"success": False,
+                                    "error": "Minor language change 4.6 -> 4.7"})
+
+    state, detail = upl.probe_language_state("http://h", "/p")
+
+    assert state == "stale"
+    assert "4.6 -> 4.7" in detail
+
+
+def test_a_major_language_change_is_also_stale(monkeypatch):
+    _probe_env(monkeypatch, opened={"error": "Major language change 3.0 -> 4.7"})
+
+    assert upl.probe_language_state("http://h", "/p")[0] == "stale"
+
+
+def test_an_unrecognised_open_failure_is_unknown_not_current(monkeypatch):
+    _probe_env(monkeypatch, opened={"error": "file not found"})
+
+    assert upl.probe_language_state("http://h", "/p")[0] == "unknown"
+
+
+def test_a_refused_checkout_is_unknown_and_takes_no_checkout_to_undo(monkeypatch):
+    posted = _probe_env(monkeypatch, checkout_ok=False)
+
+    state, detail = upl.probe_language_state("http://h", "/p")
+
+    assert state == "unknown"
+    assert "checkout failed" in detail
+    assert "server/version_control/undo_checkout" not in posted
+
+
+def test_a_preexisting_checkout_is_reused_and_NOT_released_by_the_probe(monkeypatch):
+    """Releasing a checkout the operator already held would discard their
+    local work."""
+    posted = _probe_env(monkeypatch, checkouts=("/p",), opened={"success": True})
+
+    assert upl.probe_language_state("http://h", "/p")[0] == "current"
+    assert posted == [], "no checkout taken, so none to undo"
+
+
+def test_a_checkout_the_probe_cannot_release_is_appended_to_leaked(monkeypatch):
+    monkeypatch.setattr(upl, "mcp_get", lambda base, endpoint, timeout=60.0, **p:
+                        {"checkouts": []} if endpoint == "server/checkouts" else {"success": True})
+    monkeypatch.setattr(upl, "mcp_post", lambda base, endpoint, **p:
+                        {"status": "checked_out"} if endpoint.endswith("/checkout")
+                        else {"error": "is in use"})
+    leaked: list[str] = []
+
+    upl.probe_language_state("http://h", "/p", leaked)
+
+    assert leaked == ["/p"]
+
+
+def test_a_transport_failure_mid_probe_is_unknown_and_still_releases(monkeypatch):
+    released: list[str] = []
+
+    def fake_get(base, endpoint, timeout=60.0, **params):
+        if endpoint == "server/checkouts":
+            return {"checkouts": []}
+        raise OSError("socket closed")
+
+    monkeypatch.setattr(upl, "mcp_get", fake_get)
+    monkeypatch.setattr(upl, "mcp_post", lambda base, endpoint, **p: (
+        released.append(endpoint), {"status": "checked_out" if endpoint.endswith("/checkout")
+                                    else "checkout_undone"})[1])
+
+    state, detail = upl.probe_language_state("http://h", "/p")
+
+    assert state == "unknown"
+    assert "socket closed" in detail
+    assert "server/version_control/undo_checkout" in released
+
+
+# --------------------------------------------------------------------------- #
+# run_folder -- timeout, log capture, bucketing
+# --------------------------------------------------------------------------- #
+
+
+def _run_folder(tmp_path, monkeypatch, runner, **overrides):
+    ghidra = _fake_ghidra(tmp_path / "gh")
+    monkeypatch.setattr(upl.subprocess, "run", runner)
+    kwargs = dict(ghidra_dir=ghidra, server="h:1", repo="diablo2", folder="/Vanilla/1.01",
+                  user="u", password="p", comment="c", apply_changes=False,
+                  timeout=5.0, log_dir=tmp_path / "logs")
+    kwargs.update(overrides)
+    return upl.run_folder(**kwargs)
+
+
+def test_run_folder_buckets_every_outcome_from_the_log(tmp_path, monkeypatch):
+    log = (
+        "INFO  REPORT: Processing project file: /Vanilla/1.01/D2Game.dll (HeadlessAnalyzer)\n"
+        "INFO  REPORT: Save succeeded for processed file: /Vanilla/1.01/D2Game.dll (HeadlessAnalyzer)\n"
+        "INFO  REPORT: Committed file changes to repository: /Vanilla/1.01/D2Game.dll (HeadlessAnalyzer)\n"
+        "WARN  Skipped processing for /Vanilla/1.01/Diablo II.exe -- failed to get exclusive"
+        " file checkout required for commit\n"
+        "ERROR /Vanilla/1.01/Fog.dll: this file was created with an older version of Ghidra.\n"
+        "ERROR /Vanilla/1.01/New.dll: this file was created with a newer version of Ghidra,"
+        " and can not be processed.\n"
+        "ERROR REPORT: Error trying to save changes to file: /Vanilla/1.01/Storm.dll\n"
+    )
+
+    class Done:
+        stdout, stderr, returncode = log, "", 0
+
+    result = _run_folder(tmp_path, monkeypatch, lambda cmd, **kw: Done())
+
+    assert result.processed == ["/Vanilla/1.01/D2Game.dll"]
+    assert result.saved == ["/Vanilla/1.01/D2Game.dll"]
+    assert result.committed == ["/Vanilla/1.01/D2Game.dll"]
+    assert result.no_exclusive_checkout == ["/Vanilla/1.01/Diablo II.exe"]
+    assert result.needs_upgrade_blocked == ["/Vanilla/1.01/Fog.dll"]
+    assert result.newer_than_ghidra == ["/Vanilla/1.01/New.dll"]
+    assert result.save_errors == ["/Vanilla/1.01/Storm.dll"]
+    assert result.unauthorized is False
+
+
+def test_run_folder_writes_the_whole_log_to_a_file_named_for_the_folder(tmp_path, monkeypatch):
+    class Done:
+        stdout, stderr, returncode = "out\n", "err\n", 0
+
+    result = _run_folder(tmp_path, monkeypatch, lambda cmd, **kw: Done())
+
+    assert Path(result.log_path).name == "Vanilla_1.01.log"
+    assert Path(result.log_path).read_text(encoding="utf-8") == "out\nerr\n"
+
+
+def test_the_root_folder_log_is_named_root_not_an_empty_string(tmp_path, monkeypatch):
+    class Done:
+        stdout, stderr, returncode = "", "", 0
+
+    result = _run_folder(tmp_path, monkeypatch, lambda cmd, **kw: Done(), folder="/")
+
+    assert Path(result.log_path).name == "root.log"
+
+
+def test_a_timeout_is_recorded_in_the_log_with_a_null_returncode(tmp_path, monkeypatch):
+    """The partial output is what says how far the run got; discarding it on
+    timeout leaves nothing to diagnose."""
+    def timing_out(cmd, **kw):
+        raise subprocess.TimeoutExpired(
+            cmd, 5.0,
+            output="INFO  REPORT: Processing project file: /Vanilla/1.01/D2Game.dll\n",
+            stderr="")
+
+    result = _run_folder(tmp_path, monkeypatch, timing_out)
+
+    assert result.returncode is None
+    assert result.processed == ["/Vanilla/1.01/D2Game.dll"], "partial progress is kept"
+    assert "*** TIMEOUT after 5.0s ***" in Path(result.log_path).read_text(encoding="utf-8")
+
+
+def test_a_timeout_with_BYTES_output_does_not_crash_the_parser(tmp_path, monkeypatch):
+    """TimeoutExpired carries bytes when the child was not opened in text mode;
+    concatenating those with a str raises inside the error handler itself."""
+    def timing_out(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd, 5.0, output=b"raw", stderr=b"raw")
+
+    result = _run_folder(tmp_path, monkeypatch, timing_out)
+
+    assert result.returncode is None
+    assert "*** TIMEOUT" in Path(result.log_path).read_text(encoding="utf-8")
+
+
+def test_an_auth_rejection_sets_the_unauthorized_flag(tmp_path, monkeypatch):
+    class Done:
+        stdout = "ERROR NotConnectedException: Unauthorized\n"
+        stderr, returncode = "", 1
+
+    result = _run_folder(tmp_path, monkeypatch, lambda cmd, **kw: Done())
+
+    assert result.unauthorized is True
+    assert result.returncode == 1
+
+
+def test_analyze_headless_is_refused_by_name_when_the_install_lacks_it(tmp_path):
+    with pytest.raises(SystemExit, match="analyzeHeadless not found"):
+        upl.analyze_headless_cmd(tmp_path / "not-a-ghidra")
+
+
+# --------------------------------------------------------------------------- #
+# Install discovery
+# --------------------------------------------------------------------------- #
+
+
+def test_an_explicit_ghidra_dir_wins_over_every_form_of_discovery(tmp_path):
+    assert upl.resolve_ghidra_dir(str(tmp_path)) == (Path(str(tmp_path)), "--ghidra-dir")
+
+
+def test_the_RUNNING_ghidra_outranks_the_environment_variable(tmp_path, monkeypatch):
+    """An upgrade written by the wrong Ghidra version is not something you can
+    take back, and GHIDRA_INSTALL_DIR has been observed naming a different
+    install than the one running."""
+    running = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+    monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+    monkeypatch.setattr(upl, "running_ghidra_dir", lambda: running)
+
+    assert upl.resolve_ghidra_dir(None) == (running, "running Ghidra process")
+
+
+def test_the_env_var_is_used_only_when_it_names_a_real_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl, "running_ghidra_dir", lambda: None)
+    monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path / "absent"))
+    monkeypatch.setattr(upl.Path, "glob", lambda self, pattern: iter(()))
+
+    resolved, source = upl.resolve_ghidra_dir(None)
+
+    assert source == "unresolved"
+    assert resolved == Path(str(tmp_path / "absent"))
+
+
+def test_a_valid_env_var_is_taken_before_scanning_the_disk(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl, "running_ghidra_dir", lambda: None)
+    monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+    assert upl.resolve_ghidra_dir(None) == (Path(str(tmp_path)), "$GHIDRA_INSTALL_DIR")
+
+
+def test_the_filesystem_scan_takes_the_last_install_by_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl, "running_ghidra_dir", lambda: None)
+    monkeypatch.delenv("GHIDRA_INSTALL_DIR", raising=False)
+    old = _fake_ghidra(tmp_path / "ghidra_11.0_PUBLIC")
+    new = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+    bare = tmp_path / "ghidra_13.0_PUBLIC"      # no support/ -- not a candidate
+    bare.mkdir()
+
+    monkeypatch.setattr(
+        upl.Path, "glob",
+        lambda self, pattern: iter([old, new, bare]) if pattern == "ghidra_*_PUBLIC" else iter(()))
+
+    assert upl.resolve_ghidra_dir(None) == (new, "filesystem scan")
+
+
+def test_the_running_install_probe_is_windows_only(monkeypatch):
+    monkeypatch.setattr(upl.sys, "platform", "linux")
+
+    assert upl.running_ghidra_dir() is None
+
+
+def test_the_running_install_comes_from_the_class_loader_line(tmp_path, monkeypatch):
+    """Keyed on `ghidra.GhidraClassLoader`, never a bare `*ghidra*` glob: this
+    repo's own VSCode Java language server carries the workspace path
+    `ghidra-mcp` on its command line and would match one."""
+    real = _fake_ghidra(tmp_path / "ghidra_12.1.2_PUBLIC")
+    listing = (
+        f'"C:\\jdk\\java.exe" -cp X;{real}\\support\\lib -Dfoo '
+        'com.example.LanguageServer C:\\src\\ghidra-mcp\n'
+        f'"C:\\jdk\\java.exe" -cp {real}\\Ghidra\\lib;q ghidra.GhidraClassLoader '
+        'ghidra.GhidraRun\n'
+    )
+
+    class Done:
+        stdout, stderr, returncode = listing, "", 0
+
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+    monkeypatch.setattr(upl.subprocess, "run", lambda cmd, **kw: Done())
+
+    assert upl.running_ghidra_dir() == Path(str(real))
+
+
+def test_a_class_loader_line_naming_a_dir_without_support_is_rejected(tmp_path, monkeypatch):
+    class Done:
+        stdout = ('"java.exe" -cp C:\\nope\\ghidra_12.1.2_PUBLIC\\lib;q '
+                  'ghidra.GhidraClassLoader ghidra.GhidraRun\n')
+        stderr, returncode = "", 0
+
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+    monkeypatch.setattr(upl.subprocess, "run", lambda cmd, **kw: Done())
+
+    assert upl.running_ghidra_dir() is None
+
+
+def test_the_running_install_probe_survives_powershell_being_unavailable(monkeypatch):
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+
+    def missing(cmd, **kw):
+        raise FileNotFoundError("powershell.exe")
+
+    monkeypatch.setattr(upl.subprocess, "run", missing)
+
+    assert upl.running_ghidra_dir() is None
+
+
+def test_the_running_install_probe_survives_a_timeout(monkeypatch):
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+
+    def slow(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd, 60)
+
+    monkeypatch.setattr(upl.subprocess, "run", slow)
+
+    assert upl.running_ghidra_dir() is None
+
+
+# --------------------------------------------------------------------------- #
+# Credential source discovery
+# --------------------------------------------------------------------------- #
+
+
+#: The exact label credential_sources() gives the registry provider. Matched
+#: exactly, not as a substring -- pytest bakes the test's own name into
+#: tmp_path, so a substring check hits any test whose name contains the word.
+REGISTRY_LABEL = "registry:HKCU\\Environment"
+
+
+def test_the_registry_is_consulted_only_on_windows(tmp_path, monkeypatch):
+    """A variable set after this process started is absent from os.environ; the
+    user-scope registry value is current."""
+    monkeypatch.setattr(upl.sys, "platform", "linux")
+    labels = [label for label, _ in upl.credential_sources(tmp_path)]
+
+    assert REGISTRY_LABEL not in labels
+    assert labels[0] == "env"
+    assert len(labels) == 3, "env, <ghidra_dir>/.env, <cwd>/.env"
+
+
+def test_an_unreadable_registry_is_not_fatal(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+    fake = type(sys)("winreg")
+    fake.HKEY_CURRENT_USER = 0
+
+    def open_key(*a, **k):
+        raise OSError("access denied")
+
+    fake.OpenKey = open_key
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+
+    labels = [label for label, _ in upl.credential_sources(tmp_path)]
+
+    assert REGISTRY_LABEL not in labels
+    assert labels[0] == "env", "the other providers still work"
+
+
+def test_registry_values_are_offered_as_a_credential_source(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl.sys, "platform", "win32")
+    stored = {"GHIDRA_SERVER_PASSWORD": "from-registry"}
+
+    class _Key:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    fake = type(sys)("winreg")
+    fake.HKEY_CURRENT_USER = 0
+    fake.OpenKey = lambda *a, **k: _Key()
+
+    def query(key, name):
+        if name not in stored:
+            raise FileNotFoundError(name)
+        return stored[name], 1
+
+    fake.QueryValueEx = query
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+
+    sources = dict(upl.credential_sources(tmp_path))
+
+    assert sources[REGISTRY_LABEL] == {"GHIDRA_SERVER_PASSWORD": "from-registry"}
+
+
+def test_no_password_anywhere_returns_unset_rather_than_an_empty_string(tmp_path, monkeypatch):
+    """An empty password is a credential the server would reject; "unset" is
+    what makes main() refuse instead of attempting an auth that cannot work."""
+    monkeypatch.setattr(upl, "credential_sources",
+                        lambda d: [("env", {"UNRELATED": "x"}), ("cwd/.env", {})])
+
+    assert upl.resolve_password(tmp_path) == (None, "unset")
+
+
+def test_the_username_falls_back_to_the_os_account(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl, "credential_sources", lambda d: [("env", {})])
+    monkeypatch.setenv("USERNAME", "someone")
+
+    assert upl.resolve_user(tmp_path) == "someone"
+
+
+def test_the_username_has_a_last_resort_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(upl, "credential_sources", lambda d: [("env", {})])
+    monkeypatch.delenv("USERNAME", raising=False)
+
+    assert upl.resolve_user(tmp_path) == "benam"
+
+
+def test_the_repo_alone_can_come_from_the_live_instance(tmp_path, monkeypatch):
+    """`--server` without `--repo` must still consult /project/info rather than
+    short-circuiting on the partial flag pair."""
+    monkeypatch.setattr(upl, "mcp_get", lambda base, endpoint, timeout=60.0, **p:
+                        {"project": "diablo2"})
+
+    server, repo, origin = upl.resolve_server_and_repo("http://h", tmp_path, "h:13100", None)
+
+    assert (server, repo) == ("h:13100", "diablo2")
+    assert "live Ghidra" in origin
+
+
+def test_the_server_falls_back_to_the_dotenv_host_and_port(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text(
+        "GHIDRA_SERVER_HOST=ghidra-host\nGHIDRA_SERVER_PORT=13100\n", encoding="utf-8")
+    monkeypatch.setattr(upl, "mcp_get", lambda *a, **k: {"project": "diablo2"})
+
+    server, repo, origin = upl.resolve_server_and_repo("http://h", tmp_path, None, None)
+
+    assert (server, repo) == ("ghidra-host:13100", "diablo2")
+    assert ".env" in origin


### PR DESCRIPTION
Pays off the coverage debt that has been red-lining pull requests which touch no Python at all, and raises the floor back above where it was before the debt appeared.

## Background

Commit `6f7e7e8` dissolved `scripts/` into `tools/`. `tools/` is a coverage source and `scripts/` was not, so 533 uncovered statements moved into the denominator in a single commit. Nothing got less tested - the measured scope grew. The floor was dropped 63.6 to 58 to 55 to unblock the queue, which was a stopgap. The comment in `tests.yml` named the two honest ways back: cover those three operator scripts, or scope them out.

They are covered. `[tool.coverage.run] omit` is untouched.

## Result

**Coverage 57.24% to 69.22%. Floor 55 to 67.**

| Module | Before | After |
| --- | --- | --- |
| `tools/upgrade_project_language.py` | 530 stmts / 343 missed / 35% | 530 / 1 / 99% |
| `tools/build_reference_index.py` | 147 / 147 / 0% | 147 / 1 / 99% |
| `tools/ghidra_server_health_check.py` | 43 / 43 / 0% | 43 / 1 / 98% |
| Total | 4425 / 1892 / 57.24% | 4425 / 1362 / 69.22% |

The single missed line in each is `sys.exit(main())` under the `__main__` guard.

The expectation going in was that the untestable parts would need scoping out. There weren't any - every external call goes through an injectable seam, including the Windows-only PowerShell probe and the `winreg` source.

`upgrade_project_language.py` already had a test file, but it covered only leaf helpers. The 343 missed statements were `main()` itself, lines 599 to 1056 - the entire driver. The new `test_upgrade_project_language_main.py` covers it and pins the behaviours CLAUDE.md documents as traps: the 24-hour refusal on a repeated whole-project `--apply`, MSYS mangling of `--folder`, the unaccounted-program reconciliation, saved-versus-committed, and the checkout-leak bookkeeping.

153 new tests. 713 passed, 8 skipped - the same pre-existing platform gates. Nothing skipped or xfailed to reach the number.

## Why the floor is 67 and not 68

A 2.2 point margin instead of the usual 1. The outage this is cleaning up was caused by a 0.5 point knife-edge, and these numbers are measured on Windows while the gate runs on Ubuntu. That risk was sized rather than guessed: only 13 platform-forked branches exist in the whole repo, and version skew measured at 69.22% on 3.13 against 69.31% on 3.10, under 0.1 of a point.

## Defect found while covering, not fixed here

`--verify` writes leaked checkouts to a hardcoded path while `--release-checkouts` reads the configurable `--stray-file`. Passing a non-default `--stray-file` therefore strands checkouts silently. Current behaviour is pinned with an explicit `NOTE:` rather than changed, since fixing it is outside this change.
