### PR TITLE
docs(params): describe every advertised parameter (294 to 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,48 @@ One shape bug this exposed and fixed: parameters can now declare that an empty
 string is *meaningful*, rather than treating empty as absent. Clearing a comment
 did not work end to end before that.
 
+### Every schema parameter now describes itself
+
+`/mcp/schema` used to advertise **294 parameters with no description at all** —
+239 of the 674 `@Param` declarations on `@McpTool` methods, plus all 55
+parameters of the hand-registered routes in `ManualToolDescriptors`. The bridge
+builds each tool's `inputSchema` from that schema, so those reached the model as
+a bare name and a type, and it had to guess formats the server already knew:
+whether an address wants a `0x` prefix, whether a count is bytes or elements,
+what a boolean does in its *false* state. That guessing is the expensive half of
+a large tool surface, and nothing failed while it went on — the annotation
+compiled, the endpoint worked, the schema was just quieter than it should be.
+
+All 294 are now written against what the code actually does with the value, and
+`ParamDescriptionCoverageTest` (offline) fails the build if a new one appears.
+
+The descriptions record behaviour that was previously only discoverable by
+experiment, for example:
+
+- **Paging is not uniform.** Endpoints going through `ServiceUtils.paged` treat
+  `limit <= 0` as "no limit"; `search_strings`, `list_functions_enhanced`,
+  `list_external_locations`, `search_functions_enhanced` and `find_code_gaps`
+  slice by hand, so `limit=0` returns an **empty** page there. `list_class_members`
+  is neither — it clamps `limit` to a minimum of 1, so `0` returns one member.
+- **Units.** `create_array_type.length` is elements; `resize_struct.new_size`,
+  `create_memory_block.size`, `add_struct_field.offset`, `max_scan_bytes` and
+  `field_offset` are bytes; `search_strings.min_length` is characters of decoded
+  text.
+- **Silent no-ops.** `batch_rename_function_components.return_type` is resolved
+  by exact data-type-manager *path*, not the recursive resolver, and a failed
+  lookup is skipped without error while the call still reports success.
+- **Five parameters are accepted and never read** by the method that declares
+  them: `analyze_data_region.include_assembly_patterns`,
+  `detect_array_bounds.analyze_loop_bounds`, `detect_array_bounds.analyze_indexing`,
+  `get_assembly_context.include_patterns`, and
+  `run_ghidra_script.capture_output`. Each is now described as such rather than
+  as a switch that does something.
+
+One existing description was wrong rather than missing and is corrected:
+`search_strings.encoding` claimed to be a "String encoding filter (omit for all
+encodings)". It never filtered — the value is echoed into each match's
+`encoding` field, substituting the literal `ascii` when blank.
+
 ### MCP-protocol conformance suite
 
 `tests/conformance/` drives the server through a real MCP client rather than raw

--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -277,10 +277,25 @@ public class AnalysisService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String startAddressStr,
-            @Param(value = "max_scan_bytes", source = ParamSource.BODY, defaultValue = "1024") int maxScanBytes,
-            @Param(value = "include_xref_map", source = ParamSource.BODY, defaultValue = "true") boolean includeXrefMap,
-            @Param(value = "include_assembly_patterns", source = ParamSource.BODY, defaultValue = "true") boolean includeAssemblyPatterns,
-            @Param(value = "include_boundary_detection", source = ParamSource.BODY, defaultValue = "true") boolean includeBoundaryDetection,
+            @Param(value = "max_scan_bytes", source = ParamSource.BODY, defaultValue = "1024",
+                   description = "How many BYTES forward from `address` to walk while collecting "
+                               + "references and hunting the next named symbol (default 1024). String "
+                               + "detection only ever reads the first 256 bytes of whatever the scan "
+                               + "covered.") int maxScanBytes,
+            @Param(value = "include_xref_map", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) adds xref_map: a per-byte map from address to the "
+                               + "sources referencing it, for every byte in the scanned range that has at "
+                               + "least one. False keeps the aggregate counts and drops the map, which is "
+                               + "most of the payload on a heavily referenced region.") boolean includeXrefMap,
+            @Param(value = "include_assembly_patterns", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Accepted but currently not read: nothing in this endpoint branches on it "
+                               + "and no assembly-pattern block is produced either way. Setting it changes "
+                               + "nothing today.") boolean includeAssemblyPatterns,
+            @Param(value = "include_boundary_detection", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) stops the forward scan at the first named symbol that "
+                               + "is not a DAT_ autogen, so the region ends where the next documented global "
+                               + "begins. False scans the full max_scan_bytes whatever symbols it "
+                               + "crosses.") boolean includeBoundaryDetection,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -450,9 +465,16 @@ public class AnalysisService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "analyze_loop_bounds", source = ParamSource.BODY, defaultValue = "true") boolean analyzeLoopBounds,
-            @Param(value = "analyze_indexing", source = ParamSource.BODY, defaultValue = "true") boolean analyzeIndexing,
-            @Param(value = "max_scan_range", source = ParamSource.BODY, defaultValue = "2048") int maxScanRange,
+            @Param(value = "analyze_loop_bounds", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Accepted but currently not read: the size estimate comes from "
+                               + "cross-references only and no loop-bound analysis runs either "
+                               + "way.") boolean analyzeLoopBounds,
+            @Param(value = "analyze_indexing", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Accepted but currently not read: no indexing analysis runs either "
+                               + "way.") boolean analyzeIndexing,
+            @Param(value = "max_scan_range", source = ParamSource.BODY, defaultValue = "2048",
+                   description = "How many BYTES forward from `address` to scan for references while "
+                               + "estimating the array's extent (default 2048).") int maxScanRange,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -517,8 +539,12 @@ public class AnalysisService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String structAddressStr,
-            @Param(value = "field_offset", source = ParamSource.BODY, defaultValue = "0") int fieldOffset,
-            @Param(value = "num_examples", source = ParamSource.BODY, defaultValue = "5") int numExamples,
+            @Param(value = "field_offset", source = ParamSource.BODY, defaultValue = "0",
+                   description = "BYTE offset of the field inside the struct at struct_address; context is "
+                               + "gathered at struct_address + this. Must be 0 to 65536.") int fieldOffset,
+            @Param(value = "num_examples", source = ParamSource.BODY, defaultValue = "5",
+                   description = "How many referencing sites to report: 1 to 50, default 5. A value "
+                               + "outside that range is REJECTED, not clamped.") int numExamples,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         // MAJOR FIX #7: Validate input parameters
         if (fieldOffset < 0 || fieldOffset > MAX_FIELD_OFFSET) {
@@ -2175,11 +2201,26 @@ public class AnalysisService {
         @McpTool(path = "/analyze_function_complete", description = "Comprehensive single-call function analysis. Accepts function name or address.", category = "analysis")
     public Response analyzeFunctionComplete(
             @Param(value = "name", description = "Function reference (name or address)") String name,
-            @Param(value = "include_xrefs", defaultValue = "true") boolean includeXrefs,
-            @Param(value = "include_callees", defaultValue = "true") boolean includeCallees,
-            @Param(value = "include_callers", defaultValue = "true") boolean includeCallers,
-            @Param(value = "include_disasm", defaultValue = "true") boolean includeDisasm,
-            @Param(value = "include_variables", defaultValue = "true") boolean includeVariables,
+            @Param(value = "include_xrefs", defaultValue = "true",
+                   description = "True (the default) adds `xrefs` — the sources referencing the entry "
+                               + "point — capped at the first 100. `xref_count` counts what was listed, so "
+                               + "a value of exactly 100 may mean 'more than 100'; use get_xrefs_to for the "
+                               + "true total.") boolean includeXrefs,
+            @Param(value = "include_callees", defaultValue = "true",
+                   description = "True (the default) adds `callees`, the names of the functions this one "
+                               + "calls, and may add a wrapper_hint when the body is a thin "
+                               + "forwarder.") boolean includeCallees,
+            @Param(value = "include_callers", defaultValue = "true",
+                   description = "True (the default) adds `callers`, the names of the functions that call "
+                               + "this one.") boolean includeCallers,
+            @Param(value = "include_disasm", defaultValue = "true",
+                   description = "True (the default) adds `disassembly`: address plus MNEMONIC only, no "
+                               + "operands, capped at the first 100 instructions of the body. Use "
+                               + "disassemble_function when you need operands or the whole "
+                               + "body.") boolean includeDisasm,
+            @Param(value = "include_variables", defaultValue = "true",
+                   description = "True (the default) adds the function's parameters and locals with their "
+                               + "types and storage.") boolean includeVariables,
             @Param(value = "include_completeness", defaultValue = "false", description = "Include completeness scoring (undefined vars, naming violations, recommendations)") boolean includeCompleteness,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
@@ -2421,8 +2462,13 @@ public class AnalysisService {
             @Param(value = "is_external", description = "Filter by external classification (true=only external, false=exclude external, omit for any)", defaultValue = "") Boolean isExternalFilter,
             @Param(value = "regex", defaultValue = "false", description = "Use regex matching") boolean regex,
             @Param(value = "sort_by", defaultValue = "address", description = "Sort field") String sortBy,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of matches to skip before this page starts; 0 begins at the "
+                               + "first. Applied after every filter and the sort.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum matches returned in this page (default 100). This endpoint "
+                               + "slices directly, so 0 returns an EMPTY page rather than everything — page "
+                               + "with offset against the `total` the response reports.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -4435,8 +4481,13 @@ public class AnalysisService {
     public Response findCodeGaps(
             @Param(value = "min_size", defaultValue = "1",
                    description = "Minimum gap size in addressable units to report (increase to filter alignment padding)") int minSize,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of gaps to skip before this page starts; 0 begins at the first. "
+                               + "Applied after the min_size filter.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum gaps returned in this page (default 100). This endpoint slices "
+                               + "directly, so 0 returns an EMPTY page rather than everything — page with "
+                               + "offset against the `total` the response reports.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();

--- a/src/main/java/com/xebyte/core/AnalysisService.java
+++ b/src/main/java/com/xebyte/core/AnalysisService.java
@@ -226,7 +226,9 @@ public class AnalysisService {
      */
     @McpTool(path = "/run_analysis", method = "POST", description = "Trigger auto-analysis on program", category = "analysis")
     public Response runAnalysis(
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/main/java/com/xebyte/core/CommentService.java
+++ b/src/main/java/com/xebyte/core/CommentService.java
@@ -269,8 +269,19 @@ public class CommentService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddress,
-            @Param(value = "decompiler_comments", source = ParamSource.BODY, defaultValue = "[]") List<Map<String, String>> decompilerComments,
-            @Param(value = "disassembly_comments", source = ParamSource.BODY, defaultValue = "[]") List<Map<String, String>> disassemblyComments,
+            @Param(value = "decompiler_comments", source = ParamSource.BODY, defaultValue = "[]",
+                   description = "JSON array of {address, comment} objects setting PRE comments — the "
+                               + "lines the decompiler shows above a statement. Every entry carries its "
+                               + "OWN address (0x<hex> or <space>:<hex>); the top-level `address` is the "
+                               + "function entry and is not used for these. An entry missing either key, "
+                               + "or whose address does not parse, is skipped silently — compare "
+                               + "decompiler_comments_set against what you sent. An empty comment string "
+                               + "clears that address's PRE comment.") List<Map<String, String>> decompilerComments,
+            @Param(value = "disassembly_comments", source = ParamSource.BODY, defaultValue = "[]",
+                   description = "JSON array of {address, comment} objects setting EOL comments — the "
+                               + "trailing comment on a listing line. Same per-entry address rules and the "
+                               + "same silent skip as decompiler_comments; an empty comment string clears "
+                               + "that address's EOL comment.") List<Map<String, String>> disassemblyComments,
             @Param(value = "plate_comment", source = ParamSource.BODY, defaultValue = "null",
                    description = "Plate comment text. Omit to leave existing plate untouched. Pass empty string to explicitly clear.") String plateComment,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
@@ -467,9 +478,15 @@ public class CommentService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddress,
-            @Param(value = "clear_plate", source = ParamSource.BODY, defaultValue = "true") boolean clearPlate,
-            @Param(value = "clear_pre", source = ParamSource.BODY, defaultValue = "true") boolean clearPre,
-            @Param(value = "clear_eol", source = ParamSource.BODY, defaultValue = "true") boolean clearEol,
+            @Param(value = "clear_plate", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) removes the function's plate comment — the block "
+                               + "above its entry. False leaves it alone.") boolean clearPlate,
+            @Param(value = "clear_pre", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) removes every PRE (decompiler) comment inside the "
+                               + "function body. False leaves them alone.") boolean clearPre,
+            @Param(value = "clear_eol", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) removes every EOL (disassembly) comment inside the "
+                               + "function body. False leaves them alone.") boolean clearEol,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();

--- a/src/main/java/com/xebyte/core/DataTypeService.java
+++ b/src/main/java/com/xebyte/core/DataTypeService.java
@@ -1457,7 +1457,9 @@ public class DataTypeService {
             @Param(value = "field_name", source = ParamSource.BODY,
                    description = "Field name or offset:N (e.g. offset:0x88).") String fieldName,
             @Param(value = "new_type", source = ParamSource.BODY) String newType,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         return modifyStructField(structName, fieldName, newType, "", programName);
     }
 
@@ -1473,7 +1475,9 @@ public class DataTypeService {
                    description = "Field name or offset:N.") String fieldName,
             @Param(value = "embedded_struct", source = ParamSource.BODY,
                    description = "Existing structure type to embed by value.") String embeddedStruct,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         if (embeddedStruct == null || embeddedStruct.isEmpty()) {
             return Response.err("embedded_struct is required");
         }
@@ -1493,7 +1497,9 @@ public class DataTypeService {
                    description = "When true (default), keep defined fields that still fit; when false with force, trailing layout may be cleared before resize.") boolean preserveFields,
             @Param(value = "force", source = ParamSource.BODY, defaultValue = "false",
                    description = "Allow shrink even when defined fields extend past new_size (clips trailing layout).") boolean force,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
 
         if (name == null || name.isEmpty()) {
             return Response.err("name is required");
@@ -1575,7 +1581,9 @@ public class DataTypeService {
                    description = "Delete a 1-byte placeholder/Demangler stub before recreate (default true).") boolean replacePlaceholder,
             @Param(value = "force", source = ParamSource.BODY, defaultValue = "false",
                    description = "Delete an existing full-sized struct before recreate (fails if referenced).") boolean force,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
 
         if (name == null || name.isEmpty()) {
             return Response.err("name is required");
@@ -1690,7 +1698,9 @@ public class DataTypeService {
             @Param(value = "type_name", source = ParamSource.BODY) String typeName,
             @Param(value = "delete_demangler_stub", source = ParamSource.BODY, defaultValue = "true",
                    description = "Delete /Demangler/* stubs (size <= 1) when a larger type with the same name exists.") boolean deleteDemanglerStub,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
 
         if (typeName == null || typeName.isEmpty()) {
             return Response.err("type_name is required");

--- a/src/main/java/com/xebyte/core/DataTypeService.java
+++ b/src/main/java/com/xebyte/core/DataTypeService.java
@@ -103,8 +103,14 @@ public class DataTypeService {
             // the declaration was wrong.
             @Param(value = "category", defaultValue = "",
                    description = "Category filter; omit to list all types") String category,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -201,8 +207,14 @@ public class DataTypeService {
     @McpTool(path = "/search_data_types", description = "Search data types by pattern", category = "datatype")
     public Response searchDataTypes(
             @Param(value = "pattern", description = "Search pattern") String pattern,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -589,9 +601,18 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_enum", method = "POST", description = "Create an enum data type", category = "datatype")
     public Response createEnum(
-            @Param(value = "name", source = ParamSource.BODY) String name,
-            @Param(value = "values", source = ParamSource.BODY, fieldsJson = true) String valuesJson,
-            @Param(value = "size", source = ParamSource.BODY, defaultValue = "4") int size,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "New enum type name, e.g. UnitType. Creation FAILS if a type with this "
+                               + "name already exists — delete it first or choose another name.") String name,
+            @Param(value = "values", source = ParamSource.BODY, fieldsJson = true,
+                   description = "JSON object mapping member name to integer value, e.g. "
+                               + "{\"UNIT_PLAYER\": 0, \"UNIT_MONSTER\": 1}. Values may be numbers, decimal "
+                               + "strings, or 0x-prefixed hex strings; floats and non-numeric strings are "
+                               + "rejected. Member names are checked for UPPERCASE_SNAKE_CASE and any "
+                               + "complaint comes back as a warning, not a failure.") String valuesJson,
+            @Param(value = "size", source = ParamSource.BODY, defaultValue = "4",
+                   description = "Storage width of the enum in BYTES — 1, 2, 4 or 8 only (default 4). "
+                               + "Anything else is rejected.") int size,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -677,8 +698,17 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_union", method = "POST", description = "Create a union data type", category = "datatype")
     public Response createUnion(
-            @Param(value = "name", source = ParamSource.BODY) String name,
-            @Param(value = "fields", source = ParamSource.BODY, fieldsJson = true) String fieldsJson,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "New union type name. An existing same-named type is REPLACED here, "
+                               + "unlike create_enum, which refuses.") String name,
+            @Param(value = "fields", source = ParamSource.BODY, fieldsJson = true,
+                   description = "JSON array of member objects, same shape as create_struct: required "
+                               + "keys name and type; field_name/fieldName and "
+                               + "field_type/fieldType/data_type/dataType are accepted as alternates. Any "
+                               + "offset key is IGNORED — union members all start at 0. A member whose type "
+                               + "cannot be resolved is skipped and reported under fields_skipped instead "
+                               + "of failing the call. Names get the project's Hungarian prefix applied "
+                               + "automatically.") String fieldsJson,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -750,8 +780,12 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_typedef", method = "POST", description = "Create a typedef alias", category = "datatype")
     public Response createTypedef(
-            @Param(value = "name", source = ParamSource.BODY) String name,
-            @Param(value = "base_type", source = ParamSource.BODY) String baseType,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "New typedef (alias) name. An existing same-named type is replaced.") String name,
+            @Param(value = "base_type", source = ParamSource.BODY,
+                   description = "Type the alias resolves to. Resolution is recursive, so pointer chains "
+                               + "(int**), array syntax (dword[16]), well-known C types and existing "
+                               + "struct/enum names all work.") String baseType,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -805,8 +839,12 @@ public class DataTypeService {
      */
     @McpTool(path = "/clone_data_type", method = "POST", description = "Clone a data type with new name", category = "datatype")
     public Response cloneDataType(
-            @Param(value = "source_type", source = ParamSource.BODY) String sourceType,
-            @Param(value = "new_name", source = ParamSource.BODY) String newName,
+            @Param(value = "source_type", source = ParamSource.BODY,
+                   description = "Simple name of the existing type to copy, matched across every "
+                               + "category (no /path prefix needed).") String sourceType,
+            @Param(value = "new_name", source = ParamSource.BODY,
+                   description = "Name for the copy. The clone is independent — later edits to "
+                               + "source_type do not follow it.") String newName,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -858,9 +896,16 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_array_type", method = "POST", description = "Create an array data type", category = "datatype")
     public Response createArrayType(
-            @Param(value = "base_type", source = ParamSource.BODY) String baseType,
-            @Param(value = "length", source = ParamSource.BODY, defaultValue = "1") int length,
-            @Param(value = "name", source = ParamSource.BODY, defaultValue = "") String name,
+            @Param(value = "base_type", source = ParamSource.BODY,
+                   description = "Element type. Resolution is recursive, so pointer chains (int**), "
+                               + "nested array syntax and existing struct/enum names all work.") String baseType,
+            @Param(value = "length", source = ParamSource.BODY, defaultValue = "1",
+                   description = "Number of ELEMENTS, not bytes — total size is length x "
+                               + "sizeof(base_type). Must be positive; default 1.") int length,
+            @Param(value = "name", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional name for the array type. Omit to let Ghidra name it after the "
+                               + "element type (e.g. dword[16]); the response reports the name actually "
+                               + "used.") String name,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -919,8 +964,14 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_pointer_type", method = "POST", description = "Create a pointer data type", category = "datatype")
     public Response createPointerType(
-            @Param(value = "base_type", source = ParamSource.BODY) String baseType,
-            @Param(value = "name", source = ParamSource.BODY, defaultValue = "") String name,
+            @Param(value = "base_type", source = ParamSource.BODY,
+                   description = "Type pointed at. `void` is special-cased to Ghidra's void type; "
+                               + "everything else resolves recursively, so int**, dword[16] and existing "
+                               + "struct/enum names all work.") String baseType,
+            @Param(value = "name", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional name for the pointer type. Omit to let Ghidra name it after "
+                               + "the pointee (e.g. UnitAny *); the response reports the name actually "
+                               + "used.") String name,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -985,9 +1036,19 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_function_signature", method = "POST", description = "Create a function signature data type", category = "datatype")
     public Response createFunctionSignature(
-            @Param(value = "name", source = ParamSource.BODY) String name,
-            @Param(value = "return_type", source = ParamSource.BODY) String returnType,
-            @Param(value = "parameters", source = ParamSource.BODY) String parametersJson,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Name for the function-definition type. This creates a SIGNATURE in the "
+                               + "data type manager; it changes no function in the listing.") String name,
+            @Param(value = "return_type", source = ParamSource.BODY,
+                   description = "Return type, resolved recursively (pointer chains, arrays, struct "
+                               + "names). Required — pass `void` for no return value.") String returnType,
+            @Param(value = "parameters", source = ParamSource.BODY,
+                   description = "JSON array of parameter objects, e.g. "
+                               + "[{\"name\":\"dwId\",\"type\":\"uint\"},{\"name\":\"pUnit\",\"type\":\"void *\"}]. "
+                               + "Only the TYPES are used: parameter names are discarded and the created "
+                               + "signature has unnamed arguments. Parsing is a plain comma/colon split, so "
+                               + "a type containing a comma or a colon does not survive it, and a parameter "
+                               + "whose type cannot be resolved is dropped silently.") String parametersJson,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -1089,8 +1150,19 @@ public class DataTypeService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "type_name", source = ParamSource.BODY) String typeName,
-            @Param(value = "clear_existing", source = ParamSource.BODY, defaultValue = "true") boolean clearExisting,
+            @Param(value = "type_name", source = ParamSource.BODY,
+                   description = "Type to apply at the address. Any name the resolver understands: a "
+                               + "built-in (uint, char *), an existing struct/enum/typedef name, a pointer "
+                               + "chain (int**), or array syntax basetype[count] such as dword[10]. Create "
+                               + "the type first with create_struct / create_enum / create_array_type if it "
+                               + "does not exist yet.") String typeName,
+            @Param(value = "clear_existing", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) clears whatever code or data occupies the FULL target "
+                               + "range first, which is what lets you retype an address sitting inside a "
+                               + "wider existing unit. False leaves existing units alone, and the write "
+                               + "then fails with a conflict if anything overlaps. Clearing is also what "
+                               + "arms the guard that refuses a write which would destroy named "
+                               + "neighbours.") boolean clearExisting,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName,
             @Param(value = "strict_mode", source = ParamSource.BODY, defaultValue = "",
                    description = "Optional per-call override for naming enforcement: 'enforce' / 'warn' / 'off'. Omit to use the project/global setting.")
@@ -1263,7 +1335,10 @@ public class DataTypeService {
             description = "Delete a data type by name. Fails if the type is referenced; use resolve_duplicate_type first to remove unused /Demangler 1-byte stubs when a full type exists.",
             category = "datatype")
     public Response deleteDataType(
-            @Param(value = "type_name", source = ParamSource.BODY) String typeName,
+            @Param(value = "type_name", source = ParamSource.BODY,
+                   description = "Simple name of the type to delete, matched across every category (no "
+                               + "/path prefix needed). Deletion fails while anything still references "
+                               + "the type.") String typeName,
             @Param(value = "resolve_demangler_duplicate", source = ParamSource.BODY, defaultValue = "false",
                    description = "If delete fails, attempt resolve_duplicate_type to remove a /Demangler size-1 stub when a larger same-named type exists.") boolean resolveDemanglerDuplicate,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
@@ -1335,11 +1410,19 @@ public class DataTypeService {
      */
     @McpTool(path = "/modify_struct_field", method = "POST", description = "Modify a field in a structure. Fields can be identified by name or by offset (for unnamed fields). For layout size changes (grow/shrink padding), use resize_struct instead of manual delete+create.", category = "datatype")
     public Response modifyStructField(
-            @Param(value = "struct_name", source = ParamSource.BODY) String structName,
+            @Param(value = "struct_name", source = ParamSource.BODY,
+                   description = "Simple name of the existing structure to edit, matched across every "
+                               + "category (no /path prefix needed).") String structName,
             @Param(value = "field_name", source = ParamSource.BODY, defaultValue = "",
                    description = "Field name to modify. For unnamed fields, use 'offset:N' (e.g., 'offset:16') to identify by byte offset.") String fieldName,
-            @Param(value = "new_type", source = ParamSource.BODY, defaultValue = "") String newType,
-            @Param(value = "new_name", source = ParamSource.BODY, defaultValue = "") String newName,
+            @Param(value = "new_type", source = ParamSource.BODY, defaultValue = "",
+                   description = "Replacement type for the field, resolved recursively (pointer chains, "
+                               + "array syntax, struct names). Leave empty to keep the current type and "
+                               + "only rename.") String newType,
+            @Param(value = "new_name", source = ParamSource.BODY, defaultValue = "",
+                   description = "Replacement field name. Leave empty to keep the current name and only "
+                               + "retype. The project's Hungarian prefix is applied automatically from the "
+                               + "field's type, so the stored name can differ from what you send.") String newName,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -1453,10 +1536,15 @@ public class DataTypeService {
             description = "Set a structure field's type by name or offset (offset:N). Same as modify_struct_field with new_type only.",
             category = "datatype")
     public Response modifyStructFieldType(
-            @Param(value = "struct_name", source = ParamSource.BODY) String structName,
+            @Param(value = "struct_name", source = ParamSource.BODY,
+                   description = "Simple name of the existing structure to edit, matched across every "
+                               + "category (no /path prefix needed).") String structName,
             @Param(value = "field_name", source = ParamSource.BODY,
                    description = "Field name or offset:N (e.g. offset:0x88).") String fieldName,
-            @Param(value = "new_type", source = ParamSource.BODY) String newType,
+            @Param(value = "new_type", source = ParamSource.BODY,
+                   description = "Replacement type for the field, resolved recursively (pointer chains, "
+                               + "array syntax, struct names). Required here — use modify_struct_field if "
+                               + "you also want to rename.") String newType,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -1470,7 +1558,9 @@ public class DataTypeService {
             description = "Replace a structure field with an embedded struct type by value (e.g. Rectangle inside LayoutNode). Uses modify_struct_field internally.",
             category = "datatype")
     public Response embedStructField(
-            @Param(value = "parent_struct", source = ParamSource.BODY) String parentStruct,
+            @Param(value = "parent_struct", source = ParamSource.BODY,
+                   description = "Simple name of the structure that CONTAINS the field being replaced — "
+                               + "the outer type, not the one being embedded.") String parentStruct,
             @Param(value = "field_name", source = ParamSource.BODY, defaultValue = "",
                    description = "Field name or offset:N.") String fieldName,
             @Param(value = "embedded_struct", source = ParamSource.BODY,
@@ -1491,8 +1581,13 @@ public class DataTypeService {
             description = "Grow or shrink an existing structure by total byte size. Defined fields whose end offset fits within new_size are preserved; growth pads with undefined filler. Refuses shrink that would clip defined fields unless force=true. See docs/STRUCT_RESIZE_WORKFLOW.md.",
             category = "datatype")
     public Response resizeStruct(
-            @Param(value = "name", source = ParamSource.BODY) String name,
-            @Param(value = "new_size", source = ParamSource.BODY) int newSize,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Simple name of the existing structure to resize, matched across every "
+                               + "category (no /path prefix needed).") String name,
+            @Param(value = "new_size", source = ParamSource.BODY,
+                   description = "New TOTAL size of the struct in bytes, not a field count. Must be "
+                               + "positive. Growing pads with undefined filler; shrinking past a defined "
+                               + "field is refused unless force=true.") int newSize,
             @Param(value = "preserve_fields", source = ParamSource.BODY, defaultValue = "true",
                    description = "When true (default), keep defined fields that still fit; when false with force, trailing layout may be cleared before resize.") boolean preserveFields,
             @Param(value = "force", source = ParamSource.BODY, defaultValue = "false",
@@ -1573,8 +1668,15 @@ public class DataTypeService {
             description = "Replace a structure in one step: optionally remove an existing same-named type, then create with fields JSON (same shape as create_struct). Use when resize_struct cannot apply or you are rebuilding layout from get_struct_layout export. Set force=true to delete a non-stub type that is not referenced.",
             category = "datatype")
     public Response recreateStruct(
-            @Param(value = "name", source = ParamSource.BODY) String name,
-            @Param(value = "fields", source = ParamSource.BODY, fieldsJson = true) String fieldsJson,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Name of the structure to (re)create. An existing same-named type is "
+                               + "deleted first, but only when replace_placeholder or force allows it.") String name,
+            @Param(value = "fields", source = ParamSource.BODY, fieldsJson = true,
+                   description = "JSON array of field objects, exactly the shape create_struct takes: "
+                               + "required keys name and type, optional offset as a decimal BYTE offset. "
+                               + "field_name/fieldName, field_type/fieldType/data_type/dataType and "
+                               + "field_offset/fieldOffset/off are accepted as alternates. Field names get "
+                               + "the project's Hungarian prefix applied automatically.") String fieldsJson,
             @Param(value = "size", source = ParamSource.BODY, defaultValue = "0",
                    description = "Optional minimum total size in bytes after create; grows with undefined padding when larger than implied field layout.") int size,
             @Param(value = "replace_placeholder", source = ParamSource.BODY, defaultValue = "true",
@@ -1695,7 +1797,9 @@ public class DataTypeService {
             description = "Find duplicate data types by simple name; delete unused /Demangler size-1 stubs when a larger canonical type exists. Helps fix 'Can't resolve datatype' and create_struct already exists on placeholders.",
             category = "datatype")
     public Response resolveDuplicateType(
-            @Param(value = "type_name", source = ParamSource.BODY) String typeName,
+            @Param(value = "type_name", source = ParamSource.BODY,
+                   description = "Simple name to look for duplicates of (no /path prefix) — every "
+                               + "category is searched for that name.") String typeName,
             @Param(value = "delete_demangler_stub", source = ParamSource.BODY, defaultValue = "true",
                    description = "Delete /Demangler/* stubs (size <= 1) when a larger type with the same name exists.") boolean deleteDemanglerStub,
             @Param(value = "program", defaultValue = "",
@@ -1911,10 +2015,22 @@ public class DataTypeService {
      */
     @McpTool(path = "/add_struct_field", method = "POST", description = "Add a field to a structure", category = "datatype")
     public Response addStructField(
-            @Param(value = "struct_name", source = ParamSource.BODY) String structName,
-            @Param(value = "field_name", source = ParamSource.BODY) String fieldName,
-            @Param(value = "field_type", source = ParamSource.BODY) String fieldType,
-            @Param(value = "offset", source = ParamSource.BODY, defaultValue = "-1") int offset,
+            @Param(value = "struct_name", source = ParamSource.BODY,
+                   description = "Simple name of the existing structure to add to, matched across every "
+                               + "category (no /path prefix needed).") String structName,
+            @Param(value = "field_name", source = ParamSource.BODY,
+                   description = "Name for the new field. The project's Hungarian prefix is applied "
+                               + "automatically from field_type, so the stored name can differ from what "
+                               + "you send — the response reports the name actually used, and "
+                               + "remove_struct_field accepts either form.") String fieldName,
+            @Param(value = "field_type", source = ParamSource.BODY,
+                   description = "Type of the new field, resolved recursively (pointer chains, array "
+                               + "syntax such as dword[8], existing struct/enum names).") String fieldType,
+            @Param(value = "offset", source = ParamSource.BODY, defaultValue = "-1",
+                   description = "BYTE offset to place the field at. -1 (the default) appends to the end. "
+                               + "A non-negative offset OVERWRITES whatever occupies that range rather than "
+                               + "shifting later fields, and grows the struct when it lies at or past the "
+                               + "current end.") int offset,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2027,8 +2143,12 @@ public class DataTypeService {
 
     @McpTool(path = "/remove_struct_field", method = "POST", description = "Remove a field from a structure (by the name you created it with, even after Hungarian auto-prefixing).", category = "datatype")
     public Response removeStructField(
-            @Param(value = "struct_name", source = ParamSource.BODY) String structName,
-            @Param(value = "field_name", source = ParamSource.BODY) String fieldName,
+            @Param(value = "struct_name", source = ParamSource.BODY,
+                   description = "Simple name of the existing structure to edit, matched across every "
+                               + "category (no /path prefix needed).") String structName,
+            @Param(value = "field_name", source = ParamSource.BODY,
+                   description = "Field to remove. Matched exactly first, then by Hungarian stem, so the "
+                               + "name you originally sent still works after auto-prefixing changed it.") String fieldName,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2095,8 +2215,12 @@ public class DataTypeService {
      */
     @McpTool(path = "/move_data_type_to_category", method = "POST", description = "Move data type to category", category = "datatype")
     public Response moveDataTypeToCategory(
-            @Param(value = "type_name", source = ParamSource.BODY) String typeName,
-            @Param(value = "category_path", source = ParamSource.BODY) String categoryPath,
+            @Param(value = "type_name", source = ParamSource.BODY,
+                   description = "Simple name of the type to move, matched across every category (no "
+                               + "/path prefix needed).") String typeName,
+            @Param(value = "category_path", source = ParamSource.BODY,
+                   description = "Destination category as a /-separated path, e.g. /D2Structs/Units. It "
+                               + "is created, with any missing parents, if it does not exist.") String categoryPath,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2444,8 +2568,13 @@ public class DataTypeService {
      */
     @McpTool(path = "/import_data_types", method = "POST", description = "Parse C source (structs/unions/enums/typedefs) into the program's data type manager via Ghidra's CParser. Returns how many types were added and any parser messages. Used to load a project's canonical type vocabulary from a generated header.", category = "datatype")
     public Response importDataTypes(
-            @Param(value = "source", source = ParamSource.BODY) String source,
-            @Param(value = "format", source = ParamSource.BODY, defaultValue = "c") String format,
+            @Param(value = "source", source = ParamSource.BODY,
+                   description = "C declarations — structs, unions, enums, typedefs — as one string of "
+                               + "source TEXT, not a file path. Passed straight to Ghidra's CParser.") String source,
+            @Param(value = "format", source = ParamSource.BODY, defaultValue = "c",
+                   description = "Accepted but ignored: parsing is always C through Ghidra's CParser "
+                               + "whatever you pass. Kept so existing callers that send it keep "
+                               + "working.") String format,
             @Param(value = "program", description = "Target program name (omit to use the active program)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2499,7 +2628,9 @@ public class DataTypeService {
      */
     @McpTool(path = "/create_data_type_category", method = "POST", description = "Create a new data type category", category = "datatype")
     public Response createDataTypeCategory(
-            @Param(value = "category_path", source = ParamSource.BODY) String categoryPath,
+            @Param(value = "category_path", source = ParamSource.BODY,
+                   description = "New category as a /-separated path, e.g. /D2Structs/Units. Missing "
+                               + "parent categories are created too.") String categoryPath,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2532,8 +2663,14 @@ public class DataTypeService {
      */
     @McpTool(path = "/list_data_type_categories", description = "List all data type categories", category = "datatype")
     public Response listDataTypeCategories(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2593,8 +2730,13 @@ public class DataTypeService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "struct_name", source = ParamSource.BODY) String structName,
-            @Param(value = "max_functions", source = ParamSource.BODY, defaultValue = "10") int maxFunctionsToAnalyze,
+            @Param(value = "struct_name", source = ParamSource.BODY,
+                   description = "Optional label for the structure being analysed. It does NOT select the "
+                               + "type — that comes from the data already applied at `address` — and is only "
+                               + "echoed back; omit it to use the applied type's own name.") String structName,
+            @Param(value = "max_functions", source = ParamSource.BODY, defaultValue = "10",
+                   description = "How many referencing functions to decompile: 1 to 100, default 10. A "
+                               + "value outside that range is REJECTED, not clamped.") int maxFunctionsToAnalyze,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         // CRITICAL FIX #3: Validate input parameters
         if (maxFunctionsToAnalyze < MIN_FUNCTIONS_TO_ANALYZE || maxFunctionsToAnalyze > MAX_FUNCTIONS_TO_ANALYZE) {
@@ -2834,7 +2976,9 @@ public class DataTypeService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String structAddressStr,
-            @Param(value = "struct_size", source = ParamSource.BODY, defaultValue = "0") int structSize,
+            @Param(value = "struct_size", source = ParamSource.BODY, defaultValue = "0",
+                   description = "Size of the structure in BYTES, or 0 (the default) to take the size "
+                               + "from the data already applied at struct_address. Must be 0 to 65536.") int structSize,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         // Validate input parameters
         if (structSize < 0 || structSize > MAX_FIELD_OFFSET) {
@@ -2966,10 +3110,24 @@ public class DataTypeService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "classification", source = ParamSource.BODY) String classification,
-            @Param(value = "name", source = ParamSource.BODY, defaultValue = "") String name,
-            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "") String comment,
-            @Param(value = "type_definition", source = ParamSource.BODY) Object typeDefinitionObj,
+            @Param(value = "classification", source = ParamSource.BODY,
+                   description = "Which shape to build, matched case-sensitively against exactly "
+                               + "PRIMITIVE, STRUCTURE, ARRAY or STRING. Any other value applies NO type at "
+                               + "all and the call falls through to the rename and comment steps.") String classification,
+            @Param(value = "name", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional label to place at the address. Applied only when a data type "
+                               + "actually ended up defined there, so it is skipped whenever the "
+                               + "classification applied nothing.") String name,
+            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional PRE comment for the address. Unlike the plate-comment tools, "
+                               + "this one DOES turn the two-character escapes for newline, tab and return "
+                               + "into real whitespace, so an escaped string arrives as multiple lines.") String comment,
+            @Param(value = "type_definition", source = ParamSource.BODY,
+                   description = "JSON object whose required keys depend on `classification`: PRIMITIVE "
+                               + "needs {\"type\": \"dword\"}; STRUCTURE needs a name plus a fields array of "
+                               + "{name, type} objects; ARRAY needs count plus either element_type or "
+                               + "element_struct; STRING takes an optional type. It must be an OBJECT — a "
+                               + "JSON string is rejected.") Object typeDefinitionObj,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();

--- a/src/main/java/com/xebyte/core/DocumentationHashService.java
+++ b/src/main/java/com/xebyte/core/DocumentationHashService.java
@@ -233,8 +233,15 @@ public class DocumentationHashService {
      */
     @McpTool(path = "/get_bulk_function_hashes", description = "Get hashes for multiple or all functions", category = "documentation")
     public Response getBulkFunctionHashes(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of matching functions to skip before this page starts; 0 begins "
+                               + "at the first. The filter is applied before the skip, so paging is stable "
+                               + "only within one filter value.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum functions whose hash is computed and returned in this page "
+                               + "(default 100). The walk still visits every function to produce "
+                               + "total_matching, so 0 returns an EMPTY page rather than "
+                               + "everything.") int limit,
             @Param(value = "filter", description = "Name filter") String filter,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
@@ -472,7 +479,16 @@ public class DocumentationHashService {
 
     @McpTool(path = "/apply_function_documentation", method = "POST", description = "Import documentation to a target function. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution.", category = "documentation")
     public Response applyFunctionDocumentation(
-            @Param(value = "json_body", source = ParamSource.BODY) String jsonBody,
+            @Param(value = "json_body", source = ParamSource.BODY,
+                   description = "The whole payload as one JSON STRING, in the shape "
+                               + "get_function_documentation emits. Required key: target_address. Optional "
+                               + "top-level keys: function_name, return_type, calling_convention, "
+                               + "plate_comment, plus the arrays parameters and comments. It is read with a "
+                               + "flat string extractor, so those keys must sit at the TOP level — a nested "
+                               + "object wrapping them is not looked into. An empty plate_comment is "
+                               + "skipped rather than clearing, and a name, convention or return type that "
+                               + "fails to apply is only logged: changes_applied reports what actually "
+                               + "landed.") String jsonBody,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -1007,7 +1023,10 @@ public class DocumentationHashService {
             @Param(value = "source_program", description = "Source program name") String sourceProgramName,
             @Param(value = "target_program", description = "Target program name") String targetProgramName,
             @Param(value = "threshold", defaultValue = "0.7", description = "Similarity threshold") double threshold,
-            @Param(value = "limit", defaultValue = "20") int limit) {
+            @Param(value = "limit", defaultValue = "20",
+                   description = "Maximum matches returned, highest similarity first (default 20). It "
+                               + "truncates the result only: every candidate in the target program is still "
+                               + "scored, so a small limit does not make the call cheaper.") int limit) {
         // Source program: use sourceProgramName if given, otherwise current program
         ServiceUtils.ProgramOrError srcPe = ServiceUtils.getProgramOrError(programProvider, sourceProgramName);
         if (srcPe.hasError()) return srcPe.error();
@@ -1043,8 +1062,15 @@ public class DocumentationHashService {
             @Param(value = "source_program", description = "Source program name") String sourceProgramName,
             @Param(value = "target_program", description = "Target program name") String targetProgramName,
             @Param(value = "threshold", defaultValue = "0.7", description = "Similarity threshold") double threshold,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "50") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of SOURCE functions to skip before this page starts; 0 begins at "
+                               + "the first. Negative values are clamped to 0, and an offset past the end "
+                               + "returns an empty match list.") int offset,
+            @Param(value = "limit", defaultValue = "50",
+                   description = "How many SOURCE functions this page tries to match (default 50) — it "
+                               + "slices the source list, not the matches. 0 returns an EMPTY page; "
+                               + "total_source_functions reports the full count to page "
+                               + "against.") int limit,
             @Param(value = "filter", description = "Name filter") String filter) {
         if (sourceProgramName == null || sourceProgramName.trim().isEmpty()) {
             return Response.err("source_program parameter is required");

--- a/src/main/java/com/xebyte/core/EmulationService.java
+++ b/src/main/java/com/xebyte/core/EmulationService.java
@@ -102,7 +102,9 @@ public class EmulationService {
                             "emulation sees only the ORIGINAL unmodified bytes, not the emulated " +
                             "result. This reads from the emulator's own state instead.")
                     String readMemoryAfterJson,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
 
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -344,7 +346,9 @@ public class EmulationService {
                     description = "Additional register values to set before each emulation (JSON object)") String initialRegistersJson,
             @Param(value = "wide_string", source = ParamSource.BODY, defaultValue = "false",
                     description = "Write candidate strings as UTF-16LE (wide) instead of ASCII") boolean wideString,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
 
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -327,7 +327,9 @@ public class FunctionService {
     // Bulk helper for decompile_function(functions=...). Merged into decompile_function in 7.0.0.
     public Response batchDecompileFunctions(
             @Param(value = "functions", description = "Comma-separated function references (names or addresses)") String functionsParam,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -394,7 +396,9 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddrStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -503,7 +507,9 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -608,7 +614,9 @@ public class FunctionService {
             @Param(value = "function_address", paramType = "address", source = ParamSource.BODY, defaultValue = "") String functionAddress,
             @Param(value = "old_variable_name", source = ParamSource.BODY, aliases = {"oldName"}) String oldVarName,
             @Param(value = "new_variable_name", source = ParamSource.BODY, aliases = {"newName"}) String newVarName,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -753,7 +761,9 @@ public class FunctionService {
                                + "<space>:<hex> (e.g., mem:1000, code:ff00); a plain name resolves by exact "
                                + "function name.") String functionAddrStr,
             @Param(value = "new_name", source = ParamSource.BODY) String newName,
-            @Param(value = "program", defaultValue = "") String programName,
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName,
             @Param(value = "strict_mode", source = ParamSource.BODY, defaultValue = "",
                    description = "Optional per-call override for naming enforcement: 'enforce' (reject "
                                + "low-quality names), 'warn' (write goes through with warnings), or 'off' "
@@ -1356,7 +1366,9 @@ public class FunctionService {
                                + "address is unambiguous.") String functionAddrStr,
             @Param(value = "variable_name", source = ParamSource.BODY, aliases = {"variableName"}) String variableName,
             @Param(value = "new_type", source = ParamSource.BODY, aliases = {"newType"}) String newType,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         // Input validation
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -1705,7 +1717,9 @@ public class FunctionService {
             @Param(value = "function_address", paramType = "address", source = ParamSource.BODY) String functionAddress,
             @Param(value = "variable_name", source = ParamSource.BODY, aliases = {"parameter_name"}) String variableName,
             @Param(value = "new_type", source = ParamSource.BODY) String newType,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         if ("this".equals(variableName)) {
             return setFunctionThisType(functionAddress, newType, programName);
         }
@@ -1976,7 +1990,9 @@ public class FunctionService {
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddrStr,
             @Param(value = "no_return", source = ParamSource.BODY, aliases = {"noReturn"}) boolean noReturn,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         // Input validation
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2065,7 +2081,9 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String instructionAddrStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         // Input validation
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2147,7 +2165,9 @@ public class FunctionService {
                                + "address is unambiguous.") String functionAddrStr,
             @Param(value = "variable_name", source = ParamSource.BODY) String variableName,
             @Param(value = "storage", source = ParamSource.BODY) String storageSpec,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -2244,7 +2264,9 @@ public class FunctionService {
     public Response getFunctionVariables(
             @Param(value = "function_name", description = "Function name (ignored if address is provided)", defaultValue = "") String functionName,
             @Param(value = "address", description = "Function address (hex, e.g. 6fc583f0). If provided, overrides function_name lookup.", defaultValue = "") String address,
-            @Param(value = "program", defaultValue = "") String programName,
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName,
             @Param(value = "limit", description = "Max local variables to return (default 200, 0 = unlimited)", defaultValue = "200") int limit,
             @Param(value = "filter", description = "Filter locals: 'all' (default), 'needs_work' (only needs_type or needs_rename), 'named' (only non-generic names)", defaultValue = "all") String filter) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
@@ -2480,7 +2502,9 @@ public class FunctionService {
             @Param(value = "parameter_renames", source = ParamSource.BODY) Map<String, String> parameterRenames,
             @Param(value = "local_renames", source = ParamSource.BODY) Map<String, String> localRenames,
             @Param(value = "return_type", source = ParamSource.BODY, defaultValue = "") String returnType,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -2586,7 +2610,9 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -2655,7 +2681,9 @@ public class FunctionService {
                                + "address is unambiguous.") String addressStr,
             @Param(value = "name", source = ParamSource.BODY, defaultValue = "") String name,
             @Param(value = "disassemble_first", source = ParamSource.BODY, defaultValue = "true") boolean disassembleFirst,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -2789,7 +2817,9 @@ public class FunctionService {
                    description = "Return the disassembled instruction list (mnemonic, operands, raw bytes, address) in the response. Disable for byte ranges where you only need the success/byte-count summary.") boolean includeInstructions,
             @Param(value = "max_instructions", source = ParamSource.BODY, defaultValue = "1000",
                    description = "Cap on number of instructions returned when include_instructions is true. Protects against runaway payload for large ranges; if the actual count exceeds this, the response sets truncated=true and instructions_total reports the real count.") int maxInstructions,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -3030,7 +3060,9 @@ public class FunctionService {
                    description = "Exclusive seed end (consistent with disassemble_bytes). Must be in the same "
                                + "address space as start_address and strictly greater. Omitted: one-address seed; "
                                + "the command still follows flow from there like clicking one address in the GUI.") String endAddress,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
 
         if (startAddress == null || startAddress.isEmpty()) {
             return Response.err("start_address parameter required");
@@ -3315,7 +3347,9 @@ public class FunctionService {
                                + "address is unambiguous.") String functionAddress,
             @Param(value = "variable_renames", source = ParamSource.BODY) Map<String, String> variableRenames,
             @Param(value = "force_individual", source = ParamSource.BODY, defaultValue = "false") boolean forceIndividual,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -3542,7 +3576,9 @@ public class FunctionService {
                    description = "JSON object mapping old variable names to {name, type} objects. "
                                + "Both fields optional: omit 'type' to rename only, omit 'name' to retype only. "
                                + "Example: {\"local_8\": {\"name\": \"dwFlags\", \"type\": \"uint\"}, \"local_c\": {\"type\": \"int\"}}") String variablesJson,
-            @Param(value = "program") String programName) {
+            @Param(value = "program",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4033,7 +4069,9 @@ public class FunctionService {
     public Response getFunctionTags(
             @Param(value = "function", paramType = "address",
                    description = "Function address (0x<hex> or <space>:<hex>) or function name") String functionRef,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4065,7 +4103,9 @@ public class FunctionService {
                    description = "Comma-separated tag names to attach (single mode).") String tagsCsv,
             @Param(value = "assignments", source = ParamSource.BODY, defaultValue = "[]",
                    description = "Bulk mode: array of {function, tags} objects. When non-empty, function/tags are ignored.") List<Map<String, String>> assignments,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4116,7 +4156,9 @@ public class FunctionService {
                    description = "Comma-separated tag names to detach (single mode).") String tagsCsv,
             @Param(value = "assignments", source = ParamSource.BODY, defaultValue = "[]",
                    description = "Bulk mode: array of {function, tags} objects. When non-empty, function/tags are ignored.") List<Map<String, String>> assignments,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4168,7 +4210,9 @@ public class FunctionService {
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "500",
                    description = "Maximum number of tags to return (default 500, which covers most programs in full)") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4200,7 +4244,9 @@ public class FunctionService {
                    description = "Tag name (case-sensitive; Ghidra treats whitespace-trimmed names as unique)") String name,
             @Param(value = "comment", source = ParamSource.BODY, defaultValue = "",
                    description = "Optional description for the tag") String comment,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4240,7 +4286,9 @@ public class FunctionService {
     public Response deleteFunctionTag(
             @Param(value = "name", source = ParamSource.BODY,
                    description = "Tag name to delete program-wide") String name,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4275,7 +4323,9 @@ public class FunctionService {
                    description = "Tag name") String name,
             @Param(value = "comment", source = ParamSource.BODY,
                    description = "New comment text (pass an empty string to clear)") String comment,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4308,7 +4358,9 @@ public class FunctionService {
             @Param(value = "tag", description = "Tag name to search for") String tagName,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "1000") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4349,7 +4401,9 @@ public class FunctionService {
     public Response batchAddFunctionTags(
             @Param(value = "assignments", source = ParamSource.BODY,
                    description = "Array of {function, tags} objects. `function` may be an address or name; `tags` is a comma-separated list.") List<Map<String, String>> assignments,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -4418,7 +4472,9 @@ public class FunctionService {
     public Response batchRemoveFunctionTags(
             @Param(value = "assignments", source = ParamSource.BODY,
                    description = "Array of {function, tags} objects.") List<Map<String, String>> assignments,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/main/java/com/xebyte/core/FunctionService.java
+++ b/src/main/java/com/xebyte/core/FunctionService.java
@@ -760,7 +760,15 @@ public class FunctionService {
                    description = "Function name or address to rename. Address accepts 0x<hex> or "
                                + "<space>:<hex> (e.g., mem:1000, code:ff00); a plain name resolves by exact "
                                + "function name.") String functionAddrStr,
-            @Param(value = "new_name", source = ParamSource.BODY) String newName,
+            @Param(value = "new_name", source = ParamSource.BODY,
+                   description = "New function name in PascalCase, verb first: GetPlayerHealth, not "
+                               + "get_player_health and not PlayerHealth. An UPPERCASE module prefix is "
+                               + "allowed and validated separately (D2COMMON_GetUnitStat). The quality "
+                               + "gate rejects a vague verb carrying fewer than two specifier tokens "
+                               + "(ProcessData), a single-token name (Get), a weak-noun-only name "
+                               + "(GetInfo), and a name whose tokens are a strict subset of an existing "
+                               + "function's within the same module prefix. strict_mode downgrades those "
+                               + "rejections to warnings.") String newName,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName,
@@ -1074,8 +1082,18 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddress,
-            @Param(value = "prototype", source = ParamSource.BODY) String prototype,
-            @Param(value = "calling_convention", source = ParamSource.BODY, defaultValue = "") String callingConvention,
+            @Param(value = "prototype", source = ParamSource.BODY,
+                   description = "Full C signature as one string, e.g. "
+                               + "int __fastcall Foo(int nCount, char *pszName). The NAME in it is parsed "
+                               + "and then discarded — it does NOT rename the function, call rename_function "
+                               + "for that. A calling convention written here is only recognised before the "
+                               + "first '(', so one inside a callback parameter type survives "
+                               + "untouched.") String prototype,
+            @Param(value = "calling_convention", source = ParamSource.BODY, defaultValue = "",
+                   description = "Convention to apply — __cdecl, __stdcall, __fastcall, __thiscall and "
+                               + "whatever else list_calling_conventions reports for this program's "
+                               + "language. When set it OVERRIDES the convention written into the "
+                               + "prototype string; omit to use whatever the prototype says.") String callingConvention,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         PrototypeResult result = setFunctionPrototype(functionAddress, prototype, callingConvention, programName);
         if (result.isSuccess()) {
@@ -1714,9 +1732,21 @@ public class FunctionService {
             description = "Set the data type of a function variable (local OR parameter) by name at the decompiler (high-level) layer. Pass variable_name='this' to type a __thiscall/__fastcall implicit this. Replaces set_local_variable_type / set_parameter_type / set_decompiler_variable_type.",
             category = "function")
     public Response setDecompilerVariableType(
-            @Param(value = "function_address", paramType = "address", source = ParamSource.BODY) String functionAddress,
-            @Param(value = "variable_name", source = ParamSource.BODY, aliases = {"parameter_name"}) String variableName,
-            @Param(value = "new_type", source = ParamSource.BODY) String newType,
+            @Param(value = "function_address", paramType = "address", source = ParamSource.BODY,
+                   description = "Entry address of the function that owns the variable. Accepts 0x<hex> "
+                               + "(default space) or <space>:<hex> (e.g., mem:1000, code:ff00); use "
+                               + "get_address_spaces first on targets that are not "
+                               + "address-space-agnostic.") String functionAddress,
+            @Param(value = "variable_name", source = ParamSource.BODY, aliases = {"parameter_name"},
+                   description = "Local or parameter to retype, named exactly as the decompiler shows it "
+                               + "(get_function_variables lists them). The literal value 'this' is "
+                               + "special-cased and routes to set_function_this_type.") String variableName,
+            @Param(value = "new_type", source = ParamSource.BODY,
+                   description = "New data type, resolved recursively (pointer chains, array syntax such "
+                               + "as dword[8], existing struct/enum names). A type starting with `undefined` "
+                               + "is REJECTED whatever the current type is — swapping one undefined width "
+                               + "for another is a no-op, not documentation. For 'this', a bare struct name "
+                               + "is auto-suffixed with ' *'.") String newType,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -1746,8 +1776,13 @@ public class FunctionService {
     public Response listClassMembers(
             @Param(value = "class_name",
                    description = "Class / struct name, e.g. 'UnitAny'.") String className,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "200") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of members to skip before this page starts; 0 begins at the "
+                               + "first. Negative values are clamped to 0.") int offset,
+            @Param(value = "limit", defaultValue = "200",
+                   description = "Maximum members returned in this page (default 200). It is clamped to a "
+                               + "MINIMUM of 1, so 0 returns one member rather than everything — page with "
+                               + "offset against total_members instead.") int limit,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         if (className == null || className.trim().isEmpty()) {
             return Response.err("class_name is required");
@@ -1989,7 +2024,11 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddrStr,
-            @Param(value = "no_return", source = ParamSource.BODY, aliases = {"noReturn"}) boolean noReturn,
+            @Param(value = "no_return", source = ParamSource.BODY, aliases = {"noReturn"},
+                   description = "True marks the function non-returning: its call sites become "
+                               + "CALL_TERMINATOR, so control-flow analysis and the decompiler stop showing "
+                               + "execution continuing past the call. False clears that back to an ordinary "
+                               + "returning function. Required — there is no default.") boolean noReturn,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -2163,8 +2202,13 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddrStr,
-            @Param(value = "variable_name", source = ParamSource.BODY) String variableName,
-            @Param(value = "storage", source = ParamSource.BODY) String storageSpec,
+            @Param(value = "variable_name", source = ParamSource.BODY,
+                   description = "Local or parameter to address, matched by exact name against the "
+                               + "function's variables.") String variableName,
+            @Param(value = "storage", source = ParamSource.BODY,
+                   description = "Storage specification: a location followed by a size in bytes, e.g. "
+                               + "Stack[-0x10]:4, EBP:4, EAX:4. The response echoes it as "
+                               + "requested_storage next to the variable's current_storage.") String storageSpec,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -2498,10 +2542,26 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddress,
-            @Param(value = "function_name", source = ParamSource.BODY, defaultValue = "") String functionName,
-            @Param(value = "parameter_renames", source = ParamSource.BODY) Map<String, String> parameterRenames,
-            @Param(value = "local_renames", source = ParamSource.BODY) Map<String, String> localRenames,
-            @Param(value = "return_type", source = ParamSource.BODY, defaultValue = "") String returnType,
+            @Param(value = "function_name", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional new name for the function; leave empty to keep the current "
+                               + "one. Unlike rename_function this writes the name directly and does NOT "
+                               + "run the naming-quality gate.") String functionName,
+            @Param(value = "parameter_renames", source = ParamSource.BODY,
+                   description = "JSON object mapping each parameter's CURRENT name to its new name. Keys "
+                               + "must match exactly; an entry naming a parameter that does not exist is "
+                               + "ignored silently, and parameters_renamed in the response reports how many "
+                               + "actually landed.") Map<String, String> parameterRenames,
+            @Param(value = "local_renames", source = ParamSource.BODY,
+                   description = "JSON object mapping each local variable's CURRENT name to its new name, "
+                               + "same rules as parameter_renames; locals_renamed reports how many "
+                               + "landed.") Map<String, String> localRenames,
+            @Param(value = "return_type", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional new return type. It is looked up by exact data-type-manager "
+                               + "PATH (/uint), not through the recursive resolver the other tools use, so "
+                               + "a bare name or a pointer chain does not resolve — and a failed lookup is "
+                               + "IGNORED SILENTLY, leaving the return type unchanged while the call still "
+                               + "reports success. Prefer set_function_prototype when the return type "
+                               + "matters.") String returnType,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -2679,8 +2739,15 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "name", source = ParamSource.BODY, defaultValue = "") String name,
-            @Param(value = "disassemble_first", source = ParamSource.BODY, defaultValue = "true") boolean disassembleFirst,
+            @Param(value = "name", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional name for the new function; leave empty to keep Ghidra's "
+                               + "generated FUN_<address>. Written directly, so the naming-quality gate "
+                               + "does not run here — use rename_function if you want it to.") String name,
+            @Param(value = "disassemble_first", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) disassembles the entry address first when no "
+                               + "instruction exists there, which is what lets you create a function over "
+                               + "raw undefined bytes. False requires the address to be disassembled "
+                               + "already; function creation fails otherwise.") boolean disassembleFirst,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -2811,8 +2878,16 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String endAddress,
-            @Param(value = "length", source = ParamSource.BODY, defaultValue = "0") Integer length,
-            @Param(value = "restrict_to_execute_memory", source = ParamSource.BODY, defaultValue = "true") boolean restrictToExecuteMemory,
+            @Param(value = "length", source = ParamSource.BODY, defaultValue = "0",
+                   description = "Number of BYTES to disassemble from start_address, as an alternative to "
+                               + "end_address; end_address wins when both are given. 0 (the default) with "
+                               + "no end_address auto-detects the run of undefined bytes and stops at a "
+                               + "100-byte safety cap.") Integer length,
+            @Param(value = "restrict_to_execute_memory", source = ParamSource.BODY, defaultValue = "true",
+                   description = "True (the default) refuses to disassemble outside memory blocks marked "
+                               + "executable, which stops a stray address turning data into instructions. "
+                               + "Set false only for code that genuinely lives in a non-execute "
+                               + "block.") boolean restrictToExecuteMemory,
             @Param(value = "include_instructions", source = ParamSource.BODY, defaultValue = "true",
                    description = "Return the disassembled instruction list (mnemonic, operands, raw bytes, address) in the response. Disable for byte ranges where you only need the success/byte-count summary.") boolean includeInstructions,
             @Param(value = "max_instructions", source = ParamSource.BODY, defaultValue = "1000",
@@ -3345,8 +3420,15 @@ public class FunctionService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String functionAddress,
-            @Param(value = "variable_renames", source = ParamSource.BODY) Map<String, String> variableRenames,
-            @Param(value = "force_individual", source = ParamSource.BODY, defaultValue = "false") boolean forceIndividual,
+            @Param(value = "variable_renames", source = ParamSource.BODY,
+                   description = "JSON object mapping each variable's CURRENT decompiler name to its new "
+                               + "name. Matching happens against the decompiler's high-level symbols, so "
+                               + "use the names get_function_variables and decompile_function report, not "
+                               + "the raw listing's.") Map<String, String> variableRenames,
+            @Param(value = "force_individual", source = ParamSource.BODY, defaultValue = "false",
+                   description = "Accepted but currently not read: the batched decompiler commit always "
+                               + "runs first and per-variable renames happen only as a fallback when it "
+                               + "throws. Setting it true changes nothing today.") boolean forceIndividual,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -4207,7 +4289,9 @@ public class FunctionService {
              description = "List all program-wide function tag definitions with their use counts.",
              category = "function")
     public Response listFunctionTags(
-            @Param(value = "offset", defaultValue = "0") int offset,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of tag definitions to skip before this page starts; 0 begins at "
+                               + "the first. Negative values are clamped to 0.") int offset,
             @Param(value = "limit", defaultValue = "500",
                    description = "Maximum number of tags to return (default 500, which covers most programs in full)") int limit,
             @Param(value = "program", defaultValue = "",
@@ -4356,8 +4440,13 @@ public class FunctionService {
              category = "function")
     public Response searchFunctionsByTag(
             @Param(value = "tag", description = "Tag name to search for") String tagName,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "1000") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of matching functions to skip before this page starts; 0 begins "
+                               + "at the first. Negative values are clamped to 0.") int offset,
+            @Param(value = "limit", defaultValue = "1000",
+                   description = "Maximum functions returned in this page (default 1000). 0 returns an "
+                               + "EMPTY page rather than everything — page with offset against the `total` "
+                               + "the response reports.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {

--- a/src/main/java/com/xebyte/core/ListingService.java
+++ b/src/main/java/com/xebyte/core/ListingService.java
@@ -32,8 +32,14 @@ public class ListingService {
 
     @McpTool(path = "/list_methods", description = "List all function names with pagination", category = "listing")
     public Response getAllFunctionNames(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -48,8 +54,14 @@ public class ListingService {
 
     @McpTool(path = "/list_classes", description = "List class and namespace names with pagination", category = "listing")
     public Response getAllClassNames(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -69,8 +81,14 @@ public class ListingService {
 
     @McpTool(path = "/list_segments", description = "List memory blocks/segments", category = "listing")
     public Response listSegments(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -94,8 +112,14 @@ public class ListingService {
 
     @McpTool(path = "/list_imports", description = "List external/imported symbols", category = "listing")
     public Response listImports(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -121,8 +145,14 @@ public class ListingService {
 
     @McpTool(path = "/list_exports", description = "List exported entry points", category = "listing")
     public Response listExports(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -146,8 +176,14 @@ public class ListingService {
 
     @McpTool(path = "/list_namespaces", description = "List namespace hierarchy", category = "listing")
     public Response listNamespaces(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -167,8 +203,14 @@ public class ListingService {
 
     @McpTool(path = "/list_data_items", description = "List defined data items", category = "listing")
     public Response listDefinedData(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -198,8 +240,14 @@ public class ListingService {
 
     @McpTool(path = "/list_data_items_by_xrefs", description = "List data items sorted by xref count (descending). By default returns only defined data items. `filter` and `type_filter` (each: all/defined/undefined) compose orthogonally to also include unnamed/untyped addresses — `filter=all,type_filter=all` returns the full data surface (named + DAT_*-style autogen + raw undefined-with-xrefs). `min_xrefs` (default 1) suppresses zero-xref noise on undefined items.", category = "listing")
     public Response listDataItemsByXrefs(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "format", defaultValue = "text",
                    description = "Deprecated, no-op: every response is JSON regardless of this value (kept only for backward-compatible calls that still pass it).") String format,
             @Param(value = "filter", defaultValue = "defined",
@@ -299,8 +347,14 @@ public class ListingService {
     @McpTool(path = "/search_functions", description = "Search functions by name pattern. Omit name_pattern to list all functions.", category = "listing")
     public Response searchFunctionsByName(
             @Param(value = "name_pattern", description = "Substring to match against function names (omit or leave empty to return all functions)", defaultValue = "") String searchTerm,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -340,8 +394,15 @@ public class ListingService {
 
     @McpTool(path = "/list_functions_enhanced", description = "List functions with thunk/external flags as JSON", category = "listing")
     public Response listFunctionsEnhanced(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "10000") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "10000",
+                   description = "Maximum functions returned, counted after `offset` is applied "
+                               + "(default 10000, which covers most programs in one call). This endpoint "
+                               + "stops at the limit rather than treating 0 as unlimited, so 0 returns an "
+                               + "EMPTY list.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -398,8 +459,14 @@ public class ListingService {
 
     @McpTool(path = "/list_strings", description = "List defined strings with optional filter", category = "listing")
     public Response listDefinedStrings(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "filter", description = "Substring filter", defaultValue = "") String filter,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
@@ -451,10 +518,20 @@ public class ListingService {
     @McpTool(path = "/search_strings", description = "Search strings by regex pattern.", category = "listing")
     public Response searchStrings(
             @Param(value = "search_term", description = "Regex search pattern") String query,
-            @Param(value = "min_length", defaultValue = "4") int minLength,
-            @Param(value = "encoding", description = "String encoding filter (omit for all encodings)", defaultValue = "") String encoding,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "min_length", defaultValue = "4",
+                   description = "Ignore strings shorter than this many CHARACTERS of decoded text "
+                               + "(not bytes on disk). Default 4 drops one- to three-character fragments.") int minLength,
+            @Param(value = "encoding", defaultValue = "",
+                   description = "Label echoed back in each match's `encoding` field. It does NOT filter: "
+                               + "every defined string is searched whatever you pass here, and matches that "
+                               + "carry no value report the literal string `ascii`.") String encoding,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of matches to skip before this page starts; 0 begins at the first "
+                               + "match. Applied after the regex and min_length filters.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum matches returned in this page (default 100). `total` in the "
+                               + "response reports how many matched before paging. Unlike the paged list "
+                               + "endpoints, 0 here returns an EMPTY page rather than everything.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -499,8 +576,14 @@ public class ListingService {
 
     @McpTool(path = "/list_globals", description = "List global DATA symbols. By default returns every global in the program (named + unnamed-but-xrefed undefined addresses). `filter` and `type_filter` (each: all/defined/undefined) compose orthogonally to scope the result — e.g., `filter=named, type_filter=undefined` returns the cleanup backlog (placeholders awaiting real types). `min_xrefs` (default 1) suppresses zero-xref noise when including undefined items. Code labels (branch targets, error handlers) are still excluded — they're not data globals. Each line ends with `xrefs=N` for prioritization.", category = "listing")
     public Response listGlobals(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "filter", defaultValue = "all",
                    description = "Symbol-naming axis: `all` (default), `defined` (only named symbols), `undefined` (only unnamed addresses, e.g. DAT_*-style and raw undefined data with xrefs).") String filter,
             @Param(value = "type_filter", defaultValue = "all",
@@ -629,8 +712,14 @@ public class ListingService {
             description = "List named global DATA symbols that have NO type of their own because a larger data unit starting at an earlier address covers them. These are invisible to /list_globals — it resolves the CONTAINING unit, so it reports the covering neighbour's type at the shadowed address and the global looks perfectly typed. Each record carries the container that swallowed it. Use this to find documentation that a neighbouring type application destroyed, or a symbol sitting inside an array where it does not belong.",
             category = "listing")
     public Response listShadowedGlobals(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "500") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "500",
+                   description = "Maximum entries returned in this page (default 500). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "include_all_sections", defaultValue = "false",
                    description = "By default only data sections are scanned, matching list_globals.") boolean includeAllSections,
             @Param(value = "program", description = "Target program name (omit to use the active program)", defaultValue = "") String programName) {
@@ -937,8 +1026,13 @@ public class ListingService {
 
     @McpTool(path = "/list_external_locations", description = "List external symbol locations", category = "listing")
     public Response listExternalLocations(
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of external locations to skip before this page starts; 0 begins "
+                               + "at the first entry. An offset past the end returns an empty list.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum external locations returned (default 100). This endpoint slices "
+                               + "the result directly and returns a bare array with no total, so 0 here "
+                               + "returns an EMPTY list rather than everything.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -985,8 +1079,14 @@ public class ListingService {
 
     @McpTool(path = "/get_external_location", description = "Get external location details by address or DLL name", category = "listing")
     public Response getExternalLocationDetails(
-            @Param(value = "address") String address,
-            @Param(value = "dll_name") String dllName,
+            @Param(value = "address", paramType = "address",
+                   description = "Address of the external location, as 0x<hex> (default space) or "
+                               + "<space>:<hex> (e.g. mem:1000). This is the selector: matching is done "
+                               + "on the address alone, so a dll_name with no address finds nothing.") String address,
+            @Param(value = "dll_name", defaultValue = "",
+                   description = "External library name (as list_imports / list_external_locations report "
+                               + "it) to scope the search to. Omit to scan every library. It narrows the "
+                               + "search only — it cannot select an entry by itself.") String dllName,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();

--- a/src/main/java/com/xebyte/core/MalwareSecurityService.java
+++ b/src/main/java/com/xebyte/core/MalwareSecurityService.java
@@ -256,7 +256,9 @@ public class MalwareSecurityService {
 
     @McpTool(path = "/analyze_api_call_chains", description = "Detect suspicious API call patterns", category = "malware")
     public Response analyzeAPICallChains(
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -441,7 +443,9 @@ public class MalwareSecurityService {
 
     @McpTool(path = "/extract_iocs_with_context", description = "Enhanced IOC extraction with context", category = "malware")
     public Response extractIOCsWithContext(
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -536,7 +540,9 @@ public class MalwareSecurityService {
 
     @McpTool(path = "/detect_malware_behaviors", description = "Detect common malware behaviors", category = "malware")
     public Response detectMalwareBehaviors(
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/main/java/com/xebyte/core/ManualToolDescriptors.java
+++ b/src/main/java/com/xebyte/core/ManualToolDescriptors.java
@@ -18,12 +18,21 @@ import java.util.Map;
  * <p>Path/method/category/description/params are sourced verbatim from
  * {@code tests/endpoints.json}'s hand-registered entries (see
  * {@code RegenerateEndpointsJson}'s "preserved (hand-registered)" merge rule --
- * that file is the existing source of truth for these routes' metadata). Params
- * carry only a name and a source inferred from the route's HTTP method (GET -&gt;
- * query, POST -&gt; body); the catalog does not track per-param type/required detail
- * for hand-registered routes, and every one of these handlers already parses its
- * own params permissively, so marking them optional-string is accurate enough for
- * tool discovery without overclaiming precision the source data doesn't have.
+ * that file is the existing source of truth for these routes' metadata). The
+ * param NAMES come from there and their source is inferred from the route's HTTP
+ * method (GET -&gt; query, POST -&gt; body); the catalog does not track per-param
+ * type/required detail for hand-registered routes, and every one of these handlers
+ * already parses its own params permissively, so marking them optional-string is
+ * accurate enough for tool discovery without overclaiming precision the source
+ * data doesn't have.
+ *
+ * <p>The param DESCRIPTIONS, by contrast, are written here against what the
+ * handlers actually do, because there is nowhere else for them to come from: an
+ * {@code @McpTool} method gets them from {@code @Param(description = ...)}, and a
+ * hand-registered route has no annotation at all. Several of these parameters are
+ * mode-dependent (the GUI plugin drives the already-open project and ignores the
+ * repository selector; the headless server holds a real server connection and
+ * reads it) or accepted and never read, and the descriptions say which.
  *
  * <p>{@code ManualToolDescriptorsParityTest} enforces that every path a server
  * registers manually has an entry here, so a future added route can't silently
@@ -33,39 +42,82 @@ public final class ManualToolDescriptors {
 
     private ManualToolDescriptors() {}
 
-    private static AnnotationScanner.ParamDescriptor p(String name, String source) {
-        return new AnnotationScanner.ParamDescriptor(name, "string", source, true, null, "", "", false);
+    private static AnnotationScanner.ParamDescriptor p(String name, String source, String description) {
+        return new AnnotationScanner.ParamDescriptor(name, "string", source, true, null, description, "", false);
     }
 
-    private static List<AnnotationScanner.ParamDescriptor> params(String method, String... names) {
+    /**
+     * Build a descriptor list from alternating name/description pairs.
+     *
+     * <p>Pairs, not bare names, on purpose: a hand-registered route's parameters
+     * reach {@code /mcp/schema} through here and nowhere else, so a parameter
+     * added without a description lands in every client's {@code inputSchema}
+     * with nothing to say. The odd-count guard makes forgetting one a build-time
+     * failure rather than a silent blank.
+     *
+     * @throws IllegalArgumentException if the varargs are not name/description pairs
+     */
+    private static List<AnnotationScanner.ParamDescriptor> params(String method, String... nameThenDescription) {
+        if (nameThenDescription.length % 2 != 0) {
+            throw new IllegalArgumentException("ManualToolDescriptors.params() takes alternating"
+                + " name/description pairs; got an odd argument count ("
+                + nameThenDescription.length + "). Every hand-registered parameter needs a description.");
+        }
         String source = "GET".equalsIgnoreCase(method) ? "query" : "body";
         List<AnnotationScanner.ParamDescriptor> out = new java.util.ArrayList<>();
-        for (String n : names) out.add(p(n, source));
+        for (int i = 0; i < nameThenDescription.length; i += 2) {
+            out.add(p(nameThenDescription[i], source, nameThenDescription[i + 1]));
+        }
         return out;
     }
 
     private static void add(Map<String, AnnotationScanner.ToolDescriptor> m,
-            String path, String method, String category, String description, String... paramNames) {
+            String path, String method, String category, String description, String... paramPairs) {
         m.put(path, new AnnotationScanner.ToolDescriptor(
-            path, method, description, category, "", params(method, paramNames)));
+            path, method, description, category, "", params(method, paramPairs)));
     }
 
     /** Keyed by path. Built once; entries never mutate after class init. */
     private static final Map<String, AnnotationScanner.ToolDescriptor> ALL = buildAll();
 
+    // Reused wording. GUI mode drives the already-open project and ignores the
+    // repository selector entirely; only the headless server, which holds a
+    // direct Ghidra Server connection, reads it.
+    private static final String REPO_HEADLESS_ONLY =
+            "Repository name on the Ghidra Server. Read only by the headless server —"
+            + " the GUI plugin works on the already-open project and ignores it.";
+
     private static Map<String, AnnotationScanner.ToolDescriptor> buildAll() {
         Map<String, AnnotationScanner.ToolDescriptor> m = new LinkedHashMap<>();
-        add(m, "/batch_apply_documentation", "POST", "analysis", "Apply all documentation to a function in one call", "address", "name", "prototype", "calling_convention", "variable_types", "variable_renames", "plate_comment", "decompiler_comments", "disassembly_comments", "goto", "score", "program");
+        add(m, "/batch_apply_documentation", "POST", "analysis",
+            "Apply all documentation to a function in one call",
+            "address", "Function entry address, as 0x<hex> or <space>:<hex>. Required: every step below is applied to the function at this address.",
+            "name", "New function name. Omit or leave empty to skip the rename step.",
+            "prototype", "Full C signature. Applied BEFORE the comment step on purpose, because setting a prototype wipes the plate comment.",
+            "calling_convention", "Convention for the prototype step, e.g. __stdcall. Read only when prototype is also given.",
+            "variable_types", "Object mapping variable name to new type. Each is applied on its own; the step reports set/failed counts plus per-variable errors.",
+            "variable_renames", "Object mapping each variable's CURRENT name to its new name.",
+            "plate_comment", "Plate comment for the function. Pass real multi-line text: an escaped newline sequence is stored as those two literal characters, not as a line break.",
+            "decompiler_comments", "Array of {address, comment} objects setting PRE comments. Each entry carries its own address; the top-level address is the function entry only.",
+            "disassembly_comments", "Array of {address, comment} objects setting EOL comments. Each entry carries its own address.",
+            "goto", "True navigates the CodeBrowser to address before anything else. Must be a JSON boolean: any other type is read as FALSE. Default false.",
+            "score", "True (the default) appends a compact completeness score. Must be a JSON boolean: any other type falls back to the default and is read as TRUE, so the string false does not switch it off.",
+            "program", "Accepted but not read by this route: every step runs against the active program. Use the individual tools when you need to target a specific one.");
         add(m, "/check_connection", "GET", "utility", "Health check endpoint");
-        add(m, "/configure_analyzer", "POST", "analysis", "Configure an analysis plugin", "name", "enabled", "program");
-        add(m, "/delete_project", "POST", "project", "Delete a Ghidra project", "projectPath");
+        add(m, "/configure_analyzer", "POST", "analysis", "Configure an analysis plugin",
+            "name", "Analyzer name exactly as Ghidra registers it, e.g. Decompiler Parameter ID.",
+            "enabled", "True enables the analyzer, false disables it. Omitting the key entirely leaves the current setting alone.",
+            "program", "Target program name (omit to use the active program). Headless mode only.");
+        add(m, "/delete_project", "POST", "project", "Delete a Ghidra project",
+            "projectPath", "Filesystem path of the project to delete: its .gpr file or the project directory. Headless mode only; the GUI plugin does not register this route.");
         add(m, "/exit_ghidra", "POST", "program", "Save and exit Ghidra");
         add(m, "/get_current_address", "GET", "getter", "Get cursor address (GUI only)");
         add(m, "/get_current_function", "GET", "getter", "Get function at cursor (GUI only)");
         add(m, "/get_current_selection", "GET", "getter", "Get highlighted address ranges in the CodeBrowser listing (GUI only). Returns {program, is_empty, ranges:[{start,end,length}], min_address, max_address, num_addresses} or an empty-selection payload when nothing is highlighted.");
         add(m, "/get_version", "GET", "utility", "Get plugin version");
         add(m, "/health", "GET", "utility", "Health check endpoint for headless server");
-        add(m, "/list_projects", "GET", "project", "List available Ghidra projects", "searchDir");
+        add(m, "/list_projects", "GET", "project", "List available Ghidra projects",
+            "searchDir", "Directory to scan for .gpr projects. Headless mode only; the GUI plugin does not register this route.");
         add(m, "/mcp/health", "GET", "utility", "HTTP server health: pool stats, uptime, memory, active request count");
         add(m, "/mcp/schema", "GET", "utility", "Machine-readable API schema with endpoint metadata");
         // /move_file and /move_folder used to live here: manually routed in the
@@ -75,28 +127,66 @@ public final class ManualToolDescriptors {
         // ProgramScriptService.{moveFile,moveFolder}, which registers them in
         // every mode. Do not re-add them here -- double registration throws
         // "cannot add context to list" on headless startup (see #180).
-        add(m, "/open_project", "POST", "headless", "Open an existing Ghidra project (.gpr file or directory). GUI mode adds optional `headless` (default true) to suppress auto-launching CodeBrowser, and optional `program` to auto-launch CodeBrowser for a specific file when headless=false. Headless server ignores the extra params.", "path", "headless", "program");
+        add(m, "/open_project", "POST", "headless", "Open an existing Ghidra project (.gpr file or directory). GUI mode adds optional `headless` (default true) to suppress auto-launching CodeBrowser, and optional `program` to auto-launch CodeBrowser for a specific file when headless=false. Headless server ignores the extra params.",
+            "path", "Path to the project: its .gpr file or the project directory holding it.",
+            "headless", "GUI mode only. True (the default) loads the project into the FrontEnd tool without opening a CodeBrowser window; false launches one for `program`. The headless server ignores it.",
+            "program", "GUI mode only, and only when headless=false: the DomainFile path to open in the launched CodeBrowser.");
         add(m, "/project/info", "GET", "project", "Get detailed project info including running tools and open programs");
-        add(m, "/server/admin/set_permissions", "POST", "server", "Set user permissions on a repository", "repo", "user", "accessLevel");
-        add(m, "/server/admin/terminate_all_checkouts", "POST", "server", "Terminate all checkouts in a folder recursively", "repo", "path");
-        add(m, "/server/admin/terminate_checkout", "POST", "server", "Terminate all checkouts on a single file", "repo", "path", "checkoutId", "checkout_id");
+        add(m, "/server/admin/set_permissions", "POST", "server", "Set user permissions on a repository",
+            "repo", REPO_HEADLESS_ONLY + " The GUI plugin answers that this operation needs headless mode.",
+            "user", "Server user whose access is being set. The repository ACL is read, this one entry replaced or appended, and every other user preserved.",
+            "accessLevel", "Numeric Ghidra access level: 0 no access, 1 read only, 2 read/write, 3 admin. Defaults to 1.");
+        add(m, "/server/admin/terminate_all_checkouts", "POST", "server", "Terminate all checkouts in a folder recursively",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Folder to walk recursively, terminating every checkout under it. Defaults to / — the whole repository or project.");
+        add(m, "/server/admin/terminate_checkout", "POST", "server", "Terminate all checkouts on a single file",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the file whose checkout is being terminated.",
+            "checkoutId", "Numeric checkout id to terminate, as /server/checkouts reports it. Headless mode only, and defaults to 0 when absent; the GUI plugin terminates by path alone.",
+            "checkout_id", "Alternative spelling of checkoutId, read only when checkoutId is absent.");
         add(m, "/server/admin/users", "GET", "server", "List all users on the server");
-        add(m, "/server/authenticate", "POST", "server", "Register server credentials for programmatic authentication", "username", "password");
-        add(m, "/server/checkouts", "GET", "server", "List all checked-out files in a folder, including server-side checkouts", "path");
-        add(m, "/server/connect", "POST", "server", "Connect to a Ghidra server", "host", "port");
+        add(m, "/server/authenticate", "POST", "server", "Register server credentials for programmatic authentication",
+            "username", "Server username. Omit to fall back to Ghidra's stored PasswordPrompt.Name, then to the OS user name.",
+            "password", "Server password. Required — the call is refused without it.");
+        add(m, "/server/checkouts", "GET", "server", "List all checked-out files in a folder, including server-side checkouts",
+            "path", "Folder to list checkouts under. Defaults to / — everything.");
+        add(m, "/server/connect", "POST", "server", "Connect to a Ghidra server",
+            "host", "Accepted but not read: the headless server connects using its configured host (GHIDRA_SERVER_* environment), and the GUI plugin uses the already-open project.",
+            "port", "Accepted but not read, for the same reason as host.");
         add(m, "/server/disconnect", "POST", "server", "Disconnect from the Ghidra server");
         add(m, "/server/repositories", "GET", "server", "List repositories on the connected server");
-        add(m, "/server/repository/create", "POST", "server", "Create a new repository on the server", "name");
-        add(m, "/server/repository/file", "GET", "server", "Get file info from a server repository", "repo", "path");
-        add(m, "/server/repository/files", "GET", "server", "List files in a server repository folder", "repo", "path");
+        add(m, "/server/repository/create", "POST", "server", "Create a new repository on the server",
+            "name", "Name for the new repository. Headless mode only; the GUI plugin refuses and points at Ghidra's Project Manager.");
+        add(m, "/server/repository/file", "GET", "server", "Get file info from a server repository",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the file to describe. Required.");
+        add(m, "/server/repository/files", "GET", "server", "List files in a server repository folder",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Folder to list. Defaults to / — the repository or project root.");
         add(m, "/server/status", "GET", "headless", "Check headless server connection status");
-        add(m, "/server/version_control/add", "POST", "server", "Add a file to version control", "repo", "path", "comment", "keepCheckedOut");
-        add(m, "/server/version_control/checkin", "POST", "server", "Check in a version-controlled file", "repo", "path", "comment", "keepCheckedOut");
-        add(m, "/server/version_control/checkout", "POST", "server", "Check out a version-controlled file", "repo", "path");
-        add(m, "/server/version_control/undo_checkout", "POST", "server", "Undo a file checkout", "repo", "path");
-        add(m, "/server/version_history", "GET", "server", "Get version history for a file", "repo", "path");
-        add(m, "/tool/goto_address", "POST", "utility", "Navigate CodeBrowser listing and decompiler to a specific address", "address");
-        add(m, "/tool/launch_codebrowser", "POST", "utility", "Open a file in CodeBrowser, launching a new one if needed", "path");
+        add(m, "/server/version_control/add", "POST", "server", "Add a file to version control",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the not-yet-versioned file to add.",
+            "comment", "Check-in comment recorded for the initial version. Defaults to a generic Added via GhidraMCP.",
+            "keepCheckedOut", "Accepted but not read on this route — neither handler passes it through. Use /server/version_control/checkin, where it does apply.");
+        add(m, "/server/version_control/checkin", "POST", "server", "Check in a version-controlled file",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the checked-out file to check in.",
+            "comment", "Check-in comment recorded on the new version. Defaults to a generic Checked in via GhidraMCP.",
+            "keepCheckedOut", "True keeps the file checked out after the version lands, so you can keep editing. False (the default) releases the checkout.");
+        add(m, "/server/version_control/checkout", "POST", "server", "Check out a version-controlled file",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the versioned file to check out.");
+        add(m, "/server/version_control/undo_checkout", "POST", "server", "Undo a file checkout",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the checked-out file to release. Any local changes not checked in are discarded.");
+        add(m, "/server/version_history", "GET", "server", "Get version history for a file",
+            "repo", REPO_HEADLESS_ONLY,
+            "path", "Path of the versioned file whose history to return.");
+        add(m, "/tool/goto_address", "POST", "utility", "Navigate CodeBrowser listing and decompiler to a specific address",
+            "address", "Address to navigate to, as 0x<hex> or <space>:<hex>. GUI mode only — it moves a CodeBrowser window.");
+        add(m, "/tool/launch_codebrowser", "POST", "utility", "Open a file in CodeBrowser, launching a new one if needed",
+            "path", "DomainFile path of the program to open, e.g. /Vanilla/1.13c/D2Common.dll. GUI mode only.");
         add(m, "/tool/running_tools", "GET", "utility", "List all running Ghidra tool windows");
         return m;
     }

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -2611,8 +2611,17 @@ public class ProgramScriptService {
 
     @McpTool(path = "/run_script_inline", method = "POST", description = "Execute inline Ghidra script code. Pass the full Java source as the 'code' body parameter. Gated by GHIDRA_MCP_ALLOW_SCRIPTS=1 (v5.4.1+).", category = "program")
     public Response runScriptInline(
-            @Param(value = "code", source = ParamSource.BODY) String code,
-            @Param(value = "args", source = ParamSource.BODY, defaultValue = "") String args,
+            @Param(value = "code", source = ParamSource.BODY,
+                   description = "Complete Java source for a GhidraScript, as one string — not a bare "
+                               + "statement. If it declares `public class X` that name is used for the "
+                               + "file; otherwise a unique McpInline_<hex> class name is generated. The "
+                               + "source is written into ~/ghidra_scripts and compiled by Ghidra, so a "
+                               + "compile error surfaces as script output rather than as a request "
+                               + "error.") String code,
+            @Param(value = "args", source = ParamSource.BODY, defaultValue = "",
+                   description = "Arguments handed to the script, split on WHITESPACE into a String[]. "
+                               + "There is no quoting, so an argument containing a space arrives as two "
+                               + "arguments.") String args,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         if (!SecurityConfig.getInstance().areScriptsAllowed()) {
             return Response.err("Script execution disabled. Set GHIDRA_MCP_ALLOW_SCRIPTS=1 "
@@ -2845,19 +2854,37 @@ public class ProgramScriptService {
 
     @McpTool(path = "/create_memory_block", method = "POST", description = "Create a new memory block. On programs with multiple address spaces (e.g., embedded targets), prefix addresses with the space name (mem:1000) to avoid ambiguous resolution.", category = "program")
     public Response createMemoryBlock(
-            @Param(value = "name", source = ParamSource.BODY) String name,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Name for the new block as it appears in the memory map, e.g. MMIO or "
+                               + "PERIPH. Required.") String name,
             @Param(value = "address", paramType = "address", source = ParamSource.BODY,
                    description = "Address in the program. Accepts 0x<hex> (default space) or <space>:<hex> "
                                + "(e.g., mem:1000, code:ff00). Note: some programs — particularly "
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "size", source = ParamSource.BODY, defaultValue = "0") long size,
-            @Param(value = "read", source = ParamSource.BODY, defaultValue = "true") boolean read,
-            @Param(value = "write", source = ParamSource.BODY, defaultValue = "true") boolean write,
-            @Param(value = "execute", source = ParamSource.BODY, defaultValue = "false") boolean execute,
-            @Param(value = "volatile", source = ParamSource.BODY, defaultValue = "false") boolean isVolatile,
-            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "") String comment,
+            @Param(value = "size", source = ParamSource.BODY, defaultValue = "0",
+                   description = "Block length in BYTES, not elements or pages. Must be positive — the "
+                               + "declared default of 0 is rejected, so this is effectively required. The "
+                               + "range address..address+size-1 must not overlap an existing "
+                               + "block.") long size,
+            @Param(value = "read", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Read permission on the new block (default true); the r in the "
+                               + "response's `permissions` string.") boolean read,
+            @Param(value = "write", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Write permission on the new block (default true); the w in the "
+                               + "response's `permissions` string.") boolean write,
+            @Param(value = "execute", source = ParamSource.BODY, defaultValue = "false",
+                   description = "Execute permission, default FALSE. Set true only for a code region — "
+                               + "leaving it false is what keeps disassembly out of a data or MMIO "
+                               + "block.") boolean execute,
+            @Param(value = "volatile", source = ParamSource.BODY, defaultValue = "false",
+                   description = "Marks the block volatile (default false): its contents can change "
+                               + "outside program flow, so the decompiler stops folding repeated reads "
+                               + "away. Set this for MMIO and peripheral register regions.") boolean isVolatile,
+            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "",
+                   description = "Optional comment stored on the memory block itself. Empty (the default) "
+                               + "leaves it unset.") String comment,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -2962,8 +2989,14 @@ public class ProgramScriptService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "category", source = ParamSource.BODY, defaultValue = "") String category,
-            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "") String comment,
+            @Param(value = "category", source = ParamSource.BODY, defaultValue = "",
+                   description = "Bookmark category, free text; empty or omitted becomes the literal "
+                               + "`Note`. An existing bookmark at this address in the SAME category is "
+                               + "replaced, while a different category adds a second bookmark. Everything "
+                               + "here is created under Ghidra's Note bookmark type.") String category,
+            @Param(value = "comment", source = ParamSource.BODY, defaultValue = "",
+                   description = "Bookmark text. Empty is allowed and stores an empty "
+                               + "comment.") String comment,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -3109,7 +3142,10 @@ public class ProgramScriptService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "category", source = ParamSource.BODY, defaultValue = "") String category,
+            @Param(value = "category", source = ParamSource.BODY, defaultValue = "",
+                   description = "Delete only bookmarks in this category. Empty (the default) deletes "
+                               + "EVERY bookmark at the address whatever its category; `deleted` in the "
+                               + "response counts how many went.") String category,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -3168,10 +3204,20 @@ public class ProgramScriptService {
 
     @McpTool(path = "/run_ghidra_script", method = "POST", description = "Execute script with output capture and timeout. Gated by GHIDRA_MCP_ALLOW_SCRIPTS=1 (v5.4.1+).", category = "program")
     public Response runGhidraScriptWithCapture(
-            @Param(value = "script_name", source = ParamSource.BODY) String scriptName,
-            @Param(value = "args", source = ParamSource.BODY, defaultValue = "") String scriptArgs,
-            @Param(value = "timeout_seconds", source = ParamSource.BODY, defaultValue = "300") int timeoutSeconds,
-            @Param(value = "capture_output", source = ParamSource.BODY, defaultValue = "true") boolean captureOutput,
+            @Param(value = "script_name", source = ParamSource.BODY,
+                   description = "Script to run. Searched in ~/ghidra_scripts, <cwd>/ghidra_scripts and "
+                               + "./ghidra_scripts, then tried as an absolute path. A name with no dot in "
+                               + "it is tried with .java, then .py, then bare.") String scriptName,
+            @Param(value = "args", source = ParamSource.BODY, defaultValue = "",
+                   description = "Arguments handed to the script, split on WHITESPACE into a String[]. "
+                               + "There is no quoting, so an argument containing a space arrives as two "
+                               + "arguments.") String scriptArgs,
+            @Param(value = "timeout_seconds", source = ParamSource.BODY, defaultValue = "300",
+                   description = "Wall-clock limit for the run in SECONDS: 1 to 1800, default 300. A value "
+                               + "outside that range is REJECTED, not clamped.") int timeoutSeconds,
+            @Param(value = "capture_output", source = ParamSource.BODY, defaultValue = "true",
+                   description = "Accepted but currently not read: the script's console output is captured "
+                               + "either way. Passing false does not suppress it today.") boolean captureOutput,
             @Param(value = "program", description = "Target program name", defaultValue = "") String programName) {
         if (!SecurityConfig.getInstance().areScriptsAllowed()) {
             return Response.err("Script execution disabled. Set GHIDRA_MCP_ALLOW_SCRIPTS=1 "

--- a/src/main/java/com/xebyte/core/ProgramScriptService.java
+++ b/src/main/java/com/xebyte/core/ProgramScriptService.java
@@ -466,7 +466,9 @@ public class ProgramScriptService {
             @Param(value = "value", source = ParamSource.BODY, description = "New value as a string; parsed according to the option type.") String value,
             @Param(value = "type", source = ParamSource.BODY, defaultValue = "",
                    description = "Value type: string|int|long|double|float|boolean. Optional when the option already exists (its current type is reused); defaults to string for a brand-new option.") String type,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -552,7 +554,9 @@ public class ProgramScriptService {
     public Response removeProgramOption(
             @Param(value = "group", source = ParamSource.BODY, description = "Option group name.") String group,
             @Param(value = "name", source = ParamSource.BODY, description = "Option name to remove.") String name,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -639,7 +643,9 @@ public class ProgramScriptService {
             @Param(value = "name", source = ParamSource.BODY, description = "Unique map name.") String name,
             @Param(value = "type", source = ParamSource.BODY, defaultValue = "string",
                    description = "Value type: int, long, string, or void.") String type,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -685,7 +691,9 @@ public class ProgramScriptService {
              category = "program")
     public Response deletePropertyMap(
             @Param(value = "name", source = ParamSource.BODY, description = "Map name to delete.") String name,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -730,7 +738,9 @@ public class ProgramScriptService {
             @Param(value = "address", paramType = "address", source = ParamSource.BODY, description = ADDRESS_PARAM_DESC) String addressStr,
             @Param(value = "value", source = ParamSource.BODY, defaultValue = "",
                    description = "Value to store, as a string; parsed per the map's type. Ignored for 'void' maps.") String value,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -808,7 +818,9 @@ public class ProgramScriptService {
     public Response getProperty(
             @Param(value = "map", description = "Property map name (from list_property_maps).") String mapName,
             @Param(value = "address", paramType = "address", description = ADDRESS_PARAM_DESC) String addressStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -849,7 +861,9 @@ public class ProgramScriptService {
     public Response removeProperty(
             @Param(value = "map", source = ParamSource.BODY, description = "Property map name.") String mapName,
             @Param(value = "address", paramType = "address", source = ParamSource.BODY, description = ADDRESS_PARAM_DESC) String addressStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -897,7 +911,9 @@ public class ProgramScriptService {
             @Param(value = "end", paramType = "address", defaultValue = "", description = "Optional inclusive end address of a range filter (requires start).") String endStr,
             @Param(value = "offset", defaultValue = "0", description = "Number of entries to skip.") int offset,
             @Param(value = "limit", defaultValue = "100", description = "Maximum number of entries to return.") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -3269,7 +3285,9 @@ public class ProgramScriptService {
     @McpTool(path = "/set_image_base", method = "POST", description = "Set the base address of the program (rebases all addresses)", category = "program")
     public Response setImageBase(
             @Param(value = "address", source = ParamSource.BODY, description = "New base address (e.g. 0x08000000)") String addressStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/main/java/com/xebyte/core/SymbolLabelService.java
+++ b/src/main/java/com/xebyte/core/SymbolLabelService.java
@@ -42,8 +42,13 @@ public class SymbolLabelService {
     public Response getFunctionLabels(
             @Param(value = "name", paramType = "address", aliases = {"function", "address", "function_address"},
                    description = "Function name or address (0x<hex> / <space>:<hex>).") String functionName,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "20") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of labels to skip before this page starts; 0 begins at the "
+                               + "first.") int offset,
+            @Param(value = "limit", defaultValue = "20",
+                   description = "Maximum labels returned in this page (default 20). Pass 0 or a negative "
+                               + "value for no limit; `total` in the response always reports the full "
+                               + "count for the function.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -95,7 +100,14 @@ public class SymbolLabelService {
             @Param(value = "target", source = ParamSource.BODY, paramType = "address",
                    aliases = {"address", "function_address", "old_name"},
                    description = "Address (0x<hex> / <space>:<hex>) or current symbol name to rename.") String target,
-            @Param(value = "new_name", source = ParamSource.BODY) String newName,
+            @Param(value = "new_name", source = ParamSource.BODY,
+                   description = "The name to apply. A data global should be g_ + Hungarian + descriptor "
+                               + "(g_dwPlayerCount); a code label should be snake_case. Convention misses "
+                               + "come back as warnings on an otherwise successful write. IMPORTANT: at a "
+                               + "CODE address with no defined data, this ADDS a label rather than renaming "
+                               + "one — the existing symbol survives and may stay primary, so the listing "
+                               + "can still show the old name after a success. Call delete_label on the old "
+                               + "name first when you meant to replace it.") String newName,
             @Param(value = "kind", source = ParamSource.BODY, defaultValue = "auto",
                    description = "auto | data | global | label | external") String kind,
             @Param(value = "old_name", source = ParamSource.BODY, defaultValue = "",

--- a/src/main/java/com/xebyte/core/SymbolLabelService.java
+++ b/src/main/java/com/xebyte/core/SymbolLabelService.java
@@ -44,7 +44,9 @@ public class SymbolLabelService {
                    description = "Function name or address (0x<hex> / <space>:<hex>).") String functionName,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "20") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -98,7 +100,9 @@ public class SymbolLabelService {
                    description = "auto | data | global | label | external") String kind,
             @Param(value = "old_name", source = ParamSource.BODY, defaultValue = "",
                    description = "For kind=label only: the current label name at the address.") String oldName,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         String k = (kind == null || kind.isBlank()) ? "auto" : kind.trim().toLowerCase();
         switch (k) {
             case "data":     return renameDataAtAddress(target, newName, programName);
@@ -129,7 +133,9 @@ public class SymbolLabelService {
                                + "address is unambiguous.") String addressStr,
             @Param(value = "old_name", source = ParamSource.BODY) String oldName,
             @Param(value = "new_name", source = ParamSource.BODY) String newName,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -200,7 +206,9 @@ public class SymbolLabelService {
                    description = "Label name (single mode).") String labelName,
             @Param(value = "labels", source = ParamSource.BODY, defaultValue = "[]",
                    description = "Bulk mode: array of {address, name} objects. When non-empty, address/name are ignored.") List<Map<String, String>> labels,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -273,7 +281,9 @@ public class SymbolLabelService {
     // Bulk helper for create_label(labels=[...]). Merged into create_label in 7.0.0.
     public Response batchCreateLabels(
             @Param(value = "labels", source = ParamSource.BODY) List<Map<String, String>> labels,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -389,7 +399,9 @@ public class SymbolLabelService {
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
             @Param(value = "name", source = ParamSource.BODY) String newName,
-            @Param(value = "program", defaultValue = "") String programName,
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName,
             @Param(value = "strict_mode", source = ParamSource.BODY, defaultValue = "",
                    description = "Optional per-call override for naming enforcement: 'enforce' / 'warn' / 'off'. Omit to use the project/global setting.")
                     String strictModeArg) {
@@ -461,7 +473,9 @@ public class SymbolLabelService {
                    description = "Label name (single mode).") String labelName,
             @Param(value = "labels", source = ParamSource.BODY, defaultValue = "[]",
                    description = "Bulk mode: array of {address, name} objects. When non-empty, address/name are ignored.") List<Map<String, String>> labels,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -542,7 +556,9 @@ public class SymbolLabelService {
     // Bulk helper for delete_label(labels=[...]). Merged into delete_label in 7.0.0.
     public Response batchDeleteLabels(
             @Param(value = "labels", source = ParamSource.BODY) List<Map<String, String>> labels,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -649,7 +665,9 @@ public class SymbolLabelService {
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
             @Param(value = "new_name", source = ParamSource.BODY, aliases = {"newName"}) String newName,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -764,7 +782,9 @@ public class SymbolLabelService {
     public Response renameGlobalVariable(
             @Param(value = "old_name", source = ParamSource.BODY) String oldName,
             @Param(value = "new_name", source = ParamSource.BODY) String newName,
-            @Param(value = "program", defaultValue = "") String programName,
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName,
             @Param(value = "strict_mode", source = ParamSource.BODY, defaultValue = "",
                    description = "Optional per-call override for naming enforcement: 'enforce' / 'warn' / 'off'. Omit to use the project/global setting.")
                     String strictModeArg) {
@@ -926,7 +946,9 @@ public class SymbolLabelService {
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String address,
             @Param(value = "new_name", source = ParamSource.BODY) String newName,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -1005,7 +1027,9 @@ public class SymbolLabelService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/main/java/com/xebyte/core/XrefCallGraphService.java
+++ b/src/main/java/com/xebyte/core/XrefCallGraphService.java
@@ -38,8 +38,14 @@ public class XrefCallGraphService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", description = "Target program name (omit to use the active program — always specify when multiple programs are open)", defaultValue = "") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
@@ -89,8 +95,14 @@ public class XrefCallGraphService {
                                + "embedded/microcontroller targets — are not address-space-agnostic; "
                                + "use get_address_spaces to discover spaces before assuming a plain hex "
                                + "address is unambiguous.") String addressStr,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -319,8 +331,14 @@ public class XrefCallGraphService {
     public Response getFunctionXrefs(
             @Param(value = "name", defaultValue = "", description = "Function name") String functionName,
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -375,8 +393,14 @@ public class XrefCallGraphService {
     public Response getFunctionJumpTargets(
             @Param(value = "name", defaultValue = "", description = "Function name") String functionName,
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -461,8 +485,14 @@ public class XrefCallGraphService {
     public Response getFunctionCallees(
             @Param(value = "name", defaultValue = "", description = "Function name") String functionName,
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -528,8 +558,14 @@ public class XrefCallGraphService {
     public Response getFunctionCallers(
             @Param(value = "name", defaultValue = "", description = "Function name") String functionName,
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
-            @Param(value = "offset", defaultValue = "0") int offset,
-            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "offset", defaultValue = "0",
+                   description = "Number of entries to skip before this page starts; 0 begins at the "
+                               + "first entry. Page by adding `limit` each call until offset reaches the "
+                               + "`total` the response reports.") int offset,
+            @Param(value = "limit", defaultValue = "100",
+                   description = "Maximum entries returned in this page (default 100). Pass 0 or a "
+                               + "negative value for no limit; `total` in the response always reports the "
+                               + "full unpaged count.") int limit,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -1320,7 +1356,13 @@ public class XrefCallGraphService {
 
     @McpTool(path = "/get_bulk_xrefs", method = "POST", description = "Batch cross-reference retrieval", category = "xref")
     public Response getBulkXrefs(
-            @Param(value = "addresses", source = ParamSource.BODY) Object addressesObj,
+            @Param(value = "addresses", source = ParamSource.BODY,
+                   description = "Addresses to fetch references TO. Accepts a JSON array of address "
+                               + "strings or one comma-separated string, each entry in the usual 0x<hex> "
+                               + "or <space>:<hex> form. The result is keyed by the exact string you sent. "
+                               + "Beware: an entry that does not parse comes back as an EMPTY array, which "
+                               + "is indistinguishable from an address that genuinely has no "
+                               + "references.") Object addressesObj,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {
@@ -1393,9 +1435,20 @@ public class XrefCallGraphService {
 
     @McpTool(path = "/get_assembly_context", method = "POST", description = "Get assembly pattern context for xref sources", category = "xref")
     public Response getAssemblyContext(
-            @Param(value = "xref_sources", source = ParamSource.BODY) Object xrefSourcesObj,
-            @Param(value = "context_instructions", source = ParamSource.BODY, defaultValue = "5") int contextInstructions,
-            @Param(value = "include_patterns", source = ParamSource.BODY) Object includePatternsObj,
+            @Param(value = "xref_sources", source = ParamSource.BODY,
+                   description = "Instruction addresses to pull context around. Accepts a JSON array of "
+                               + "address strings or one comma-separated string, each in the usual 0x<hex> "
+                               + "or <space>:<hex> form. The result is keyed by the exact string you sent, "
+                               + "and an address with no instruction at it gets its own error entry rather "
+                               + "than failing the batch.") Object xrefSourcesObj,
+            @Param(value = "context_instructions", source = ParamSource.BODY, defaultValue = "5",
+                   description = "How many instructions to include on EACH side of every source address "
+                               + "(default 5), so the window is up to 2n+1 instructions. The walk stops "
+                               + "early at the start or end of the listing.") int contextInstructions,
+            @Param(value = "include_patterns", source = ParamSource.BODY,
+                   description = "Accepted but currently not read. Mnemonic pattern detection always runs "
+                               + "and patterns_detected is always present; there is no way to switch it off "
+                               + "today.") Object includePatternsObj,
             @Param(value = "program", defaultValue = "",
                    description = "Target program name (omit to use the active program — always specify "
                                + "when multiple programs are open)") String programName) {

--- a/src/main/java/com/xebyte/core/XrefCallGraphService.java
+++ b/src/main/java/com/xebyte/core/XrefCallGraphService.java
@@ -91,7 +91,9 @@ public class XrefCallGraphService {
                                + "address is unambiguous.") String addressStr,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "100") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -160,7 +162,9 @@ public class XrefCallGraphService {
                                + "re-analysis), ANALYSIS, IMPORTED, DEFAULT.") String sourceTypeStr,
             @Param(value = "operand_index", source = ParamSource.BODY, defaultValue = "-1",
                    description = "Operand index the reference attaches to. -1 = mnemonic/data operand.") int operandIndex,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -229,7 +233,9 @@ public class XrefCallGraphService {
             @Param(value = "operand_index", source = ParamSource.BODY, defaultValue = "-1",
                    description = "Operand index to match. -1 (default) = remove references on any operand; "
                                + ">= 0 = remove only the reference on that operand.") int operandIndex,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -315,7 +321,9 @@ public class XrefCallGraphService {
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "100") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -369,7 +377,9 @@ public class XrefCallGraphService {
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "100") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -453,7 +463,9 @@ public class XrefCallGraphService {
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "100") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -518,7 +530,9 @@ public class XrefCallGraphService {
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
             @Param(value = "offset", defaultValue = "0") int offset,
             @Param(value = "limit", defaultValue = "100") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -573,7 +587,9 @@ public class XrefCallGraphService {
             @Param(value = "address", defaultValue = "", description = "Function entry-point address (hex) — alternative to name") String address,
             @Param(value = "depth", defaultValue = "2", description = "Traversal depth") int depth,
             @Param(value = "direction", defaultValue = "both", description = "Traversal direction (both/callers/callees)") String direction,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -736,7 +752,9 @@ public class XrefCallGraphService {
     public Response getFullCallGraph(
             @Param(value = "format", defaultValue = "edges", description = "Output format: edges (text), adjacency, dot, mermaid, json_edges (address-based JSON for automation)") String format,
             @Param(value = "limit", defaultValue = "1000", description = "Max edges to return. 0 = unlimited.") int limit,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -897,7 +915,9 @@ public class XrefCallGraphService {
             @Param(value = "start_function", description = "Start function name") String startFunction,
             @Param(value = "end_function", description = "End function name") String endFunction,
             @Param(value = "analysis_type", defaultValue = "summary", description = "Analysis type (summary/paths/cycles)") String analysisType,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -1301,7 +1321,9 @@ public class XrefCallGraphService {
     @McpTool(path = "/get_bulk_xrefs", method = "POST", description = "Batch cross-reference retrieval", category = "xref")
     public Response getBulkXrefs(
             @Param(value = "addresses", source = ParamSource.BODY) Object addressesObj,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();
@@ -1374,7 +1396,9 @@ public class XrefCallGraphService {
             @Param(value = "xref_sources", source = ParamSource.BODY) Object xrefSourcesObj,
             @Param(value = "context_instructions", source = ParamSource.BODY, defaultValue = "5") int contextInstructions,
             @Param(value = "include_patterns", source = ParamSource.BODY) Object includePatternsObj,
-            @Param(value = "program", defaultValue = "") String programName) {
+            @Param(value = "program", defaultValue = "",
+                   description = "Target program name (omit to use the active program — always specify "
+                               + "when multiple programs are open)") String programName) {
         ServiceUtils.ProgramOrError pe = ServiceUtils.getProgramOrError(programProvider, programName);
         if (pe.hasError()) return pe.error();
         Program program = pe.program();

--- a/src/main/java/com/xebyte/headless/HeadlessManagementService.java
+++ b/src/main/java/com/xebyte/headless/HeadlessManagementService.java
@@ -120,8 +120,13 @@ public class HeadlessManagementService {
 
     @McpTool(path = "/create_project", method = "POST", description = "Create a new Ghidra project", category = "headless")
     public Response createProject(
-            @Param(value = "parentDir", source = ParamSource.BODY) String parentDir,
-            @Param(value = "name", source = ParamSource.BODY) String name) {
+            @Param(value = "parentDir", source = ParamSource.BODY,
+                   description = "Existing filesystem directory that will CONTAIN the new project, e.g. "
+                               + "C:/ghidra_projects. It must resolve inside the server's configured file "
+                               + "root or the call is denied.") String parentDir,
+            @Param(value = "name", source = ParamSource.BODY,
+                   description = "Project name. The project is created at parentDir/name and the response "
+                               + "echoes that path.") String name) {
         if (parentDir == null || parentDir.isEmpty()) return Response.err("parentDir required");
         if (name == null || name.isEmpty()) return Response.err("name required");
         File parent = resolveWithinRootOrLog(parentDir, "/create_project");
@@ -143,7 +148,9 @@ public class HeadlessManagementService {
 
     @McpTool(path = "/open_project", method = "POST", description = "Open an existing Ghidra project (.gpr file or directory)", category = "headless")
     public Response openProject(
-            @Param(value = "path", source = ParamSource.BODY) String projectPath) {
+            @Param(value = "path", source = ParamSource.BODY,
+                   description = "Path to an existing project: either its .gpr file or the project "
+                               + "directory holding it.") String projectPath) {
         if (projectPath == null || projectPath.isEmpty()) {
             return Response.err("Project path required");
         }

--- a/src/test/java/com/xebyte/offline/ParamDescriptionCoverageTest.java
+++ b/src/test/java/com/xebyte/offline/ParamDescriptionCoverageTest.java
@@ -1,0 +1,84 @@
+package com.xebyte.offline;
+
+import com.xebyte.core.AnnotationScanner;
+import com.xebyte.core.ManualToolDescriptors;
+import com.xebyte.core.ProgramProvider;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Every parameter the server advertises in {@code /mcp/schema} must carry a
+ * description.
+ *
+ * <p>Why this is a test and not a convention: the bridge builds each tool's
+ * {@code inputSchema} from that schema, so a parameter with no description
+ * reaches the model as a bare name and a type. The model then has to guess the
+ * format it was already told server-side — whether an address wants a {@code 0x}
+ * prefix, whether a count is bytes or elements, what a boolean does in its false
+ * state. That guessing is the expensive half of a large tool surface, and it is
+ * invisible from the Java side because nothing fails: the annotation compiles,
+ * the endpoint works, and the schema is merely quieter than it should be.
+ *
+ * <p>Measured before this test existed (2026-08-30, at dev e4d293c): 239 of 674
+ * {@code @Param} declarations on {@code @McpTool} methods had no description,
+ * plus all 55 hand-registered parameters in {@link ManualToolDescriptors}.
+ *
+ * <p>Both halves are checked here because they are two different sources for the
+ * same field: an annotated tool gets its text from
+ * {@code @Param(description = ...)}, while a hand-registered route has no
+ * annotation at all and gets it from {@link ManualToolDescriptors}. Closing only
+ * one leaves the other free to regrow.
+ */
+public class ParamDescriptionCoverageTest extends TestCase {
+
+    /** Every {@code @Param} on an {@code @McpTool} method must describe itself. */
+    public void testAnnotatedParamsAllHaveDescriptions() {
+        ProgramProvider provider = ServiceFactory.stubProvider();
+        AnnotationScanner scanner = new AnnotationScanner(provider, ServiceFactory.buildAllServices());
+
+        List<String> missing = collectMissing(scanner.getDescriptors());
+
+        assertTrue("These @Param declarations reach /mcp/schema with no description, so the"
+                + " bridge advertises them to the model as a bare name and type. Add"
+                + " description = \"...\" to each, saying what the code actually does with the"
+                + " value — the accepted format for an address, the unit for a count, what a"
+                + " boolean does in BOTH states:\n  " + String.join("\n  ", missing),
+            missing.isEmpty());
+    }
+
+    /**
+     * Hand-registered routes have no annotation to carry a description, so
+     * {@link ManualToolDescriptors} is the only place theirs can live.
+     */
+    public void testManualRouteParamsAllHaveDescriptions() {
+        ProgramProvider provider = ServiceFactory.stubProvider();
+        AnnotationScanner scanner = new AnnotationScanner(provider, new Object[] {});
+
+        Set<String> paths = ManualToolDescriptors.knownPaths();
+        ManualToolDescriptors.addAll(scanner, paths.toArray(new String[0]));
+
+        List<String> missing = collectMissing(scanner.getDescriptors());
+
+        assertTrue("These hand-registered parameters reach /mcp/schema with no description."
+                + " They have no @Param annotation to carry one, so the text belongs in"
+                + " ManualToolDescriptors.buildAll() as the second half of the name/description"
+                + " pair:\n  " + String.join("\n  ", missing),
+            missing.isEmpty());
+    }
+
+    private static List<String> collectMissing(List<AnnotationScanner.ToolDescriptor> descriptors) {
+        List<String> missing = new ArrayList<>();
+        for (AnnotationScanner.ToolDescriptor tool : descriptors) {
+            for (AnnotationScanner.ParamDescriptor param : tool.params()) {
+                String description = param.description();
+                if (description == null || description.isBlank()) {
+                    missing.add(tool.path() + " (" + param.name() + ")");
+                }
+            }
+        }
+        return missing;
+    }
+}

--- a/tests/unit/test_param_description_inventory.py
+++ b/tests/unit/test_param_description_inventory.py
@@ -1,0 +1,517 @@
+"""Unit tests for tools.param_description_inventory.
+
+This script is the reproducible measurement behind "294 undescribed schema
+parameters went to 0" — the number in the CHANGELOG, and the one anybody
+re-checking the claim will re-run against an old checkout. A parser whose
+output is quoted as evidence has to be tested, or the evidence is just an
+assertion.
+
+The Java side already has `ParamDescriptionCoverageTest` as the build-time gate.
+These tests cover the thing that gate cannot: whether the counting is right.
+Most of them are about the ways naive parsing gets Java wrong — a `//` inside a
+string literal, a comma inside `Map<String, String>`, a second annotation
+stacked before the signature, a description split across `+` concatenation.
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.param_description_inventory import (
+    SKIP_FILES,
+    SRC,
+    _display_path,
+    _skip_annotations,
+    collect,
+    concat_string_literals,
+    iter_sources,
+    main,
+    match_paren,
+    parse_param_anno,
+    render,
+    scan_file,
+    split_top_level,
+    strip_comments,
+    summarize,
+    unescape_java,
+    unquote,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_comments
+# ---------------------------------------------------------------------------
+
+class TestStripComments:
+    def test_blanks_line_comment_but_keeps_newline(self):
+        out = strip_comments("int a; // gone\nint b;")
+        assert out.startswith("int a; ")
+        assert "gone" not in out
+        assert out.endswith("\nint b;")
+
+    def test_offsets_and_line_count_survive(self):
+        src = "a\n/* one\n   two */\nb"
+        out = strip_comments(src)
+        assert len(out) == len(src), "offsets must be preserved for line reporting"
+        assert out.count("\n") == src.count("\n")
+        assert "one" not in out and "two" not in out
+
+    def test_string_literal_containing_slashes_is_not_a_comment(self):
+        # The real trigger: a description mentioning a path or a URL.
+        src = 'description = "see http://x and // not a comment"'
+        assert strip_comments(src) == src
+
+    def test_block_comment_opener_inside_string_is_ignored(self):
+        src = 'String s = "/* not a comment */"; int a;'
+        assert strip_comments(src) == src
+
+    def test_escaped_quote_does_not_end_the_string(self):
+        src = 'String s = "he said \\"hi\\" // still string"; // gone'
+        out = strip_comments(src)
+        assert "still string" in out
+        assert "gone" not in out
+
+    def test_char_literal_quote_does_not_open_a_string(self):
+        # A lone '"' char literal used to swallow the rest of the file.
+        src = "char q = '\"'; // gone\nint after;"
+        out = strip_comments(src)
+        assert "gone" not in out
+        assert "int after;" in out
+
+    def test_escaped_char_literal(self):
+        src = "char c = '\\''; // gone\nint after;"
+        out = strip_comments(src)
+        assert "gone" not in out
+        assert "int after;" in out
+
+    def test_unterminated_block_comment_does_not_hang(self):
+        assert "x" not in strip_comments("int a; /* x")
+
+
+# ---------------------------------------------------------------------------
+# match_paren
+# ---------------------------------------------------------------------------
+
+class TestMatchParen:
+    def test_simple(self):
+        assert match_paren("f(a)", 1) == 3
+
+    def test_nested(self):
+        text = "f(g(x), h(y))"
+        assert match_paren(text, 1) == len(text) - 1
+
+    def test_paren_inside_string_is_ignored(self):
+        text = 'f("a) not the end", b)'
+        assert text[match_paren(text, 1)] == ")"
+        assert match_paren(text, 1) == len(text) - 1
+
+    def test_escaped_quote_inside_string(self):
+        text = 'f("a\\") still string", b)'
+        assert match_paren(text, 1) == len(text) - 1
+
+    def test_unbalanced_raises(self):
+        with pytest.raises(ValueError, match="unbalanced"):
+            match_paren("f(a", 1)
+
+
+# ---------------------------------------------------------------------------
+# split_top_level
+# ---------------------------------------------------------------------------
+
+class TestSplitTopLevel:
+    def test_plain_split(self):
+        assert [p.strip() for p in split_top_level("a, b, c")] == ["a", "b", "c"]
+
+    def test_generic_comma_is_not_a_separator(self):
+        # Map<String, String> is a real parameter type in FunctionService.
+        parts = split_top_level("Map<String, String> renames, String program")
+        assert len(parts) == 2
+        assert "Map<String, String>" in parts[0]
+
+    def test_nested_parens_and_braces(self):
+        parts = split_top_level('@Param(value = "a", aliases = {"x", "y"}) String a, int b')
+        assert len(parts) == 2
+        assert parts[1].strip() == "int b"
+
+    def test_comma_inside_string_is_not_a_separator(self):
+        parts = split_top_level('@Param(description = "one, two") String a, int b')
+        assert len(parts) == 2
+
+    def test_escaped_quote_inside_string(self):
+        parts = split_top_level('@Param(description = "say \\"a, b\\"") String a, int b')
+        assert len(parts) == 2
+
+    def test_trailing_whitespace_only_chunk_is_dropped(self):
+        assert split_top_level("a,   ") == ["a"]
+
+    def test_empty_input(self):
+        assert split_top_level("") == []
+
+
+# ---------------------------------------------------------------------------
+# annotation element parsing
+# ---------------------------------------------------------------------------
+
+class TestParseParamAnno:
+    def test_named_elements(self):
+        elems = parse_param_anno('value = "program", defaultValue = "", source = ParamSource.BODY')
+        assert unquote(elems["value"]) == "program"
+        assert unquote(elems["defaultValue"]) == ""
+        assert elems["source"] == "ParamSource.BODY"
+
+    def test_positional_form_gets_a_value(self):
+        assert unquote(parse_param_anno('"address"')["value"]) == "address"
+
+    def test_array_element(self):
+        elems = parse_param_anno('value = "a", aliases = {"x", "y"}')
+        assert elems["aliases"] == '{"x", "y"}'
+        assert unquote(elems["value"]) == "a"
+
+    def test_boolean_and_dotted_values(self):
+        elems = parse_param_anno("fieldsJson = true, source = ParamSource.QUERY")
+        assert elems["fieldsJson"] == "true"
+        assert elems["source"] == "ParamSource.QUERY"
+
+    def test_no_elements_at_all(self):
+        assert parse_param_anno("") == {}
+
+
+class TestUnquote:
+    def test_none_passes_through(self):
+        assert unquote(None) is None
+
+    def test_strips_quotes_and_whitespace(self):
+        assert unquote('  "abc" ') == "abc"
+
+    def test_bare_token_passes_through(self):
+        assert unquote("ParamSource.BODY") == "ParamSource.BODY"
+
+    def test_empty_string_literal(self):
+        assert unquote('""') == ""
+
+    def test_concatenated_value_is_joined_not_truncated(self):
+        assert unquote('"aa" + "bb"') == "aabb"
+
+
+class TestConcatStringLiterals:
+    def test_joins_java_concatenation(self):
+        raw = '"Address in the program. " + "Accepts 0x<hex>."'
+        assert concat_string_literals(raw) == "Address in the program. Accepts 0x<hex>."
+
+    def test_joins_across_newlines(self):
+        # How every long description in the tree is actually written.
+        raw = '"one "\n            + "two "\n            + "three"'
+        assert concat_string_literals(raw) == "one two three"
+
+    def test_single_literal(self):
+        assert concat_string_literals('"one"') == "one"
+
+    def test_non_literal_passes_through(self):
+        assert concat_string_literals("SOME_CONSTANT") == "SOME_CONSTANT"
+
+    def test_escapes_are_resolved(self):
+        assert concat_string_literals(r'"say \"hi\""') == 'say "hi"'
+
+
+class TestUnescapeJava:
+    @pytest.mark.parametrize("raw,expected", [
+        (r"\"", '"'),
+        (r"\'", "'"),
+        (r"\n", "\n"),
+        (r"\t", "\t"),
+        (r"\r", "\r"),
+        ("\\\\", "\\"),
+        ("plain", "plain"),
+    ])
+    def test_known_escapes(self, raw, expected):
+        assert unescape_java(raw) == expected
+
+    def test_backslash_before_quote_is_one_pass(self):
+        # A single left-to-right pass: the \\ must not be re-read as escaping
+        # the following quote.
+        assert unescape_java(r"a\\" + r'\"b') == 'a\\"b'
+
+    def test_unknown_escape_is_left_alone(self):
+        assert unescape_java(r"\q") == r"\q"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+class TestDisplayPath:
+    def test_relative_to_repo_uses_forward_slashes(self, tmp_path: Path):
+        target = tmp_path / "src" / "main" / "X.java"
+        assert _display_path(target, tmp_path) == "src/main/X.java"
+
+    def test_off_tree_path_falls_back_to_the_name(self, tmp_path: Path):
+        # Scanning an extracted old checkout puts sources outside the repo root.
+        assert _display_path(Path("/elsewhere/Y.java"), tmp_path) == "Y.java"
+
+
+class TestSkipAnnotations:
+    def test_stops_at_the_signature(self):
+        code = "  public Response f("
+        assert code[_skip_annotations(code, 0)] == "p"
+
+    def test_skips_a_stacked_annotation_with_parens(self):
+        code = '\n    @SuppressWarnings("unchecked")\n    public Response f('
+        assert code[_skip_annotations(code, 0):].startswith("public Response f(")
+
+    def test_skips_a_marker_annotation_without_parens(self):
+        code = "\n    @Override\n    public Response f("
+        assert code[_skip_annotations(code, 0):].startswith("public Response f(")
+
+    def test_end_of_input(self):
+        code = "   \n  "
+        assert _skip_annotations(code, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# scan_file — the whole pipeline over real-shaped Java
+# ---------------------------------------------------------------------------
+
+JAVA = '''package com.xebyte.core;
+
+/** Javadoc mentioning @Param(value = "ghost") must not become a parameter. */
+public class FakeService {
+
+    @McpTool(path = "/documented_tool", method = "POST", description = "d", category = "c")
+    public Response documented(
+            @Param(value = "address", paramType = "address", source = ParamSource.BODY,
+                   description = "Address in the program. Accepts 0x<hex> "
+                               + "or <space>:<hex>.") String addressStr,
+            @Param(value = "renames", source = ParamSource.BODY) Map<String, String> renames,
+            @Param(value = "limit", defaultValue = "100") int limit,
+            @Param(value = "quoted", description = "Send {\\"a\\": 1}.\\nSecond line.") String quoted,
+            TaskMonitor monitor) {
+        // @Param(value = "commented_out") int ignored
+        return null;
+    }
+
+    @McpTool(path = "/blank_description", description = "d", category = "c")
+    @SuppressWarnings("unchecked")
+    public Response blank(
+            @Param(value = "empty", description = "") String empty,
+            @Param(value = "spaces", description = "   ") String spaces) {
+        return null;
+    }
+
+    @McpTool(path = "/no_params", description = "d", category = "c")
+    public Response noParams() {
+        return null;
+    }
+
+    // Legacy helper: annotated but NOT an @McpTool, so it is not in the schema.
+    public Response helper(
+            @Param(value = "unreachable") String unreachable) {
+        return null;
+    }
+}
+'''
+
+
+@pytest.fixture()
+def java_file(tmp_path: Path) -> Path:
+    src = tmp_path / "src" / "main" / "java" / "com" / "xebyte"
+    src.mkdir(parents=True)
+    path = src / "FakeService.java"
+    path.write_text(JAVA, encoding="utf-8")
+    return path
+
+
+class TestScanFile:
+    def test_finds_exactly_the_mcptool_parameters(self, java_file: Path, tmp_path: Path):
+        rows = scan_file(java_file, tmp_path)
+        assert [r["param"] for r in rows] == [
+            "address", "renames", "limit", "quoted", "empty", "spaces",
+        ]
+
+    def test_unannotated_signature_parameter_is_not_a_schema_parameter(
+            self, java_file: Path, tmp_path: Path):
+        # `TaskMonitor monitor` is a plain Java argument, never an MCP input.
+        assert "monitor" not in {r["param"] for r in scan_file(java_file, tmp_path)}
+
+    def test_escapes_in_a_description_are_resolved(self, java_file: Path, tmp_path: Path):
+        row = next(r for r in scan_file(java_file, tmp_path) if r["param"] == "quoted")
+        assert row["description"] == 'Send {"a": 1}.\nSecond line.'
+
+    def test_ignores_params_on_non_mcptool_helpers(self, java_file: Path, tmp_path: Path):
+        names = {r["param"] for r in scan_file(java_file, tmp_path)}
+        assert "unreachable" not in names, "a helper's dead annotation is not in the schema"
+
+    def test_ignores_params_in_javadoc_and_comments(self, java_file: Path, tmp_path: Path):
+        names = {r["param"] for r in scan_file(java_file, tmp_path)}
+        assert "ghost" not in names
+        assert "commented_out" not in names
+
+    def test_concatenated_description_counts_as_documented(self, java_file: Path, tmp_path: Path):
+        row = next(r for r in scan_file(java_file, tmp_path) if r["param"] == "address")
+        assert row["documented"] is True
+        assert row["description"] == "Address in the program. Accepts 0x<hex> or <space>:<hex>."
+
+    def test_empty_and_whitespace_descriptions_count_as_undocumented(
+            self, java_file: Path, tmp_path: Path):
+        rows = {r["param"]: r for r in scan_file(java_file, tmp_path)}
+        assert rows["empty"]["documented"] is False
+        assert rows["spaces"]["documented"] is False, "whitespace is not a description"
+
+    def test_missing_description_element_counts_as_undocumented(
+            self, java_file: Path, tmp_path: Path):
+        rows = {r["param"]: r for r in scan_file(java_file, tmp_path)}
+        assert rows["limit"]["documented"] is False
+        assert rows["limit"]["description"] == ""
+
+    def test_records_tool_path_source_and_default(self, java_file: Path, tmp_path: Path):
+        rows = {r["param"]: r for r in scan_file(java_file, tmp_path)}
+        assert rows["address"]["path"] == "/documented_tool"
+        assert rows["address"]["source"] == "ParamSource.BODY"
+        assert rows["limit"]["source"] == "QUERY(default)", "QUERY is the annotation's default"
+        assert rows["limit"]["default"] == "100"
+        assert rows["address"]["default"] is None
+
+    def test_generic_type_survives_the_comma(self, java_file: Path, tmp_path: Path):
+        row = next(r for r in scan_file(java_file, tmp_path) if r["param"] == "renames")
+        assert row["java_type"] == "Map<String, String>"
+
+    def test_stacked_annotation_does_not_hide_the_parameters(
+            self, java_file: Path, tmp_path: Path):
+        # /blank_description carries @SuppressWarnings between @McpTool and the
+        # signature; a scanner that grabs the next '(' finds zero params there.
+        assert {r["param"] for r in scan_file(java_file, tmp_path)
+                if r["path"] == "/blank_description"} == {"empty", "spaces"}
+
+    def test_line_numbers_point_into_the_original_source(self, java_file: Path, tmp_path: Path):
+        lines = java_file.read_text(encoding="utf-8").split("\n")
+        for row in scan_file(java_file, tmp_path):
+            assert "public Response" in lines[row["line"] - 1]
+
+    def test_service_and_file_fields(self, java_file: Path, tmp_path: Path):
+        row = scan_file(java_file, tmp_path)[0]
+        assert row["service"] == "FakeService"
+        assert row["file"].endswith("com/xebyte/FakeService.java")
+
+    def test_tool_with_no_parameters_yields_no_rows(self, java_file: Path, tmp_path: Path):
+        assert not [r for r in scan_file(java_file, tmp_path) if r["path"] == "/no_params"]
+
+    def test_tool_name_falls_back_when_path_is_absent(self, tmp_path: Path):
+        path = tmp_path / "N.java"
+        path.write_text(
+            '@McpTool(name = "named_tool")\npublic Response f(@Param("a") String a) {}\n',
+            encoding="utf-8")
+        row = scan_file(path, tmp_path)[0]
+        assert row["tool"] == "named_tool"
+        assert row["path"] == ""
+        assert row["param"] == "a", "positional @Param(\"a\") must resolve"
+
+    def test_truncated_annotation_at_eof_is_skipped_not_crashed(self, tmp_path: Path):
+        path = tmp_path / "T.java"
+        path.write_text('@McpTool(path = "/x")', encoding="utf-8")
+        assert scan_file(path, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# tree walk + aggregation
+# ---------------------------------------------------------------------------
+
+class TestIterSources:
+    def test_skips_the_annotation_declarations(self, tmp_path: Path):
+        for name in ("Param.java", "McpTool.java", "Service.java"):
+            (tmp_path / name).write_text("", encoding="utf-8")
+        assert [p.name for p in iter_sources(tmp_path)] == ["Service.java"]
+
+    def test_skip_set_is_what_it_claims(self):
+        assert SKIP_FILES == {"Param.java", "McpTool.java"}
+
+    def test_recurses_and_sorts(self, tmp_path: Path):
+        (tmp_path / "b").mkdir()
+        (tmp_path / "b" / "B.java").write_text("", encoding="utf-8")
+        (tmp_path / "A.java").write_text("", encoding="utf-8")
+        (tmp_path / "notes.txt").write_text("", encoding="utf-8")
+        assert [p.name for p in iter_sources(tmp_path)] == ["A.java", "B.java"]
+
+
+class TestSummarize:
+    def test_counts_per_service(self):
+        rows = [
+            {"service": "A", "documented": True},
+            {"service": "A", "documented": False},
+            {"service": "B", "documented": True},
+        ]
+        assert summarize(rows) == {"A": (2, 1), "B": (1, 0)}
+
+    def test_empty(self):
+        assert summarize([]) == {}
+
+
+class TestCollect:
+    def test_scans_the_tree(self, java_file: Path, tmp_path: Path):
+        rows = collect(java_file.parent, tmp_path)
+        assert len(rows) == 6
+        assert sum(1 for r in rows if not r["documented"]) == 4
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def test_summary_report(self, java_file: Path, tmp_path: Path):
+        out = io.StringIO()
+        assert main([], src_root=java_file.parent, repo=tmp_path, out=out) == 0
+        text = out.getvalue()
+        assert "FakeService" in text
+        assert "TOTAL" in text
+        assert "@McpTool methods with params: 2" in text, "no_params contributes no rows"
+
+    def test_list_flag_names_each_undocumented_parameter(self, java_file: Path, tmp_path: Path):
+        out = io.StringIO()
+        main(["--list"], src_root=java_file.parent, repo=tmp_path, out=out)
+        text = out.getvalue()
+        assert "Undocumented parameters:" in text
+        for name in ("limit", "renames", "empty", "spaces"):
+            assert f"({name})" in text
+        assert "(address)" not in text, "documented params must not be listed"
+
+    def test_json_flag_emits_parseable_rows(self, java_file: Path, tmp_path: Path):
+        out = io.StringIO()
+        main(["--json"], src_root=java_file.parent, repo=tmp_path, out=out)
+        rows = json.loads(out.getvalue())
+        assert len(rows) == 6
+        assert {"file", "service", "tool", "path", "line", "param", "java_type",
+                "source", "default", "documented", "description"} == set(rows[0])
+
+    def test_defaults_to_stdout(self, java_file: Path, tmp_path: Path, capsys):
+        assert main([], src_root=java_file.parent, repo=tmp_path) == 0
+        assert "TOTAL" in capsys.readouterr().out
+
+    def test_render_without_list_omits_the_detail_section(self):
+        out = io.StringIO()
+        render([{"service": "S", "documented": False, "file": "f", "tool": "t",
+                 "param": "p", "java_type": "int", "source": "q", "default": None}],
+               show_list=False, out=out)
+        assert "Undocumented parameters:" not in out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# The claim itself
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not SRC.is_dir(), reason="Java sources not present in this checkout")
+def test_repo_has_no_undescribed_schema_parameters():
+    """The Python-side twin of ParamDescriptionCoverageTest.
+
+    That Java test is the build gate; this one keeps the *measurement* honest,
+    so a parser regression that silently stopped finding parameters would show
+    up here as a suspiciously small total rather than as a clean zero.
+    """
+    rows = collect()
+    assert len(rows) > 500, "scanner found implausibly few parameters — parser regression?"
+    undocumented = [f"{r['path'] or r['tool']}({r['param']})"
+                    for r in rows if not r["documented"]]
+    assert undocumented == [], (
+        f"{len(undocumented)} @Param declarations reach /mcp/schema with no description: "
+        + ", ".join(undocumented[:20]))

--- a/tools/param_description_inventory.py
+++ b/tools/param_description_inventory.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Inventory @Param annotations that carry no description.
+
+Parses the Java sources under src/main/java/com/xebyte/ (no compilation, no
+running Ghidra), pairs every @Param with its enclosing @McpTool method, and
+reports which ones lack a non-empty `description = "..."` element.
+
+Usage:
+    python tools/param_description_inventory.py            # summary
+    python tools/param_description_inventory.py --list      # every undocumented param
+    python tools/param_description_inventory.py --json      # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src" / "main" / "java" / "com" / "xebyte"
+
+
+def strip_comments(text: str) -> str:
+    """Blank out // and /* */ comments, preserving offsets and line count."""
+    out = list(text)
+    i, n = 0, len(text)
+    in_line = in_block = in_str = in_chr = False
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line:
+            if c == "\n":
+                in_line = False
+            else:
+                out[i] = " "
+        elif in_block:
+            if c == "*" and nxt == "/":
+                out[i] = out[i + 1] = " "
+                i += 2
+                in_block = False
+                continue
+            if c != "\n":
+                out[i] = " "
+        elif in_str:
+            if c == "\\":
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+        elif in_chr:
+            if c == "\\":
+                i += 2
+                continue
+            if c == "'":
+                in_chr = False
+        else:
+            if c == "/" and nxt == "/":
+                in_line = True
+                out[i] = " "
+            elif c == "/" and nxt == "*":
+                in_block = True
+                out[i] = " "
+            elif c == '"':
+                in_str = True
+            elif c == "'":
+                in_chr = True
+        i += 1
+    return "".join(out)
+
+
+def match_paren(text: str, open_idx: int) -> int:
+    """Index of the ')' matching the '(' at open_idx, skipping strings."""
+    depth = 0
+    i = open_idx
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    break
+                i += 1
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    raise ValueError("unbalanced parens")
+
+
+def split_top_level(text: str) -> list[str]:
+    """Split on commas that are not nested in (), {}, <> or strings."""
+    parts, buf = [], []
+    depth = 0
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            buf.append(c)
+            i += 1
+            while i < n:
+                buf.append(text[i])
+                if text[i] == "\\":
+                    i += 1
+                    if i < n:
+                        buf.append(text[i])
+                    i += 1
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c in "({[<":
+            depth += 1
+        elif c in ")}]>":
+            depth -= 1
+        elif c == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    if "".join(buf).strip():
+        parts.append("".join(buf))
+    return parts
+
+
+ANNO_ELEM = re.compile(r'(\w+)\s*=\s*("(?:[^"\\]|\\.)*"|\{[^}]*\}|[\w.]+)')
+STR_LIT = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def parse_param_anno(anno_body: str) -> dict:
+    """Parse the inside of @Param(...) into a dict of element -> raw value."""
+    elems = dict(ANNO_ELEM.findall(anno_body))
+    if "value" not in elems:
+        # positional form: @Param("name")
+        m = STR_LIT.search(anno_body)
+        if m:
+            elems["value"] = '"%s"' % m.group(1)
+    return elems
+
+
+def unquote(v: str | None) -> str | None:
+    if v is None:
+        return None
+    v = v.strip()
+    if v.startswith('"') and v.endswith('"'):
+        return v[1:-1]
+    return v
+
+
+def concat_string_literals(raw: str) -> str:
+    """Java allows "a" + "b"; join the literals."""
+    lits = STR_LIT.findall(raw)
+    return "".join(lits) if lits else raw
+
+
+def scan_file(path: Path) -> list[dict]:
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    code = strip_comments(raw)
+    results = []
+    for m in re.finditer(r"@McpTool\s*\(", code):
+        anno_open = m.end() - 1
+        anno_close = match_paren(code, anno_open)
+        anno_body = code[anno_open + 1: anno_close]
+        tool_elems = parse_param_anno(anno_body)
+        tool_name = unquote(tool_elems.get("name")) or unquote(tool_elems.get("value")) or "?"
+        tool_path = unquote(tool_elems.get("path")) or ""
+        # Find the method signature's parameter list: the first '(' after the
+        # annotation block that is preceded by an identifier at statement level.
+        j = anno_close + 1
+        # skip further annotations on the method
+        while True:
+            mm = re.compile(r"\S").search(code, j)
+            if not mm:
+                break
+            if code[mm.start()] == "@":
+                a_open = code.index("(", mm.start()) if "(" in code[mm.start(): mm.start() + 200] else -1
+                nxt_at = code.find("@", mm.start() + 1)
+                # annotation may have no parens
+                lparen = code.find("(", mm.start())
+                nl = code.find("\n", mm.start())
+                if lparen != -1 and (nl == -1 or lparen < nl):
+                    j = match_paren(code, lparen) + 1
+                else:
+                    j = mm.start() + 1
+                continue
+            break
+        sig_open = code.find("(", j)
+        if sig_open == -1:
+            continue
+        sig_close = match_paren(code, sig_open)
+        params_src = code[sig_open + 1: sig_close]
+        line = raw[:sig_open].count("\n") + 1
+        for piece in split_top_level(params_src):
+            piece = piece.strip()
+            if "@Param" not in piece:
+                continue
+            p_at = piece.index("@Param")
+            p_open = piece.index("(", p_at)
+            p_close = match_paren(piece, p_open)
+            body = piece[p_open + 1: p_close]
+            elems = parse_param_anno(body)
+            name = unquote(elems.get("value")) or "?"
+            desc_raw = elems.get("description")
+            desc = concat_string_literals(desc_raw) if desc_raw else ""
+            java_decl = piece[p_close + 1:].strip()
+            results.append({
+                "file": str(path.relative_to(REPO)).replace("\\", "/"),
+                "service": path.stem,
+                "tool": tool_name,
+                "path": tool_path,
+                "line": line,
+                "param": name,
+                "java_type": java_decl.rsplit(" ", 1)[0].strip() if " " in java_decl else java_decl,
+                "source": unquote(elems.get("source")) or "QUERY(default)",
+                "default": unquote(elems.get("defaultValue")),
+                "documented": bool(desc.strip()),
+                "description": desc,
+            })
+    return results
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true", help="print every undocumented param")
+    ap.add_argument("--json", action="store_true", help="dump all params as JSON")
+    args = ap.parse_args()
+
+    rows = []
+    for path in sorted(SRC.rglob("*.java")):
+        if path.name in {"Param.java", "McpTool.java"}:
+            continue
+        rows.extend(scan_file(path))
+
+    if args.json:
+        json.dump(rows, sys.stdout, indent=2)
+        print()
+        return 0
+
+    undoc = [r for r in rows if not r["documented"]]
+    by_service: dict[str, list[dict]] = {}
+    for r in rows:
+        by_service.setdefault(r["service"], []).append(r)
+
+    print(f"{'service':<32} {'params':>7} {'undoc':>7}")
+    print("-" * 50)
+    for svc in sorted(by_service):
+        svc_rows = by_service[svc]
+        u = sum(1 for r in svc_rows if not r["documented"])
+        if u or True:
+            print(f"{svc:<32} {len(svc_rows):>7} {u:>7}")
+    print("-" * 50)
+    print(f"{'TOTAL':<32} {len(rows):>7} {len(undoc):>7}")
+    tools = {(r['file'], r['tool']) for r in rows}
+    print(f"\n@McpTool methods with params: {len(tools)}")
+
+    if args.list:
+        print("\nUndocumented parameters:")
+        for r in sorted(undoc, key=lambda x: (x["service"], x["tool"], x["param"])):
+            print(f"  {r['service']}.{r['tool']}({r['param']})  [{r['java_type']}]"
+                  f" src={r['source']} default={r['default']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/param_description_inventory.py
+++ b/tools/param_description_inventory.py
@@ -5,6 +5,14 @@ Parses the Java sources under src/main/java/com/xebyte/ (no compilation, no
 running Ghidra), pairs every @Param with its enclosing @McpTool method, and
 reports which ones lack a non-empty `description = "..."` element.
 
+This is the measurement behind "294 undescribed parameters went to 0": the Java
+side has `ParamDescriptionCoverageTest` as the build-time gate, and this script
+is the reproducible count, runnable against any checkout including an old one::
+
+    git archive <sha> src/main/java | tar -x -C /tmp/base
+    cp tools/param_description_inventory.py /tmp/base/tools/
+    cd /tmp/base && python tools/param_description_inventory.py
+
 Usage:
     python tools/param_description_inventory.py            # summary
     python tools/param_description_inventory.py --list      # every undocumented param
@@ -18,13 +26,24 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import IO, Iterable, Iterator
 
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "src" / "main" / "java" / "com" / "xebyte"
 
+#: Annotation declarations, not tool definitions -- they carry `@Param` only in
+#: their own javadoc, so scanning them would invent parameters that don't exist.
+SKIP_FILES = frozenset({"Param.java", "McpTool.java"})
+
 
 def strip_comments(text: str) -> str:
-    """Blank out // and /* */ comments, preserving offsets and line count."""
+    """Blank out // and /* */ comments, preserving offsets and line count.
+
+    Offsets must survive because the caller reports line numbers against the
+    ORIGINAL text; newlines inside block comments are kept for the same reason.
+    String and char literals are respected, so a "//" inside a description
+    string is not mistaken for a comment.
+    """
     out = list(text)
     i, n = 0, len(text)
     in_line = in_block = in_str = in_chr = False
@@ -72,7 +91,7 @@ def strip_comments(text: str) -> str:
 
 
 def match_paren(text: str, open_idx: int) -> int:
-    """Index of the ')' matching the '(' at open_idx, skipping strings."""
+    """Index of the ')' matching the '(' at open_idx, skipping string literals."""
     depth = 0
     i = open_idx
     n = len(text)
@@ -98,8 +117,13 @@ def match_paren(text: str, open_idx: int) -> int:
 
 
 def split_top_level(text: str) -> list[str]:
-    """Split on commas that are not nested in (), {}, <> or strings."""
-    parts, buf = [], []
+    """Split on commas that are not nested in (), {}, [], <> or strings.
+
+    The angle brackets matter: a parameter typed `Map<String, String>` carries a
+    comma that is not a parameter separator.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
     depth = 0
     i, n = 0, len(text)
     while i < n:
@@ -136,15 +160,34 @@ def split_top_level(text: str) -> list[str]:
     return parts
 
 
-ANNO_ELEM = re.compile(r'(\w+)\s*=\s*("(?:[^"\\]|\\.)*"|\{[^}]*\}|[\w.]+)')
+_LIT = r'"(?:[^"\\]|\\.)*"'
+#: One annotation element. The value alternative accepts a Java `"a" + "b"`
+#: concatenation, not just a lone literal: every long description in the tree is
+#: written that way, and matching only the first segment silently truncated them.
+ANNO_ELEM = re.compile(r'(\w+)\s*=\s*(' + _LIT + r'(?:\s*\+\s*' + _LIT + r')*'
+                       r'|\{[^}]*\}|[\w.]+)')
 STR_LIT = re.compile(r'"((?:[^"\\]|\\.)*)"')
 
+#: Java escapes that appear inside the description literals we extract. Applied
+#: in one left-to-right pass, so a `\\` before a quote cannot be re-consumed.
+_ESCAPES = {"\\": "\\", '"': '"', "'": "'", "n": "\n", "t": "\t", "r": "\r"}
+_ESCAPE_RE = re.compile(r"\\(.)")
 
-def parse_param_anno(anno_body: str) -> dict:
-    """Parse the inside of @Param(...) into a dict of element -> raw value."""
+
+def unescape_java(s: str) -> str:
+    """Resolve Java string escapes; leave anything unrecognised alone."""
+    return _ESCAPE_RE.sub(lambda m: _ESCAPES.get(m.group(1), m.group(0)), s)
+
+
+NON_SPACE = re.compile(r"\S")
+ANNO_NAME = re.compile(r"@\s*[\w.]+")
+
+
+def parse_param_anno(anno_body: str) -> dict[str, str]:
+    """Parse the inside of an annotation's parens into element -> raw value."""
     elems = dict(ANNO_ELEM.findall(anno_body))
     if "value" not in elems:
-        # positional form: @Param("name")
+        # Positional form: @Param("name") rather than @Param(value = "name").
         m = STR_LIT.search(anno_body)
         if m:
             elems["value"] = '"%s"' % m.group(1)
@@ -152,77 +195,95 @@ def parse_param_anno(anno_body: str) -> dict:
 
 
 def unquote(v: str | None) -> str | None:
+    """Resolve a Java string-literal value; pass anything else through.
+
+    Handles the concatenated form too, so `value` and `path` behave the same way
+    `description` does rather than losing everything after the first `+`.
+    """
     if v is None:
         return None
     v = v.strip()
     if v.startswith('"') and v.endswith('"'):
-        return v[1:-1]
+        return concat_string_literals(v)
     return v
 
 
 def concat_string_literals(raw: str) -> str:
-    """Java allows "a" + "b"; join the literals."""
+    """Join a Java `"a" + "b"` concatenation into the string it produces."""
     lits = STR_LIT.findall(raw)
-    return "".join(lits) if lits else raw
+    return unescape_java("".join(lits)) if lits else raw
 
 
-def scan_file(path: Path) -> list[dict]:
+def _display_path(path: Path, repo: Path) -> str:
+    """Repo-relative POSIX path, falling back to the bare name off-tree."""
+    try:
+        return str(path.relative_to(repo)).replace("\\", "/")
+    except ValueError:
+        return path.name
+
+
+def _skip_annotations(code: str, start: int) -> int:
+    """Advance past any further annotations stacked on the method.
+
+    A method may carry `@McpTool(...)` plus e.g. `@SuppressWarnings("unchecked")`
+    before its signature; without this the scanner would mistake the second
+    annotation's parens for the parameter list and find no parameters at all.
+
+    Returns the offset of the first character that is not part of an annotation.
+    """
+    j = start
+    while True:
+        mm = NON_SPACE.search(code, j)
+        if not mm:
+            return j
+        if code[mm.start()] != "@":
+            return mm.start()
+        name = ANNO_NAME.match(code, mm.start())
+        after_name = name.end() if name else mm.start() + 1
+        lparen = code.find("(", after_name)
+        nl = code.find("\n", after_name)
+        if lparen != -1 and (nl == -1 or lparen < nl):
+            j = match_paren(code, lparen) + 1
+        else:
+            # Marker annotation with no parens, e.g. @Override.
+            j = after_name
+
+
+def scan_file(path: Path, repo: Path = REPO) -> list[dict]:
+    """Every @Param on an @McpTool method in one Java source file."""
     raw = path.read_text(encoding="utf-8", errors="replace")
     code = strip_comments(raw)
-    results = []
+    results: list[dict] = []
     for m in re.finditer(r"@McpTool\s*\(", code):
         anno_open = m.end() - 1
         anno_close = match_paren(code, anno_open)
-        anno_body = code[anno_open + 1: anno_close]
-        tool_elems = parse_param_anno(anno_body)
+        tool_elems = parse_param_anno(code[anno_open + 1: anno_close])
         tool_name = unquote(tool_elems.get("name")) or unquote(tool_elems.get("value")) or "?"
         tool_path = unquote(tool_elems.get("path")) or ""
-        # Find the method signature's parameter list: the first '(' after the
-        # annotation block that is preceded by an identifier at statement level.
-        j = anno_close + 1
-        # skip further annotations on the method
-        while True:
-            mm = re.compile(r"\S").search(code, j)
-            if not mm:
-                break
-            if code[mm.start()] == "@":
-                a_open = code.index("(", mm.start()) if "(" in code[mm.start(): mm.start() + 200] else -1
-                nxt_at = code.find("@", mm.start() + 1)
-                # annotation may have no parens
-                lparen = code.find("(", mm.start())
-                nl = code.find("\n", mm.start())
-                if lparen != -1 and (nl == -1 or lparen < nl):
-                    j = match_paren(code, lparen) + 1
-                else:
-                    j = mm.start() + 1
-                continue
-            break
-        sig_open = code.find("(", j)
+
+        sig_open = code.find("(", _skip_annotations(code, anno_close + 1))
         if sig_open == -1:
             continue
         sig_close = match_paren(code, sig_open)
-        params_src = code[sig_open + 1: sig_close]
         line = raw[:sig_open].count("\n") + 1
-        for piece in split_top_level(params_src):
+
+        for piece in split_top_level(code[sig_open + 1: sig_close]):
             piece = piece.strip()
             if "@Param" not in piece:
                 continue
-            p_at = piece.index("@Param")
-            p_open = piece.index("(", p_at)
+            p_open = piece.index("(", piece.index("@Param"))
             p_close = match_paren(piece, p_open)
-            body = piece[p_open + 1: p_close]
-            elems = parse_param_anno(body)
-            name = unquote(elems.get("value")) or "?"
+            elems = parse_param_anno(piece[p_open + 1: p_close])
             desc_raw = elems.get("description")
             desc = concat_string_literals(desc_raw) if desc_raw else ""
             java_decl = piece[p_close + 1:].strip()
             results.append({
-                "file": str(path.relative_to(REPO)).replace("\\", "/"),
+                "file": _display_path(path, repo),
                 "service": path.stem,
                 "tool": tool_name,
                 "path": tool_path,
                 "line": line,
-                "param": name,
+                "param": unquote(elems.get("value")) or "?",
                 "java_type": java_decl.rsplit(" ", 1)[0].strip() if " " in java_decl else java_decl,
                 "source": unquote(elems.get("source")) or "QUERY(default)",
                 "default": unquote(elems.get("defaultValue")),
@@ -232,47 +293,69 @@ def scan_file(path: Path) -> list[dict]:
     return results
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--list", action="store_true", help="print every undocumented param")
-    ap.add_argument("--json", action="store_true", help="dump all params as JSON")
-    args = ap.parse_args()
+def iter_sources(src_root: Path) -> Iterator[Path]:
+    """Java files worth scanning, in a stable order."""
+    for path in sorted(src_root.rglob("*.java")):
+        if path.name not in SKIP_FILES:
+            yield path
 
-    rows = []
-    for path in sorted(SRC.rglob("*.java")):
-        if path.name in {"Param.java", "McpTool.java"}:
-            continue
-        rows.extend(scan_file(path))
 
-    if args.json:
-        json.dump(rows, sys.stdout, indent=2)
-        print()
-        return 0
+def collect(src_root: Path = SRC, repo: Path = REPO) -> list[dict]:
+    """Scan a whole source tree."""
+    rows: list[dict] = []
+    for path in iter_sources(src_root):
+        rows.extend(scan_file(path, repo))
+    return rows
 
+
+def summarize(rows: Iterable[dict]) -> dict[str, tuple[int, int]]:
+    """service -> (total params, undocumented params)."""
+    out: dict[str, tuple[int, int]] = {}
+    for row in rows:
+        total, undoc = out.get(row["service"], (0, 0))
+        out[row["service"]] = (total + 1, undoc + (0 if row["documented"] else 1))
+    return out
+
+
+def render(rows: list[dict], show_list: bool, out: IO[str]) -> None:
+    """Print the human-readable report."""
     undoc = [r for r in rows if not r["documented"]]
-    by_service: dict[str, list[dict]] = {}
-    for r in rows:
-        by_service.setdefault(r["service"], []).append(r)
+    by_service = summarize(rows)
 
-    print(f"{'service':<32} {'params':>7} {'undoc':>7}")
-    print("-" * 50)
+    print(f"{'service':<32} {'params':>7} {'undoc':>7}", file=out)
+    print("-" * 50, file=out)
     for svc in sorted(by_service):
-        svc_rows = by_service[svc]
-        u = sum(1 for r in svc_rows if not r["documented"])
-        if u or True:
-            print(f"{svc:<32} {len(svc_rows):>7} {u:>7}")
-    print("-" * 50)
-    print(f"{'TOTAL':<32} {len(rows):>7} {len(undoc):>7}")
-    tools = {(r['file'], r['tool']) for r in rows}
-    print(f"\n@McpTool methods with params: {len(tools)}")
+        total, missing = by_service[svc]
+        print(f"{svc:<32} {total:>7} {missing:>7}", file=out)
+    print("-" * 50, file=out)
+    print(f"{'TOTAL':<32} {len(rows):>7} {len(undoc):>7}", file=out)
+    tools = {(r["file"], r["tool"]) for r in rows}
+    print(f"\n@McpTool methods with params: {len(tools)}", file=out)
 
-    if args.list:
-        print("\nUndocumented parameters:")
+    if show_list:
+        print("\nUndocumented parameters:", file=out)
         for r in sorted(undoc, key=lambda x: (x["service"], x["tool"], x["param"])):
             print(f"  {r['service']}.{r['tool']}({r['param']})  [{r['java_type']}]"
-                  f" src={r['source']} default={r['default']}")
+                  f" src={r['source']} default={r['default']}", file=out)
+
+
+def main(argv: list[str] | None = None, src_root: Path = SRC,
+         repo: Path = REPO, out: IO[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--list", action="store_true", help="print every undocumented param")
+    ap.add_argument("--json", action="store_true", help="dump all params as JSON")
+    args = ap.parse_args(argv)
+    stream = out if out is not None else sys.stdout
+
+    rows = collect(src_root, repo)
+    if args.json:
+        json.dump(rows, stream, indent=2)
+        print(file=stream)
+        return 0
+
+    render(rows, args.list, stream)
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())


### PR DESCRIPTION
Every parameter this server advertises now carries a description. The count went from 294 undocumented to 0.

## Why

The server publishes descriptions for documented parameters, but a large share were never documented at all, so a model calling these tools saw bare names and types and had to guess formats the code already knew. Contributor measurement in #425 put the gap at 274 from the bridge side. The true number is 294, and it splits in two, which is why the figures differ:

| Population | Before | After |
| --- | ---: | ---: |
| `@Param` on `@McpTool` methods | 239 of 674 | 0 |
| Hand-registered routes (`ManualToolDescriptors`) | 55 of 55 | 0 |

The second population had no annotation that could carry a description at all - `ManualToolDescriptors.p()` hardcoded the empty string for all 55. `params()` now takes name and description pairs and throws on an odd count, so the shape cannot silently regress.

Descriptions were written by reading what each method does with the parameter, not by restating its name: address formats, what a boolean does in both states, accepted values for enum-like strings, and units where bytes, elements and counts were ambiguous.

Note this is a strict improvement to the existing surface. It adds no tools.

## Findings that came out of the sweep

- **Nine parameters are advertised and never read** by the code declaring them: `include_assembly_patterns`, `analyze_loop_bounds`, `analyze_indexing`, `include_patterns`, `capture_output`, `force_individual`, plus `host` and `port` on `/server/connect` and `keepCheckedOut` on `/server/version_control/add`. They are described honestly as inert rather than invented into switches that do something. A follow-up issue is drafted.
- **One existing description was wrong rather than missing.** `/search_strings` `encoding` claimed to filter results. It never filtered - the value is echoed into each match and defaults to the literal `ascii`. Corrected.
- **`limit` has three incompatible meanings** across endpoints: `<=0` means unlimited in some, `0` means an empty page in others, and elsewhere it is clamped to a minimum of 1. `ParamTypeConsistencyTest` cannot see this because all three are `int`. Reported rather than papered over with vague wording.

Two traps were deliberately **not** encoded, because asserting them would become wrong the moment #452 lands: the `program` query-parameter rule, and the old `set_variable_storage` behaviour.

## Verification

- `mvn clean compile -q` - exit 0.
- Offline Java: 446, 0 failures (444 before the new test, +2 from it).
- `RegenerateEndpointsJson` leaves `tests/endpoints.json` byte-identical and parity green. The catalog tracks parameter names and never descriptions, so the README consistency check does not fire.
- `pytest tests/unit/` - 568 collected, 8 platform skips, 0 failures.
- New `ParamDescriptionCoverageTest` was negative-verified: one description was blanked, the test failed, the description was restored.
- Before and after proven by re-running the committed inventory tool against a clean `git archive` of the base commit: 239 to 0.

## Needs a live server

`tests/conformance/snapshots/mcp_schema.snap` stores full parameter description text and is now stale. It needs a refresh against a running server before this is green end to end.

## Merge order

Expect a conflict with the `create_memory_block` branch in the `ProgramScriptService.java` annotation block. Contributor PR #425 should land before this.
