### PR TITLE
ci(dependabot): group codeql-action bumps, drop the removed fun-doc ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@
 # Covers every package ecosystem in the repo:
 #   * GitHub Actions used by the workflows under .github/workflows/
 #   * Python requirements at the repo root (bridge runtime + test + debugger)
-#   * Python requirements under fun-doc/ (the documentation workflow)
 #   * Maven (pom.xml) for the Java plugin
 #   * Gradle (build.gradle) for the alternate Gradle build path
 #
@@ -26,6 +25,19 @@ updates:
     labels:
       - dependencies
       - github-actions
+    # github/codeql-action/init and .../analyze MUST move together. CodeQL
+    # refuses to run when the two halves disagree, failing with
+    # "Loaded a configuration file for version 'X', but running version 'Y'".
+    # Ungrouped, Dependabot files one PR per path, so each one is red on its
+    # own and neither can be merged to prove the other — measured on #443
+    # (init 4.37.6 -> 4.37.7) and #445 (analyze 4.37.6 -> 4.37.7), both of
+    # which failed Analyze (java-kotlin) and Analyze (python) for exactly
+    # this reason while every other check passed. Grouping them makes the
+    # pair arrive as a single mergeable PR.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: pip
     directory: "/"
@@ -35,16 +47,6 @@ updates:
     labels:
       - dependencies
       - python
-
-  - package-ecosystem: pip
-    directory: "/fun-doc"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - python
-      - fun-doc
 
   - package-ecosystem: maven
     directory: "/"


### PR DESCRIPTION
Two independent problems in one file, both producing recurring red CI for reasons unrelated to any change under review.

## The CodeQL split

`github/codeql-action/init` and `.../analyze` must move together. CodeQL refuses to run when the two halves disagree:

```
Loaded a configuration file for version '4.37.9', but running version '4.37.6'
```

Ungrouped, Dependabot files one pull request per action path, so each half is red on its own and neither can be merged to prove the other. Measured on #443 (init 4.37.6 to 4.37.7) and #445 (analyze 4.37.6 to 4.37.7): both failed `Analyze (java-kotlin)` and `Analyze (python)` for exactly this reason, while all twelve other checks passed on each.

This is not a one-off - it recurs on every CodeQL release. Grouping makes the pair arrive as a single mergeable pull request.

Once this lands, close #443 and #445 and let Dependabot recreate them as one.

## The dead fun-doc ecosystem

The `/fun-doc` pip entry points at a directory that has not existed since fun-doc moved to the d2-game-exe repository on 2026-08-11. Dependabot has been polling it weekly ever since and failing every time. The `pip in /fun-doc` entries in the run history are that, not a dependency problem.

## Verification

The file parses as valid YAML and the github-actions ecosystem now carries exactly one group, `codeql-action`. Config-only change; no code or workflow behaviour is affected.